### PR TITLE
fix: Chat interface UI is cluttered, repetitive, and breaks on mobile

### DIFF
--- a/app/services/chat_sessions/close.rb
+++ b/app/services/chat_sessions/close.rb
@@ -20,16 +20,12 @@ module ChatSessions
     def call
       validate!
 
-      if chat_session.messages.where(role: "user").none?
-        cleanup_workspace if chat_session.mode == "workspace"
-        chat_session.destroy!
-        return chat_session
-      end
+      return destroy_empty_session unless user_messages?
 
       ActiveRecord::Base.transaction do
         compute_totals
-        transition_to_closed
-        cleanup_workspace if chat_session.mode == "workspace"
+        cleanup_workspace_resources if workspace_session?
+        transition_to_closed(workspace_cleanup_attributes)
       end
 
       chat_session
@@ -41,6 +37,20 @@ module ChatSessions
       return if %w[active idle].include?(chat_session.status)
 
       raise ArgumentError, "chat session must be active or idle to close (current: #{chat_session.status})"
+    end
+
+    def destroy_empty_session
+      cleanup_workspace_resources if workspace_session?
+      chat_session.destroy!
+      chat_session
+    end
+
+    def user_messages?
+      chat_session.messages.where(role: "user").exists?
+    end
+
+    def workspace_session?
+      chat_session.mode == "workspace"
     end
 
     def compute_totals
@@ -62,16 +72,25 @@ module ChatSessions
       )
     end
 
-    def transition_to_closed
-      chat_session.update!(status: "closed")
+    def transition_to_closed(attributes = {})
+      chat_session.update!({ status: "closed" }.merge(attributes))
     end
 
-    def cleanup_workspace
-      cleanup_container if chat_session.container_id.present?
-      cleanup_volume if chat_session.workspace_volume.present?
+    def workspace_cleanup_attributes
+      return {} unless workspace_session?
+
+      {
+        container_id: nil,
+        workspace_volume: nil
+      }
     end
 
-    def cleanup_container
+    def cleanup_workspace_resources
+      cleanup_container_resource if chat_session.container_id.present?
+      cleanup_volume_resource if chat_session.workspace_volume.present?
+    end
+
+    def cleanup_container_resource
       # Placeholder for container cleanup via Containers::Provision or Docker API.
       # In production, this destroys the persistent workspace container.
       Rails.logger.info(
@@ -79,10 +98,9 @@ module ChatSessions
         chat_session_id: chat_session.id,
         container_id: chat_session.container_id
       )
-      chat_session.update!(container_id: nil)
     end
 
-    def cleanup_volume
+    def cleanup_volume_resource
       # Placeholder for volume cleanup.
       # In production, this removes the persistent workspace volume.
       Rails.logger.info(
@@ -90,7 +108,6 @@ module ChatSessions
         chat_session_id: chat_session.id,
         workspace_volume: chat_session.workspace_volume
       )
-      chat_session.update!(workspace_volume: nil)
     end
   end
 end

--- a/app/services/chat_sessions/close.rb
+++ b/app/services/chat_sessions/close.rb
@@ -20,6 +20,12 @@ module ChatSessions
     def call
       validate!
 
+      if chat_session.messages.where(role: "user").none?
+        cleanup_workspace if chat_session.mode == "workspace"
+        chat_session.destroy!
+        return chat_session
+      end
+
       ActiveRecord::Base.transaction do
         compute_totals
         transition_to_closed

--- a/app/views/chat_messages/_bubble.html.erb
+++ b/app/views/chat_messages/_bubble.html.erb
@@ -1,0 +1,22 @@
+<article class="<%= chat_message_bubble_classes(message) %>"
+         data-controller="chat-message"
+         data-chat-message-role-value="<%= message.role %>"
+         data-chat-message-markdown-value="<%= message.role == 'assistant' && message.content.present? %>"
+         data-message-id="<%= message.id %>">
+  <div class="mb-2 flex items-center gap-2">
+    <%= chat_message_role_badge(message) %>
+    <span class="text-xs font-medium text-gray-400"><%= chat_message_label(message) %></span>
+    <span class="text-xs text-gray-300"><%= local_time(message.created_at, format: :relative) %></span>
+  </div>
+
+  <% if message.tool_name.present? || message.role == "tool" %>
+    <%= render "chat_messages/tool_call", message: message %>
+  <% elsif message.role == "assistant" %>
+    <div data-chat-message-target="content"
+         data-raw-content="<%= message.content.to_s %>">
+      <%= simple_format(h(message.content.to_s)) %>
+    </div>
+  <% else %>
+    <div class="whitespace-pre-wrap break-words leading-6"><%= message.content.to_s %></div>
+  <% end %>
+</article>

--- a/app/views/chat_messages/_message.html.erb
+++ b/app/views/chat_messages/_message.html.erb
@@ -1,5 +1,5 @@
 <% if message.role == "system" %>
-  <details>
+  <details class="group">
     <summary class="mx-auto flex cursor-pointer items-center justify-center gap-2 rounded-md bg-gray-50 px-4 py-1.5 text-xs font-medium text-gray-500 ring-1 ring-gray-200 hover:bg-gray-100">
       <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z" />

--- a/app/views/chat_messages/_message.html.erb
+++ b/app/views/chat_messages/_message.html.erb
@@ -1,24 +1,20 @@
-<div class="<%= chat_message_wrapper_classes(message) %>">
-  <article class="<%= chat_message_bubble_classes(message) %>"
-           data-controller="chat-message"
-           data-chat-message-role-value="<%= message.role %>"
-           data-chat-message-markdown-value="<%= message.role == 'assistant' && message.content.present? %>"
-           data-message-id="<%= message.id %>">
-    <div class="mb-2 flex items-center gap-2">
-      <%= chat_message_role_badge(message) %>
-      <span class="text-xs font-medium text-gray-400"><%= chat_message_label(message) %></span>
-      <span class="text-xs text-gray-300"><%= local_time(message.created_at, format: :relative) %></span>
+<% if message.role == "system" %>
+  <details>
+    <summary class="mx-auto flex cursor-pointer items-center justify-center gap-2 rounded-md bg-gray-50 px-4 py-1.5 text-xs font-medium text-gray-500 ring-1 ring-gray-200 hover:bg-gray-100">
+      <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z" />
+      </svg>
+      <span>System prompt</span>
+      <svg class="h-3 w-3 transition-transform group-open:rotate-180" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+      </svg>
+    </summary>
+    <div class="flex justify-center mt-2">
+      <%= render "chat_messages/bubble", message: message %>
     </div>
-
-    <% if message.tool_name.present? || message.role == "tool" %>
-      <%= render "chat_messages/tool_call", message: message %>
-    <% elsif message.role == "assistant" %>
-      <div data-chat-message-target="content"
-           data-raw-content="<%= message.content.to_s %>">
-        <%= simple_format(h(message.content.to_s)) %>
-      </div>
-    <% else %>
-      <div class="whitespace-pre-wrap break-words leading-6"><%= message.content.to_s %></div>
-    <% end %>
-  </article>
-</div>
+  </details>
+<% else %>
+  <div class="<%= chat_message_wrapper_classes(message) %>">
+    <%= render "chat_messages/bubble", message: message %>
+  </div>
+<% end %>

--- a/app/views/chat_sessions/show.html.erb
+++ b/app/views/chat_sessions/show.html.erb
@@ -19,12 +19,12 @@
                available_models: @available_models %>
 
     <section class="overflow-hidden rounded-lg bg-white shadow">
-      <div class="flex min-h-[70vh] flex-col"
+      <div class="flex min-h-[70vh] flex-col overflow-x-hidden"
            data-controller="chat"
            data-chat-session-id-value="<%= @chat_session.id %>">
         <header class="border-b border-gray-200 px-4 py-5 sm:px-6">
           <div class="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
-            <div class="min-w-0 flex-1">
+            <div class="min-w-0 flex-1 overflow-hidden">
               <% if can_update_chat_session %>
                 <%= form_with model: @chat_session,
                               url: chat_session_path(@chat_session),
@@ -180,15 +180,7 @@
                     </div>
                   </div>
                 </form>
-                <% if can_update_chat_session %>
-                  <div class="mt-2 flex items-center justify-end">
-                    <%= render "chat_sessions/chat_config_bar",
-                               chat_session: @chat_session,
-                               available_projects: @available_projects,
-                               available_models: @available_models,
-                               available_runners: @available_runners %>
-                  </div>
-                <% end %>
+
               <% else %>
                 <p class="text-sm text-gray-500">You have read-only access to this chat.</p>
               <% end %>

--- a/spec/jobs/chat_sessions/idle_reaper_job_spec.rb
+++ b/spec/jobs/chat_sessions/idle_reaper_job_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe ChatSessions::IdleReaperJob do
         account: account,
         created_by: user,
         idle_timeout_at: 1.minute.ago)
+      create(:chat_message, chat_session: session)
 
       described_class.new.perform
 
@@ -35,6 +36,7 @@ RSpec.describe ChatSessions::IdleReaperJob do
         account: account,
         created_by: user,
         idle_timeout_at: 1.minute.ago)
+      create(:chat_message, chat_session: session)
       create(:token_usage, :chat, chat_session: session, input_tokens: 50, output_tokens: 25, cost_cents: 0)
 
       described_class.new.perform
@@ -52,6 +54,8 @@ RSpec.describe ChatSessions::IdleReaperJob do
         account: account,
         created_by: user,
         idle_timeout_at: 1.minute.ago)
+      create(:chat_message, chat_session: session1)
+      create(:chat_message, chat_session: session2)
 
       allow(ChatSessions::Close).to receive(:call)
         .with(chat_session: anything)

--- a/spec/requests/chat_sessions_spec.rb
+++ b/spec/requests/chat_sessions_spec.rb
@@ -376,6 +376,7 @@ RSpec.describe "ChatSessions" do
       before { sign_in user }
 
       it "closes the session and returns 204" do
+        create(:chat_message, chat_session: chat_session)
         delete chat_session_path(chat_session, format: :json)
         expect(response).to have_http_status(:no_content)
         expect(chat_session.reload.status).to eq("closed")

--- a/spec/services/chat_sessions/close_spec.rb
+++ b/spec/services/chat_sessions/close_spec.rb
@@ -8,13 +8,24 @@ RSpec.describe ChatSessions::Close do
   let(:chat_session) { create(:chat_session, account: account, created_by: user) }
 
   describe ".call" do
-    it "transitions session to closed" do
+    it "destroys sessions with no user messages" do
+      session = create(:chat_session, account: account, created_by: user)
+      create(:chat_message, :system, chat_session: session)
+
+      expect {
+        described_class.call(chat_session: session)
+      }.to change(ChatSession, :count).by(-1)
+    end
+
+    it "transitions session to closed when user messages exist" do
+      create(:chat_message, chat_session: chat_session)
       described_class.call(chat_session: chat_session)
 
       expect(chat_session.reload.status).to eq("closed")
     end
 
     it "computes token totals in metadata" do
+      create(:chat_message, chat_session: chat_session)
       create(:token_usage, :chat, chat_session: chat_session, input_tokens: 100, output_tokens: 50)
       create(:token_usage, :chat, chat_session: chat_session, input_tokens: 200, output_tokens: 75)
 
@@ -36,6 +47,7 @@ RSpec.describe ChatSessions::Close do
     end
 
     it "records closed_at timestamp" do
+      create(:chat_message, chat_session: chat_session)
       freeze_time do
         described_class.call(chat_session: chat_session)
 
@@ -45,6 +57,7 @@ RSpec.describe ChatSessions::Close do
 
     it "allows closing idle sessions" do
       idle_session = create(:chat_session, :idle, account: account, created_by: user)
+      create(:chat_message, chat_session: idle_session)
 
       described_class.call(chat_session: idle_session)
 
@@ -61,11 +74,20 @@ RSpec.describe ChatSessions::Close do
 
     it "clears container_id for workspace sessions" do
       ws_session = create(:chat_session, :workspace, account: account, created_by: user)
+      create(:chat_message, chat_session: ws_session)
 
       described_class.call(chat_session: ws_session)
 
       expect(ws_session.reload.container_id).to be_nil
       expect(ws_session.workspace_volume).to be_nil
+    end
+
+    it "clears container_id when destroying empty workspace sessions" do
+      ws_session = create(:chat_session, :workspace, account: account, created_by: user)
+
+      described_class.call(chat_session: ws_session)
+
+      expect { ws_session.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 end


### PR DESCRIPTION
## Summary

This change streamlines the chat experience so the interface is easier to use, works cleanly on mobile, and only preserves conversations that contain actual user activity. It removes redundant controls, reduces default visual noise from system prompts, fixes responsive layout issues that blocked key actions on small screens, and prevents empty chats from being archived.

## Changes

- **UI**
  - Removed the duplicate runner/model configuration bar from the chat page so each control appears in a single authoritative location.
  - Made system messages collapsible by default, reducing the amount of vertical space consumed before a conversation starts.
  - Extracted shared message bubble markup into a dedicated partial to keep the message rendering path simpler after introducing the system-message toggle.

- **Responsive layout**
  - Updated the chat layout containers to prevent horizontal overflow on mobile.
  - Ensured the header/content column can shrink correctly on smaller screens so controls like the project selector remain accessible.

- **Chat session lifecycle**
  - Changed chat session closing behavior so sessions with no user messages are destroyed instead of archived.
  - Preserved normal close/archive behavior for sessions that contain actual user conversation.

- **Tests and maintenance**
  - Updated close-service specs and related chat tests to reflect the new empty-session lifecycle behavior.
  - Adjusted view structure to satisfy template linting constraints introduced by the collapsible system prompt UI.

## Design Decisions

- The duplicate runner/model selectors were removed rather than synchronized across multiple surfaces. Keeping one authoritative control reduces ambiguity and avoids state-consistency problems between parallel selectors.
- System prompts use native `<details>`/`<summary>` behavior, which keeps the implementation lightweight and accessible while defaulting to a less cluttered layout.
- Empty sessions are deleted at close time instead of being filtered later in archive views. This keeps persistence rules aligned with product expectations and avoids accumulating meaningless records.
- The message bubble markup was extracted into a partial to accommodate the new conditional rendering without fighting ERB/HTML linting rules.

## Operational Concerns

- No database migration or infrastructure change is required.
- Deployment risk is low and concentrated in chat UI rendering and chat session close behavior.

## Screenshots

Attach before/after screenshots of:
- Chat page with duplicate selectors removed
- Collapsed system prompt treatment
- Mobile layout showing the project selector remains accessible

---

Closes #2283