### PR TITLE
fix(deps): centralize bundler version on Gemfile.lock BUNDLED WITH

### DIFF
--- a/.github/workflows/pr-artifact-check.yml
+++ b/.github/workflows/pr-artifact-check.yml
@@ -206,8 +206,11 @@ jobs:
           fi
 
           if [ -z "${checksums_bundler}" ]; then
-            echo "::error::Could not read bundler version from Gemfile.lock CHECKSUMS section"
-            exit 1
+            # No CHECKSUMS bundler entry means there is no drift surface to check
+            # (the drift bug requires `bundle install` to rewrite that line). Pass
+            # quietly so a future bundler/format change does not block every PR.
+            echo "::notice::Gemfile.lock has no CHECKSUMS bundler entry; skipping consistency check."
+            exit 0
           fi
 
           if [ "${bundled_with}" != "${checksums_bundler}" ]; then

--- a/.github/workflows/pr-artifact-check.yml
+++ b/.github/workflows/pr-artifact-check.yml
@@ -191,3 +191,33 @@ jobs:
           fi
 
           echo "No artifact violations detected. PR is clean."
+
+      - name: Check Gemfile.lock bundler version consistency
+        run: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          bundled_with=$(awk '/^BUNDLED WITH$/{getline; gsub(/^ +/, "", $0); print $0}' Gemfile.lock)
+          checksums_bundler=$(grep -E "^  bundler \([0-9]" Gemfile.lock | sed -E 's/.*bundler \(([^)]+)\).*/\1/' | head -n 1)
+
+          if [ -z "${bundled_with}" ]; then
+            echo "::error::Could not read BUNDLED WITH from Gemfile.lock"
+            exit 1
+          fi
+
+          if [ -z "${checksums_bundler}" ]; then
+            echo "::error::Could not read bundler version from Gemfile.lock CHECKSUMS section"
+            exit 1
+          fi
+
+          if [ "${bundled_with}" != "${checksums_bundler}" ]; then
+            echo "::error::Gemfile.lock bundler version mismatch: BUNDLED WITH=${bundled_with}, CHECKSUMS=${checksums_bundler}"
+            echo ""
+            echo "This usually means 'bundle install' was run with a different bundler"
+            echo "than the one declared in BUNDLED WITH (often by Dependabot's host bundler)."
+            echo "Re-run 'bundle install' with bundler ${bundled_with} and recommit Gemfile.lock,"
+            echo "or run 'bundle update --bundler' to intentionally bump BUNDLED WITH to ${checksums_bundler}."
+            exit 1
+          fi
+
+          echo "Gemfile.lock bundler versions match: ${bundled_with}"

--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -103,7 +103,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # agent image stays in lockstep with the app, devcontainer, and CI environments.
 ARG BUNDLER_VERSION
 RUN if [ -z "${BUNDLER_VERSION}" ]; then \
-        echo "ERROR: BUNDLER_VERSION build-arg is required (sourced from Gemfile.lock BUNDLED WITH)" >&2; \
+        echo "ERROR: BUNDLER_VERSION build-arg is required." >&2; \
+        echo "Use scripts/build-agent-image.sh, which extracts it from Gemfile.lock's BUNDLED WITH." >&2; \
         exit 1; \
     fi \
     && gem install --no-document "bundler:${BUNDLER_VERSION}"

--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -98,8 +98,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install the Bundler version pinned in Gemfile.lock.
-ARG BUNDLER_VERSION=4.0.11
-RUN gem install --no-document "bundler:${BUNDLER_VERSION}"
+# BUNDLER_VERSION is extracted from Gemfile.lock's `BUNDLED WITH` at build time
+# by scripts/build-agent-image.sh and .github/workflows/agent-image.yml so the
+# agent image stays in lockstep with the app, devcontainer, and CI environments.
+ARG BUNDLER_VERSION
+RUN if [ -z "${BUNDLER_VERSION}" ]; then \
+        echo "ERROR: BUNDLER_VERSION build-arg is required (sourced from Gemfile.lock BUNDLED WITH)" >&2; \
+        exit 1; \
+    fi \
+    && gem install --no-document "bundler:${BUNDLER_VERSION}"
 
 # Install agent-harness globally so lightweight utility scripts inside the
 # agent container can use the same transport layer as the Rails app.


### PR DESCRIPTION
## Summary

Closes a drift hazard where `docker/agent/Dockerfile` hardcoded `ARG BUNDLER_VERSION=4.0.11` while every other environment (`Dockerfile`, `.devcontainer/Dockerfile`, `bin/setup`, CI's `ruby/setup-ruby`) derived the bundler version from `Gemfile.lock`'s `BUNDLED WITH`. The hardcoded default would silently fall behind whenever the project bumped bundler.

Also adds a CI guard that rejects PRs where `Gemfile.lock`'s `BUNDLED WITH` and CHECKSUMS bundler entry disagree — the failure mode that recently produced PR #2293 (a one-line revert of a Dependabot-introduced CHECKSUMS bump that didn't update `BUNDLED WITH`).

## Changes

- **`docker/agent/Dockerfile`** — drop the `ARG BUNDLER_VERSION=4.0.11` default. `BUNDLER_VERSION` is now a required build-arg, matching the pattern already used for `CLAUDE_INSTALL_COMMAND`, `CODEX_PACKAGE`, etc. `scripts/build-agent-image.sh:42` and `.github/workflows/agent-image.yml:152-161` already extract it from `BUNDLED WITH`, so the supported build paths are unchanged. Any direct `docker build docker/agent` now fails loudly with a pointer to the right script instead of silently installing stale bundler.
- **`.github/workflows/pr-artifact-check.yml`** — new step `Check Gemfile.lock bundler version consistency` asserts that `BUNDLED WITH` matches the CHECKSUMS bundler entry. If CHECKSUMS has no bundler line (future format change, opt-out), the step skips with a `::notice::` instead of failing — keeps the check from blocking every PR if the lockfile format changes.

## Why this matters

After these changes, `Gemfile.lock`'s `BUNDLED WITH` is the unambiguous single source of truth for bundler across all 5 environments (app image, devcontainer, host setup, CI runners, agent runners), and CI rejects the drift pattern at PR time instead of after merge.

## Test plan

- [x] Dry-run the new CI guard logic against current `Gemfile.lock` — passes (`BUNDLED WITH = CHECKSUMS bundler = 4.0.11`).
- [x] Dry-run the empty-CHECKSUMS path — exits 0 with notice.
- [x] Confirm no other Dockerfile or script hardcodes `BUNDLER_VERSION` outside the lockfile.
- [ ] CI runs the new step on this PR.
- [ ] Verify `agent-image.yml` build still succeeds (touched by `docker/agent/**` path filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)