### PR TITLE
feat: PDF import for project knowledge base and team marketplace

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -149,6 +149,9 @@ gem "good_job", "~> 4.18"
 # Pagination [https://github.com/ddnexus/pagy]
 gem "pagy", "~> 43.5"
 
+# PDF text extraction for knowledge imports
+gem "pdf-reader"
+
 # Search and filtering [https://github.com/activerecord-hackery/ransack]
 gem "ransack"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    Ascii85 (2.0.1)
     action_text-trix (2.1.18)
       railties
     actioncable (8.1.3)
@@ -80,6 +81,7 @@ GEM
       uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    afm (1.0.0)
     agent-harness (0.18.2)
       logger (>= 1.6, < 2.0)
     ast (2.4.3)
@@ -252,6 +254,7 @@ GEM
       bigdecimal
       rake (~> 13.3)
     hashdiff (1.2.1)
+    hashery (2.1.2)
     herb (0.10.1-aarch64-linux-gnu)
     herb (0.10.1-aarch64-linux-musl)
     herb (0.10.1-arm-linux-gnu)
@@ -356,6 +359,12 @@ GEM
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
+    pdf-reader (2.15.1)
+      Ascii85 (>= 1.0, < 3.0, != 2.0.0)
+      afm (>= 0.2.1, < 2)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
     pg (1.6.3)
     pg (1.6.3-aarch64-linux)
     pg (1.6.3-aarch64-linux-musl)
@@ -507,6 +516,7 @@ GEM
       rexml (~> 3.2)
       rover-df (~> 0.3)
     ruby-progressbar (1.13.0)
+    ruby-rc4 (0.1.5)
     ruby_llm (1.15.0)
       base64
       event_stream_parser (~> 1)
@@ -581,6 +591,7 @@ GEM
     thruster (0.1.21-x86_64-linux)
     timeout (0.6.1)
     tsort (0.2.0)
+    ttfunk (1.7.0)
     turbo-rails (2.0.23)
       actionpack (>= 7.1.0)
       railties (>= 7.1.0)
@@ -660,6 +671,7 @@ DEPENDENCIES
   logidze
   octokit
   pagy (~> 43.5)
+  pdf-reader
   pg (~> 1.1)
   pg_query
   propshaft
@@ -691,6 +703,7 @@ DEPENDENCIES
   webmock
 
 CHECKSUMS
+  Ascii85 (2.0.1) sha256=15cb5d941808543cbb9e7e6aea3c8ec3877f154c3461e8b3673e97f7ecedbe5a
   action_text-trix (2.1.18) sha256=3fdb83f8bff4145d098be283cdd47ac41caf5110bfa6df4695ed7127d7fb3642
   actioncable (8.1.3) sha256=e5bc7f75e44e6a22de29c4f43176927c3a9ce4824464b74ed18d8226e75a80f0
   actionmailbox (8.1.3) sha256=df7da474eaa0e70df4ed5a6fef66eb3b3b0f2dbf7f14518deee8d77f1b4aae59
@@ -705,6 +718,7 @@ CHECKSUMS
   activestorage (8.1.3) sha256=0564ce9309143951a67615e1bb4e090ee54b8befed417133cae614479b46384d
   activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  afm (1.0.0) sha256=5bd4d6f6241e7014ef090985ec6f4c3e9745f6de0828ddd58bc1efdd138f4545
   agent-harness (0.18.2) sha256=ee7fba0996bd5f31367d83de087a336b9ce7472a50652d0e4239e13463cef9f0
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   avo (4.0.0.beta.37) sha256=5135fa5d6cd593b8267e1d5a706ab2722117996bce3079f58ffd46dccdc0ebef
@@ -775,6 +789,7 @@ CHECKSUMS
   google-protobuf (4.34.1-x86_64-linux-gnu) sha256=87088c9fd8e47b5b40ca498fc1195add6149e941ff7e81c532a5b0b8876d4cc9
   google-protobuf (4.34.1-x86_64-linux-musl) sha256=8c0e91436fbe504ffc64f0bd621f2e69adbcce8ed2c58439d7a21117069cfdd7
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
+  hashery (2.1.2) sha256=d239cc2310401903f6b79d458c2bbef5bf74c46f3f974ae9c1061fb74a404862
   herb (0.10.1-aarch64-linux-gnu) sha256=fd9f4f8e0bcd9a421de55ff8810066550e9bcba8c8bf53737b32a04eb2fcbc49
   herb (0.10.1-aarch64-linux-musl) sha256=bc6dac577c25bb7b35fe812987a9da7056aabd3a9394941c2aadf68bcca7c58e
   herb (0.10.1-arm-linux-gnu) sha256=965fcb7bb59c7307c2dfdb8fa03ae06724184886bcb015088585e5163036a425
@@ -827,6 +842,7 @@ CHECKSUMS
   pagy (43.5.5) sha256=86790336da3a1966e3503c226989577f1f56e3353dad10353445e8c988412548
   parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356
   parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
+  pdf-reader (2.15.1) sha256=18c6a986a84a3117fa49f4279fc2de51f5d2399b71833df5d2bccd595c7068ce
   pg (1.6.3) sha256=1388d0563e13d2758c1089e35e973a3249e955c659592d10e5b77c468f628a99
   pg (1.6.3-aarch64-linux) sha256=0698ad563e02383c27510b76bf7d4cd2de19cd1d16a5013f375dd473e4be72ea
   pg (1.6.3-aarch64-linux-musl) sha256=06a75f4ea04b05140146f2a10550b8e0d9f006a79cdaf8b5b130cde40e3ecc2c
@@ -881,6 +897,7 @@ CHECKSUMS
   rubocop-rspec (3.9.0) sha256=8fa70a3619408237d789aeecfb9beef40576acc855173e60939d63332fdb55e2
   ruby-maat (1.2.0) sha256=558797d7e1267126a56fbfc9db2d29002a5e5d2bc330b8a45ba106c0771ff844
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  ruby-rc4 (0.1.5) sha256=00cc40a39d20b53f5459e7ea006a92cf584e9bc275e2a6f7aa1515510e896c03
   ruby_llm (1.15.0) sha256=ca207465bca1cca007010a79fce500d4012b1fbe188b025040cd37b884fb98af
   ruby_llm-schema (0.3.1) sha256=bfec093db924f8995e598c338147507e71b4dedfeb59de2de3ebf7985938d3d4
   ruby_parser (3.22.0) sha256=1eb4937cd9eb220aa2d194e352a24dba90aef00751e24c8dfffdb14000f15d23
@@ -911,6 +928,7 @@ CHECKSUMS
   thruster (0.1.21-x86_64-linux) sha256=6e2fbcf826540a72d3710ae4db072c2333287ac2ee57e7e52f35bc10900d74a7
   timeout (0.6.1) sha256=78f57368a7e7bbadec56971f78a3f5ecbcfb59b7fcbb0a3ed6ddc08a5094accb
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
+  ttfunk (1.7.0) sha256=2370ba484b1891c70bdcafd3448cfd82a32dd794802d81d720a64c15d3ef2a96
   turbo-rails (2.0.23) sha256=ee0d90733aafff056cf51ff11e803d65e43cae258cc55f6492020ec1f9f9315f
   turbo_power (0.7.0) sha256=ad95d147e0fa761d0023ad9ca00528c7b7ddf6bba8ca2e23755d5b21b290d967
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b

--- a/app/controllers/marketplace_entry_pdf_imports_controller.rb
+++ b/app/controllers/marketplace_entry_pdf_imports_controller.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class MarketplaceEntryPdfImportsController < ApplicationController
+  def new
+    @marketplace_entry = build_marketplace_entry
+    authorize @marketplace_entry
+  end
+
+  def create
+    @marketplace_entry = build_marketplace_entry
+    authorize @marketplace_entry
+
+    entry = MarketplaceEntries::ImportFromPdf.call(
+      account: current_account,
+      actor: current_user,
+      params: marketplace_entry_pdf_import_params
+    )
+
+    redirect_to marketplace_entry_path(entry), notice: "Marketplace entry created from PDF."
+  rescue Knowledge::PdfImports::ImportError, MarketplaceEntries::ImportFromPdf::ImportError => e
+    @marketplace_entry.errors.add(:base, e.message)
+    render :new, status: :unprocessable_content
+  end
+
+  private
+
+  def build_marketplace_entry
+    current_account.marketplace_entries.build(
+      name: marketplace_entry_pdf_import_params[:name],
+      entry_type: marketplace_entry_pdf_import_params[:entry_type].presence || "skill",
+      description: marketplace_entry_pdf_import_params[:description],
+      usage_guidance: marketplace_entry_pdf_import_params[:usage_guidance],
+      provider_format: "canonical_v1",
+      team_scope: "account",
+      status: marketplace_entry_pdf_import_params[:status].presence || "draft"
+    ).tap do |entry|
+      entry.tags_csv = marketplace_entry_pdf_import_params[:tags_csv].to_s
+    end
+  end
+
+  def marketplace_entry_pdf_import_params
+    params.fetch(:marketplace_entry, {}).permit(
+      :name, :entry_type, :description, :usage_guidance, :tags_csv, :status, :pdf_file
+    )
+  end
+end

--- a/app/controllers/projects/pdf_knowledge_imports_controller.rb
+++ b/app/controllers/projects/pdf_knowledge_imports_controller.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Projects
+  class PdfKnowledgeImportsController < ApplicationController
+    before_action :set_project
+
+    def new
+      authorize @project, :update?
+    end
+
+    def create
+      authorize @project, :update?
+
+      result = Knowledge::PdfImports::ImportToProject.call(
+        project: @project,
+        file: pdf_import_params[:pdf_file],
+        actor: current_user
+      )
+
+      redirect_to @project,
+        notice: "Imported #{result.fetch(:artifact_identifier)} into the project knowledge base."
+    rescue Knowledge::PdfImports::ImportError => e
+      flash.now[:alert] = e.message
+      render :new, status: :unprocessable_content
+    end
+
+    private
+
+    def set_project
+      @project = policy_scope(Project).find(params[:project_id])
+    end
+
+    def pdf_import_params
+      params.fetch(:pdf_import, {}).permit(:pdf_file)
+    end
+  end
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -116,6 +116,10 @@ class Account < ApplicationRecord
     trial? && trial_ends_at.present? && trial_ends_at < Time.current
   end
 
+  def paid_plan?
+    plan.in?(%w[professional enterprise])
+  end
+
   def current_onboarding_step
     onboarding_steps.ordered.where.not(status: %w[completed skipped]).first
   end

--- a/app/services/knowledge/context_bundle/build.rb
+++ b/app/services/knowledge/context_bundle/build.rb
@@ -21,7 +21,7 @@ module Knowledge
       # Section builders in priority order.
       # Conventions section is not yet implemented — will be added when
       # a conventions collector lands in the knowledge pipeline.
-      SECTION_ORDER = %i[business_context routes symbols schema hotspots decisions stats].freeze
+      SECTION_ORDER = %i[business_context documents routes symbols schema hotspots decisions stats].freeze
 
       attr_reader :issue, :project, :agent_run, :agent_run_id, :token_budget, :section_order
 
@@ -133,6 +133,33 @@ module Knowledge
         artifact_section(name: :routes, heading: "Relevant Routes", content: lines.join("\n"), artifacts: artifacts)
       end
 
+      def build_documents_section
+        artifacts = active_artifacts("reference_document")
+        return nil if artifacts.empty?
+
+        total_chunks = 0
+        lines = artifacts.map do |artifact|
+          title = artifact.metadata&.dig("title") || artifact.identifier
+          summary_chunks = artifact.active_ordered_chunks.select { |chunk| chunk.chunk_type == "summary" }
+          total_chunks += summary_chunks.size
+
+          if summary_chunks.any?
+            bullet_lines = summary_chunks.first(4).map { |chunk| "- #{chunk.content}" }
+            "#### #{title}\n#{bullet_lines.join("\n")}"
+          else
+            "#### #{title}\n- #{artifact.content.to_s.tr("\n", " ").truncate(300)}"
+          end
+        end
+
+        artifact_section(
+          name: :documents,
+          heading: "Imported Documents",
+          content: lines.join("\n\n"),
+          artifacts: artifacts,
+          chunk_count: total_chunks
+        )
+      end
+
       def build_symbols_section
         artifacts = active_artifacts("symbol")
         return nil if artifacts.empty?
@@ -234,6 +261,7 @@ module Knowledge
       def section_artifact_type(section_name)
         {
           business_context: "business_context",
+          documents: "reference_document",
           routes: "route",
           symbols: "symbol",
           hotspots: "churn_hotspot",
@@ -292,6 +320,12 @@ module Knowledge
             .includes(:knowledge_chunks)
             .order(:identifier)
             .limit(20)
+            .to_a
+        elsif type == "reference_document"
+          scope
+            .includes(:knowledge_chunks)
+            .order(:identifier)
+            .limit(10)
             .to_a
         elsif type == "churn_hotspot"
           # Order by hotspot rank (lower = hotter), with nulls last, then by

--- a/app/services/knowledge/context_bundle/build.rb
+++ b/app/services/knowledge/context_bundle/build.rb
@@ -317,13 +317,13 @@ module Knowledge
 
         if type == "business_context"
           scope
-            .includes(:knowledge_chunks)
+            .includes(:active_ordered_chunks)
             .order(:identifier)
             .limit(20)
             .to_a
         elsif type == "reference_document"
           scope
-            .includes(:knowledge_chunks)
+            .includes(:active_ordered_chunks)
             .order(:identifier)
             .limit(10)
             .to_a
@@ -342,7 +342,7 @@ module Knowledge
             .to_a
         elsif type == "schema"
           scope
-            .includes(:knowledge_chunks)
+            .includes(:active_ordered_chunks)
             .order(:identifier)
             .limit(20)
             .to_a

--- a/app/services/knowledge/pdf_imports/chunker.rb
+++ b/app/services/knowledge/pdf_imports/chunker.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module Knowledge
+  module PdfImports
+    class Chunker
+      MAX_CHUNK_CHARS = 1200
+      SUMMARY_SENTENCE_LIMIT = 2
+
+      def initialize(document:)
+        @document = document
+      end
+
+      def self.call(...)
+        new(...).call
+      end
+
+      def call
+        sequence = 0
+        chunks = []
+
+        document.pages.each do |page|
+          heading = nil
+
+          paragraphs_for(page.fetch(:text)).each do |paragraph|
+            if heading_candidate?(paragraph)
+              heading = paragraph
+              next
+            end
+
+            split_content(paragraph).each do |content_part|
+              full_content = [ heading, content_part ].compact.join("\n\n")
+              chunks << build_chunk(
+                chunk_type: "context",
+                content: "Page #{page.fetch(:number)}\n#{full_content}",
+                sequence: sequence,
+                page_number: page.fetch(:number)
+              )
+              sequence += 1
+
+              summary_content = summarize(content_part, heading:, page_number: page.fetch(:number))
+              next if summary_content.blank?
+
+              chunks << build_chunk(
+                chunk_type: "summary",
+                content: summary_content,
+                sequence: sequence,
+                page_number: page.fetch(:number)
+              )
+              sequence += 1
+            end
+          end
+        end
+
+        chunks
+      end
+
+      private
+
+      attr_reader :document
+
+      def paragraphs_for(text)
+        text.split(/\n{2,}/).map(&:strip).reject(&:blank?)
+      end
+
+      def heading_candidate?(paragraph)
+        return false if paragraph.length > 100
+        return false if paragraph.include?(".")
+
+        paragraph.lines.count <= 2 || paragraph == paragraph.upcase
+      end
+
+      def split_content(content)
+        return [ content ] if content.length <= MAX_CHUNK_CHARS
+
+        content.split(/(?<=[.!?])\s+/).each_with_object([ +"" ]) do |sentence, parts|
+          current = parts.last
+
+          if current.blank?
+            current << sentence
+          elsif current.length + sentence.length + 1 <= MAX_CHUNK_CHARS
+            current << " #{sentence}"
+          else
+            parts << sentence.dup
+          end
+        end
+      end
+
+      def summarize(content, heading:, page_number:)
+        sentences = content.split(/(?<=[.!?])\s+/).reject(&:blank?).first(SUMMARY_SENTENCE_LIMIT)
+        summary = sentences.join(" ").presence || content.tr("\n", " ").truncate(220)
+        label = [ heading, "page #{page_number}" ].compact.join(" - ")
+
+        [ label.presence, summary ].compact.join(": ").truncate(280)
+      end
+
+      def build_chunk(chunk_type:, content:, sequence:, page_number:)
+        {
+          chunk_type: chunk_type,
+          content: content,
+          sequence: sequence,
+          scope_tags: [ "pdf_import", "page_#{page_number}" ]
+        }
+      end
+    end
+  end
+end

--- a/app/services/knowledge/pdf_imports/import_error.rb
+++ b/app/services/knowledge/pdf_imports/import_error.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Knowledge
+  module PdfImports
+    class ImportError < StandardError; end
+  end
+end

--- a/app/services/knowledge/pdf_imports/import_to_project.rb
+++ b/app/services/knowledge/pdf_imports/import_to_project.rb
@@ -5,6 +5,7 @@ module Knowledge
     class ImportToProject
       ARTIFACT_TYPE = "reference_document"
       COLLECTOR_TYPE = "pdf_import"
+      MAX_PDF_SIZE = 50.megabytes
 
       def initialize(project:, file:, actor:)
         @project = project
@@ -19,6 +20,7 @@ module Knowledge
       def call
         validate_plan!
         validate_file!
+        validate_size!
 
         document = Parser.call(file: file)
         chunks = Chunker.call(document: document)
@@ -76,6 +78,13 @@ module Knowledge
         return if file.content_type.to_s == "application/pdf"
 
         raise ImportError, "Only PDF uploads are supported."
+      end
+
+      def validate_size!
+        return unless file.respond_to?(:size)
+        return if file.size <= MAX_PDF_SIZE
+
+        raise ImportError, "PDF must be smaller than 50 MB."
       end
 
       def project_version

--- a/app/services/knowledge/pdf_imports/import_to_project.rb
+++ b/app/services/knowledge/pdf_imports/import_to_project.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+module Knowledge
+  module PdfImports
+    class ImportToProject
+      ARTIFACT_TYPE = "reference_document"
+      COLLECTOR_TYPE = "pdf_import"
+
+      def initialize(project:, file:, actor:)
+        @project = project
+        @file = file
+        @actor = actor
+      end
+
+      def self.call(...)
+        new(...).call
+      end
+
+      def call
+        validate_plan!
+        validate_file!
+
+        document = Parser.call(file: file)
+        chunks = Chunker.call(document: document)
+
+        collector_run = nil
+
+        ActiveRecord::Base.transaction do
+          collector_run = project_version.collector_runs.create!(
+            collector_type: COLLECTOR_TYPE,
+            status: "running",
+            started_at: Time.current,
+            metadata: {
+              source_name: document.source_name,
+              title: document.title,
+              imported_by_user_id: actor&.id
+            }
+          )
+
+          Knowledge::ArtifactStore.call(
+            project: project,
+            collector_run: collector_run,
+            artifact_data_list: [ artifact_data_for(document, chunks) ]
+          )
+
+          collector_run.mark_completed!(count: 1)
+          project.update!(knowledge_status: "ready")
+        end
+
+        KnowledgeArtifact.bust_artifact_counts_cache(project.id)
+        EmbedChunksJob.perform_later(project.id)
+
+        {
+          artifact_identifier: artifact_identifier(document),
+          collector_run: collector_run,
+          chunk_count: chunks.size
+        }
+      rescue StandardError => e
+        collector_run&.mark_failed!(error: e.message) if collector_run&.persisted? && collector_run.status == "running"
+        raise
+      end
+
+      private
+
+      attr_reader :project, :file, :actor
+
+      def validate_plan!
+        return if project.account.paid_plan?
+
+        raise ImportError, "PDF knowledge import is available on professional and enterprise plans."
+      end
+
+      def validate_file!
+        raise ImportError, "Choose a PDF file to import." if file.blank?
+        return if file.original_filename.to_s.downcase.end_with?(".pdf")
+        return if file.content_type.to_s == "application/pdf"
+
+        raise ImportError, "Only PDF uploads are supported."
+      end
+
+      def project_version
+        @project_version ||= project.project_versions.by_recency.first || project.project_versions.create!(
+          commit_sha: "0" * 40,
+          branch: project.default_branch || "main"
+        )
+      end
+
+      def artifact_data_for(document, chunks)
+        {
+          artifact_type: ARTIFACT_TYPE,
+          scope_path: "pdf_uploads/#{document.source_name}",
+          identifier: artifact_identifier(document),
+          content: full_document_content(document),
+          metadata: {
+            source_name: document.source_name,
+            title: document.title,
+            page_count: document.page_count,
+            imported_by_user_id: actor&.id,
+            imported_at: Time.current.iso8601
+          },
+          chunks: chunks
+        }
+      end
+
+      def artifact_identifier(document)
+        document.title.presence || File.basename(document.source_name, ".*")
+      end
+
+      def full_document_content(document)
+        document.pages.map do |page|
+          "Page #{page.fetch(:number)}\n#{page.fetch(:text)}"
+        end.join("\n\n")
+      end
+    end
+  end
+end

--- a/app/services/knowledge/pdf_imports/parser.rb
+++ b/app/services/knowledge/pdf_imports/parser.rb
@@ -34,7 +34,11 @@ module Knowledge
           source_name: source_name
         )
       rescue PDF::Reader::MalformedPDFError, PDF::Reader::EncryptedPDFError,
-        PDF::Reader::UnsupportedFeatureError, ArgumentError => e
+        PDF::Reader::UnsupportedFeatureError => e
+        raise ImportError, "Could not read PDF: #{e.message}"
+      rescue ArgumentError => e
+        raise unless pdf_reader_error?(e)
+
         raise ImportError, "Could not read PDF: #{e.message}"
       ensure
         io&.rewind if io.respond_to?(:rewind)
@@ -67,6 +71,10 @@ module Knowledge
           .gsub(/[ \t]+/, " ")
           .gsub(/\n{3,}/, "\n\n")
           .strip
+      end
+
+      def pdf_reader_error?(error)
+        error.backtrace_locations&.first&.path&.include?("/pdf/reader")
       end
     end
   end

--- a/app/services/knowledge/pdf_imports/parser.rb
+++ b/app/services/knowledge/pdf_imports/parser.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "pdf/reader"
+
+module Knowledge
+  module PdfImports
+    class Parser
+      ParsedDocument = Struct.new(:title, :page_count, :pages, :source_name, keyword_init: true)
+
+      def initialize(file:)
+        @file = file
+      end
+
+      def self.call(...)
+        new(...).call
+      end
+
+      def call
+        io = source_io
+        reader = PDF::Reader.new(io)
+        pages = reader.pages.map.with_index(1) do |page, page_number|
+          text = normalize_text(page.text)
+          next if text.blank?
+
+          { number: page_number, text: text }
+        end.compact
+
+        raise ImportError, "The PDF did not contain extractable text." if pages.empty?
+
+        ParsedDocument.new(
+          title: normalized_title(reader),
+          page_count: reader.page_count,
+          pages: pages,
+          source_name: source_name
+        )
+      rescue PDF::Reader::MalformedPDFError, PDF::Reader::EncryptedPDFError,
+        PDF::Reader::UnsupportedFeatureError, ArgumentError => e
+        raise ImportError, "Could not read PDF: #{e.message}"
+      ensure
+        io&.rewind if io.respond_to?(:rewind)
+      end
+
+      private
+
+      attr_reader :file
+
+      def source_io
+        io = file.respond_to?(:tempfile) ? file.tempfile : file
+        io.rewind if io.respond_to?(:rewind)
+        io
+      end
+
+      def source_name
+        file.respond_to?(:original_filename) ? file.original_filename.to_s : "document.pdf"
+      end
+
+      def normalized_title(reader)
+        raw_title = reader.info&.[](:Title) || reader.info&.[]("Title")
+        raw_title.to_s.strip.presence || File.basename(source_name, ".*").tr("_-", " ").squish.titleize
+      end
+
+      def normalize_text(text)
+        text.to_s
+          .encode("UTF-8", invalid: :replace, undef: :replace, replace: "")
+          .gsub(/\u0000/, "")
+          .gsub(/\r\n?/, "\n")
+          .gsub(/[ \t]+/, " ")
+          .gsub(/\n{3,}/, "\n\n")
+          .strip
+      end
+    end
+  end
+end

--- a/app/services/marketplace_entries/import_from_pdf.rb
+++ b/app/services/marketplace_entries/import_from_pdf.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+module MarketplaceEntries
+  class ImportFromPdf
+    class ImportError < StandardError; end
+
+    def initialize(account:, actor:, params:)
+      @account = account
+      @actor = actor
+      @params = params
+    end
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def call
+      validate_plan!
+      validate_file!
+
+      document = Knowledge::PdfImports::Parser.call(file: params[:pdf_file])
+      chunks = Knowledge::PdfImports::Chunker.call(document: document)
+
+      entry = account.marketplace_entries.build(
+        name: params[:name].presence || document.title,
+        entry_type: params[:entry_type].presence || "skill",
+        description: params[:description].presence || "Imported from #{document.source_name}",
+        provider_format: "canonical_v1",
+        usage_guidance: usage_guidance(document),
+        team_scope: "account",
+        status: params[:status].presence || "draft",
+        added_by_name: actor&.name.presence || actor&.email.to_s,
+        added_by_email: actor&.email.to_s
+      )
+      entry.tags_csv = params[:tags_csv].to_s
+
+      ActiveRecord::Base.transaction do
+        entry.save!
+        entry.create_version!(
+          changelog: "Imported from PDF #{document.source_name}",
+          canonical_artifact: canonical_artifact_for(document, chunks),
+          renderers: {},
+          compatibility_constraints: {},
+          review_metadata: review_metadata_for(document, chunks)
+        )
+      end
+
+      entry
+    rescue ActiveRecord::RecordInvalid => e
+      raise ImportError, e.record.errors.full_messages.to_sentence
+    end
+
+    private
+
+    attr_reader :account, :actor, :params
+
+    def validate_plan!
+      return if account.paid_plan?
+
+      raise ImportError, "Marketplace PDF import is available on professional and enterprise plans."
+    end
+
+    def validate_file!
+      file = params[:pdf_file]
+      raise ImportError, "Choose a PDF file to import." if file.blank?
+      return if file.original_filename.to_s.downcase.end_with?(".pdf")
+      return if file.content_type.to_s == "application/pdf"
+
+      raise ImportError, "Only PDF uploads are supported."
+    end
+
+    def usage_guidance(document)
+      params[:usage_guidance].presence ||
+        "Imported from #{document.source_name}. Attach this entry when the run needs guidance from #{document.title}."
+    end
+
+    def canonical_artifact_for(document, chunks)
+      {
+        "attachment_strategy" => "prompt_append",
+        "content" => prompt_body(document, chunks),
+        "source_document" => {
+          "title" => document.title,
+          "filename" => document.source_name,
+          "page_count" => document.page_count
+        }
+      }
+    end
+
+    def review_metadata_for(document, chunks)
+      {
+        "imported_from_pdf" => true,
+        "filename" => document.source_name,
+        "page_count" => document.page_count,
+        "chunk_count" => chunks.count,
+        "imported_by_user_id" => actor&.id
+      }
+    end
+
+    def prompt_body(document, chunks)
+      summary_lines = chunks
+        .select { |chunk| chunk[:chunk_type] == "summary" }
+        .first(12)
+        .map { |chunk| "- #{chunk[:content]}" }
+
+      body_lines = []
+      body_lines << "Reference material: #{document.title}"
+      body_lines << "Imported from #{document.source_name} (#{document.page_count} pages)."
+      body_lines << ""
+      body_lines << "Use this material as authoritative guidance when it is relevant to the task."
+      body_lines << ""
+      body_lines << "Key excerpts:"
+      body_lines.concat(summary_lines.presence || fallback_lines(document))
+
+      body_lines.join("\n").strip
+    end
+
+    def fallback_lines(document)
+      document.pages.first(5).map do |page|
+        "- Page #{page.fetch(:number)}: #{page.fetch(:text).tr("\n", " ").truncate(220)}"
+      end
+    end
+  end
+end

--- a/app/services/marketplace_entries/import_from_pdf.rb
+++ b/app/services/marketplace_entries/import_from_pdf.rb
@@ -3,6 +3,7 @@
 module MarketplaceEntries
   class ImportFromPdf
     class ImportError < StandardError; end
+    MAX_PDF_SIZE = 50.megabytes
 
     def initialize(account:, actor:, params:)
       @account = account
@@ -17,6 +18,7 @@ module MarketplaceEntries
     def call
       validate_plan!
       validate_file!
+      validate_size!
 
       document = Knowledge::PdfImports::Parser.call(file: params[:pdf_file])
       chunks = Knowledge::PdfImports::Chunker.call(document: document)
@@ -67,6 +69,14 @@ module MarketplaceEntries
       return if file.content_type.to_s == "application/pdf"
 
       raise ImportError, "Only PDF uploads are supported."
+    end
+
+    def validate_size!
+      file = params[:pdf_file]
+      return unless file.respond_to?(:size)
+      return if file.size <= MAX_PDF_SIZE
+
+      raise ImportError, "PDF must be smaller than 50 MB."
     end
 
     def usage_guidance(document)

--- a/app/services/screenshots/capture_targets.rb
+++ b/app/services/screenshots/capture_targets.rb
@@ -86,6 +86,7 @@ module Screenshots
       marketplace_entry_new: Target.new(slug: "marketplace_entry_new", path_builder: "/marketplace_entries/new", requires_auth: true),
       marketplace_entry_show: Target.new(slug: "marketplace_entry_show", path_builder: ->(seed_data) { "/marketplace_entries/#{seed_data.fetch(:marketplace_entry).id}" }, requires_auth: true),
       marketplace_entry_edit: Target.new(slug: "marketplace_entry_edit", path_builder: ->(seed_data) { "/marketplace_entries/#{seed_data.fetch(:marketplace_entry).id}/edit" }, requires_auth: true),
+      marketplace_entry_pdf_import_new: Target.new(slug: "marketplace_entry_pdf_import_new", path_builder: "/marketplace_entry_pdf_import/new", requires_auth: true),
       service_containers: Target.new(slug: "service_containers", path_builder: "/service_containers", requires_auth: true),
       service_container_new: Target.new(slug: "service_container_new", path_builder: "/service_containers/new", requires_auth: true),
       service_container_show: Target.new(slug: "service_container_show", path_builder: ->(seed_data) { "/service_containers/#{seed_data.fetch(:service_container).id}" }, requires_auth: true),
@@ -150,6 +151,7 @@ module Screenshots
       project_cost_snapshot: Target.new(slug: "project_cost_snapshot", path_builder: ->(seed_data) { "/projects/#{seed_data.fetch(:project).id}/cost_snapshot" }, requires_auth: true),
       project_cost_dashboard: Target.new(slug: "project_cost_dashboard", path_builder: ->(seed_data) { "/projects/#{seed_data.fetch(:project).id}/cost_dashboard" }, requires_auth: true),
       project_context_intake: Target.new(slug: "project_context_intake", path_builder: ->(seed_data) { "/projects/#{seed_data.fetch(:project).id}/context_intake" }, requires_auth: true),
+      project_pdf_knowledge_import_new: Target.new(slug: "project_pdf_knowledge_import_new", path_builder: ->(seed_data) { "/projects/#{seed_data.fetch(:project).id}/pdf_knowledge_import/new" }, requires_auth: true),
       project_knowledge_search: Target.new(slug: "project_knowledge_search", path_builder: ->(seed_data) { "/projects/#{seed_data.fetch(:project).id}/knowledge/search" }, requires_auth: true),
       project_knowledge_browse: Target.new(slug: "project_knowledge_browse", path_builder: ->(seed_data) { "/projects/#{seed_data.fetch(:project).id}/knowledge/browse" }, requires_auth: true),
       project_knowledge_browse_show: Target.new(slug: "project_knowledge_browse_show", path_builder: ->(seed_data) { "/projects/#{seed_data.fetch(:project).id}/knowledge/browse/route" }, requires_auth: true),
@@ -254,7 +256,9 @@ module Screenshots
       "projects/mcp_servers_controller.rb" => [ :project_edit ],
       "projects/knowledge_recommendations_controller.rb" => [ :project_knowledge_recommendations ],
       "projects/screenshot_configs_controller.rb" => [ :project_edit ],
-      "projects/convention_settings_controller.rb" => [ :project_convention_settings ]
+      "projects/convention_settings_controller.rb" => [ :project_convention_settings ],
+      "projects/pdf_knowledge_imports_controller.rb" => [ :project_pdf_knowledge_import_new ],
+      "marketplace_entry_pdf_imports_controller.rb" => [ :marketplace_entry_pdf_import_new ]
     }.freeze
 
     def targets_for(path)
@@ -347,6 +351,7 @@ module Screenshots
       when /\Arunners\// then providers_targets(relative_path.delete_prefix("runners/"))
       when /\Aservice_containers\// then rest_resource_targets(relative_path, "service_containers", index: :service_containers, new: :service_container_new, show: :service_container_show, edit: :service_container_edit)
       when /\Amarketplace_entries\// then rest_resource_targets(relative_path, "marketplace_entries", index: :marketplace_entries, new: :marketplace_entry_new, show: :marketplace_entry_show, edit: :marketplace_entry_edit)
+      when /\Amarketplace_entry_pdf_imports\// then [ :marketplace_entry_pdf_import_new ]
       when /\Amcp_server_definitions\// then rest_resource_targets(relative_path, "mcp_server_definitions", index: :mcp_server_definitions, new: :mcp_server_definition_new, show: :mcp_server_definition_show, edit: :mcp_server_definition_edit)
       when "agent_runs/_detail.html.erb", "agent_runs/_detail_actions.html.erb" then [ :project_agent_run_show ]
       when /\Aagent_runs\// then [ :agent_runs ]
@@ -361,6 +366,7 @@ module Screenshots
       when /\Aknowledge\/artifacts\// then [ :project_knowledge_artifact_show ]
       when /\Aknowledge\/browse\// then knowledge_browse_targets(relative_path.delete_prefix("knowledge/browse/"))
       when /\Aknowledge\/context_intake\// then [ :project_context_intake ]
+      when /\Aprojects\/pdf_knowledge_imports\// then [ :project_pdf_knowledge_import_new ]
       when /\Aknowledge\/search\// then knowledge_search_targets(relative_path.delete_prefix("knowledge/search/"))
       when /\Aquality_dashboards\// then [ :quality_dashboard ]
       when "projects/agent_runs/provenance.html.erb" then [ :project_agent_run_provenance ]

--- a/app/views/marketplace_entries/index.html.erb
+++ b/app/views/marketplace_entries/index.html.erb
@@ -6,7 +6,12 @@
       <h1 class="text-2xl font-semibold text-gray-900">Marketplace Entries</h1>
       <p class="mt-1 text-sm text-gray-500">Shared team skills, prompts, plugins, MCP servers, provider presets, and run enhancements.</p>
     </div>
-    <%= link_to "New Entry", new_marketplace_entry_path, class: "inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500" %>
+    <div class="flex items-center gap-3">
+      <% if current_account.paid_plan? %>
+        <%= link_to "Import PDF", new_marketplace_entry_pdf_import_path, class: "inline-flex items-center rounded-md border border-indigo-200 px-4 py-2 text-sm font-semibold text-indigo-700 shadow-sm hover:bg-indigo-50" %>
+      <% end %>
+      <%= link_to "New Entry", new_marketplace_entry_path, class: "inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500" %>
+    </div>
   </div>
 
   <div class="mt-6 overflow-hidden rounded-lg bg-white shadow">

--- a/app/views/marketplace_entry_pdf_imports/new.html.erb
+++ b/app/views/marketplace_entry_pdf_imports/new.html.erb
@@ -1,0 +1,69 @@
+<% content_for(:title) { "Import Marketplace PDF - Paid" } %>
+
+<div class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+  <h1 class="text-2xl font-semibold text-gray-900">Import PDF to Team Marketplace</h1>
+  <p class="mt-1 text-sm text-gray-500">Turn a PDF into a reusable skill, agent, or enhancement with prompt-ready summaries generated from the extracted content.</p>
+
+  <div class="mt-6 rounded-lg bg-white p-6 shadow">
+    <%= form_with model: @marketplace_entry, url: marketplace_entry_pdf_import_path, class: "space-y-6" do |form| %>
+      <% if @marketplace_entry.errors.any? %>
+        <div class="rounded-md bg-red-50 p-4 text-sm text-red-700">
+          <p class="font-semibold"><%= pluralize(@marketplace_entry.errors.count, "error") %> prevented the import:</p>
+          <ul class="mt-2 list-disc pl-5">
+            <% @marketplace_entry.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <div class="grid gap-6 md:grid-cols-2">
+        <div>
+          <%= form.label :name, class: "block text-sm font-medium text-gray-700" %>
+          <%= form.text_field :name, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm sm:text-sm" %>
+        </div>
+
+        <div>
+          <%= form.label :entry_type, "Type", class: "block text-sm font-medium text-gray-700" %>
+          <%= form.select :entry_type, MarketplaceEntry::ENTRY_TYPES.map { |type| [ type.humanize, type ] }, {}, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm sm:text-sm" %>
+        </div>
+      </div>
+
+      <div>
+        <%= form.label :pdf_file, "PDF File", class: "block text-sm font-medium text-gray-700" %>
+        <%= form.file_field :pdf_file, accept: "application/pdf,.pdf", class: "mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm" %>
+      </div>
+
+      <div>
+        <%= form.label :description, class: "block text-sm font-medium text-gray-700" %>
+        <%= form.text_area :description, rows: 3, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm sm:text-sm" %>
+      </div>
+
+      <div>
+        <%= form.label :usage_guidance, class: "block text-sm font-medium text-gray-700" %>
+        <%= form.text_area :usage_guidance, rows: 4, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm sm:text-sm" %>
+      </div>
+
+      <div class="grid gap-6 md:grid-cols-2">
+        <div>
+          <%= form.label :tags_csv, "Tags", class: "block text-sm font-medium text-gray-700" %>
+          <%= form.text_field :tags_csv, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm sm:text-sm", placeholder: "css, docs, frontend" %>
+        </div>
+
+        <div>
+          <%= form.label :status, class: "block text-sm font-medium text-gray-700" %>
+          <%= form.select :status, MarketplaceEntry::STATUSES.map { |status| [ status.humanize, status ] }, {}, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm sm:text-sm" %>
+        </div>
+      </div>
+
+      <div class="rounded-md border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+        The importer creates a prompt-append marketplace artifact from the PDF summaries so teammates can attach it directly to agent runs.
+      </div>
+
+      <div class="flex items-center justify-end gap-4 border-t border-gray-200 pt-4">
+        <%= link_to "Cancel", marketplace_entries_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700" %>
+        <%= form.submit "Create From PDF", class: "inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/projects/_knowledge.html.erb
+++ b/app/views/projects/_knowledge.html.erb
@@ -26,6 +26,9 @@
       <% if policy(project).update? %>
         <%= link_to "Business Context", project_context_intake_path(project), class: "text-sm font-medium text-indigo-600 hover:text-indigo-500" %>
         <%= link_to "Recommendations", project_knowledge_recommendations_path(project), class: "text-sm font-medium text-indigo-600 hover:text-indigo-500" %>
+        <% if project.account.paid_plan? %>
+          <%= link_to "Import PDF", new_project_pdf_knowledge_import_path(project), class: "text-sm font-medium text-indigo-600 hover:text-indigo-500" %>
+        <% end %>
       <% end %>
       <%= link_to "Browse", project_knowledge_browse_index_path(project), class: "text-sm font-medium text-indigo-600 hover:text-indigo-500" %>
       <%= link_to "Search", project_knowledge_search_path(project), class: "text-sm font-medium text-indigo-600 hover:text-indigo-500" %>

--- a/app/views/projects/pdf_knowledge_imports/new.html.erb
+++ b/app/views/projects/pdf_knowledge_imports/new.html.erb
@@ -1,0 +1,37 @@
+<% content_for(:title) { "Import PDF Knowledge - #{@project.name} - Paid" } %>
+
+<div class="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+  <div class="mb-6">
+    <%= link_to @project, class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+      <svg class="mr-1 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
+      </svg>
+      Back to Project
+    <% end %>
+  </div>
+
+  <h1 class="text-2xl font-semibold text-gray-900">Import PDF to Project Knowledge</h1>
+  <p class="mt-1 text-sm text-gray-500">Upload reference material and Paid will extract text, create knowledge chunks, and enqueue embeddings for retrieval.</p>
+
+  <div class="mt-6 rounded-lg bg-white p-6 shadow">
+    <% if flash.now[:alert].present? %>
+      <div class="mb-4 rounded-md bg-red-50 p-4 text-sm text-red-700"><%= flash.now[:alert] %></div>
+    <% end %>
+
+    <%= form_with url: project_pdf_knowledge_import_path(@project), scope: :pdf_import, class: "space-y-6" do |form| %>
+      <div>
+        <%= form.label :pdf_file, "PDF File", class: "block text-sm font-medium text-gray-700" %>
+        <%= form.file_field :pdf_file, accept: "application/pdf,.pdf", class: "mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm" %>
+      </div>
+
+      <div class="rounded-md border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+        Imports are available on professional and enterprise plans. Uploaded PDFs are parsed into searchable chunks and summary snippets for agent prompt context.
+      </div>
+
+      <div class="flex items-center justify-end gap-4 border-t border-gray-200 pt-4">
+        <%= link_to "Cancel", @project, class: "text-sm font-medium text-gray-500 hover:text-gray-700" %>
+        <%= form.submit "Import PDF", class: "inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,6 +103,7 @@ Rails.application.routes.draw do
   # MCP server definitions management
   resources :mcp_server_definitions
   resources :marketplace_entries
+  resource :marketplace_entry_pdf_import, only: [ :new, :create ], controller: "marketplace_entry_pdf_imports"
 
   # All agent runs across projects
   resources :agent_runs, only: [ :index ] do
@@ -210,6 +211,7 @@ Rails.application.routes.draw do
       controller: "knowledge/context_intake" do
       post :complete
     end
+    resource :pdf_knowledge_import, only: [ :new, :create ], controller: "projects/pdf_knowledge_imports"
     post :ensure_labels, on: :member
 
     resources :knowledge_recommendations, only: [ :index, :update ],

--- a/spec/fixtures/files/sample.pdf
+++ b/spec/fixtures/files/sample.pdf
@@ -1,0 +1,2 @@
+%PDF-1.4
+placeholder pdf fixture used by request specs that stub the parser

--- a/spec/requests/marketplace_entry_pdf_imports_spec.rb
+++ b/spec/requests/marketplace_entry_pdf_imports_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "MarketplaceEntryPdfImports" do
+  let(:account) { create(:account, plan: "professional") }
+  let(:user) { create(:user, :member, account: account) }
+  let(:uploaded_file) do
+    Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/sample.pdf"), "application/pdf")
+  end
+
+  before { sign_in user }
+
+  describe "GET /marketplace_entry_pdf_import/new" do
+    it "renders the import form" do
+      get new_marketplace_entry_pdf_import_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Import PDF to Team Marketplace")
+    end
+  end
+
+  describe "POST /marketplace_entry_pdf_import" do
+    it "creates the marketplace entry from a PDF" do
+      entry = create(:marketplace_entry, account: account, name: "Modern CSS Coach")
+
+      allow(MarketplaceEntries::ImportFromPdf).to receive(:call).and_return(entry)
+
+      post marketplace_entry_pdf_import_path, params: {
+        marketplace_entry: {
+          name: "Modern CSS Coach",
+          entry_type: "skill",
+          status: "draft",
+          pdf_file: uploaded_file
+        }
+      }
+
+      expect(response).to redirect_to(marketplace_entry_path(entry))
+      expect(flash[:notice]).to eq("Marketplace entry created from PDF.")
+    end
+
+    it "rerenders the form when the import fails" do
+      allow(MarketplaceEntries::ImportFromPdf).to receive(:call)
+        .and_raise(MarketplaceEntries::ImportFromPdf::ImportError, "Choose a PDF file to import.")
+
+      post marketplace_entry_pdf_import_path, params: {
+        marketplace_entry: {
+          name: "Modern CSS Coach",
+          entry_type: "skill",
+          status: "draft",
+          pdf_file: uploaded_file
+        }
+      }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("Choose a PDF file to import.")
+    end
+  end
+end

--- a/spec/requests/projects/pdf_knowledge_imports_spec.rb
+++ b/spec/requests/projects/pdf_knowledge_imports_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Projects::PdfKnowledgeImports" do
+  let(:account) { create(:account, plan: "professional") }
+  let(:user) { create(:user, :admin, account: account) }
+  let(:project) { create(:project, account: account) }
+  let(:uploaded_file) do
+    Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/files/sample.pdf"), "application/pdf")
+  end
+
+  before { sign_in user }
+
+  describe "GET /projects/:project_id/pdf_knowledge_import/new" do
+    it "renders the import form" do
+      get new_project_pdf_knowledge_import_path(project)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Import PDF to Project Knowledge")
+    end
+  end
+
+  describe "POST /projects/:project_id/pdf_knowledge_import" do
+    it "imports the PDF and redirects back to the project" do
+      allow(Knowledge::PdfImports::ImportToProject).to receive(:call).and_return(
+        artifact_identifier: "Modern CSS"
+      )
+
+      post project_pdf_knowledge_import_path(project), params: { pdf_import: { pdf_file: uploaded_file } }
+
+      expect(response).to redirect_to(project_path(project))
+      expect(flash[:notice]).to eq("Imported Modern CSS into the project knowledge base.")
+    end
+
+    it "rerenders the form when the import fails" do
+      allow(Knowledge::PdfImports::ImportToProject).to receive(:call)
+        .and_raise(Knowledge::PdfImports::ImportError, "Only PDF uploads are supported.")
+
+      post project_pdf_knowledge_import_path(project), params: { pdf_import: { pdf_file: uploaded_file } }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("Only PDF uploads are supported.")
+    end
+  end
+end

--- a/spec/services/knowledge/context_bundle/build_spec.rb
+++ b/spec/services/knowledge/context_bundle/build_spec.rb
@@ -72,6 +72,12 @@ RSpec.describe Knowledge::ContextBundle::Build do
         expect(result[:content]).to include("Modern CSS")
         expect(result[:content]).to include("Prefer grid for two-dimensional layouts")
       end
+
+      it "preloads active ordered chunks for document artifacts" do
+        artifacts = described_class.new(issue: issue, project: project).send(:active_artifacts, "reference_document")
+
+        expect(artifacts.map { |artifact| artifact.association(:active_ordered_chunks) }).to all(be_loaded)
+      end
     end
 
     context "with symbol artifacts" do
@@ -219,13 +225,18 @@ RSpec.describe Knowledge::ContextBundle::Build do
 
     context "with schema artifacts" do
       before do
-        create(:knowledge_artifact,
+        artifact = create(:knowledge_artifact,
           project: project,
           collector_run: collector_run,
           artifact_type: "schema",
           identifier: "users",
           content: "users (id bigint, email text)",
           status: "active")
+        create(:knowledge_chunk,
+          knowledge_artifact: artifact,
+          project: project,
+          chunk_type: "context",
+          content: "Users belong to accounts.")
       end
 
       it "includes a schema section" do
@@ -234,12 +245,19 @@ RSpec.describe Knowledge::ContextBundle::Build do
         expect(result[:sections]).to include(:schema)
         expect(result[:content]).to include("Data Model")
         expect(result[:content]).to include("users (id bigint, email text)")
+        expect(result[:content]).to include("Users belong to accounts.")
       end
 
       it "includes schema in artifact_type_counts" do
         result = described_class.call(issue: issue, project: project, agent_run_id: agent_run.id)
 
         expect(result[:artifact_type_counts]).to include("schema" => 1)
+      end
+
+      it "preloads active ordered chunks for schema artifacts" do
+        artifacts = described_class.new(issue: issue, project: project).send(:active_artifacts, "schema")
+
+        expect(artifacts.map { |artifact| artifact.association(:active_ordered_chunks) }).to all(be_loaded)
       end
     end
 
@@ -356,6 +374,12 @@ RSpec.describe Knowledge::ContextBundle::Build do
           [ "route", agent_run.goal, "bundle", 1, 0 ]
         ])
         expect(KnowledgeUsageStat.where(agent_run: agent_run).pluck(:token_count)).to all(be_positive)
+      end
+
+      it "preloads active ordered chunks for business context artifacts" do
+        artifacts = described_class.new(issue: issue, project: project).send(:active_artifacts, "business_context")
+
+        expect(artifacts.map { |artifact| artifact.association(:active_ordered_chunks) }).to all(be_loaded)
       end
 
       it "upserts usage records idempotently" do

--- a/spec/services/knowledge/context_bundle/build_spec.rb
+++ b/spec/services/knowledge/context_bundle/build_spec.rb
@@ -47,6 +47,33 @@ RSpec.describe Knowledge::ContextBundle::Build do
       end
     end
 
+    context "with imported document artifacts" do
+      before do
+        artifact = create(:knowledge_artifact,
+          project: project,
+          collector_run: collector_run,
+          artifact_type: "reference_document",
+          identifier: "Modern CSS",
+          content: "Imported CSS guidance",
+          metadata: { "title" => "Modern CSS" },
+          status: "active")
+        create(:knowledge_chunk,
+          knowledge_artifact: artifact,
+          project: project,
+          chunk_type: "summary",
+          content: "Page 1: Prefer grid for two-dimensional layouts.")
+      end
+
+      it "includes imported document summaries" do
+        result = described_class.call(issue: issue, project: project)
+
+        expect(result[:sections]).to include(:documents)
+        expect(result[:content]).to include("Imported Documents")
+        expect(result[:content]).to include("Modern CSS")
+        expect(result[:content]).to include("Prefer grid for two-dimensional layouts")
+      end
+    end
+
     context "with symbol artifacts" do
       before do
         create(:knowledge_artifact,

--- a/spec/services/knowledge/pdf_imports/chunker_spec.rb
+++ b/spec/services/knowledge/pdf_imports/chunker_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Knowledge::PdfImports::Chunker do
+  let(:document) do
+    Knowledge::PdfImports::Parser::ParsedDocument.new(
+      title: "Modern CSS",
+      page_count: 1,
+      source_name: "modern_css.pdf",
+      pages: [
+        {
+          number: 1,
+          text: "LAYOUT PRINCIPLES\n\nUse grid for two-dimensional layouts. Prefer gaps over margin shims."
+        }
+      ]
+    )
+  end
+
+  it "creates context and summary chunks while preserving page and heading context" do
+    chunks = described_class.call(document: document)
+
+    expect(chunks.map { |chunk| chunk[:chunk_type] }).to eq(%w[context summary])
+    expect(chunks.first[:content]).to include("Page 1")
+    expect(chunks.first[:content]).to include("LAYOUT PRINCIPLES")
+    expect(chunks.last[:content]).to include("LAYOUT PRINCIPLES - page 1")
+    expect(chunks.first[:scope_tags]).to include("pdf_import", "page_1")
+  end
+end

--- a/spec/services/knowledge/pdf_imports/import_to_project_spec.rb
+++ b/spec/services/knowledge/pdf_imports/import_to_project_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Knowledge::PdfImports::ImportToProject do
     instance_double(
       ActionDispatch::Http::UploadedFile,
       original_filename: "modern_css.pdf",
-      content_type: "application/pdf"
+      content_type: "application/pdf",
+      size: 1.megabyte
     )
   end
   let(:document) do
@@ -62,5 +63,13 @@ RSpec.describe Knowledge::PdfImports::ImportToProject do
     expect {
       described_class.call(project: project, file: file, actor: actor)
     }.to raise_error(Knowledge::PdfImports::ImportError, /available on professional and enterprise plans/)
+  end
+
+  it "rejects oversized PDFs" do
+    allow(file).to receive(:size).and_return(51.megabytes)
+
+    expect {
+      described_class.call(project: project, file: file, actor: actor)
+    }.to raise_error(Knowledge::PdfImports::ImportError, "PDF must be smaller than 50 MB.")
   end
 end

--- a/spec/services/knowledge/pdf_imports/import_to_project_spec.rb
+++ b/spec/services/knowledge/pdf_imports/import_to_project_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Knowledge::PdfImports::ImportToProject do
+  include ActiveJob::TestHelper
+
+  let(:account) { create(:account, plan: "professional") }
+  let(:project) { create(:project, account: account) }
+  let(:actor) { create(:user, :admin, account: account) }
+  let(:file) do
+    instance_double(
+      ActionDispatch::Http::UploadedFile,
+      original_filename: "modern_css.pdf",
+      content_type: "application/pdf"
+    )
+  end
+  let(:document) do
+    Knowledge::PdfImports::Parser::ParsedDocument.new(
+      title: "Modern CSS",
+      page_count: 2,
+      source_name: "modern_css.pdf",
+      pages: [
+        { number: 1, text: "Page one text" },
+        { number: 2, text: "Page two text" }
+      ]
+    )
+  end
+  let(:chunks) do
+    [
+      { chunk_type: "context", content: "Page 1\nGrid guidance", sequence: 0, scope_tags: [ "pdf_import", "page_1" ] },
+      { chunk_type: "summary", content: "page 1: Grid guidance", sequence: 1, scope_tags: [ "pdf_import", "page_1" ] }
+    ]
+  end
+
+  before do
+    ActiveJob::Base.queue_adapter = :test
+    clear_enqueued_jobs
+    allow(Knowledge::PdfImports::Parser).to receive(:call).and_return(document)
+    allow(Knowledge::PdfImports::Chunker).to receive(:call).and_return(chunks)
+  end
+
+  it "stores a reference document artifact, chunks, and enqueues embeddings" do
+    expect {
+      described_class.call(project: project, file: file, actor: actor)
+    }.to change(KnowledgeArtifact, :count).by(1)
+      .and change(KnowledgeChunk, :count).by(2)
+      .and change(CollectorRun, :count).by(1)
+
+    artifact = project.knowledge_artifacts.order(:id).last
+
+    expect(artifact.artifact_type).to eq("reference_document")
+    expect(artifact.identifier).to eq("Modern CSS")
+    expect(artifact.metadata).to include("page_count" => 2, "source_name" => "modern_css.pdf")
+    expect(project.reload.knowledge_status).to eq("ready")
+    expect(enqueued_jobs.map { |job| job[:job] }).to include(EmbedChunksJob)
+  end
+
+  it "rejects non-paid plans" do
+    project.account.update!(plan: "trial")
+
+    expect {
+      described_class.call(project: project, file: file, actor: actor)
+    }.to raise_error(Knowledge::PdfImports::ImportError, /available on professional and enterprise plans/)
+  end
+end

--- a/spec/services/knowledge/pdf_imports/parser_spec.rb
+++ b/spec/services/knowledge/pdf_imports/parser_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Knowledge::PdfImports::Parser do
+  let(:file) do
+    instance_double(
+      ActionDispatch::Http::UploadedFile,
+      original_filename: "modern_css.pdf",
+      tempfile: StringIO.new("pdf")
+    )
+  end
+
+  it "extracts normalized page text and title metadata" do
+    page = instance_double(PDF::Reader::Page, text: "  CSS\n\nLayouts\t\tand spacing  ")
+    reader = instance_double(PDF::Reader, pages: [ page ], page_count: 1, info: { Title: "Modern CSS" })
+
+    allow(PDF::Reader).to receive(:new).and_return(reader)
+
+    document = described_class.call(file: file)
+
+    expect(document.title).to eq("Modern CSS")
+    expect(document.page_count).to eq(1)
+    expect(document.pages).to eq([ { number: 1, text: "CSS\n\nLayouts and spacing" } ])
+    expect(document.source_name).to eq("modern_css.pdf")
+  end
+
+  it "raises when the PDF has no extractable text" do
+    page = instance_double(PDF::Reader::Page, text: "   ")
+    reader = instance_double(PDF::Reader, pages: [ page ], page_count: 1, info: {})
+
+    allow(PDF::Reader).to receive(:new).and_return(reader)
+
+    expect {
+      described_class.call(file: file)
+    }.to raise_error(Knowledge::PdfImports::ImportError, "The PDF did not contain extractable text.")
+  end
+end

--- a/spec/services/knowledge/pdf_imports/parser_spec.rb
+++ b/spec/services/knowledge/pdf_imports/parser_spec.rb
@@ -35,4 +35,24 @@ RSpec.describe Knowledge::PdfImports::Parser do
       described_class.call(file: file)
     }.to raise_error(Knowledge::PdfImports::ImportError, "The PDF did not contain extractable text.")
   end
+
+  it "wraps pdf-reader argument errors as import errors" do
+    error = ArgumentError.new("bad object")
+    allow(error).to receive(:backtrace_locations).and_return([ instance_double(Thread::Backtrace::Location, path: "/gems/pdf-reader-2.15.1/lib/pdf/reader.rb") ])
+    allow(PDF::Reader).to receive(:new).and_raise(error)
+
+    expect {
+      described_class.call(file: file)
+    }.to raise_error(Knowledge::PdfImports::ImportError, "Could not read PDF: bad object")
+  end
+
+  it "re-raises non pdf-reader argument errors" do
+    error = ArgumentError.new("wrong number of arguments")
+    allow(error).to receive(:backtrace_locations).and_return([ instance_double(Thread::Backtrace::Location, path: "/workspace/app/services/knowledge/pdf_imports/parser.rb") ])
+    allow(PDF::Reader).to receive(:new).and_raise(error)
+
+    expect {
+      described_class.call(file: file)
+    }.to raise_error(error)
+  end
 end

--- a/spec/services/marketplace_entries/import_from_pdf_spec.rb
+++ b/spec/services/marketplace_entries/import_from_pdf_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe MarketplaceEntries::ImportFromPdf do
+  let(:account) { create(:account, plan: "professional") }
+  let(:actor) { create(:user, :member, account: account) }
+  let(:file) do
+    instance_double(
+      ActionDispatch::Http::UploadedFile,
+      original_filename: "modern_css.pdf",
+      content_type: "application/pdf"
+    )
+  end
+  let(:document) do
+    Knowledge::PdfImports::Parser::ParsedDocument.new(
+      title: "Modern CSS",
+      page_count: 1,
+      source_name: "modern_css.pdf",
+      pages: [ { number: 1, text: "Prefer grid and gap." } ]
+    )
+  end
+  let(:chunks) do
+    [
+      { chunk_type: "summary", content: "Layout guidance - page 1: Prefer grid and gap.", sequence: 0, scope_tags: [ "pdf_import", "page_1" ] }
+    ]
+  end
+
+  before do
+    allow(Knowledge::PdfImports::Parser).to receive(:call).and_return(document)
+    allow(Knowledge::PdfImports::Chunker).to receive(:call).and_return(chunks)
+  end
+
+  it "creates a marketplace entry with prompt-ready imported content" do
+    entry = described_class.call(
+      account: account,
+      actor: actor,
+      params: {
+        name: "Modern CSS Coach",
+        entry_type: "skill",
+        description: "",
+        usage_guidance: "",
+        tags_csv: "css,frontend",
+        status: "active",
+        pdf_file: file
+      }
+    )
+
+    expect(entry).to be_persisted
+    expect(entry.current_version).to be_present
+    expect(entry.current_version.canonical_artifact.fetch("attachment_strategy")).to eq("prompt_append")
+    expect(entry.current_version.canonical_artifact.fetch("content")).to include("Reference material: Modern CSS")
+    expect(entry.current_version.canonical_artifact.fetch("content")).to include("Prefer grid and gap")
+  end
+end

--- a/spec/services/marketplace_entries/import_from_pdf_spec.rb
+++ b/spec/services/marketplace_entries/import_from_pdf_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe MarketplaceEntries::ImportFromPdf do
     instance_double(
       ActionDispatch::Http::UploadedFile,
       original_filename: "modern_css.pdf",
-      content_type: "application/pdf"
+      content_type: "application/pdf",
+      size: 1.megabyte
     )
   end
   let(:document) do
@@ -51,5 +52,17 @@ RSpec.describe MarketplaceEntries::ImportFromPdf do
     expect(entry.current_version.canonical_artifact.fetch("attachment_strategy")).to eq("prompt_append")
     expect(entry.current_version.canonical_artifact.fetch("content")).to include("Reference material: Modern CSS")
     expect(entry.current_version.canonical_artifact.fetch("content")).to include("Prefer grid and gap")
+  end
+
+  it "rejects oversized PDFs" do
+    allow(file).to receive(:size).and_return(51.megabytes)
+
+    expect {
+      described_class.call(
+        account: account,
+        actor: actor,
+        params: { pdf_file: file }
+      )
+    }.to raise_error(described_class::ImportError, "PDF must be smaller than 50 MB.")
   end
 end


### PR DESCRIPTION
## Summary

Implemented PDF import for both project knowledge and the team marketplace, including PDF parsing/chunking, artifact creation, summary chunk generation, embedding job enqueueing, UI entry points, paid-plan gating, and prompt-context retrieval support for imported document knowledge. I also added screenshot target coverage for the new import pages so the existing UI-change guard stays green.

Validation passed with `bundle exec rubocop` and `bundle exec rspec` on the full repo. The changes are committed as `7fe9c0b` with message `feat(knowledge): import PDFs into project and marketplace contexts`. The worktree is clean.

---

Closes #2284