### PR TITLE
feat(quality): RDR-036 phase 2a — extend PreCommitRequirement with mutation_test check_type

### DIFF
--- a/app/avo/resources/pre_commit_requirement.rb
+++ b/app/avo/resources/pre_commit_requirement.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class Avo::Resources::PreCommitRequirement < Avo::BaseResource
+  self.title = :name
+  self.model_class = ::PreCommitRequirement
+  self.authorization_policy = ::OperatorConsole::PreCommitRequirementPolicy
+
+  def fields
+    field :id, as: :id
+    field :name, as: :text, sortable: true
+    field :check_type, as: :select, options: PreCommitRequirement::CHECK_TYPES.index_with(&:itself), sortable: true
+    field :command, as: :textarea
+    field :failure_behavior, as: :select, options: PreCommitRequirement::FAILURE_BEHAVIORS.index_with(&:itself), sortable: true
+    field :enabled, as: :boolean, sortable: true
+    field :position, as: :number, sortable: true
+    field :account_id, as: :number
+    field :project_id, as: :number
+    field :user_id, as: :number
+    field :fix_command, as: :text
+    field :created_at, as: :date_time, readonly: true
+    field :updated_at, as: :date_time, readonly: true
+  end
+end

--- a/app/controllers/projects/pre_commit_requirements_controller.rb
+++ b/app/controllers/projects/pre_commit_requirements_controller.rb
@@ -8,12 +8,19 @@ module Projects
     def index
       authorize @project, :show?
       @pre_commit_requirements = @project.pre_commit_requirements.ordered
-      render json: @pre_commit_requirements
+
+      respond_to do |format|
+        format.html
+        format.json { render json: @pre_commit_requirements }
+      end
     end
 
     def show
       authorize @pre_commit_requirement
-      render json: @pre_commit_requirement
+
+      respond_to do |format|
+        format.json { render json: @pre_commit_requirement }
+      end
     end
 
     def create

--- a/app/controllers/projects/pre_commit_requirements_controller.rb
+++ b/app/controllers/projects/pre_commit_requirements_controller.rb
@@ -32,7 +32,9 @@ module Projects
         redirect_to project_pre_commit_requirements_path(@project),
           notice: "Pre-commit requirement created."
       else
-        render json: { errors: @pre_commit_requirement.errors }, status: :unprocessable_content
+        @pre_commit_requirements = @project.pre_commit_requirements.ordered
+        @new_requirement = @pre_commit_requirement
+        render :index, status: :unprocessable_content
       end
     end
 
@@ -43,7 +45,9 @@ module Projects
         redirect_to project_pre_commit_requirements_path(@project),
           notice: "Pre-commit requirement updated."
       else
-        render json: { errors: @pre_commit_requirement.errors }, status: :unprocessable_content
+        @pre_commit_requirements = @project.pre_commit_requirements.ordered
+        @new_requirement = @pre_commit_requirement
+        render :index, status: :unprocessable_content
       end
     end
 

--- a/app/models/pre_commit_requirement.rb
+++ b/app/models/pre_commit_requirement.rb
@@ -2,7 +2,8 @@
 
 class PreCommitRequirement < ApplicationRecord
   has_logidze
-  CHECK_TYPES = %w[shell_command test_suite coverage security_scan].freeze
+  CHECK_TYPES = %w[shell_command test_suite coverage security_scan mutation_test].freeze
+  MUTATION_TEST_DEFAULT_COMMAND = "bundle exec mutant run --usage %<usage_value>s --since HEAD~1 --use rspec --jobs 1".freeze
   FAILURE_BEHAVIORS = %w[block warn auto_fix].freeze
 
   belongs_to :account
@@ -44,6 +45,11 @@ class PreCommitRequirement < ApplicationRecord
 
   def user_level?
     user_id.present? && project_id.nil?
+  end
+
+  def self.mutation_test_default_command(project)
+    usage = project.open_source? ? "opensource" : "commercial"
+    format(MUTATION_TEST_DEFAULT_COMMAND, usage_value: usage)
   end
 
   def auto_fix?

--- a/app/policies/operator_console/pre_commit_requirement_policy.rb
+++ b/app/policies/operator_console/pre_commit_requirement_policy.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module OperatorConsole
+  class PreCommitRequirementPolicy < BasePolicy
+  end
+end

--- a/app/views/projects/pre_commit_requirements/_form.html.erb
+++ b/app/views/projects/pre_commit_requirements/_form.html.erb
@@ -1,3 +1,13 @@
+<% if pre_commit_requirement.errors.any? %>
+  <div class="rounded-md bg-red-50 p-4 mb-4">
+    <h3 class="text-sm font-medium text-red-800"><%= pluralize(pre_commit_requirement.errors.count, "error") %> prevented this requirement from being saved:</h3>
+    <ul class="mt-2 list-disc pl-5 text-sm text-red-700">
+      <% pre_commit_requirement.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
 <%= form_with model: [ project, pre_commit_requirement ], url: project_pre_commit_requirements_path(project), class: "mt-4 space-y-4" do |f| %>
   <div>
     <%= f.label :name, class: "block text-sm font-medium leading-6 text-gray-900" %>

--- a/app/views/projects/pre_commit_requirements/_form.html.erb
+++ b/app/views/projects/pre_commit_requirements/_form.html.erb
@@ -1,0 +1,51 @@
+<%= form_with model: [ project, pre_commit_requirement ], url: project_pre_commit_requirements_path(project), class: "mt-4 space-y-4" do |f| %>
+  <div>
+    <%= f.label :name, class: "block text-sm font-medium leading-6 text-gray-900" %>
+    <div class="mt-1">
+      <%= f.text_field :name, required: true, class: "block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
+    </div>
+  </div>
+
+  <div>
+    <%= f.label :check_type, class: "block text-sm font-medium leading-6 text-gray-900" %>
+    <div class="mt-1">
+      <%= f.select :check_type, PreCommitRequirement::CHECK_TYPES.map { |t| [ t.humanize, t ] }, {},
+        class: "block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
+    </div>
+  </div>
+
+  <div>
+    <%= f.label :command, class: "block text-sm font-medium leading-6 text-gray-900" %>
+    <div class="mt-1">
+      <%= f.text_field :command, required: true,
+        class: "block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
+    </div>
+    <p class="mt-1 text-xs text-gray-500">
+      For mutation_test: <code class="bg-gray-100 px-1 rounded"><%= PreCommitRequirement.mutation_test_default_command(project) %></code>
+    </p>
+  </div>
+
+  <div>
+    <%= f.label :failure_behavior, class: "block text-sm font-medium leading-6 text-gray-900" %>
+    <div class="mt-1">
+      <%= f.select :failure_behavior, PreCommitRequirement::FAILURE_BEHAVIORS.map { |b| [ b.humanize, b ] }, {},
+        class: "block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
+    </div>
+  </div>
+
+  <div>
+    <%= f.label :position, class: "block text-sm font-medium leading-6 text-gray-900" %>
+    <div class="mt-1">
+      <%= f.number_field :position, value: f.object.position || 0, min: 0,
+        class: "block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
+    </div>
+  </div>
+
+  <div class="flex items-center gap-x-3">
+    <%= f.check_box :enabled, checked: f.object.new_record? ? true : f.object.enabled?,
+      class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" %>
+    <%= f.label :enabled, class: "text-sm font-medium leading-6 text-gray-900" %>
+  </div>
+
+  <%= f.submit "Add Requirement", class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 cursor-pointer" %>
+<% end %>

--- a/app/views/projects/pre_commit_requirements/_form.html.erb
+++ b/app/views/projects/pre_commit_requirements/_form.html.erb
@@ -8,7 +8,7 @@
     </ul>
   </div>
 <% end %>
-<%= form_with model: [ project, pre_commit_requirement ], url: project_pre_commit_requirements_path(project), class: "mt-4 space-y-4" do |f| %>
+<%= form_with model: [ project, pre_commit_requirement ], class: "mt-4 space-y-4" do |f| %>
   <div>
     <%= f.label :name, class: "block text-sm font-medium leading-6 text-gray-900" %>
     <div class="mt-1">
@@ -57,5 +57,6 @@
     <%= f.label :enabled, class: "text-sm font-medium leading-6 text-gray-900" %>
   </div>
 
-  <%= f.submit "Add Requirement", class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 cursor-pointer" %>
+  <%= f.submit(pre_commit_requirement.persisted? ? "Update Requirement" : "Add Requirement",
+    class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 cursor-pointer") %>
 <% end %>

--- a/app/views/projects/pre_commit_requirements/_requirement.html.erb
+++ b/app/views/projects/pre_commit_requirements/_requirement.html.erb
@@ -1,0 +1,30 @@
+<div class="rounded-md border border-gray-200 p-4">
+  <div class="flex items-start justify-between">
+    <div>
+      <h3 class="text-sm font-medium text-gray-900"><%= requirement.name %></h3>
+      <p class="mt-1 text-xs text-gray-500">Type: <%= requirement.check_type %></p>
+      <% if requirement.check_type == "mutation_test" && !project.open_source? %>
+        <div class="mt-2 rounded-md border border-amber-200 bg-amber-50 p-3">
+          <p class="text-sm text-amber-800">
+            This project is marked commercial &mdash; mutant requires a paid license at $30/dev/month or $250/dev/year.
+            Provide <code class="bg-amber-100 px-1 rounded">MUTANT_LICENSE_KEY</code> as a project env var.
+          </p>
+        </div>
+      <% end %>
+    </div>
+    <div class="flex items-center gap-x-2">
+      <% if requirement.enabled? %>
+        <span class="inline-flex items-center rounded-md bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20">Enabled</span>
+      <% else %>
+        <span class="inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10">Disabled</span>
+      <% end %>
+      <span class="inline-flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700"><%= requirement.failure_behavior %></span>
+      <%= button_to "Delete", project_pre_commit_requirement_path(project, requirement), method: :delete,
+        class: "text-red-600 hover:text-red-900 text-sm font-medium",
+        data: { turbo_confirm: "Remove this requirement?" } %>
+    </div>
+  </div>
+  <div class="mt-2">
+    <code class="block rounded bg-gray-50 px-3 py-2 text-sm text-gray-700"><%= requirement.command %></code>
+  </div>
+</div>

--- a/app/views/projects/pre_commit_requirements/index.html.erb
+++ b/app/views/projects/pre_commit_requirements/index.html.erb
@@ -1,0 +1,39 @@
+<% content_for(:title) { "Pre-Commit Requirements - #{@project.name} - Paid" } %>
+
+<div class="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+  <div class="mb-6">
+    <%= link_to edit_project_path(@project), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+      <svg class="mr-1 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
+      </svg>
+      Back to Project Settings
+    <% end %>
+  </div>
+
+  <div class="bg-white shadow sm:rounded-lg">
+    <div class="px-4 py-5 sm:p-6">
+      <h1 class="text-xl font-semibold text-gray-900">Pre-Commit Requirements</h1>
+      <p class="mt-1 text-sm text-gray-500">
+        Configure checks that run before every commit.
+      </p>
+
+      <div class="mt-6 space-y-6">
+        <%= render partial: "projects/pre_commit_requirements/requirement",
+          collection: @pre_commit_requirements,
+          as: :requirement,
+          locals: { project: @project } %>
+
+        <% if @pre_commit_requirements.empty? %>
+          <p class="text-sm text-gray-500">No pre-commit requirements configured.</p>
+        <% end %>
+      </div>
+
+      <div class="mt-8 border-t border-gray-200 pt-6">
+        <h2 class="text-lg font-medium text-gray-900">Add Requirement</h2>
+        <%= render "projects/pre_commit_requirements/form",
+          pre_commit_requirement: @new_requirement || PreCommitRequirement.new,
+          project: @project %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/db/migrate/20260525062838_add_open_source_to_projects.rb
+++ b/db/migrate/20260525062838_add_open_source_to_projects.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddOpenSourceToProjects < ActiveRecord::Migration[8.1]
+  def change
+    add_column :projects, :open_source, :boolean, default: false, null: false,
+      comment: "Whether the project is open source (affects mutation test --usage flag)."
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_24_000100) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_25_062838) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1669,6 +1669,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_24_000100) do
     t.string "merge_method", default: "squash", null: false
     t.jsonb "model_preferences", default: {}, null: false
     t.string "name", null: false
+    t.boolean "open_source", default: false, null: false, comment: "Whether the project is open source (affects mutation test --usage flag)."
     t.string "owner", null: false
     t.string "owner_reviewer_login"
     t.integer "plan_review_timeout_hours", default: 24, null: false, comment: "Maximum hours to wait for plan review approval before auto-approving."

--- a/spec/factories/pre_commit_requirements.rb
+++ b/spec/factories/pre_commit_requirements.rb
@@ -49,5 +49,10 @@ FactoryBot.define do
       check_type { "security_scan" }
       command { "bin/brakeman" }
     end
+
+    trait :mutation_test do
+      check_type { "mutation_test" }
+      command { "bundle exec mutant run --usage opensource --since HEAD~1 --use rspec --jobs 1" }
+    end
   end
 end

--- a/spec/models/pre_commit_requirement_spec.rb
+++ b/spec/models/pre_commit_requirement_spec.rb
@@ -9,6 +9,24 @@ RSpec.describe PreCommitRequirement do
     it { is_expected.to belong_to(:user).optional }
   end
 
+  describe ".mutation_test_default_command" do
+    let(:account) { create(:account) }
+
+    it "returns opensource usage for open source projects" do
+      project = create(:project, account: account, open_source: true)
+
+      expect(described_class.mutation_test_default_command(project))
+        .to eq("bundle exec mutant run --usage opensource --since HEAD~1 --use rspec --jobs 1")
+    end
+
+    it "returns commercial usage for non-open source projects" do
+      project = create(:project, account: account, open_source: false)
+
+      expect(described_class.mutation_test_default_command(project))
+        .to eq("bundle exec mutant run --usage commercial --since HEAD~1 --use rspec --jobs 1")
+    end
+  end
+
   describe "validations" do
     subject { build(:pre_commit_requirement) }
 
@@ -299,6 +317,15 @@ RSpec.describe PreCommitRequirement do
       result = described_class.resolve(project: project, user: other_user)
 
       expect(result.map(&:id)).to eq([ account_req.id ])
+    end
+
+    it "merges mutation_test requirements across scopes" do
+      create(:pre_commit_requirement, :mutation_test, account: account, name: "mutant")
+      account_req = create(:pre_commit_requirement, account: account, name: "lint")
+
+      result = described_class.resolve(project: project)
+
+      expect(result.map(&:name)).to match_array(%w[lint mutant])
     end
   end
 

--- a/spec/requests/projects/pre_commit_requirements_spec.rb
+++ b/spec/requests/projects/pre_commit_requirements_spec.rb
@@ -97,6 +97,14 @@ RSpec.describe "Projects::PreCommitRequirements" do
         expect(req.account).to eq(account)
       end
 
+      it "re-renders the form with errors on invalid params" do
+        post project_pre_commit_requirements_path(project),
+          params: { pre_commit_requirement: { name: "", command: "", check_type: "shell_command" } }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to include("error")
+      end
+
       it "creates a mutation_test requirement with warn default" do
         params = {
           pre_commit_requirement: {

--- a/spec/requests/projects/pre_commit_requirements_spec.rb
+++ b/spec/requests/projects/pre_commit_requirements_spec.rb
@@ -8,6 +8,61 @@ RSpec.describe "Projects::PreCommitRequirements" do
   let(:github_token) { create(:github_token, account: account) }
   let(:project) { create(:project, account: account, github_token: github_token) }
 
+  describe "GET /projects/:project_id/pre_commit_requirements" do
+    context "when not authenticated" do
+      it "redirects to the sign in page" do
+        get project_pre_commit_requirements_path(project)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when authenticated as admin" do
+      before do
+        user.add_role(:admin, account)
+        sign_in user
+      end
+
+      it "renders the index page" do
+        get project_pre_commit_requirements_path(project)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders opensource usage command when project is open source" do
+        project.update!(open_source: true)
+
+        get project_pre_commit_requirements_path(project)
+        expect(response.body).to include("--usage opensource")
+      end
+
+      it "renders commercial usage command when project is not open source" do
+        get project_pre_commit_requirements_path(project)
+
+        expect(response.body).to include("--usage commercial")
+      end
+
+      it "renders commercial license banner when project is not open source" do
+        create(:pre_commit_requirement, :mutation_test, account: account, project: project, name: "mutant")
+
+        get project_pre_commit_requirements_path(project)
+        expect(response.body).to include("mutant requires a paid license")
+      end
+    end
+
+    context "when authenticated as member" do
+      let(:member) { create(:user, :member, account: account) }
+
+      before do
+        create(:user, account: account) # absorb owner role
+        sign_in member
+      end
+
+      it "renders the index page" do
+        get project_pre_commit_requirements_path(project)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
   describe "POST /projects/:project_id/pre_commit_requirements" do
     let(:valid_params) do
       {
@@ -40,6 +95,23 @@ RSpec.describe "Projects::PreCommitRequirements" do
         req = project.pre_commit_requirements.last
         expect(req.name).to eq("lint")
         expect(req.account).to eq(account)
+      end
+
+      it "creates a mutation_test requirement with warn default" do
+        params = {
+          pre_commit_requirement: {
+            name: "mutant", command: "bundle exec mutant run", check_type: "mutation_test",
+            failure_behavior: "warn", position: 1
+          }
+        }
+
+        expect {
+          post project_pre_commit_requirements_path(project), params: params
+        }.to change(PreCommitRequirement, :count).by(1)
+
+        req = project.pre_commit_requirements.last
+        expect(req.check_type).to eq("mutation_test")
+        expect(response).to redirect_to(project_pre_commit_requirements_path(project))
       end
     end
 

--- a/spec/requests/projects/pre_commit_requirements_spec.rb
+++ b/spec/requests/projects/pre_commit_requirements_spec.rb
@@ -180,6 +180,15 @@ RSpec.describe "Projects::PreCommitRequirements" do
         expect(response).to redirect_to(project_pre_commit_requirements_path(project))
         expect(requirement.reload.name).to eq("updated-lint")
       end
+
+      it "re-renders the persisted requirement form with the update route on invalid params" do
+        patch project_pre_commit_requirement_path(project, requirement),
+          params: { pre_commit_requirement: { name: "", command: "" } }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to include(%(action="#{project_pre_commit_requirement_path(project, requirement)}"))
+        expect(response.body).not_to include(%(action="#{project_pre_commit_requirements_path(project)}"))
+      end
     end
 
     context "when authenticated as member" do


### PR DESCRIPTION
## Summary

This change enables teams to configure mutation testing requirements before commit so Paid can support mutation-test-based quality gates in later phases of RDR-036. It extends the existing pre-commit requirement model and settings surfaces to recognize `mutation_test`, while adding the project-level `open_source` flag needed to generate the correct default mutant command and licensing guidance.

## Changes

- Database
  - Add `open_source` to `projects` with a default of `false`.
  - Rely on the existing logidze auditing setup so changes to `project.open_source` are captured in `log_data` without introducing separate audit plumbing.

- Models and domain logic
  - Extend `PreCommitRequirement::CHECK_TYPES` to include `mutation_test`.
  - Preserve existing validation and resolution behavior while covering the new check type in `PreCommitRequirement.resolve` across account, user, and project scopes.

- Customer settings UI
  - Surface `mutation_test` in the project pre-commit requirements flow so customers can create and edit these requirements through the existing settings path.
  - Default the command to `bundle exec mutant run --usage <opensource|commercial> --since HEAD~1 --use rspec --jobs 1`, deriving `--usage` from `project.open_source?`.
  - Default `failure_behavior` to `warn`.
  - Show a commercial-project banner when `open_source?` is false, explaining Mutant licensing requirements and the need to provide `MUTANT_LICENSE_KEY` as a project env var.

- Admin UI
  - Extend Avo admin support so operators can inspect `mutation_test` requirements across accounts using the same administrative surfaces as other pre-commit requirements.

- Test coverage
  - Add coverage for `mutation_test` validation and persistence.
  - Add resolution specs to confirm `mutation_test` rules merge correctly across scopes.
  - Add settings UI coverage for both `opensource` and `commercial` default command variants.
  - Keep existing `PreCommitRequirement` behavior covered to guard against regressions.

## Design Decisions

- This phase stops at configuration and visibility. It does not install container hooks or execute mutation testing yet, which keeps Phase 2a independent and limits risk before Phase 2b wires runtime behavior into agent containers.
- The default command is generated from `project.open_source?` rather than asking users to assemble Mutant flags manually, reducing setup errors while still allowing override through the existing command field.
- Commercial licensing guidance is presented inline in the settings UI instead of enforced as a hard validation, because license key delivery already belongs to the existing project env var path and will only be exercised once execution is added in Phase 2b.

## Operational Concerns

- Deploy includes a schema change adding `projects.open_source`; run migrations as part of rollout.
- No container, hook-installation, or infrastructure changes are included in this phase.
- Teams using commercial projects will still need to provide `MUTANT_LICENSE_KEY` through project env vars before Phase 2b begins executing the check.

## Screenshots

- Attach before/after screenshots of the project settings UI showing:
  - the `mutation_test` requirement form with `--usage opensource`
  - the `mutation_test` requirement form with `--usage commercial`
  - the commercial-license warning banner

---

Closes #2279