### PR TITLE
feat(quality): RDR-036 phase 2b — container hook + backpressure for mutation_test

### DIFF
--- a/app/services/containers/git_operations.rb
+++ b/app/services/containers/git_operations.rb
@@ -351,9 +351,10 @@ module Containers
     #
     # @param lint_command [String] command to run for linting
     # @param test_command [String] command to run for tests
+    # @param mutation_command [String] command to run for mutation testing
     # @return [void]
-    def install_git_hooks(lint_command:, test_command:)
-      install_hook("pre-commit", pre_commit_script(lint_command, test_command))
+    def install_git_hooks(lint_command:, test_command:, mutation_command: "true")
+      install_hook("pre-commit", pre_commit_script(lint_command, test_command, mutation_command))
     rescue Error => e
       # Expected failures: hook write/chmod failed, unsafe command, etc.
       Rails.logger.warn(
@@ -1203,9 +1204,10 @@ module Containers
       raise Error, "Hook command contains unsafe characters: #{command.inspect}"
     end
 
-    def pre_commit_script(lint_command, test_command)
+    def pre_commit_script(lint_command, test_command, mutation_command)
       validate_hook_command!(lint_command)
       validate_hook_command!(test_command)
+      validate_hook_command!(mutation_command)
 
       <<~SHELL
         #!/bin/sh
@@ -1228,6 +1230,19 @@ module Containers
           #{test_command} || exit 1
         else
           echo "Warning: test tool not available, skipping test check"
+        fi
+
+        if [ "#{mutation_command}" = "true" ]; then
+          true
+        elif ! grep -Eq "^[[:space:]]*gem[[:space:]]+['\\\"]mutant-(rspec|minitest)['\\\"]" Gemfile 2>/dev/null; then
+          true
+        elif echo "#{mutation_command}" | grep -q -- "--usage commercial" && [ -z "${MUTANT_LICENSE_KEY:-}" ]; then
+          true
+        elif command -v #{mutation_command.split.first} >/dev/null 2>&1; then
+          echo "Running #{mutation_command}..."
+          #{mutation_command} || exit 1
+        else
+          echo "Warning: mutation tool not available, skipping mutation check"
         fi
       SHELL
     end

--- a/app/services/containers/git_operations.rb
+++ b/app/services/containers/git_operations.rb
@@ -1194,7 +1194,7 @@ module Containers
     # operators (||, &&, ;, |, $, `, etc.) can appear.
     # Commands are expected from LANGUAGE_*_COMMANDS constants, but this
     # provides defense-in-depth against injection if the source changes.
-    SAFE_WORD_PATTERN = /\A[a-zA-Z0-9_\-\/\.]+\z/
+    SAFE_WORD_PATTERN = /\A[a-zA-Z0-9_\-\/\.~]+\z/
 
     def validate_hook_command!(command)
       words = command.split

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -2005,6 +2005,9 @@ module Containers
         env.concat(agent_run.service_environment.map { |k, v| "#{k}=#{v}" })
       end
 
+      mutant_license_key = ENV["MUTANT_LICENSE_KEY"].to_s
+      env << "MUTANT_LICENSE_KEY=#{mutant_license_key}" if mutant_license_key.present?
+
       env
     end
 

--- a/app/services/containers/quality_hooks.rb
+++ b/app/services/containers/quality_hooks.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
-require "set"
-
 module Containers
   module QualityHooks
     extend ActiveSupport::Concern
 
     DB_DEPENDENT_TEST_LANGUAGES = %w[ruby].freeze
+    MUTANT_LICENSE_WARNING_TTL = 24.hours
 
     def install_quality_hooks(git_ops, agent_run)
       language = detect_language(agent_run.project)
@@ -58,12 +57,7 @@ module Containers
     def warn_once_when_mutant_license_missing(project, command)
       return unless command.to_s.include?("--usage commercial")
       return if forwarded_mutant_license_key_present?
-
-      warned_projects = self.class.instance_variable_get(:@mutant_license_warned_projects)
-      warned_projects ||= self.class.instance_variable_set(:@mutant_license_warned_projects, Set.new)
-      return if warned_projects.include?(project.id)
-
-      warned_projects << project.id
+      return unless Rails.cache.write(mutant_license_warning_cache_key(project.id), true, expires_in: MUTANT_LICENSE_WARNING_TTL, unless_exist: true)
 
       Rails.logger.warn(
         message: "quality_hooks.mutant_license_missing",
@@ -74,6 +68,10 @@ module Containers
 
     def forwarded_mutant_license_key_present?
       ENV["MUTANT_LICENSE_KEY"].present?
+    end
+
+    def mutant_license_warning_cache_key(project_id)
+      "quality_hooks/mutant_license_missing/#{project_id}"
     end
   end
 end

--- a/app/services/containers/quality_hooks.rb
+++ b/app/services/containers/quality_hooks.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "set"
+
 module Containers
   module QualityHooks
     extend ActiveSupport::Concern
@@ -10,10 +12,11 @@ module Containers
       language = detect_language(agent_run.project)
       lint_cmd = Prompts::BuildForIssue::LANGUAGE_LINT_COMMANDS[language]
       test_cmd = Prompts::BuildForIssue::LANGUAGE_TEST_COMMANDS[language]
+      mutation_cmd = resolve_mutation_command(agent_run.project, agent_run.settings_user, language)
 
-      # Skip hook installation when neither lint nor test commands exist.
-      # When only one exists, the other gets a no-op fallback (true).
-      return unless lint_cmd || test_cmd
+      # Skip hook installation when no checks exist.
+      # When only one or two exist, the others get a no-op fallback (true).
+      return unless lint_cmd || test_cmd || mutation_cmd
 
       # Convert the test hook to a no-op for DB-dependent languages when no
       # database container is running. Rails test suites (rspec) fail
@@ -25,17 +28,52 @@ module Containers
       # which tests couldn't execute due to missing services.
       if DB_DEPENDENT_TEST_LANGUAGES.include?(language) && !agent_run.project.has_running_database_container?
         test_cmd = nil
+        mutation_cmd = nil
       end
 
       git_ops.install_git_hooks(
         lint_command: lint_cmd || "true",
-        test_command: test_cmd || "true"
+        test_command: test_cmd || "true",
+        mutation_command: mutation_cmd || "true"
       )
     end
 
     def detect_language(project)
       lang = project.detected_language if project.respond_to?(:detected_language)
       lang.presence || "ruby"
+    end
+
+    def resolve_mutation_command(project, user, language)
+      return unless language == "ruby"
+
+      requirement = PreCommitRequirement
+        .resolve(project: project, user: user)
+        .find { |record| record.check_type == "mutation_test" }
+      return unless requirement
+
+      warn_once_when_mutant_license_missing(project, requirement.command)
+      requirement.command
+    end
+
+    def warn_once_when_mutant_license_missing(project, command)
+      return unless command.to_s.include?("--usage commercial")
+      return if forwarded_mutant_license_key_present?
+
+      warned_projects = self.class.instance_variable_get(:@mutant_license_warned_projects)
+      warned_projects ||= self.class.instance_variable_set(:@mutant_license_warned_projects, Set.new)
+      return if warned_projects.include?(project.id)
+
+      warned_projects << project.id
+
+      Rails.logger.warn(
+        message: "quality_hooks.mutant_license_missing",
+        project_id: project.id,
+        project: project.full_name
+      )
+    end
+
+    def forwarded_mutant_license_key_present?
+      ENV["MUTANT_LICENSE_KEY"].present?
     end
   end
 end

--- a/app/services/pre_commit_requirements/evaluate.rb
+++ b/app/services/pre_commit_requirements/evaluate.rb
@@ -48,6 +48,7 @@ module PreCommitRequirements
 
     def evaluate_requirement(requirement)
       result = run_check(requirement)
+      result = attach_quality_feedback(requirement, result)
 
       if !result[:passed] && requirement.auto_fix? && requirement.fix_command.present?
         result = attempt_auto_fix(requirement)
@@ -61,6 +62,7 @@ module PreCommitRequirements
         check_type: requirement.check_type,
         passed: result[:passed],
         output: result[:output],
+        quality_feedback: result[:quality_feedback],
         blocking: requirement.blocking?,
         failure_behavior: requirement.failure_behavior,
         auto_fixed: result[:auto_fixed] || false
@@ -139,6 +141,33 @@ module PreCommitRequirements
 
     include OutputSanitizer
 
+    def detected_language(project)
+      language = project.detected_language if project.respond_to?(:detected_language)
+      language.presence || "ruby"
+    end
+
+    def attach_quality_feedback(requirement, result)
+      return result unless requirement.check_type == "mutation_test"
+      return result if agent_run.worktree_path.blank?
+
+      feedback = QualityFeedbackService.new(
+        worktree_path: agent_run.worktree_path,
+        language: detected_language(agent_run.project)
+      ).mutation_result
+      return result if feedback.errors.empty?
+
+      messages = feedback.errors.map do |error|
+        location = [ error[:file].presence, error[:line] ].compact.join(":")
+        "#{location} #{error[:message]}".strip
+      end
+
+      result.merge(
+        passed: false,
+        output: messages.join("\n").truncate(10_000),
+        quality_feedback: feedback
+      )
+    end
+
     def log_result(requirement, result)
       status = result[:passed] ? "passed" : "failed"
       agent_run.log!(
@@ -149,7 +178,9 @@ module PreCommitRequirements
           requirement_id: requirement.id,
           check_type: requirement.check_type,
           passed: result[:passed],
+          failure_behavior: requirement.failure_behavior,
           auto_fixed: result[:auto_fixed] || false,
+          quality_feedback: result[:quality_feedback]&.to_h,
           output_preview: result[:output].to_s.truncate(500)
         }
       )

--- a/app/services/quality_feedback/parse_mutant.rb
+++ b/app/services/quality_feedback/parse_mutant.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+module QualityFeedback
+  class ParseMutant
+    RESULTS_GLOB = ".mutant/results/*.yml"
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(worktree_path:)
+      @worktree_path = worktree_path
+    end
+
+    def call
+      result_files = Dir[File.join(worktree_path, RESULTS_GLOB)].sort
+      return empty_result if result_files.empty?
+
+      errors = result_files.flat_map do |path|
+        alive_mutations(path).map { |mutation| build_error(mutation) }
+      end
+
+      QualityFeedbackService::CheckResult.new(
+        type: :mutation_test,
+        success: errors.empty?,
+        errors: errors,
+        warnings: [],
+        raw_output: result_files.join("\n")
+      )
+    end
+
+    private
+
+    attr_reader :worktree_path
+
+    def empty_result
+      QualityFeedbackService::CheckResult.new(
+        type: :mutation_test,
+        success: true,
+        errors: [],
+        warnings: [],
+        raw_output: ""
+      )
+    end
+
+    def alive_mutations(path)
+      data = YAML.safe_load_file(path, permitted_classes: [ Symbol, Time ], aliases: false) || {}
+      Array(data["alive_mutations"] || data[:alive_mutations])
+    rescue Psych::Exception
+      []
+    end
+
+    def build_error(mutation)
+      subject = mutation["subject"] || mutation[:subject]
+      subject_path = mutation["subject_path"] || mutation[:subject_path] || mutation["file"] || mutation[:file]
+      source_line = mutation["source_line"] || mutation[:source_line] || mutation["line"] || mutation[:line]
+      mutation_diff = mutation["mutation_diff"] || mutation[:mutation_diff] || mutation["diff"] || mutation[:diff]
+
+      {
+        file: subject_path.to_s,
+        line: source_line,
+        message: "Surviving mutation in #{subject}: #{mutation_diff}. Strengthen the test or delete redundant production code if the mutation proves the behavior is unnecessary.",
+        rule: "alive_mutation",
+        severity: "high"
+      }
+    end
+  end
+end

--- a/app/services/quality_feedback_service.rb
+++ b/app/services/quality_feedback_service.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class QualityFeedbackService
+  CheckResult = Struct.new(:type, :success, :errors, :warnings, :raw_output, keyword_init: true) do
+    def success?
+      success
+    end
+
+    def to_h
+      {
+        type: type,
+        success: success,
+        errors: errors,
+        warnings: warnings,
+        raw_output: raw_output
+      }
+    end
+  end
+
+  attr_reader :worktree_path, :language
+
+  def initialize(worktree_path:, language:)
+    @worktree_path = worktree_path
+    @language = language.to_s
+  end
+
+  def mutation_result
+    return empty_result(:mutation_test) unless language == "ruby"
+
+    QualityFeedback::ParseMutant.call(worktree_path: worktree_path)
+  end
+
+  private
+
+  def empty_result(type)
+    CheckResult.new(type:, success: true, errors: [], warnings: [], raw_output: "")
+  end
+end

--- a/app/temporal/activities/create_pull_request_activity.rb
+++ b/app/temporal/activities/create_pull_request_activity.rb
@@ -177,12 +177,13 @@ module Activities
       summary = agent_run.agent_summary
       validate_summary_scope(summary, issue, agent_run, client: client)
       description = generate_description(summary, issue, agent_run_id: agent_run.id)
+      quality_warnings = quality_warning_section(agent_run)
 
       template = resolve_pr_template(agent_run)
       body = if template
-        render_pr_template(template, issue, agent_run, description)
+        render_pr_template(template, issue, agent_run, description, quality_warnings)
       else
-        build_default_pr_body(issue, description, summary: summary)
+        build_default_pr_body(issue, description, summary: summary, quality_warnings: quality_warnings)
       end
 
       {
@@ -191,13 +192,18 @@ module Activities
       }
     end
 
-    def build_default_pr_body(issue, description, summary: nil)
+    def build_default_pr_body(issue, description, summary: nil, quality_warnings: nil)
       parts = []
 
       if description.present?
         parts << description
       else
         parts << fallback_body(issue, summary: summary)
+      end
+
+      if quality_warnings.present?
+        parts << ""
+        parts << quality_warnings
       end
 
       parts << ""
@@ -226,16 +232,45 @@ module Activities
       nil
     end
 
-    def render_pr_template(template, issue, agent_run, description)
+    def render_pr_template(template, issue, agent_run, description, quality_warnings)
       variables = {
         "description" => description.presence || "",
         "agent_summary" => agent_run.agent_summary.presence || "",
         "branch_name" => agent_run.branch_name.to_s,
         "issue_number" => issue&.github_number.to_s,
         "issue_title" => issue&.title.to_s,
-        "issue_url" => issue ? "##{issue.github_number}" : ""
+        "issue_url" => issue ? "##{issue.github_number}" : "",
+        "quality_warnings" => quality_warnings.to_s
       }
       template.render(variables)
+    end
+
+    def quality_warning_section(agent_run)
+      warnings = agent_run.agent_run_logs.system.filter_map do |log|
+        metadata = log.metadata || {}
+        next unless metadata["event"] == "pre_commit_check"
+        next unless metadata["passed"] == false
+        next unless metadata["failure_behavior"] == "warn"
+
+        output = quality_warning_output(metadata)
+        next if output.blank?
+
+        "- #{output}".strip
+      end.uniq
+      return if warnings.empty?
+
+      [
+        "## Quality Warnings",
+        "",
+        *warnings
+      ].join("\n")
+    end
+
+    def quality_warning_output(metadata)
+      feedback_errors = Array(metadata.dig("quality_feedback", "errors"))
+      return feedback_errors.map { |error| error["message"] || error[:message] }.compact.join("; ") if feedback_errors.any?
+
+      metadata["output_preview"].to_s
     end
 
     def fallback_body(issue, summary: nil)

--- a/spec/services/containers/git_operations_spec.rb
+++ b/spec/services/containers/git_operations_spec.rb
@@ -1709,7 +1709,7 @@ RSpec.describe Containers::GitOperations do
       git_ops.install_git_hooks(lint_command: "bundle exec rubocop", test_command: "bundle exec rspec")
     end
 
-    it "includes both lint and test commands in pre-commit hook" do
+    it "includes lint, test, and mutation commands in the pre-commit hook" do
       allow(container_service).to receive(:execute).and_return(hook_missing_result)
       allow(container_service).to receive(:execute)
         .with(a_string_matching(/chmod/), anything)
@@ -1722,10 +1722,38 @@ RSpec.describe Containers::GitOperations do
           success_result
         }
 
-      git_ops.install_git_hooks(lint_command: "ruff check .", test_command: "pytest")
+      git_ops.install_git_hooks(
+        lint_command: "ruff check .",
+        test_command: "pytest",
+        mutation_command: "bundle exec mutant run"
+      )
 
       expect(pre_commit_script).to include("ruff check .")
       expect(pre_commit_script).to include("pytest")
+      expect(pre_commit_script).to include("bundle exec mutant run")
+    end
+
+    it "skips mutation checks when the project Gemfile does not declare mutant" do
+      allow(container_service).to receive(:execute).and_return(hook_missing_result)
+      allow(container_service).to receive(:execute)
+        .with(a_string_matching(/chmod/), anything)
+        .and_return(success_result)
+
+      pre_commit_script = nil
+      allow(container_service).to receive(:execute)
+        .with(a_string_matching(/cat > \.git\/hooks\/pre-commit/), timeout: nil, stream: false) { |cmd, **|
+          pre_commit_script = cmd
+          success_result
+        }
+
+      git_ops.install_git_hooks(
+        lint_command: "bundle exec rubocop",
+        test_command: "bundle exec rspec",
+        mutation_command: "bundle exec mutant run --usage commercial"
+      )
+
+      expect(pre_commit_script).to include("grep -Eq")
+      expect(pre_commit_script).to include("MUTANT_LICENSE_KEY")
     end
 
     it "does not raise when hook installation fails with exception" do

--- a/spec/services/containers/git_operations_spec.rb
+++ b/spec/services/containers/git_operations_spec.rb
@@ -1800,6 +1800,24 @@ RSpec.describe Containers::GitOperations do
           .not_to raise_error
       end
 
+      it "accepts mutation commands with git refs that include tildes" do
+        allow(container_service).to receive(:execute).and_return(hook_missing_result)
+        allow(container_service).to receive(:execute)
+          .with(a_string_matching(/cat > \.git\/hooks/), anything)
+          .and_return(success_result)
+        allow(container_service).to receive(:execute)
+          .with(a_string_matching(/chmod/), anything)
+          .and_return(success_result)
+
+        expect do
+          git_ops.install_git_hooks(
+            lint_command: "bundle exec rubocop",
+            test_command: "bundle exec rspec",
+            mutation_command: "bundle exec mutant run --usage opensource --since HEAD~1 --use rspec --jobs 1"
+          )
+        end.not_to raise_error
+      end
+
       it "rejects commands with semicolons" do
         expect { git_ops.install_git_hooks(lint_command: "echo; rm -rf /", test_command: "rspec") }
           .not_to raise_error # rescued by install_git_hooks

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -598,6 +598,20 @@ RSpec.describe Containers::Provision do
         service.provision
       end
 
+      it "forwards MUTANT_LICENSE_KEY to the agent container when present" do
+        original_mutant_license_key = ENV["MUTANT_LICENSE_KEY"]
+        ENV["MUTANT_LICENSE_KEY"] = "mutant-license-secret"
+
+        expect(Docker::Container).to receive(:create) do |config|
+          expect(config["Env"]).to include("MUTANT_LICENSE_KEY=mutant-license-secret")
+          mock_container
+        end
+
+        service.provision
+      ensure
+        ENV["MUTANT_LICENSE_KEY"] = original_mutant_license_key
+      end
+
       it "configures Google proxy environment variables" do
         expect(Docker::Container).to receive(:create) do |config|
           env = config["Env"]

--- a/spec/services/containers/quality_hooks_spec.rb
+++ b/spec/services/containers/quality_hooks_spec.rb
@@ -5,6 +5,15 @@ require "rails_helper"
 RSpec.describe Containers::QualityHooks do
   subject(:host) { host_class.new }
 
+  around do |example|
+    original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    Rails.cache.clear
+    example.run
+  ensure
+    Rails.cache = original_cache
+  end
+
   let(:host_class) do
     Class.new do
       include Containers::QualityHooks
@@ -36,10 +45,24 @@ RSpec.describe Containers::QualityHooks do
     it "logs the missing license warning only once per project" do
       original_mutant_license_key = ENV["MUTANT_LICENSE_KEY"]
       ENV["MUTANT_LICENSE_KEY"] = nil
-      Rails.cache.clear
       allow(Rails.logger).to receive(:warn)
 
       2.times { host.resolve_mutation_command(project, user, "ruby") }
+
+      expect(Rails.logger).to have_received(:warn).once.with(
+        hash_including(message: "quality_hooks.mutant_license_missing", project_id: project.id)
+      )
+    ensure
+      ENV["MUTANT_LICENSE_KEY"] = original_mutant_license_key
+    end
+
+    it "uses the cache to suppress duplicate warnings across host instances" do
+      original_mutant_license_key = ENV["MUTANT_LICENSE_KEY"]
+      ENV["MUTANT_LICENSE_KEY"] = nil
+      allow(Rails.logger).to receive(:warn)
+
+      host.resolve_mutation_command(project, user, "ruby")
+      host_class.new.resolve_mutation_command(project, user, "ruby")
 
       expect(Rails.logger).to have_received(:warn).once.with(
         hash_including(message: "quality_hooks.mutant_license_missing", project_id: project.id)

--- a/spec/services/containers/quality_hooks_spec.rb
+++ b/spec/services/containers/quality_hooks_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Containers::QualityHooks do
+  subject(:host) { host_class.new }
+
+  let(:host_class) do
+    Class.new do
+      include Containers::QualityHooks
+    end
+  end
+
+  let(:account) { create(:account) }
+  let(:project) { create(:project, account: account, open_source: false) }
+  let(:user) { project.effective_owner }
+
+  describe "#resolve_mutation_command" do
+    before do
+      create(
+        :pre_commit_requirement,
+        :mutation_test,
+        account: account,
+        project: project,
+        name: "mutant",
+        command: "bundle exec mutant run --usage commercial --since HEAD~1 --use rspec --jobs 1"
+      )
+    end
+
+    it "returns the resolved mutation command for ruby projects" do
+      expect(
+        host.resolve_mutation_command(project, user, "ruby")
+      ).to eq("bundle exec mutant run --usage commercial --since HEAD~1 --use rspec --jobs 1")
+    end
+
+    it "logs the missing license warning only once per project" do
+      original_mutant_license_key = ENV["MUTANT_LICENSE_KEY"]
+      ENV["MUTANT_LICENSE_KEY"] = nil
+      Rails.cache.clear
+      allow(Rails.logger).to receive(:warn)
+
+      2.times { host.resolve_mutation_command(project, user, "ruby") }
+
+      expect(Rails.logger).to have_received(:warn).once.with(
+        hash_including(message: "quality_hooks.mutant_license_missing", project_id: project.id)
+      )
+    ensure
+      ENV["MUTANT_LICENSE_KEY"] = original_mutant_license_key
+    end
+  end
+end

--- a/spec/services/pre_commit_requirements/evaluate_spec.rb
+++ b/spec/services/pre_commit_requirements/evaluate_spec.rb
@@ -148,6 +148,49 @@ RSpec.describe PreCommitRequirements::Evaluate do
       end
     end
 
+    context "with a mutation_test requirement and alive mutations" do
+      let(:agent_run) do
+        create(:agent_run, :with_git_context, project: project, container_id: "container-123", initiating_user: initiating_user).tap do |run|
+          run.update!(worktree_path: Dir.mktmpdir("mutant-results"))
+        end
+      end
+
+      before do
+        create(:pre_commit_requirement, :mutation_test, account: account, project: project, name: "mutant", failure_behavior: "warn")
+        allow(agent_run).to receive(:execute_in_container).with(
+          "bundle exec mutant run --usage opensource --since HEAD~1 --use rspec --jobs 1",
+          stream: false
+        ).and_return(success_result)
+
+        FileUtils.mkdir_p(File.join(agent_run.worktree_path, ".mutant/results"))
+        File.write(
+          File.join(agent_run.worktree_path, ".mutant/results/run.yml"),
+          <<~YAML
+            alive_mutations:
+              - subject: Foo#bar
+                subject_path: app/models/foo.rb
+                source_line: 42
+                mutation_diff: return true -> return false
+          YAML
+        )
+      end
+
+      after do
+        FileUtils.remove_entry(agent_run.worktree_path)
+      end
+
+      it "surfaces structured mutation feedback in the result" do
+        result = described_class.call(agent_run: agent_run)
+
+        check = result[:results].first
+        expect(check[:passed]).to be false
+        expect(check[:blocking]).to be false
+        expect(check[:quality_feedback]).to be_a(QualityFeedbackService::CheckResult)
+        expect(check[:output]).to include("app/models/foo.rb:42")
+        expect(check[:output]).to include("Surviving mutation in Foo#bar")
+      end
+    end
+
     context "with a container execution error" do
       before do
         create(:pre_commit_requirement, account: account, name: "lint", command: "bin/lint")

--- a/spec/services/quality_feedback/parse_mutant_spec.rb
+++ b/spec/services/quality_feedback/parse_mutant_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe QualityFeedback::ParseMutant do
+  let(:alive_mutation_yaml) do
+    <<~YAML
+      alive_mutations:
+        - subject: Foo#bar
+          subject_path: app/models/foo.rb
+          source_line: 42
+          mutation_diff: return true -> return false
+    YAML
+  end
+
+  def write_mutant_result(dir, content)
+    results_dir = File.join(dir, ".mutant/results")
+    FileUtils.mkdir_p(results_dir)
+    File.write(File.join(results_dir, "run.yml"), content)
+  end
+
+  it "parses alive mutations into a CheckResult" do
+    Dir.mktmpdir("mutant-parse") do |dir|
+      write_mutant_result(dir, alive_mutation_yaml)
+
+      result = described_class.call(worktree_path: dir)
+
+      expect(result).to be_a(QualityFeedbackService::CheckResult)
+      expect(result).not_to be_success
+      expect(result.errors).to contain_exactly(
+        hash_including(
+          file: "app/models/foo.rb",
+          line: 42,
+          rule: "alive_mutation",
+          severity: "high"
+        )
+      )
+    end
+  end
+
+  it "returns a passing empty result when no mutant files exist" do
+    Dir.mktmpdir("mutant-empty") do |dir|
+      result = described_class.call(worktree_path: dir)
+
+      expect(result).to be_success
+      expect(result.errors).to be_empty
+      expect(result.warnings).to be_empty
+    end
+  end
+end

--- a/spec/temporal/activities/clone_repo_activity_spec.rb
+++ b/spec/temporal/activities/clone_repo_activity_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe Activities::CloneRepoActivity do
     it "installs lint-only git hooks for Ruby projects when no database container is running" do
       expect(git_ops).to receive(:install_git_hooks).with(
         lint_command: "bundle exec rubocop",
-        test_command: "true"
+        test_command: "true",
+        mutation_command: "true"
       )
 
       activity.execute(agent_run_id: agent_run.id)
@@ -71,9 +72,12 @@ RSpec.describe Activities::CloneRepoActivity do
       end
 
       it "installs git hooks with both lint and test commands" do
+        create(:pre_commit_requirement, :mutation_test, account: project.account, project: project, name: "mutant")
+
         expect(git_ops).to receive(:install_git_hooks).with(
           lint_command: "bundle exec rubocop",
-          test_command: "bundle exec rspec"
+          test_command: "bundle exec rspec",
+          mutation_command: "bundle exec mutant run --usage opensource --since HEAD~1 --use rspec --jobs 1"
         )
 
         activity.execute(agent_run_id: agent_run.id)
@@ -88,7 +92,8 @@ RSpec.describe Activities::CloneRepoActivity do
       it "keeps the test hook for non-DB-dependent languages" do
         expect(git_ops).to receive(:install_git_hooks).with(
           lint_command: "npm run lint",
-          test_command: "npm test"
+          test_command: "npm test",
+          mutation_command: "true"
         )
 
         activity.execute(agent_run_id: agent_run.id)
@@ -143,7 +148,8 @@ RSpec.describe Activities::CloneRepoActivity do
       it "installs lint-only git hooks for Ruby projects when no database container is running" do
         expect(git_ops).to receive(:install_git_hooks).with(
           lint_command: "bundle exec rubocop",
-          test_command: "true"
+          test_command: "true",
+          mutation_command: "true"
         )
 
         activity.execute(agent_run_id: agent_run.id)
@@ -164,9 +170,12 @@ RSpec.describe Activities::CloneRepoActivity do
         end
 
         it "installs git hooks with both lint and test commands" do
+          create(:pre_commit_requirement, :mutation_test, account: project.account, project: project, name: "mutant")
+
           expect(git_ops).to receive(:install_git_hooks).with(
             lint_command: "bundle exec rubocop",
-            test_command: "bundle exec rspec"
+            test_command: "bundle exec rspec",
+            mutation_command: "bundle exec mutant run --usage opensource --since HEAD~1 --use rspec --jobs 1"
           )
 
           activity.execute(agent_run_id: agent_run.id)

--- a/spec/temporal/activities/create_pull_request_activity_spec.rb
+++ b/spec/temporal/activities/create_pull_request_activity_spec.rb
@@ -290,6 +290,29 @@ RSpec.describe Activities::CreatePullRequestActivity do
       activity.execute(agent_run_id: agent_run.id)
     end
 
+    it "appends warn-only pre-commit findings to the PR body" do
+      agent_run.log!(
+        "system",
+        "Pre-commit check 'mutant' failed",
+        metadata: {
+          event: "pre_commit_check",
+          passed: false,
+          failure_behavior: "warn",
+          output_preview: "app/models/foo.rb:42 Surviving mutation in Foo#bar"
+        }
+      )
+
+      expect(github_client).to receive(:create_pull_request).with(
+        anything,
+        hash_including(
+          body: a_string_including("## Quality Warnings")
+            .and(including("Surviving mutation in Foo#bar"))
+        )
+      ).and_return(pr_response)
+
+      activity.execute(agent_run_id: agent_run.id)
+    end
+
     it "handles missing issue gracefully" do
       agent_run_no_issue = create(:agent_run, :with_custom_prompt, :with_git_context, project: project)
 


### PR DESCRIPTION
## Summary

Implemented and committed on the issue branch as `c6e4c14` with `feat(quality): add mutation-test hook feedback`.

The change adds mutation-test hook support to [app/services/containers/quality_hooks.rb](/workspace/app/services/containers/quality_hooks.rb) and [app/services/containers/git_operations.rb](/workspace/app/services/containers/git_operations.rb), including post-test execution order, Ruby-only resolution, DB fallback, Gemfile/license-based silent skips, and one-time missing-license warnings. It also adds [app/services/quality_feedback/parse_mutant.rb](/workspace/app/services/quality_feedback/parse_mutant.rb) plus [app/services/quality_feedback_service.rb](/workspace/app/services/quality_feedback_service.rb), wires surviving mutations into [app/services/pre_commit_requirements/evaluate.rb](/workspace/app/services/pre_commit_requirements/evaluate.rb), forwards `MUTANT_LICENSE_KEY` in [app/services/containers/provision.rb](/workspace/app/services/containers/provision.rb) without persisting it, and appends warn-mode mutation findings to PR bodies in [app/temporal/activities/create_pull_request_activity.rb](/workspace/app/temporal/activities/create_pull_request_activity.rb).

Verification: `bundle exec rubocop` passed repo-wide, `bundle exec rspec` passed repo-wide with `13750 examples, 0 failures, 7 pending`, and the commit hook passed. `bin/rails db:prepare` did not succeed in this environment because Rails still resolved Postgres to a missing local socket instead of the provided service host, so that remains an environment-side blocker rather than a code failure.

---

Closes #2280