### PR TITLE
feat(compliance): Phase 6.4 — Compliance & Deployment Assurance

### DIFF
--- a/app/controllers/accounts/compliance_dashboards_controller.rb
+++ b/app/controllers/accounts/compliance_dashboards_controller.rb
@@ -35,7 +35,7 @@ module Accounts
     end
 
     def export
-      authorize current_account, :show?
+      authorize current_account, :update?
 
       pack = Accounts::Compliance::EvidencePack.call(
         account: current_account,

--- a/app/controllers/accounts/compliance_dashboards_controller.rb
+++ b/app/controllers/accounts/compliance_dashboards_controller.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module Accounts
+  class ComplianceDashboardsController < ApplicationController
+    before_action :set_tenant_setting
+    before_action :load_compliance_dashboard, only: :show
+
+    def show
+      authorize current_account, :show?
+    end
+
+    def update
+      authorize current_account, :update?
+
+      ActiveRecord::Base.transaction do
+        @tenant_setting.deployment_assurance_configuration = deployment_assurance_params
+        @tenant_setting.save!
+
+        if @tenant_setting.saved_changes.except("updated_at").any?
+          Accounts::RecordActivity.call(
+            account: current_account,
+            actor: current_user,
+            action: "compliance.assurance_updated",
+            subject: @tenant_setting,
+            metadata: { changed_fields: [ "deployment_assurance" ] }
+          )
+        end
+      end
+
+      redirect_to account_compliance_dashboard_path, notice: "Compliance and deployment assurance settings saved."
+    rescue ActiveRecord::RecordInvalid
+      load_compliance_dashboard
+      flash.now[:alert] = "Unable to save compliance settings."
+      render :show, status: :unprocessable_content
+    end
+
+    def export
+      authorize current_account, :show?
+
+      pack = Accounts::Compliance::EvidencePack.call(
+        account: current_account,
+        tenant_setting: @tenant_setting,
+        billing_visible: BillingPolicy.new(current_user, current_account).billing?
+      )
+
+      send_data JSON.pretty_generate(pack),
+        filename: "compliance-evidence-#{current_account.slug}-#{Date.current}.json",
+        type: "application/json"
+    end
+
+    private
+
+    def set_tenant_setting
+      @tenant_setting = current_account.tenant_setting!
+    end
+
+    def load_compliance_dashboard
+      @compliance_dashboard = Accounts::Compliance::Dashboard.call(
+        account: current_account,
+        tenant_setting: @tenant_setting,
+        billing_visible: BillingPolicy.new(current_user, current_account).billing?
+      )
+    end
+
+    def deployment_assurance_params
+      params.fetch(:deployment_assurance, ActionController::Parameters.new).permit(
+        :deployment_model,
+        :network_boundary,
+        :reference_architecture,
+        :operations_owner,
+        customer_managed_keys: %i[
+          enabled
+          provider
+          key_reference
+          last_rotated_at
+          rotation_interval_days
+        ],
+        secret_rotation: %i[
+          documented
+          owner
+          last_completed_at
+          interval_days
+        ],
+        disaster_recovery: %i[
+          backup_cadence
+          backup_last_verified_at
+          restore_last_tested_at
+          upgrade_last_validated_at
+          air_gap_package_validated_at
+          rpo_hours
+          rto_hours
+        ]
+      ).to_h
+    end
+  end
+end

--- a/app/controllers/concerns/account_administration_page.rb
+++ b/app/controllers/concerns/account_administration_page.rb
@@ -14,6 +14,11 @@ module AccountAdministrationPage
     @recent_invoices = current_account.billing_invoices.order(created_at: :desc).limit(5)
     @recent_activity = current_account.account_activity_events.includes(:actor).recent.limit(20)
     @billing_visible = BillingPolicy.new(current_user, current_account).billing?
+    @compliance_dashboard = Accounts::Compliance::Dashboard.call(
+      account: current_account,
+      tenant_setting: @tenant_setting,
+      billing_visible: @billing_visible
+    )
   end
 
   def render_account_administration_error(message = "Something went wrong. Please try again.")

--- a/app/models/account_activity_event.rb
+++ b/app/models/account_activity_event.rb
@@ -33,6 +33,8 @@ class AccountActivityEvent < ApplicationRecord
       "Deactivated the account"
     when "tenant_configuration.updated"
       "Updated tenant configuration"
+    when "compliance.assurance_updated"
+      "Updated compliance and deployment assurance settings"
     else
       action.humanize
     end
@@ -40,7 +42,7 @@ class AccountActivityEvent < ApplicationRecord
 
   def detail_lines
     case action
-    when "account.updated", "tenant_configuration.updated"
+    when "account.updated", "tenant_configuration.updated", "compliance.assurance_updated"
       Array(metadata.to_h["changed_fields"]).map { |field| "#{field.humanize} changed" }
     when "ownership.transferred"
       [ "Previous owner: #{metadata_value('from_email')}" ]

--- a/app/models/tenant_setting.rb
+++ b/app/models/tenant_setting.rb
@@ -31,6 +31,34 @@ class TenantSetting < ApplicationRecord
     "default_goal" => "create_pr",
     "auto_continue" => true
   }.freeze
+  DEFAULT_DEPLOYMENT_ASSURANCE = {
+    "deployment_model" => "self_hosted",
+    "network_boundary" => "private_vpc",
+    "reference_architecture" => "single_tenant",
+    "operations_owner" => "",
+    "customer_managed_keys" => {
+      "enabled" => false,
+      "provider" => "",
+      "key_reference" => "",
+      "last_rotated_at" => "",
+      "rotation_interval_days" => 90
+    },
+    "secret_rotation" => {
+      "documented" => false,
+      "owner" => "",
+      "last_completed_at" => "",
+      "interval_days" => 90
+    },
+    "disaster_recovery" => {
+      "backup_cadence" => "daily",
+      "backup_last_verified_at" => "",
+      "restore_last_tested_at" => "",
+      "upgrade_last_validated_at" => "",
+      "air_gap_package_validated_at" => "",
+      "rpo_hours" => 24,
+      "rto_hours" => 8
+    }
+  }.freeze
   DEFAULT_WORKER_SETTINGS = {
     "temporal_workflow_slots" => 20,
     "temporal_activity_slots" => 4,
@@ -165,6 +193,16 @@ class TenantSetting < ApplicationRecord
 
   def effective_chat_settings
     merge_defaults(DEFAULT_CHAT_SETTINGS, features.fetch("chat_settings", {}))
+  end
+
+  def deployment_assurance_configuration
+    merge_defaults(DEFAULT_DEPLOYMENT_ASSURANCE, features.fetch("deployment_assurance", {}))
+  end
+
+  def deployment_assurance_configuration=(value)
+    merged_features = normalize_hash(features)
+    merged_features["deployment_assurance"] = normalize_deployment_assurance(value)
+    self.features = merged_features
   end
 
   def chat_session_token_limit
@@ -356,6 +394,30 @@ class TenantSetting < ApplicationRecord
 
       WORKER_SETTING_INTEGER_KEYS.each do |key|
         normalized[key] = normalized[key].present? ? normalized[key].to_i : nil if normalized.key?(key)
+      end
+    end
+  end
+
+  def normalize_deployment_assurance(value)
+    merge_defaults(DEFAULT_DEPLOYMENT_ASSURANCE, normalize_hash(value)).tap do |normalized|
+      normalized["customer_managed_keys"]["enabled"] =
+        ActiveModel::Type::Boolean.new.cast(normalized.dig("customer_managed_keys", "enabled"))
+      normalized["secret_rotation"]["documented"] =
+        ActiveModel::Type::Boolean.new.cast(normalized.dig("secret_rotation", "documented"))
+
+      %w[rotation_interval_days].each do |key|
+        normalized["customer_managed_keys"][key] =
+          normalized.dig("customer_managed_keys", key).present? ? normalized.dig("customer_managed_keys", key).to_i : nil
+      end
+
+      %w[interval_days].each do |key|
+        normalized["secret_rotation"][key] =
+          normalized.dig("secret_rotation", key).present? ? normalized.dig("secret_rotation", key).to_i : nil
+      end
+
+      %w[rpo_hours rto_hours].each do |key|
+        normalized["disaster_recovery"][key] =
+          normalized.dig("disaster_recovery", key).present? ? normalized.dig("disaster_recovery", key).to_i : nil
       end
     end
   end

--- a/app/models/tenant_setting.rb
+++ b/app/models/tenant_setting.rb
@@ -100,6 +100,7 @@ class TenantSetting < ApplicationRecord
   validate :validate_default_budgets
   validate :validate_agent_settings
   validate :validate_worker_settings
+  validate :validate_quality_thresholds
   validate :validate_deployment_assurance
   validates :self_repo_full_name,
     format: { with: REPO_NAME_FORMAT, message: "must be in owner/repo format" },
@@ -333,6 +334,13 @@ class TenantSetting < ApplicationRecord
     end
   end
 
+  def validate_quality_thresholds
+    return unless quality_thresholds.is_a?(Hash)
+
+    validate_quality_threshold_integer(quality_thresholds["min_recent_runs"], key: "min_recent_runs") if quality_thresholds.key?("min_recent_runs")
+    validate_quality_threshold_integer(quality_thresholds["lookback_window_hours"], key: "lookback_window_hours") if quality_thresholds.key?("lookback_window_hours")
+  end
+
   def validate_deployment_assurance
     return unless features.is_a?(Hash)
 
@@ -451,6 +459,12 @@ class TenantSetting < ApplicationRecord
     return if value.is_a?(Integer) && value.between?(1, PG_INT_MAX)
 
     errors.add(:features, "deployment_assurance.#{path} must be an integer between 1 and #{PG_INT_MAX}")
+  end
+
+  def validate_quality_threshold_integer(value, key:)
+    return if value.is_a?(Integer) && value.between?(1, PG_INT_MAX)
+
+    errors.add(:quality_thresholds, "#{key} must be an integer between 1 and #{PG_INT_MAX}")
   end
 
   def normalize_integer_value(value)

--- a/app/models/tenant_setting.rb
+++ b/app/models/tenant_setting.rb
@@ -100,6 +100,7 @@ class TenantSetting < ApplicationRecord
   validate :validate_default_budgets
   validate :validate_agent_settings
   validate :validate_worker_settings
+  validate :validate_deployment_assurance
   validates :self_repo_full_name,
     format: { with: REPO_NAME_FORMAT, message: "must be in owner/repo format" },
     allow_nil: true,
@@ -332,6 +333,30 @@ class TenantSetting < ApplicationRecord
     end
   end
 
+  def validate_deployment_assurance
+    return unless features.is_a?(Hash)
+
+    assurance = features.fetch("deployment_assurance", nil)
+    return unless assurance.is_a?(Hash)
+
+    validate_deployment_assurance_integer(
+      assurance.dig("customer_managed_keys", "rotation_interval_days"),
+      path: "customer_managed_keys.rotation_interval_days"
+    )
+    validate_deployment_assurance_integer(
+      assurance.dig("secret_rotation", "interval_days"),
+      path: "secret_rotation.interval_days"
+    )
+    validate_deployment_assurance_integer(
+      assurance.dig("disaster_recovery", "rpo_hours"),
+      path: "disaster_recovery.rpo_hours"
+    )
+    validate_deployment_assurance_integer(
+      assurance.dig("disaster_recovery", "rto_hours"),
+      path: "disaster_recovery.rto_hours"
+    )
+  end
+
   def normalize_budget_hash(value)
     normalized_value = normalize_hash(value)
     return normalized_value unless normalized_value.is_a?(Hash)
@@ -342,7 +367,7 @@ class TenantSetting < ApplicationRecord
       result[budget_type.to_s] = normalize_hash(settings).tap do |normalized|
         normalized["enabled"] = ActiveModel::Type::Boolean.new.cast(normalized["enabled"])
         %w[limit_cents alert_threshold_percent grace_buffer_percent].each do |key|
-          normalized[key] = normalized[key].present? ? normalized[key].to_i : nil
+          normalized[key] = normalize_integer_value(normalized[key])
         end
       end
     end
@@ -360,7 +385,7 @@ class TenantSetting < ApplicationRecord
       next unless normalized.is_a?(Hash)
 
       keys.each do |key|
-        normalized[key] = normalized[key].present? ? normalized[key].to_i : nil if normalized.key?(key)
+        normalized[key] = normalize_integer_value(normalized[key]) if normalized.key?(key)
       end
     end
   end
@@ -374,7 +399,7 @@ class TenantSetting < ApplicationRecord
         normalized[key] = normalized[key].present? ? normalized[key].to_f : nil if normalized.key?(key)
       end
       %w[min_recent_runs lookback_window_hours].each do |key|
-        normalized[key] = normalized[key].present? ? normalized[key].to_i : nil if normalized.key?(key)
+        normalized[key] = normalize_integer_value(normalized[key]) if normalized.key?(key)
       end
     end
   end
@@ -393,7 +418,7 @@ class TenantSetting < ApplicationRecord
       next unless normalized.is_a?(Hash)
 
       WORKER_SETTING_INTEGER_KEYS.each do |key|
-        normalized[key] = normalized[key].present? ? normalized[key].to_i : nil if normalized.key?(key)
+        normalized[key] = normalize_integer_value(normalized[key]) if normalized.key?(key)
       end
     end
   end
@@ -407,19 +432,31 @@ class TenantSetting < ApplicationRecord
 
       %w[rotation_interval_days].each do |key|
         normalized["customer_managed_keys"][key] =
-          normalized.dig("customer_managed_keys", key).present? ? normalized.dig("customer_managed_keys", key).to_i : nil
+          normalize_integer_value(normalized.dig("customer_managed_keys", key))
       end
 
       %w[interval_days].each do |key|
         normalized["secret_rotation"][key] =
-          normalized.dig("secret_rotation", key).present? ? normalized.dig("secret_rotation", key).to_i : nil
+          normalize_integer_value(normalized.dig("secret_rotation", key))
       end
 
       %w[rpo_hours rto_hours].each do |key|
         normalized["disaster_recovery"][key] =
-          normalized.dig("disaster_recovery", key).present? ? normalized.dig("disaster_recovery", key).to_i : nil
+          normalize_integer_value(normalized.dig("disaster_recovery", key))
       end
     end
+  end
+
+  def validate_deployment_assurance_integer(value, path:)
+    return if value.is_a?(Integer) && value.between?(1, PG_INT_MAX)
+
+    errors.add(:features, "deployment_assurance.#{path} must be an integer between 1 and #{PG_INT_MAX}")
+  end
+
+  def normalize_integer_value(value)
+    return nil unless value.present?
+
+    Integer(value, exception: false) || value
   end
 
   def apply_guardrail_columns

--- a/app/models/tenant_setting.rb
+++ b/app/models/tenant_setting.rb
@@ -59,6 +59,10 @@ class TenantSetting < ApplicationRecord
       "rto_hours" => 8
     }
   }.freeze
+  DEPLOYMENT_ASSURANCE_MODELS = %w[self_hosted private_vpc air_gapped].freeze
+  DEPLOYMENT_ASSURANCE_NETWORK_BOUNDARIES = %w[private_vpc public_ingress offline].freeze
+  DEPLOYMENT_ASSURANCE_REFERENCE_ARCHITECTURES = %w[single_tenant private_services offline_promotion].freeze
+  DEPLOYMENT_ASSURANCE_BACKUP_CADENCES = %w[hourly daily weekly].freeze
   DEFAULT_WORKER_SETTINGS = {
     "temporal_workflow_slots" => 20,
     "temporal_activity_slots" => 4,
@@ -347,6 +351,26 @@ class TenantSetting < ApplicationRecord
     assurance = features.fetch("deployment_assurance", nil)
     return unless assurance.is_a?(Hash)
 
+    validate_deployment_assurance_option(
+      assurance["deployment_model"],
+      path: "deployment_model",
+      allowed_values: DEPLOYMENT_ASSURANCE_MODELS
+    )
+    validate_deployment_assurance_option(
+      assurance["network_boundary"],
+      path: "network_boundary",
+      allowed_values: DEPLOYMENT_ASSURANCE_NETWORK_BOUNDARIES
+    )
+    validate_deployment_assurance_option(
+      assurance["reference_architecture"],
+      path: "reference_architecture",
+      allowed_values: DEPLOYMENT_ASSURANCE_REFERENCE_ARCHITECTURES
+    )
+    validate_deployment_assurance_option(
+      assurance.dig("disaster_recovery", "backup_cadence"),
+      path: "disaster_recovery.backup_cadence",
+      allowed_values: DEPLOYMENT_ASSURANCE_BACKUP_CADENCES
+    )
     validate_deployment_assurance_integer(
       assurance.dig("customer_managed_keys", "rotation_interval_days"),
       path: "customer_managed_keys.rotation_interval_days"
@@ -459,6 +483,12 @@ class TenantSetting < ApplicationRecord
     return if value.is_a?(Integer) && value.between?(1, PG_INT_MAX)
 
     errors.add(:features, "deployment_assurance.#{path} must be an integer between 1 and #{PG_INT_MAX}")
+  end
+
+  def validate_deployment_assurance_option(value, path:, allowed_values:)
+    return if allowed_values.include?(value)
+
+    errors.add(:features, "deployment_assurance.#{path} must be one of: #{allowed_values.join(', ')}")
   end
 
   def validate_quality_threshold_integer(value, key:)

--- a/app/services/accounts/compliance/dashboard.rb
+++ b/app/services/accounts/compliance/dashboard.rb
@@ -208,7 +208,9 @@ module Accounts
         keys = deployment_assurance["customer_managed_keys"]
         enabled = keys["enabled"] == true
         status =
-          if enabled && keys["provider"].present? && keys["key_reference"].present?
+          if !enabled
+            :not_applicable
+          elsif keys["provider"].present? && keys["key_reference"].present?
             if fresh_within?(keys["last_rotated_at"], days: keys["rotation_interval_days"].presence || 90)
               :compliant
             else

--- a/app/services/accounts/compliance/dashboard.rb
+++ b/app/services/accounts/compliance/dashboard.rb
@@ -211,7 +211,7 @@ module Accounts
           if !enabled
             :not_applicable
           elsif keys["provider"].present? && keys["key_reference"].present?
-            if fresh_within?(keys["last_rotated_at"], days: keys["rotation_interval_days"].presence || 90)
+            if fresh_within?(keys["last_rotated_at"], days: deployment_interval(keys["rotation_interval_days"], default: 90))
               :compliant
             else
               :warning
@@ -236,7 +236,7 @@ module Accounts
       def secret_rotation_control
         rotation = deployment_assurance["secret_rotation"]
         documented = rotation["documented"] == true
-        interval_days = rotation["interval_days"].presence || 90
+        interval_days = deployment_interval(rotation["interval_days"], default: 90)
 
         status =
           if documented && rotation["owner"].present? && fresh_within?(rotation["last_completed_at"], days: interval_days)
@@ -367,6 +367,10 @@ module Accounts
 
       def display_date(value)
         parse_date(value)&.iso8601 || "Not recorded"
+      end
+
+      def deployment_interval(value, default:)
+        Integer(value, exception: false) || default
       end
     end
   end

--- a/app/services/accounts/compliance/dashboard.rb
+++ b/app/services/accounts/compliance/dashboard.rb
@@ -1,0 +1,371 @@
+# frozen_string_literal: true
+
+module Accounts
+  module Compliance
+    class Dashboard
+      REFERENCE_ARCHITECTURES = [
+        {
+          key: "self_hosted",
+          name: "Self-hosted",
+          summary: "Single-tenant deployment with isolated Rails, PostgreSQL, Redis, and object storage.",
+          doc_path: "docs/compliance/reference-architectures.md#self-hosted-reference-architecture"
+        },
+        {
+          key: "private_vpc",
+          name: "Private VPC",
+          summary: "Private-network deployment with controlled ingress, egress, and managed persistence services.",
+          doc_path: "docs/compliance/reference-architectures.md#private-vpc-reference-architecture"
+        },
+        {
+          key: "air_gapped",
+          name: "Air-gapped",
+          summary: "Offline package promotion model for environments that prohibit direct internet connectivity.",
+          doc_path: "docs/compliance/reference-architectures.md#air-gapped-reference-architecture"
+        }
+      ].freeze
+
+      RUNBOOKS = [
+        {
+          key: "backup_restore",
+          name: "Backup and Restore",
+          summary: "Backup cadence, restore rehearsal, and evidence capture expectations.",
+          doc_path: "docs/compliance/operational-assurance-runbooks.md#backup-and-restore"
+        },
+        {
+          key: "upgrade_validation",
+          name: "Upgrade Validation",
+          summary: "Pre-upgrade checks, rollback planning, and post-upgrade verification.",
+          doc_path: "docs/compliance/operational-assurance-runbooks.md#upgrade-validation"
+        },
+        {
+          key: "secret_rotation",
+          name: "Secret Rotation",
+          summary: "Customer-managed key rotation and provider credential renewal workflow.",
+          doc_path: "docs/compliance/operational-assurance-runbooks.md#secret-rotation"
+        }
+      ].freeze
+
+      CONTROL_MAPPINGS = {
+        deployment_topology: {
+          title: "Deployment topology documented",
+          requirement: "Reference architecture, network boundary, and operator ownership are recorded.",
+          mappings: [ "SOC 2 CC1.2", "SOC 2 CC6.6", "ISO 27001 A.5.8" ],
+          guidance: "Capture the deployment model and operations owner used for this tenant."
+        },
+        configuration_snapshot: {
+          title: "Configuration snapshot exportable",
+          requirement: "Security reviewers can inspect account and tenant configuration without bespoke screenshots.",
+          mappings: [ "SOC 2 CC2.1", "ISO 27001 A.5.37" ],
+          guidance: "Use the evidence export to attach current account and tenant configuration to a review."
+        },
+        audit_export: {
+          title: "Audit activity exportable",
+          requirement: "Administrative actions are recorded and can be exported for review.",
+          mappings: [ "SOC 2 CC7.2", "ISO 27001 A.8.15" ],
+          guidance: "Generate an evidence pack after lifecycle, membership, or tenant configuration changes."
+        },
+        customer_managed_keys: {
+          title: "Customer-managed key posture",
+          requirement: "The tenant documents whether a customer-managed key is enabled and where it is rotated.",
+          mappings: [ "SOC 2 CC6.1", "ISO 27001 A.8.24" ],
+          guidance: "Record the KMS provider, key reference, and last rotation date for buyer review."
+        },
+        secret_rotation: {
+          title: "Secret rotation workflow",
+          requirement: "Credential rotation has an owner, cadence, and recent execution evidence.",
+          mappings: [ "SOC 2 CC6.1", "ISO 27001 A.5.17" ],
+          guidance: "Track the operator owner and the last completed secret rotation date."
+        },
+        backup_verification: {
+          title: "Backup verification",
+          requirement: "Backups have a declared cadence and recent verification evidence.",
+          mappings: [ "SOC 2 A1.2", "ISO 27001 A.8.13" ],
+          guidance: "Record the backup cadence and when the most recent backup verification completed."
+        },
+        restore_validation: {
+          title: "Restore validation",
+          requirement: "Disaster recovery restores are tested on a recurring basis.",
+          mappings: [ "SOC 2 A1.3", "ISO 27001 A.5.30" ],
+          guidance: "Run and record a restore exercise at least once per quarter."
+        },
+        upgrade_validation: {
+          title: "Upgrade validation",
+          requirement: "Upgrades are rehearsed with rollback planning before production rollout.",
+          mappings: [ "SOC 2 CC8.1", "ISO 27001 A.8.32" ],
+          guidance: "Record the most recent validated upgrade rehearsal and expected rollback window."
+        },
+        air_gap_validation: {
+          title: "Air-gap package validation",
+          requirement: "Offline deployment packages are validated when the tenant uses an air-gapped model.",
+          mappings: [ "SOC 2 CC6.7", "ISO 27001 A.5.14" ],
+          guidance: "Re-validate offline artifacts whenever the deployment package or dependencies change."
+        }
+      }.freeze
+
+      def self.call(...)
+        new(...).call
+      end
+
+      def initialize(account:, tenant_setting:, billing_visible: false)
+        @account = account
+        @tenant_setting = tenant_setting
+        @billing_visible = billing_visible
+      end
+
+      def call
+        controls = [
+          deployment_topology_control,
+          configuration_snapshot_control,
+          audit_export_control,
+          customer_managed_keys_control,
+          secret_rotation_control,
+          backup_verification_control,
+          restore_validation_control,
+          upgrade_validation_control,
+          air_gap_validation_control
+        ]
+
+        applicable_controls = controls.reject { |control| control[:status] == :not_applicable }
+        counts = {
+          compliant: applicable_controls.count { |control| control[:status] == :compliant },
+          warning: applicable_controls.count { |control| control[:status] == :warning },
+          gap: applicable_controls.count { |control| control[:status] == :gap },
+          not_applicable: controls.count { |control| control[:status] == :not_applicable }
+        }
+
+        readiness_score =
+          if applicable_controls.empty?
+            100
+          else
+            (((counts[:compliant] + (counts[:warning] * 0.5)) / applicable_controls.size.to_f) * 100).round
+          end
+
+        {
+          deployment_assurance: deployment_assurance,
+          reference_architectures: REFERENCE_ARCHITECTURES,
+          runbooks: RUNBOOKS,
+          controls: controls,
+          counts: counts,
+          readiness_score: readiness_score,
+          billing_visible: billing_visible
+        }
+      end
+
+      private
+
+      attr_reader :account, :tenant_setting, :billing_visible
+
+      def deployment_assurance
+        tenant_setting.deployment_assurance_configuration
+      end
+
+      def control(id, status:, evidence:)
+        CONTROL_MAPPINGS.fetch(id).merge(id: id, status: status, evidence: evidence)
+      end
+
+      def deployment_topology_control
+        owner = deployment_assurance["operations_owner"].to_s
+        status = owner.present? ? :compliant : :warning
+
+        control(
+          :deployment_topology,
+          status: status,
+          evidence: [
+            "Deployment model: #{deployment_assurance['deployment_model'].humanize}",
+            "Network boundary: #{deployment_assurance['network_boundary'].humanize}",
+            "Reference architecture: #{deployment_assurance['reference_architecture'].humanize}",
+            owner.presence ? "Operations owner: #{owner}" : "Operations owner missing"
+          ]
+        )
+      end
+
+      def configuration_snapshot_control
+        control(
+          :configuration_snapshot,
+          status: :compliant,
+          evidence: [
+            "Tenant settings snapshot available",
+            "Account defaults included in evidence export"
+          ]
+        )
+      end
+
+      def audit_export_control
+        event_count = account.account_activity_events.count
+        status = event_count.positive? ? :compliant : :warning
+
+        control(
+          :audit_export,
+          status: status,
+          evidence: [
+            "Recent account activity entries: #{event_count}",
+            "Administrative audit export available from evidence pack"
+          ]
+        )
+      end
+
+      def customer_managed_keys_control
+        keys = deployment_assurance["customer_managed_keys"]
+        enabled = keys["enabled"] == true
+        status =
+          if enabled && keys["provider"].present? && keys["key_reference"].present?
+            if fresh_within?(keys["last_rotated_at"], days: keys["rotation_interval_days"].presence || 90)
+              :compliant
+            else
+              :warning
+            end
+          else
+            :gap
+          end
+
+        control(
+          :customer_managed_keys,
+          status: status,
+          evidence: [
+            "Enabled: #{enabled ? 'Yes' : 'No'}",
+            "Provider: #{keys['provider'].presence || 'Not recorded'}",
+            "Key reference: #{keys['key_reference'].presence || 'Not recorded'}",
+            "Last rotated: #{display_date(keys['last_rotated_at'])}",
+            "Rotation interval: #{keys['rotation_interval_days']} days"
+          ]
+        )
+      end
+
+      def secret_rotation_control
+        rotation = deployment_assurance["secret_rotation"]
+        documented = rotation["documented"] == true
+        interval_days = rotation["interval_days"].presence || 90
+
+        status =
+          if documented && rotation["owner"].present? && fresh_within?(rotation["last_completed_at"], days: interval_days)
+            :compliant
+          elsif documented && rotation["owner"].present?
+            :warning
+          else
+            :gap
+          end
+
+        control(
+          :secret_rotation,
+          status: status,
+          evidence: [
+            "Workflow documented: #{documented ? 'Yes' : 'No'}",
+            "Owner: #{rotation['owner'].presence || 'Not recorded'}",
+            "Last completed: #{display_date(rotation['last_completed_at'])}",
+            "Rotation interval: #{interval_days} days"
+          ]
+        )
+      end
+
+      def backup_verification_control
+        recovery = deployment_assurance["disaster_recovery"]
+        status =
+          if fresh_within?(recovery["backup_last_verified_at"], days: 30)
+            :compliant
+          elsif parse_date(recovery["backup_last_verified_at"])
+            :warning
+          else
+            :gap
+          end
+
+        control(
+          :backup_verification,
+          status: status,
+          evidence: [
+            "Backup cadence: #{recovery['backup_cadence'].humanize}",
+            "Last verified: #{display_date(recovery['backup_last_verified_at'])}",
+            "Target RPO: #{recovery['rpo_hours']} hours"
+          ]
+        )
+      end
+
+      def restore_validation_control
+        recovery = deployment_assurance["disaster_recovery"]
+        status =
+          if fresh_within?(recovery["restore_last_tested_at"], days: 90)
+            :compliant
+          elsif parse_date(recovery["restore_last_tested_at"])
+            :warning
+          else
+            :gap
+          end
+
+        control(
+          :restore_validation,
+          status: status,
+          evidence: [
+            "Last restore test: #{display_date(recovery['restore_last_tested_at'])}",
+            "Target RTO: #{recovery['rto_hours']} hours"
+          ]
+        )
+      end
+
+      def upgrade_validation_control
+        recovery = deployment_assurance["disaster_recovery"]
+        status =
+          if fresh_within?(recovery["upgrade_last_validated_at"], days: 90)
+            :compliant
+          elsif parse_date(recovery["upgrade_last_validated_at"])
+            :warning
+          else
+            :gap
+          end
+
+        control(
+          :upgrade_validation,
+          status: status,
+          evidence: [
+            "Last validated upgrade: #{display_date(recovery['upgrade_last_validated_at'])}",
+            "Rollback planning documented in runbook"
+          ]
+        )
+      end
+
+      def air_gap_validation_control
+        unless deployment_assurance["deployment_model"] == "air_gapped"
+          return control(
+            :air_gap_validation,
+            status: :not_applicable,
+            evidence: [ "Tenant is not using an air-gapped deployment model" ]
+          )
+        end
+
+        recovery = deployment_assurance["disaster_recovery"]
+        status =
+          if fresh_within?(recovery["air_gap_package_validated_at"], days: 90)
+            :compliant
+          elsif parse_date(recovery["air_gap_package_validated_at"])
+            :warning
+          else
+            :gap
+          end
+
+        control(
+          :air_gap_validation,
+          status: status,
+          evidence: [
+            "Offline package validated: #{display_date(recovery['air_gap_package_validated_at'])}"
+          ]
+        )
+      end
+
+      def fresh_within?(value, days:)
+        date = parse_date(value)
+        date.present? && date >= days.days.ago.to_date
+      end
+
+      def parse_date(value)
+        return value.to_date if value.respond_to?(:to_date)
+        return nil if value.blank?
+
+        Date.parse(value.to_s)
+      rescue Date::Error
+        nil
+      end
+
+      def display_date(value)
+        parse_date(value)&.iso8601 || "Not recorded"
+      end
+    end
+  end
+end

--- a/app/services/accounts/compliance/evidence_pack.rb
+++ b/app/services/accounts/compliance/evidence_pack.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Accounts
+  module Compliance
+    class EvidencePack
+      def self.call(...)
+        new(...).call
+      end
+
+      def initialize(account:, tenant_setting:, billing_visible: false)
+        @account = account
+        @tenant_setting = tenant_setting
+        @billing_visible = billing_visible
+      end
+
+      def call
+        {
+          schema_version: "2026-05-24",
+          generated_at: Time.current.iso8601,
+          account: {
+            id: account.id,
+            name: account.name,
+            slug: account.slug,
+            plan: account.plan,
+            status: account.status
+          },
+          control_summary: dashboard.slice(:readiness_score, :counts),
+          controls: dashboard[:controls],
+          reference_architectures: dashboard[:reference_architectures],
+          runbooks: dashboard[:runbooks],
+          configuration_snapshot: {
+            account_defaults: {
+              default_max_tokens_per_run: account.default_max_tokens_per_run,
+              scheduler_paused: account.scheduler_paused?,
+              trial_ends_at: account.trial_ends_at&.iso8601
+            },
+            tenant_configuration: tenant_setting.configuration,
+            deployment_assurance: tenant_setting.deployment_assurance_configuration
+          },
+          audit_export: account.account_activity_events.recent.limit(100).map do |event|
+            {
+              occurred_at: event.created_at.iso8601,
+              actor: event.actor_label,
+              action: event.action,
+              description: event.description,
+              metadata: event.metadata
+            }
+          end,
+          billing_snapshot: billing_snapshot
+        }
+      end
+
+      private
+
+      attr_reader :account, :tenant_setting, :billing_visible
+
+      def dashboard
+        @dashboard ||= Dashboard.call(
+          account: account,
+          tenant_setting: tenant_setting,
+          billing_visible: billing_visible
+        )
+      end
+
+      def billing_snapshot
+        return { visible: false } unless billing_visible
+
+        current_period = account.billing_periods.order(starts_at: :desc).first
+        latest_invoice = account.billing_invoices.order(created_at: :desc).first
+        active_plan = account.billing_plans.active.order(created_at: :desc).first
+
+        {
+          visible: true,
+          active_plan: active_plan&.slice(:name, :billing_model, :period_type),
+          current_period: current_period&.slice(:starts_at, :ends_at, :total_cost_cents, :total_runs),
+          latest_invoice: latest_invoice&.slice(:external_id, :status, :issued_at, :total_cents)
+        }
+      end
+    end
+  end
+end

--- a/app/services/accounts/compliance/evidence_pack.rb
+++ b/app/services/accounts/compliance/evidence_pack.rb
@@ -37,7 +37,7 @@ module Accounts
             tenant_configuration: tenant_setting.configuration,
             deployment_assurance: tenant_setting.deployment_assurance_configuration
           },
-          audit_export: account.account_activity_events.recent.limit(100).map do |event|
+          audit_export: account.account_activity_events.recent.includes(:actor).limit(100).map do |event|
             {
               occurred_at: event.created_at.iso8601,
               actor: event.actor_label,

--- a/app/services/screenshots/capture_targets.rb
+++ b/app/services/screenshots/capture_targets.rb
@@ -76,6 +76,7 @@ module Screenshots
       provider_api_key_edit: Target.new(slug: "provider_api_key_edit", path_builder: ->(seed_data) { "/provider_api_keys/#{seed_data.fetch(:provider_api_key).id}/edit" }, requires_auth: true),
       user_settings: Target.new(slug: "user_settings", path_builder: "/user_settings/edit", requires_auth: true),
       account: Target.new(slug: "account", path_builder: "/account", requires_auth: true),
+      account_compliance_dashboard: Target.new(slug: "account_compliance_dashboard", path_builder: "/account_compliance_dashboard", requires_auth: true),
       tenant_configuration: Target.new(slug: "tenant_configuration", path_builder: "/tenant_configuration/edit", requires_auth: true),
       providers: Target.new(slug: "providers", path_builder: "/runners", requires_auth: true),
       providers_new: Target.new(slug: "providers_new", path_builder: "/runners/new?form_variant=subscription", requires_auth: true),
@@ -226,6 +227,7 @@ module Screenshots
     # Nested controller path => target keys
     NESTED_CONTROLLER_TARGETS = {
       "users/registrations_controller.rb" => [ :sign_up ],
+      "accounts/compliance_dashboards_controller.rb" => [ :account_compliance_dashboard ],
       "projects/agent_runs_controller.rb" => %i[project_agent_runs project_agent_run_new project_agent_run_show],
       "projects/bundle_performance_dashboards_controller.rb" => [ :project_bundle_performance_dashboard ],
       "projects/cost_dashboards_controller.rb" => [ :project_cost_dashboard ],
@@ -330,6 +332,7 @@ module Screenshots
       when /\Agithub_tokens\// then rest_resource_targets(relative_path, "github_tokens", index: :github_tokens, new: :github_token_new, show: :github_token_show, edit: :github_token_show)
       when /\Alinear_tokens\// then rest_resource_targets(relative_path, "linear_tokens", index: :linear_tokens, new: :linear_token_new, show: :linear_token_show, edit: :linear_token_show)
       when /\Auser_settings\// then [ :user_settings ]
+      when /\Aaccounts\/compliance_dashboards\// then [ :account_compliance_dashboard ]
       when /\Aaccounts\// then [ :account ]
       when /\Atenant_configurations\// then [ :tenant_configuration ]
       when /\Aprovider_api_keys\// then rest_resource_targets(relative_path, "provider_api_keys", index: :provider_api_keys, new: :provider_api_key_new, show: :provider_api_key_show, edit: :provider_api_key_edit)

--- a/app/views/accounts/compliance_dashboards/show.html.erb
+++ b/app/views/accounts/compliance_dashboards/show.html.erb
@@ -1,0 +1,259 @@
+<% content_for :title, "Compliance Dashboard" %>
+
+<% deployment_assurance = @compliance_dashboard[:deployment_assurance] %>
+<% customer_managed_keys = deployment_assurance["customer_managed_keys"] %>
+<% secret_rotation = deployment_assurance["secret_rotation"] %>
+<% disaster_recovery = deployment_assurance["disaster_recovery"] %>
+
+<div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+  <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+    <div>
+      <p class="text-sm font-medium uppercase tracking-[0.2em] text-amber-700 dark:text-amber-300">Compliance</p>
+      <h1 class="mt-2 text-3xl font-semibold text-gray-900 dark:text-white">Deployment Assurance</h1>
+      <p class="mt-2 max-w-3xl text-sm text-gray-600 dark:text-gray-300">
+        Capture deployment posture, customer-managed key status, rotation evidence, and operational runbook validation in one place.
+      </p>
+    </div>
+
+    <div class="flex flex-wrap gap-3">
+      <%= link_to "Back to account", account_path, class: "rounded-full border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-900" %>
+      <%= link_to "Export evidence pack", export_account_compliance_dashboard_path(format: :json), class: "rounded-full bg-amber-600 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-500" %>
+    </div>
+  </div>
+
+  <% if @tenant_setting.errors.any? %>
+    <div class="mt-6 rounded-2xl bg-red-50 px-4 py-3 text-sm text-red-800 dark:bg-red-950/40 dark:text-red-200">
+      <%= @tenant_setting.errors.full_messages.to_sentence %>
+    </div>
+  <% end %>
+
+  <div class="mt-8 grid gap-4 md:grid-cols-4">
+    <div class="rounded-3xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800 md:col-span-2">
+      <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Readiness score</p>
+      <p class="mt-2 text-4xl font-semibold text-gray-900 dark:text-white"><%= @compliance_dashboard[:readiness_score] %>%</p>
+      <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">Score reflects compliant controls plus partial credit for warnings.</p>
+    </div>
+    <div class="rounded-3xl border border-amber-200 bg-amber-50 p-5 shadow-sm dark:border-amber-800 dark:bg-amber-950/20">
+      <p class="text-xs uppercase tracking-wide text-amber-700 dark:text-amber-300">Warnings</p>
+      <p class="mt-2 text-4xl font-semibold text-gray-900 dark:text-white"><%= @compliance_dashboard.dig(:counts, :warning) %></p>
+    </div>
+    <div class="rounded-3xl border border-rose-200 bg-rose-50 p-5 shadow-sm dark:border-rose-800 dark:bg-rose-950/20">
+      <p class="text-xs uppercase tracking-wide text-rose-700 dark:text-rose-300">Gaps</p>
+      <p class="mt-2 text-4xl font-semibold text-gray-900 dark:text-white"><%= @compliance_dashboard.dig(:counts, :gap) %></p>
+    </div>
+  </div>
+
+  <div class="mt-8 grid gap-8 xl:grid-cols-[minmax(0,1.4fr)_minmax(320px,0.9fr)]">
+    <div class="space-y-8">
+      <section class="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <div class="flex items-center justify-between gap-4">
+          <div>
+            <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Control gaps</h2>
+            <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">Each control maps to common buyer asks and includes concrete evidence expected from operators.</p>
+          </div>
+        </div>
+
+        <div class="mt-6 space-y-4">
+          <% @compliance_dashboard[:controls].each do |control| %>
+            <% tone = case control[:status]
+                     when :compliant then "border-emerald-200 bg-emerald-50 dark:border-emerald-900 dark:bg-emerald-950/20"
+                     when :warning then "border-amber-200 bg-amber-50 dark:border-amber-900 dark:bg-amber-950/20"
+                     when :gap then "border-rose-200 bg-rose-50 dark:border-rose-900 dark:bg-rose-950/20"
+                     else "border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-900/50"
+                     end %>
+            <article class="rounded-2xl border p-4 <%= tone %>">
+              <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                <div>
+                  <div class="flex items-center gap-3">
+                    <h3 class="text-lg font-semibold text-gray-900 dark:text-white"><%= control[:title] %></h3>
+                    <span class="inline-flex rounded-full px-3 py-1 text-xs font-semibold <%= control[:status] == :compliant ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200' : control[:status] == :warning ? 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200' : control[:status] == :gap ? 'bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-200' : 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-200' %>">
+                      <%= control[:status].to_s.humanize %>
+                    </span>
+                  </div>
+                  <p class="mt-1 text-sm text-gray-700 dark:text-gray-200"><%= control[:requirement] %></p>
+                </div>
+                <p class="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400"><%= control[:mappings].join(" • ") %></p>
+              </div>
+
+              <ul class="mt-4 space-y-1 text-sm text-gray-700 dark:text-gray-200">
+                <% control[:evidence].each do |line| %>
+                  <li><%= line %></li>
+                <% end %>
+              </ul>
+
+              <p class="mt-4 text-sm text-gray-600 dark:text-gray-300"><%= control[:guidance] %></p>
+            </article>
+          <% end %>
+        </div>
+      </section>
+
+      <section class="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <div>
+          <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Deployment assurance settings</h2>
+          <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">These values feed the dashboard and exported evidence pack.</p>
+        </div>
+
+        <%= form_with url: account_compliance_dashboard_path, method: :patch, class: "mt-6 space-y-8" do %>
+          <section class="grid gap-4 md:grid-cols-2">
+            <div>
+              <%= label_tag "deployment_assurance_deployment_model", "Deployment model", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+              <%= select_tag "deployment_assurance[deployment_model]", options_for_select([["Self hosted", "self_hosted"], ["Private VPC", "private_vpc"], ["Air gapped", "air_gapped"]], deployment_assurance["deployment_model"]), id: "deployment_assurance_deployment_model", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+            </div>
+            <div>
+              <%= label_tag "deployment_assurance_network_boundary", "Network boundary", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+              <%= select_tag "deployment_assurance[network_boundary]", options_for_select([["Private VPC", "private_vpc"], ["Controlled public ingress", "public_ingress"], ["Offline", "offline"]], deployment_assurance["network_boundary"]), id: "deployment_assurance_network_boundary", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+            </div>
+            <div>
+              <%= label_tag "deployment_assurance_reference_architecture", "Reference architecture", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+              <%= select_tag "deployment_assurance[reference_architecture]", options_for_select([["Single tenant", "single_tenant"], ["Private services", "private_services"], ["Offline promotion", "offline_promotion"]], deployment_assurance["reference_architecture"]), id: "deployment_assurance_reference_architecture", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+            </div>
+            <div>
+              <%= label_tag "deployment_assurance_operations_owner", "Operations owner", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+              <%= text_field_tag "deployment_assurance[operations_owner]", deployment_assurance["operations_owner"], id: "deployment_assurance_operations_owner", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white", placeholder: "platform-team@example.com" %>
+            </div>
+          </section>
+
+          <section class="rounded-2xl border border-gray-200 p-4 dark:border-gray-700">
+            <div class="flex items-center justify-between gap-3">
+              <div>
+                <h3 class="text-lg font-semibold text-gray-900 dark:text-white">Customer-managed keys</h3>
+                <p class="text-sm text-gray-600 dark:text-gray-300">Capture external KMS ownership and key rotation evidence.</p>
+              </div>
+              <label class="inline-flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-200">
+                <%= hidden_field_tag "deployment_assurance[customer_managed_keys][enabled]", "0" %>
+                <%= check_box_tag "deployment_assurance[customer_managed_keys][enabled]", "1", customer_managed_keys["enabled"] == true %>
+                Enabled
+              </label>
+            </div>
+
+            <div class="mt-4 grid gap-4 md:grid-cols-2">
+              <div>
+                <%= label_tag "deployment_assurance_customer_managed_keys_provider", "KMS provider", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= text_field_tag "deployment_assurance[customer_managed_keys][provider]", customer_managed_keys["provider"], id: "deployment_assurance_customer_managed_keys_provider", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white", placeholder: "AWS KMS" %>
+              </div>
+              <div>
+                <%= label_tag "deployment_assurance_customer_managed_keys_key_reference", "Key reference", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= text_field_tag "deployment_assurance[customer_managed_keys][key_reference]", customer_managed_keys["key_reference"], id: "deployment_assurance_customer_managed_keys_key_reference", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white", placeholder: "arn:aws:kms:..." %>
+              </div>
+              <div>
+                <%= label_tag "deployment_assurance_customer_managed_keys_last_rotated_at", "Last rotated", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= date_field_tag "deployment_assurance[customer_managed_keys][last_rotated_at]", customer_managed_keys["last_rotated_at"], id: "deployment_assurance_customer_managed_keys_last_rotated_at", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+              <div>
+                <%= label_tag "deployment_assurance_customer_managed_keys_rotation_interval_days", "Rotation interval days", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= number_field_tag "deployment_assurance[customer_managed_keys][rotation_interval_days]", customer_managed_keys["rotation_interval_days"], min: 1, class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+            </div>
+          </section>
+
+          <section class="rounded-2xl border border-gray-200 p-4 dark:border-gray-700">
+            <div class="flex items-center justify-between gap-3">
+              <div>
+                <h3 class="text-lg font-semibold text-gray-900 dark:text-white">Secret rotation workflow</h3>
+                <p class="text-sm text-gray-600 dark:text-gray-300">Track the operator, cadence, and last successful credential rotation.</p>
+              </div>
+              <label class="inline-flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-200">
+                <%= hidden_field_tag "deployment_assurance[secret_rotation][documented]", "0" %>
+                <%= check_box_tag "deployment_assurance[secret_rotation][documented]", "1", secret_rotation["documented"] == true %>
+                Documented
+              </label>
+            </div>
+
+            <div class="mt-4 grid gap-4 md:grid-cols-3">
+              <div>
+                <%= label_tag "deployment_assurance_secret_rotation_owner", "Owner", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= text_field_tag "deployment_assurance[secret_rotation][owner]", secret_rotation["owner"], id: "deployment_assurance_secret_rotation_owner", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white", placeholder: "security@example.com" %>
+              </div>
+              <div>
+                <%= label_tag "deployment_assurance_secret_rotation_last_completed_at", "Last completed", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= date_field_tag "deployment_assurance[secret_rotation][last_completed_at]", secret_rotation["last_completed_at"], id: "deployment_assurance_secret_rotation_last_completed_at", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+              <div>
+                <%= label_tag "deployment_assurance_secret_rotation_interval_days", "Rotation interval days", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= number_field_tag "deployment_assurance[secret_rotation][interval_days]", secret_rotation["interval_days"], min: 1, class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+            </div>
+          </section>
+
+          <section class="rounded-2xl border border-gray-200 p-4 dark:border-gray-700">
+            <div>
+              <h3 class="text-lg font-semibold text-gray-900 dark:text-white">Disaster recovery and upgrades</h3>
+              <p class="text-sm text-gray-600 dark:text-gray-300">Record the most recent backup verification, restore rehearsal, upgrade validation, and offline package test.</p>
+            </div>
+
+            <div class="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+              <div>
+                <%= label_tag "deployment_assurance_disaster_recovery_backup_cadence", "Backup cadence", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= select_tag "deployment_assurance[disaster_recovery][backup_cadence]", options_for_select([["Hourly", "hourly"], ["Daily", "daily"], ["Weekly", "weekly"]], disaster_recovery["backup_cadence"]), id: "deployment_assurance_disaster_recovery_backup_cadence", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+              <div>
+                <%= label_tag "deployment_assurance_disaster_recovery_rpo_hours", "Target RPO hours", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= number_field_tag "deployment_assurance[disaster_recovery][rpo_hours]", disaster_recovery["rpo_hours"], min: 1, class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+              <div>
+                <%= label_tag "deployment_assurance_disaster_recovery_rto_hours", "Target RTO hours", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= number_field_tag "deployment_assurance[disaster_recovery][rto_hours]", disaster_recovery["rto_hours"], min: 1, class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+              <div>
+                <%= label_tag "deployment_assurance_disaster_recovery_backup_last_verified_at", "Backup verified", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= date_field_tag "deployment_assurance[disaster_recovery][backup_last_verified_at]", disaster_recovery["backup_last_verified_at"], id: "deployment_assurance_disaster_recovery_backup_last_verified_at", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+              <div>
+                <%= label_tag "deployment_assurance_disaster_recovery_restore_last_tested_at", "Restore tested", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= date_field_tag "deployment_assurance[disaster_recovery][restore_last_tested_at]", disaster_recovery["restore_last_tested_at"], id: "deployment_assurance_disaster_recovery_restore_last_tested_at", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+              <div>
+                <%= label_tag "deployment_assurance_disaster_recovery_upgrade_last_validated_at", "Upgrade validated", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= date_field_tag "deployment_assurance[disaster_recovery][upgrade_last_validated_at]", disaster_recovery["upgrade_last_validated_at"], id: "deployment_assurance_disaster_recovery_upgrade_last_validated_at", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+              <div>
+                <%= label_tag "deployment_assurance_disaster_recovery_air_gap_package_validated_at", "Air-gap package validated", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= date_field_tag "deployment_assurance[disaster_recovery][air_gap_package_validated_at]", disaster_recovery["air_gap_package_validated_at"], id: "deployment_assurance_disaster_recovery_air_gap_package_validated_at", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+            </div>
+          </section>
+
+          <div class="flex justify-end">
+            <%= submit_tag "Save compliance settings", class: "rounded-full bg-gray-900 px-5 py-2.5 text-sm font-semibold text-white hover:bg-gray-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200" %>
+          </div>
+        <% end %>
+      </section>
+    </div>
+
+    <div class="space-y-8">
+      <section class="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <div>
+          <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Reference architectures</h2>
+          <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">Hardened deployment variants published in-repo for platform and security review.</p>
+        </div>
+
+        <div class="mt-6 space-y-4">
+          <% @compliance_dashboard[:reference_architectures].each do |architecture| %>
+            <article class="rounded-2xl border border-gray-200 p-4 dark:border-gray-700">
+              <h3 class="font-semibold text-gray-900 dark:text-white"><%= architecture[:name] %></h3>
+              <p class="mt-1 text-sm text-gray-600 dark:text-gray-300"><%= architecture[:summary] %></p>
+              <p class="mt-3 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400"><%= architecture[:doc_path] %></p>
+            </article>
+          <% end %>
+        </div>
+      </section>
+
+      <section class="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <div>
+          <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Operational runbooks</h2>
+          <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">Runbook paths included in the evidence pack for review packets.</p>
+        </div>
+
+        <div class="mt-6 space-y-4">
+          <% @compliance_dashboard[:runbooks].each do |runbook| %>
+            <article class="rounded-2xl border border-gray-200 p-4 dark:border-gray-700">
+              <h3 class="font-semibold text-gray-900 dark:text-white"><%= runbook[:name] %></h3>
+              <p class="mt-1 text-sm text-gray-600 dark:text-gray-300"><%= runbook[:summary] %></p>
+              <p class="mt-3 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400"><%= runbook[:doc_path] %></p>
+            </article>
+          <% end %>
+        </div>
+      </section>
+    </div>
+  </div>
+</div>

--- a/app/views/accounts/compliance_dashboards/show.html.erb
+++ b/app/views/accounts/compliance_dashboards/show.html.erb
@@ -1,5 +1,6 @@
 <% content_for :title, "Compliance Dashboard" %>
 
+<% can_manage_compliance = policy(current_account).update? %>
 <% deployment_assurance = @compliance_dashboard[:deployment_assurance] %>
 <% customer_managed_keys = deployment_assurance["customer_managed_keys"] %>
 <% secret_rotation = deployment_assurance["secret_rotation"] %>
@@ -17,7 +18,9 @@
 
     <div class="flex flex-wrap gap-3">
       <%= link_to "Back to account", account_path, class: "rounded-full border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-900" %>
-      <%= link_to "Export evidence pack", export_account_compliance_dashboard_path(format: :json), class: "rounded-full bg-amber-600 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-500" %>
+      <% if can_manage_compliance %>
+        <%= link_to "Export evidence pack", export_account_compliance_dashboard_path(format: :json), class: "rounded-full bg-amber-600 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-500" %>
+      <% end %>
     </div>
   </div>
 
@@ -92,6 +95,12 @@
           <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Deployment assurance settings</h2>
           <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">These values feed the dashboard and exported evidence pack.</p>
         </div>
+
+        <% unless can_manage_compliance %>
+          <div class="mt-4 rounded-2xl bg-sky-50 px-4 py-3 text-sm text-sky-900 dark:bg-sky-950/40 dark:text-sky-200">
+            Account admins and owners can update deployment assurance settings and export the evidence pack.
+          </div>
+        <% end %>
 
         <%= form_with url: account_compliance_dashboard_path, method: :patch, class: "mt-6 space-y-8" do %>
           <section class="grid gap-4 md:grid-cols-2">
@@ -213,9 +222,11 @@
             </div>
           </section>
 
-          <div class="flex justify-end">
-            <%= submit_tag "Save compliance settings", class: "rounded-full bg-gray-900 px-5 py-2.5 text-sm font-semibold text-white hover:bg-gray-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200" %>
-          </div>
+          <% if can_manage_compliance %>
+            <div class="flex justify-end">
+              <%= submit_tag "Save compliance settings", class: "rounded-full bg-gray-900 px-5 py-2.5 text-sm font-semibold text-white hover:bg-gray-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200" %>
+            </div>
+          <% end %>
         <% end %>
       </section>
     </div>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -209,6 +209,34 @@
         </dl>
       </section>
 
+      <section class="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Compliance & Deployment Assurance</h2>
+            <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">Track hardened deployment posture, export compliance evidence, and surface operational gaps for security review.</p>
+          </div>
+          <div class="flex flex-wrap gap-3">
+            <%= link_to "Open dashboard", account_compliance_dashboard_path, class: "rounded-full bg-amber-600 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-500" %>
+            <%= link_to "Export evidence", export_account_compliance_dashboard_path(format: :json), class: "rounded-full border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-900" %>
+          </div>
+        </div>
+
+        <div class="mt-6 grid gap-4 md:grid-cols-3">
+          <div class="rounded-2xl bg-emerald-50 p-4 dark:bg-emerald-950/20">
+            <p class="text-xs uppercase tracking-wide text-emerald-700 dark:text-emerald-300">Readiness score</p>
+            <p class="mt-2 text-3xl font-semibold text-gray-900 dark:text-white"><%= @compliance_dashboard[:readiness_score] %>%</p>
+          </div>
+          <div class="rounded-2xl bg-amber-50 p-4 dark:bg-amber-950/20">
+            <p class="text-xs uppercase tracking-wide text-amber-700 dark:text-amber-300">Warnings</p>
+            <p class="mt-2 text-3xl font-semibold text-gray-900 dark:text-white"><%= @compliance_dashboard.dig(:counts, :warning) %></p>
+          </div>
+          <div class="rounded-2xl bg-rose-50 p-4 dark:bg-rose-950/20">
+            <p class="text-xs uppercase tracking-wide text-rose-700 dark:text-rose-300">Gaps</p>
+            <p class="mt-2 text-3xl font-semibold text-gray-900 dark:text-white"><%= @compliance_dashboard.dig(:counts, :gap) %></p>
+          </div>
+        </div>
+      </section>
+
       <% if @billing_visible %>
         <section class="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
           <div>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -217,7 +217,9 @@
           </div>
           <div class="flex flex-wrap gap-3">
             <%= link_to "Open dashboard", account_compliance_dashboard_path, class: "rounded-full bg-amber-600 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-500" %>
-            <%= link_to "Export evidence", export_account_compliance_dashboard_path(format: :json), class: "rounded-full border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-900" %>
+            <% if policy(current_account).update? %>
+              <%= link_to "Export evidence", export_account_compliance_dashboard_path(format: :json), class: "rounded-full border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-900" %>
+            <% end %>
           </div>
         </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,9 @@ Rails.application.routes.draw do
 
   # Customer-facing account administration
   resource :account, only: [ :show, :update ]
+  resource :account_compliance_dashboard, only: [ :show, :update ], controller: "accounts/compliance_dashboards" do
+    get :export
+  end
   resources :account_memberships, only: [ :create, :update, :destroy ]
   resource :account_ownership_transfer, only: [ :create ]
   resource :account_lifecycle, only: [ :update ]

--- a/docs/compliance/operational-assurance-runbooks.md
+++ b/docs/compliance/operational-assurance-runbooks.md
@@ -1,0 +1,22 @@
+# Operational Assurance Runbooks
+
+## Backup and Restore
+
+1. Verify the configured backup cadence for PostgreSQL, Redis, and object storage.
+2. Capture the most recent successful backup verification date in the compliance dashboard.
+3. Rehearse a restore into a clean environment at least quarterly and record the restore validation date.
+4. Confirm observed recovery time stays within the documented RTO and recovery point stays within the documented RPO.
+
+## Upgrade Validation
+
+1. Stage the target Paid release in a non-production environment that matches the production topology.
+2. Run migrations, smoke tests, and critical account workflows before approving production rollout.
+3. Document rollback prerequisites and rollback timing before the production change window.
+4. Record the last validated upgrade date in the compliance dashboard after the rehearsal completes.
+
+## Secret Rotation
+
+1. Rotate customer-managed keys and provider credentials on the tenant-defined interval or after personnel/incident triggers.
+2. Update the compliance dashboard with the KMS provider, key reference, and most recent key rotation date.
+3. Record the operator owner and most recent secret rotation workflow completion date.
+4. Export a compliance evidence pack after each rotation cycle for audit review.

--- a/docs/compliance/reference-architectures.md
+++ b/docs/compliance/reference-architectures.md
@@ -1,0 +1,19 @@
+# Reference Architectures
+
+## Self-hosted reference architecture
+
+- Deploy Paid Rails, PostgreSQL, Redis, and object storage inside a single tenant boundary.
+- Terminate ingress at a managed reverse proxy or load balancer with TLS and IP allowlists.
+- Run agent containers on dedicated worker hosts with isolated Docker storage and outbound egress controls.
+
+## Private VPC reference architecture
+
+- Place Paid web, worker, database, and cache tiers on private subnets with tightly scoped security groups.
+- Expose operator access through VPN, bastion, or identity-aware proxy rather than broad public ingress.
+- Prefer managed PostgreSQL, Redis, and object storage with customer-controlled network policies and backup retention.
+
+## Air-gapped reference architecture
+
+- Build release artifacts in a connected staging environment, then promote signed packages into the disconnected network.
+- Mirror Ruby gems, Yarn packages, container images, and model/runtime dependencies into an approved offline registry.
+- Validate restore, upgrade, and rollback procedures against the promoted artifact set before production rollout.

--- a/spec/models/tenant_setting_spec.rb
+++ b/spec/models/tenant_setting_spec.rb
@@ -230,6 +230,25 @@ RSpec.describe TenantSetting do
       expect(setting.features.dig("deployment_assurance", "customer_managed_keys", "enabled")).to be(true)
       expect(setting.features.dig("deployment_assurance", "customer_managed_keys", "rotation_interval_days")).to eq(120)
     end
+
+    it "rejects invalid integer input instead of coercing it to zero" do
+      setting = build(:tenant_setting)
+
+      setting.deployment_assurance_configuration = {
+        "customer_managed_keys" => { "rotation_interval_days" => "oops" },
+        "secret_rotation" => { "interval_days" => "still-nope" },
+        "disaster_recovery" => { "rpo_hours" => "bad", "rto_hours" => "worse" }
+      }
+
+      expect(setting).not_to be_valid
+      expect(setting.features.dig("deployment_assurance", "customer_managed_keys", "rotation_interval_days")).to eq("oops")
+      expect(setting.errors[:features]).to include(
+        "deployment_assurance.customer_managed_keys.rotation_interval_days must be an integer between 1 and 2147483647",
+        "deployment_assurance.secret_rotation.interval_days must be an integer between 1 and 2147483647",
+        "deployment_assurance.disaster_recovery.rpo_hours must be an integer between 1 and 2147483647",
+        "deployment_assurance.disaster_recovery.rto_hours must be an integer between 1 and 2147483647"
+      )
+    end
   end
 
   describe "worker_settings" do
@@ -270,6 +289,14 @@ RSpec.describe TenantSetting do
       setting = build(:tenant_setting, worker_settings: { "temporal_workflow_slots" => "25" })
       setting.valid?
       expect(setting.worker_settings["temporal_workflow_slots"]).to eq(25)
+    end
+
+    it "keeps invalid integer input invalid instead of coercing it to zero" do
+      setting = build(:tenant_setting, worker_settings: { "temporal_workflow_slots" => "oops" })
+
+      expect(setting).not_to be_valid
+      expect(setting.worker_settings["temporal_workflow_slots"]).to eq("oops")
+      expect(setting.errors[:worker_settings]).to include("temporal_workflow_slots must be an integer between 1 and 100")
     end
 
     it "provides accessor for individual settings" do

--- a/spec/models/tenant_setting_spec.rb
+++ b/spec/models/tenant_setting_spec.rb
@@ -205,6 +205,33 @@ RSpec.describe TenantSetting do
     end
   end
 
+  describe "#deployment_assurance_configuration" do
+    it "returns merged deployment assurance defaults" do
+      setting = build(:tenant_setting)
+
+      expect(setting.deployment_assurance_configuration["deployment_model"]).to eq("self_hosted")
+      expect(setting.deployment_assurance_configuration.dig("customer_managed_keys", "rotation_interval_days")).to eq(90)
+    end
+
+    it "persists deployment assurance data under features without losing other feature flags" do
+      setting = build(:tenant_setting, features: { "test_feature_flag" => true })
+
+      setting.deployment_assurance_configuration = {
+        "deployment_model" => "air_gapped",
+        "customer_managed_keys" => {
+          "enabled" => "1",
+          "provider" => "AWS KMS",
+          "rotation_interval_days" => "120"
+        }
+      }
+
+      expect(setting.features["test_feature_flag"]).to be(true)
+      expect(setting.features.dig("deployment_assurance", "deployment_model")).to eq("air_gapped")
+      expect(setting.features.dig("deployment_assurance", "customer_managed_keys", "enabled")).to be(true)
+      expect(setting.features.dig("deployment_assurance", "customer_managed_keys", "rotation_interval_days")).to eq(120)
+    end
+  end
+
   describe "worker_settings" do
     it "returns defaults when no worker_settings configured" do
       setting = build(:tenant_setting)

--- a/spec/models/tenant_setting_spec.rb
+++ b/spec/models/tenant_setting_spec.rb
@@ -251,6 +251,24 @@ RSpec.describe TenantSetting do
     end
   end
 
+  describe "quality_thresholds" do
+    it "rejects invalid integer input instead of persisting malformed strings" do
+      setting = build(:tenant_setting, quality_thresholds: {
+        "enabled" => "1",
+        "min_recent_runs" => "oops",
+        "lookback_window_hours" => "still-nope"
+      })
+
+      expect(setting).not_to be_valid
+      expect(setting.quality_thresholds["min_recent_runs"]).to eq("oops")
+      expect(setting.quality_thresholds["lookback_window_hours"]).to eq("still-nope")
+      expect(setting.errors[:quality_thresholds]).to include(
+        "min_recent_runs must be an integer between 1 and 2147483647",
+        "lookback_window_hours must be an integer between 1 and 2147483647"
+      )
+    end
+  end
+
   describe "worker_settings" do
     it "returns defaults when no worker_settings configured" do
       setting = build(:tenant_setting)

--- a/spec/models/tenant_setting_spec.rb
+++ b/spec/models/tenant_setting_spec.rb
@@ -249,6 +249,25 @@ RSpec.describe TenantSetting do
         "deployment_assurance.disaster_recovery.rto_hours must be an integer between 1 and 2147483647"
       )
     end
+
+    it "rejects unsupported deployment assurance option values" do
+      setting = build(:tenant_setting)
+
+      setting.deployment_assurance_configuration = {
+        "deployment_model" => "public_cloud",
+        "network_boundary" => "open_internet",
+        "reference_architecture" => "shared_tenant",
+        "disaster_recovery" => { "backup_cadence" => "monthly" }
+      }
+
+      expect(setting).not_to be_valid
+      expect(setting.errors[:features]).to include(
+        "deployment_assurance.deployment_model must be one of: self_hosted, private_vpc, air_gapped",
+        "deployment_assurance.network_boundary must be one of: private_vpc, public_ingress, offline",
+        "deployment_assurance.reference_architecture must be one of: single_tenant, private_services, offline_promotion",
+        "deployment_assurance.disaster_recovery.backup_cadence must be one of: hourly, daily, weekly"
+      )
+    end
   end
 
   describe "quality_thresholds" do

--- a/spec/requests/accounts/compliance_dashboards_spec.rb
+++ b/spec/requests/accounts/compliance_dashboards_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Accounts::ComplianceDashboards" do
+  let(:account) { create(:account, name: "Acme") }
+  let(:owner) { create(:user, :owner, account: account) }
+  let(:deployment_assurance_params) do
+    {
+      deployment_assurance: {
+        deployment_model: "private_vpc",
+        network_boundary: "private_vpc",
+        reference_architecture: "private_services",
+        operations_owner: "platform@example.com",
+        customer_managed_keys: {
+          enabled: "1",
+          provider: "AWS KMS",
+          key_reference: "arn:aws:kms:us-east-1:123:key/abc",
+          last_rotated_at: Date.current.iso8601,
+          rotation_interval_days: "90"
+        },
+        secret_rotation: {
+          documented: "1",
+          owner: "security@example.com",
+          last_completed_at: Date.current.iso8601,
+          interval_days: "60"
+        },
+        disaster_recovery: {
+          backup_cadence: "daily",
+          backup_last_verified_at: Date.current.iso8601,
+          restore_last_tested_at: Date.current.iso8601,
+          upgrade_last_validated_at: Date.current.iso8601,
+          air_gap_package_validated_at: "",
+          rpo_hours: "4",
+          rto_hours: "8"
+        }
+      }
+    }
+  end
+
+  before do
+    sign_in owner
+  end
+
+  describe "GET /account_compliance_dashboard" do
+    it "renders the compliance dashboard" do
+      get account_compliance_dashboard_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Deployment Assurance")
+      expect(response.body).to include("Control gaps")
+      expect(response.body).to include("Reference architectures")
+    end
+  end
+
+  describe "PATCH /account_compliance_dashboard" do
+    it "updates deployment assurance settings and records activity" do
+      expect do
+        patch account_compliance_dashboard_path, params: deployment_assurance_params
+      end.to change(AccountActivityEvent, :count).by(1)
+
+      expect(response).to redirect_to(account_compliance_dashboard_path)
+
+      assurance = account.tenant_setting!.reload.deployment_assurance_configuration
+      expect(assurance["deployment_model"]).to eq("private_vpc")
+      expect(assurance.dig("customer_managed_keys", "enabled")).to be(true)
+      expect(assurance.dig("secret_rotation", "interval_days")).to eq(60)
+      expect(account.account_activity_events.recent.first.action).to eq("compliance.assurance_updated")
+    end
+  end
+
+  describe "GET /account_compliance_dashboard/export" do
+    it "exports the evidence pack as JSON" do
+      get export_account_compliance_dashboard_path(format: :json)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("application/json")
+
+      body = JSON.parse(response.body)
+      expect(body.fetch("account").fetch("name")).to eq("Acme")
+      expect(body).to include("control_summary", "controls", "configuration_snapshot", "audit_export")
+    end
+  end
+end

--- a/spec/requests/accounts/compliance_dashboards_spec.rb
+++ b/spec/requests/accounts/compliance_dashboards_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe "Accounts::ComplianceDashboards" do
   let(:account) { create(:account, name: "Acme") }
   let(:owner) { create(:user, :owner, account: account) }
+  let(:member) { create(:user, :member, account: account) }
   let(:deployment_assurance_params) do
     {
       deployment_assurance: {
@@ -51,6 +52,17 @@ RSpec.describe "Accounts::ComplianceDashboards" do
       expect(response.body).to include("Control gaps")
       expect(response.body).to include("Reference architectures")
     end
+
+    it "hides the evidence export link from members" do
+      sign_out owner
+      sign_in member
+
+      get account_compliance_dashboard_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("Export evidence pack")
+      expect(response.body).not_to include("Save compliance settings")
+    end
   end
 
   describe "PATCH /account_compliance_dashboard" do
@@ -79,6 +91,15 @@ RSpec.describe "Accounts::ComplianceDashboards" do
       body = JSON.parse(response.body)
       expect(body.fetch("account").fetch("name")).to eq("Acme")
       expect(body).to include("control_summary", "controls", "configuration_snapshot", "audit_export")
+    end
+
+    it "forbids members from exporting the evidence pack" do
+      sign_out owner
+      sign_in member
+
+      get export_account_compliance_dashboard_path(format: :json)
+
+      expect(response).to redirect_to(root_path)
     end
   end
 end

--- a/spec/requests/accounts/compliance_dashboards_spec.rb
+++ b/spec/requests/accounts/compliance_dashboards_spec.rb
@@ -79,6 +79,19 @@ RSpec.describe "Accounts::ComplianceDashboards" do
       expect(assurance.dig("secret_rotation", "interval_days")).to eq(60)
       expect(account.account_activity_events.recent.first.action).to eq("compliance.assurance_updated")
     end
+
+    it "rejects invalid numeric deployment assurance settings" do
+      expect do
+        patch account_compliance_dashboard_path, params: deployment_assurance_params.deep_merge(
+          deployment_assurance: {
+            customer_managed_keys: { rotation_interval_days: "oops" }
+          }
+        )
+      end.not_to change(AccountActivityEvent, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(account.tenant_setting!.reload.deployment_assurance_configuration.dig("customer_managed_keys", "rotation_interval_days")).to eq(90)
+    end
   end
 
   describe "GET /account_compliance_dashboard/export" do

--- a/spec/requests/accounts/compliance_dashboards_spec.rb
+++ b/spec/requests/accounts/compliance_dashboards_spec.rb
@@ -92,6 +92,27 @@ RSpec.describe "Accounts::ComplianceDashboards" do
       expect(response).to have_http_status(:unprocessable_content)
       expect(account.tenant_setting!.reload.deployment_assurance_configuration.dig("customer_managed_keys", "rotation_interval_days")).to eq(90)
     end
+
+    it "rejects unsupported deployment assurance option values" do
+      patch account_compliance_dashboard_path, params: deployment_assurance_params.deep_merge(
+        deployment_assurance: {
+          deployment_model: "public_cloud",
+          network_boundary: "open_internet",
+          reference_architecture: "shared_tenant",
+          disaster_recovery: {
+            backup_cadence: "monthly"
+          }
+        }
+      )
+
+      expect(response).to have_http_status(:unprocessable_content)
+
+      assurance = account.tenant_setting!.reload.deployment_assurance_configuration
+      expect(assurance["deployment_model"]).to eq("self_hosted")
+      expect(assurance["network_boundary"]).to eq("private_vpc")
+      expect(assurance["reference_architecture"]).to eq("single_tenant")
+      expect(assurance.dig("disaster_recovery", "backup_cadence")).to eq("daily")
+    end
   end
 
   describe "GET /account_compliance_dashboard/export" do

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe "Accounts" do
       expect(response.body).to include("Account Administration")
       expect(response.body).to include("Team")
       expect(response.body).to include("Tenant Limits and Usage")
+      expect(response.body).to include("Compliance & Deployment Assurance")
       expect(response.body).to include("Billing")
       expect(response.body).to include("Activity Trail")
     end

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -41,6 +41,17 @@ RSpec.describe "Accounts" do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Account Administration")
     end
+
+    it "hides compliance evidence export from non-admin readers" do
+      viewer = create(:user, :viewer, account: account)
+      sign_out owner
+      sign_in viewer
+
+      get account_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("Export evidence")
+    end
   end
 
   describe "PATCH /account" do

--- a/spec/requests/tenant_configurations_spec.rb
+++ b/spec/requests/tenant_configurations_spec.rb
@@ -159,6 +159,23 @@ RSpec.describe "TenantConfigurations" do
       expect(account.tenant_setting.reload.default_goal).to eq("create_pr")
     end
 
+    it "rejects malformed quality-threshold integers" do
+      patch tenant_configuration_path, params: {
+        tenant_setting: {
+          quality_thresholds: {
+            enabled: "1",
+            composite_score_threshold: "0.75",
+            min_recent_runs: "oops",
+            lookback_window_hours: "24hours"
+          }
+        }
+      }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      setting = account.tenant_setting.reload
+      expect(setting.quality_thresholds).to eq({})
+    end
+
     it "rejects invalid rollout percentages" do
       patch tenant_configuration_path, params: rollout_params(percentage_of_actors: "101")
 

--- a/spec/services/accounts/compliance/dashboard_spec.rb
+++ b/spec/services/accounts/compliance/dashboard_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Accounts::Compliance::Dashboard do
+  describe ".call" do
+    let(:account) { create(:account) }
+    let(:tenant_setting) { account.tenant_setting! }
+    let(:recent_deployment_assurance) do
+      {
+        "deployment_model" => "air_gapped",
+        "network_boundary" => "offline",
+        "reference_architecture" => "offline_promotion",
+        "operations_owner" => "platform@example.com",
+        "customer_managed_keys" => {
+          "enabled" => true,
+          "provider" => "AWS KMS",
+          "key_reference" => "arn:aws:kms:us-east-1:123:key/abc",
+          "last_rotated_at" => 10.days.ago.to_date.iso8601,
+          "rotation_interval_days" => 90
+        },
+        "secret_rotation" => {
+          "documented" => true,
+          "owner" => "security@example.com",
+          "last_completed_at" => 7.days.ago.to_date.iso8601,
+          "interval_days" => 90
+        },
+        "disaster_recovery" => {
+          "backup_cadence" => "daily",
+          "backup_last_verified_at" => 5.days.ago.to_date.iso8601,
+          "restore_last_tested_at" => 20.days.ago.to_date.iso8601,
+          "upgrade_last_validated_at" => 30.days.ago.to_date.iso8601,
+          "air_gap_package_validated_at" => 15.days.ago.to_date.iso8601,
+          "rpo_hours" => 4,
+          "rto_hours" => 8
+        }
+      }
+    end
+
+    it "surfaces default gaps for missing compliance evidence" do
+      result = described_class.call(account: account, tenant_setting: tenant_setting, billing_visible: false)
+      controls = result[:controls].index_by { |control| control[:id] }
+
+      expect(result[:readiness_score]).to be < 100
+      expect(controls[:customer_managed_keys][:status]).to eq(:gap)
+      expect(controls[:secret_rotation][:status]).to eq(:gap)
+      expect(controls[:air_gap_validation][:status]).to eq(:not_applicable)
+    end
+
+    it "marks controls compliant when recent evidence is present" do
+      create(:user, :owner, account: account)
+      Accounts::RecordActivity.call(account: account, action: "tenant_configuration.updated")
+
+      tenant_setting.deployment_assurance_configuration = recent_deployment_assurance
+      tenant_setting.save!
+
+      result = described_class.call(account: account, tenant_setting: tenant_setting, billing_visible: true)
+      controls = result[:controls].index_by { |control| control[:id] }
+
+      expect(result[:readiness_score]).to eq(100)
+      expect(controls[:deployment_topology][:status]).to eq(:compliant)
+      expect(controls[:audit_export][:status]).to eq(:compliant)
+      expect(controls[:customer_managed_keys][:status]).to eq(:compliant)
+      expect(controls[:air_gap_validation][:status]).to eq(:compliant)
+    end
+  end
+end

--- a/spec/services/accounts/compliance/dashboard_spec.rb
+++ b/spec/services/accounts/compliance/dashboard_spec.rb
@@ -42,9 +42,21 @@ RSpec.describe Accounts::Compliance::Dashboard do
       controls = result[:controls].index_by { |control| control[:id] }
 
       expect(result[:readiness_score]).to be < 100
-      expect(controls[:customer_managed_keys][:status]).to eq(:gap)
+      expect(controls[:customer_managed_keys][:status]).to eq(:not_applicable)
       expect(controls[:secret_rotation][:status]).to eq(:gap)
       expect(controls[:air_gap_validation][:status]).to eq(:not_applicable)
+    end
+
+    it "treats enabled customer-managed keys without supporting evidence as a gap" do
+      tenant_setting.deployment_assurance_configuration = {
+        "customer_managed_keys" => { "enabled" => true }
+      }
+      tenant_setting.save!
+
+      result = described_class.call(account: account, tenant_setting: tenant_setting, billing_visible: false)
+      controls = result[:controls].index_by { |control| control[:id] }
+
+      expect(controls[:customer_managed_keys][:status]).to eq(:gap)
     end
 
     it "marks controls compliant when recent evidence is present" do

--- a/spec/services/screenshots/capture_targets_spec.rb
+++ b/spec/services/screenshots/capture_targets_spec.rb
@@ -311,6 +311,12 @@ RSpec.describe Screenshots::CaptureTargets, :no_db do
       expect(targets.map(&:slug)).to eq([ "sign_up" ])
     end
 
+    it "maps nested account compliance controllers to the compliance dashboard page" do
+      targets = described_class.call(changed_files: [ "app/controllers/accounts/compliance_dashboards_controller.rb" ])
+
+      expect(targets.map(&:slug)).to eq([ "account_compliance_dashboard" ])
+    end
+
     it "covers every current non-api controller that detect_ui_changes can surface" do
       controller_paths = Dir[Rails.root.join("app/controllers/**/*_controller.rb")]
         .map { |path| path.delete_prefix("#{Rails.root}/") }


### PR DESCRIPTION
## Summary

Implemented Phase 6.4’s first full slice on the account-admin surface: a new compliance dashboard with control-gap scoring, deployment-assurance settings, evidence-pack export, and in-repo reference architecture/runbook docs. The main pieces are the new controller/view at [app/controllers/accounts/compliance_dashboards_controller.rb](/workspace/app/controllers/accounts/compliance_dashboards_controller.rb:1) and [app/views/accounts/compliance_dashboards/show.html.erb](/workspace/app/views/accounts/compliance_dashboards/show.html.erb:1), the posture/evidence services at [app/services/accounts/compliance/dashboard.rb](/workspace/app/services/accounts/compliance/dashboard.rb:1) and [app/services/accounts/compliance/evidence_pack.rb](/workspace/app/services/accounts/compliance/evidence_pack.rb:1), the `TenantSetting` deployment-assurance storage helpers in [app/models/tenant_setting.rb](/workspace/app/models/tenant_setting.rb:1), and the docs in [docs/compliance/reference-architectures.md](/workspace/docs/compliance/reference-architectures.md:1) and [docs/compliance/operational-assurance-runbooks.md](/workspace/docs/compliance/operational-assurance-runbooks.md:1). I also wired the feature into the existing account page and updated screenshot-target coverage so UI-change detection stays green.

Validation passed. `bundle exec rubocop` passed, and `bundle exec rspec` passed with `13608 examples, 0 failures, 7 pending` after fixing the late-suite screenshot registry failure. `bin/rails db:prepare` also succeeded once the Postgres host/user env from the provided `DATABASE_URL` was applied. The changes are committed as `c2b0c55` with message `feat(compliance): add deployment assurance dashboard`.

---

Closes #2227