### PR TITLE
feat(style-guides): seed Ruby and Rails-specific style guide content

### DIFF
--- a/db/seeds/style_guides.rb
+++ b/db/seeds/style_guides.rb
@@ -12,10 +12,9 @@
 # failed compression runs). Until compression completes, the injection
 # layer falls back to truncated raw_content (8KB per guide).
 #
-# Content is intentionally language-agnostic — principles and prose,
-# no language-specific syntax in examples. Language-specific guides
-# (Ruby, Rails, etc.) belong in separate records with `language:` set,
-# once StyleGuide.resolve_for grows a language filter.
+# Content is intentionally language-agnostic unless a guide explicitly
+# sets `language:`. Language-specific guides (Ruby, Rails, etc.) are
+# seeded separately so only matching projects receive them.
 #
 # To add a new global default: append to GUIDES below. Re-running seeds
 # is idempotent.
@@ -285,6 +284,108 @@ module Seeds
 
           When the same expensive computation runs repeatedly with the same inputs, cache the result. **But only if you have an invalidation strategy.** An unbounded cache without invalidation is a memory leak with extra steps, and a cache without invalidation rules silently serves stale data the moment its inputs change.
         MD
+      },
+      {
+        name: "Ruby Conventions",
+        language: "ruby",
+        raw_content: <<~'MD'
+          Ruby-specific conventions for maintainable application code.
+
+          ### File Headers and Encoding
+
+          Add `# frozen_string_literal: true` at the top of Ruby files unless a file intentionally needs mutable string literals. When accepting external text input, normalize it to valid UTF-8 before storing, logging, or feeding it into downstream processing so invalid byte sequences fail at the boundary instead of deep in the app.
+
+          ### Naming
+
+          Use Ruby's conventional names:
+
+          - Methods and variables use `snake_case`.
+          - Classes and modules use `CamelCase`.
+          - Predicate methods end in `?`.
+
+          Do not add Java-style prefixes like `get_` or `set_`; in Ruby, readers and writers are expressed directly through method names and accessors. Prefer intention-revealing names over abbreviations.
+
+          ### Parameters and Method Shape
+
+          Avoid boolean flag parameters such as `notify: true` or `async: false`. A boolean argument usually means the method does two things; split it into separate methods or move the choice to the caller.
+
+          ### Dead Code and Future Work
+
+          Do not leave commented-out code in the codebase. Delete it and rely on git history if it is needed later.
+
+          TODO comments require an issue reference in the exact form `# TODO(#123): short description`. Untracked TODOs turn into permanent clutter because nobody owns them.
+        MD
+      },
+      {
+        name: "Service Objects (Servo)",
+        language: "ruby",
+        raw_content: <<~'MD'
+          Service objects hold business actions; keep them consistent and easy to find.
+
+          ### Naming and Namespacing
+
+          Name services with a verb-noun structure such as `AgentRuns::Create` or `Projects::Import`. Namespace by domain or capability, not by controller or workflow, so related operations stay together.
+
+          Prefer placing services under `app/services/<domain>/` with a module hierarchy matching the path. If a new action belongs to an existing domain, add it there instead of creating a parallel folder with duplicated concepts.
+
+          ### Servo Structure
+
+          Use `Servo::Base` for service objects. Define explicit inputs and outputs at the boundary so callers can see the contract without reading the implementation.
+
+          A service should:
+
+          - Accept a small, well-defined set of inputs.
+          - Return a clear result object or domain record.
+          - Encapsulate one business action.
+
+          Keep orchestration thin: validate structural preconditions, call the service, and handle the result. Push the business action itself into the service object.
+        MD
+      },
+      {
+        name: "Rails Patterns",
+        language: "ruby",
+        raw_content: <<~'MD'
+          Rails-specific patterns for the current application stack.
+
+          ### Controllers and Views
+
+          Keep controllers thin. They should coordinate request/response concerns and delegate business work to service objects. Prefer one main object instantiation per controller action.
+
+          The current view stack is ERB. Preserve existing ERB patterns unless a migration explicitly introduces a different component layer. Phlex is a future direction, not something to assume is already present.
+
+          ### Hotwire and Turbo
+
+          When working in interactive Rails UI flows, prefer existing Hotwire/Turbo patterns over adding custom JavaScript. Use Turbo Frames and Streams when they fit the current flow; do not introduce parallel interaction models without a clear reason.
+
+          ### Background Work
+
+          Use GoodJob for normal Rails background jobs. Reserve Temporal-oriented workflow logic for durable, multi-step orchestration concerns where workflow state and retries belong in the orchestrator rather than in ad hoc job chaining.
+        MD
+      },
+      {
+        name: "Database and Migrations",
+        language: "ruby",
+        raw_content: <<~'MD'
+          Database rules for Rails schema changes and persistence code.
+
+          ### IDs and Foreign Keys
+
+          Use UUIDs for external-facing identifiers and bigints for internal foreign keys unless the surrounding schema establishes a different pattern. Add foreign key constraints and indexes for foreign keys.
+
+          ### Migration Style
+
+          Generate migrations with Rails generators instead of creating files manually. Prefer Rails migration helpers for tables, columns, indexes, and foreign keys rather than raw SQL.
+
+          Raw SQL is the exception, not the default. Use it only when the database feature does not have an appropriate Rails helper. Row-level security and policy statements are the documented exception; keep that SQL minimal and isolated.
+
+          ### schema.rb and fx
+
+          The project uses `db/schema.rb`, not `structure.sql`. PostgreSQL functions and triggers should follow the `fx` workflow so schema dumping stays compatible with the Ruby schema format. Use `create_function`, `update_function`, `create_trigger`, and `update_trigger` instead of hand-written `CREATE FUNCTION` blocks.
+
+          ### Logidze
+
+          Add logidze only to tables where change history matters: settings, configuration, access control, financial records, and similar behavioral data. Do not add it to high-volume operational tables or append-only event streams where trigger overhead outweighs the audit value.
+        MD
       }
     ].freeze
 
@@ -294,6 +395,7 @@ module Seeds
           name: attrs[:name], account_id: nil, project_id: nil
         )
         guide.active = true if guide.new_record?
+        guide.language = attrs[:language]
         guide.raw_content = attrs[:raw_content]
 
         # Recompress on: create, raw_content change, or a previously missing /

--- a/spec/db/seeds_style_guides_spec.rb
+++ b/spec/db/seeds_style_guides_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module SeedsStyleGuidesSpec
+  RUBY_GUIDE_NAMES = [
+    "Ruby Conventions",
+    "Service Objects (Servo)",
+    "Rails Patterns",
+    "Database and Migrations"
+  ].freeze
+
+  def load_style_guides_seed!
+    silence_warnings do
+      load Rails.root.join("db/seeds/style_guides.rb").to_s
+    end
+  end
+end
+
+RSpec.describe StyleGuide, type: :model do
+  include ActiveJob::TestHelper
+  include SeedsStyleGuidesSpec
+
+  before do
+    clear_enqueued_jobs
+    clear_performed_jobs
+  end
+
+  it "seeds the Ruby-specific global guides as active language-scoped records" do
+    load_style_guides_seed!
+
+    guides = described_class.global.active.where(language: "ruby").order(:name)
+
+    expect(guides.pluck(:name)).to eq(SeedsStyleGuidesSpec::RUBY_GUIDE_NAMES.sort)
+  end
+
+  it "is idempotent when re-run" do
+    load_style_guides_seed!
+    total_seeded = Seeds::StyleGuides::GUIDES.size
+
+    described_class.global.update_all(compressed_content: "compressed", compression_metadata: {})
+    clear_enqueued_jobs
+
+    expect {
+      load_style_guides_seed!
+    }.not_to change(described_class.global, :count)
+
+    expect(described_class.global.count).to eq(total_seeded)
+    expect(enqueued_jobs).to be_empty
+  end
+
+  it "enqueues compression when raw_content changes on an existing seeded guide" do
+    load_style_guides_seed!
+
+    guide = described_class.global.find_by!(name: "Ruby Conventions")
+    guide.update_columns(
+      raw_content: "outdated content",
+      compressed_content: "compressed",
+      compression_metadata: {}
+    )
+
+    clear_enqueued_jobs
+
+    expect {
+      load_style_guides_seed!
+    }.to have_enqueued_job(StyleGuideCompressionJob).with(guide.id)
+  end
+end

--- a/spec/services/prompts/build_for_issue_spec.rb
+++ b/spec/services/prompts/build_for_issue_spec.rb
@@ -498,6 +498,34 @@ RSpec.describe Prompts::BuildForIssue do
         expect(prompt).to include("# Style Guide")
         expect(prompt).to include("Seeded Ruby Guide")
       end
+
+      it "includes both language-agnostic and Ruby-specific guides for Ruby projects" do
+        create(:style_guide, :global, name: "Global Guide", raw_content: "Applies everywhere.")
+        create(:style_guide, :global, name: "Ruby Language Guide", raw_content: "Ruby-only.", language: "ruby")
+        create(:style_guide, :global, name: "Python Guide", raw_content: "Python-only.", language: "python")
+
+        real_project.define_singleton_method(:detected_language) { "ruby" }
+
+        prompt = described_class.call(issue: real_issue, project: real_project)
+
+        expect(prompt).to include("Global Guide")
+        expect(prompt).to include("Ruby Language Guide")
+        expect(prompt).to include("Ruby-only.")
+        expect(prompt).not_to include("Python Guide")
+      end
+
+      it "excludes Ruby-specific guides for non-Ruby projects" do
+        create(:style_guide, :global, name: "Global Guide", raw_content: "Applies everywhere.")
+        create(:style_guide, :global, name: "Ruby Language Guide", raw_content: "Ruby-only.", language: "ruby")
+
+        real_project.define_singleton_method(:detected_language) { "python" }
+
+        prompt = described_class.call(issue: real_issue, project: real_project)
+
+        expect(prompt).to include("Global Guide")
+        expect(prompt).not_to include("Ruby Language Guide")
+        expect(prompt).not_to include("Ruby-only.")
+      end
     end
 
     context "when issue body is nil" do


### PR DESCRIPTION
## Summary

Implemented and committed as `0172738` with message `feat(style-guides): seed ruby and rails global guides`.

The change adds four global Ruby-scoped seeded guides in [db/seeds/style_guides.rb](/workspace/db/seeds/style_guides.rb), sets `language` during seed upserts, and adds coverage in [spec/db/seeds_style_guides_spec.rb](/workspace/spec/db/seeds_style_guides_spec.rb) and [spec/services/prompts/build_for_issue_spec.rb](/workspace/spec/services/prompts/build_for_issue_spec.rb) to verify:
- Ruby projects get both language-agnostic and Ruby-specific guides
- non-Ruby projects do not receive Ruby-only guide content
- seed re-runs stay idempotent and enqueue compression when seeded content changes

Validation passed:
- `bin/rails db:prepare`
- `bundle exec rubocop`
- `bundle exec rspec`

The repo is clean with no uncommitted changes.

---

Closes #2251