### PR TITLE
feat(quality): RDR-036 phase 3b — nightly mutation sweep job + dashboard widget

### DIFF
--- a/app/jobs/scheduled_mutation_sweep_job.rb
+++ b/app/jobs/scheduled_mutation_sweep_job.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+class ScheduledMutationSweepJob < ApplicationJob
+  include GoodJob::ActiveJobExtensions::Concurrency
+  include Containers::QualityHooks
+
+  queue_as :metrics
+
+  good_job_control_concurrency_with(total_limit: 1)
+
+  def perform(project_id: nil, sweep_date: Date.current.iso8601)
+    @sweep_date = Date.iso8601(sweep_date)
+
+    project = project_id ? eligible_project(project_id) : next_project
+    return unless project
+
+    run_project_sweep(project)
+    enqueue_next_project
+  end
+
+  private
+
+  attr_reader :sweep_date
+
+  def eligible_projects
+    Project
+      .joins(:pre_commit_requirements)
+      .merge(PreCommitRequirement.enabled.where(check_type: "mutation_test"))
+      .distinct
+      .order(:id)
+  end
+
+  def eligible_project(project_id)
+    project = eligible_projects.find_by(id: project_id)
+    return unless project
+    return unless ruby_project?(project)
+    return if swept_on_date?(project)
+
+    project
+  end
+
+  def next_project
+    eligible_projects.find do |project|
+      ruby_project?(project) && !swept_on_date?(project)
+    end
+  end
+
+  def ruby_project?(project)
+    detect_language(project) == "ruby"
+  end
+
+  def swept_on_date?(project)
+    QualityMetric.by_project(project.id)
+      .scheduled_mutation_sweep
+      .where(created_at: sweep_date.all_day)
+      .exists?
+  end
+
+  def run_project_sweep(project)
+    MutationSweeps::Run.call(project:, sweep_date:)
+  rescue StandardError => e
+    Rails.logger.warn(
+      message: "scheduled_mutation_sweep.project_failed",
+      project_id: project.id,
+      error_class: e.class.name,
+      error: e.message,
+      sweep_date: sweep_date.iso8601
+    )
+  end
+
+  def enqueue_next_project
+    self.class.perform_later(sweep_date: sweep_date.iso8601) if next_project
+  end
+end

--- a/app/jobs/scheduled_mutation_sweep_job.rb
+++ b/app/jobs/scheduled_mutation_sweep_job.rb
@@ -8,14 +8,19 @@ class ScheduledMutationSweepJob < ApplicationJob
 
   good_job_control_concurrency_with(total_limit: 1)
 
-  def perform(project_id: nil, sweep_date: Date.current.iso8601)
+  def perform(project_id: nil, sweep_date: Date.current.iso8601, attempted_project_ids: [])
     @sweep_date = Date.iso8601(sweep_date)
+    attempted_project_ids = attempted_project_ids.map(&:to_i)
 
-    project = project_id ? eligible_project(project_id) : next_project
+    project = if project_id
+      eligible_project(project_id, excluding_project_ids: attempted_project_ids)
+    else
+      next_project(excluding_project_ids: attempted_project_ids)
+    end
     return unless project
 
     run_project_sweep(project)
-    enqueue_next_project
+    enqueue_next_project(attempted_project_ids: attempted_project_ids | [ project.id ])
   end
 
   private
@@ -30,18 +35,19 @@ class ScheduledMutationSweepJob < ApplicationJob
       .order(:id)
   end
 
-  def eligible_project(project_id)
+  def eligible_project(project_id, excluding_project_ids: [])
     project = eligible_projects.find_by(id: project_id)
     return unless project
+    return if excluding_project_ids.include?(project.id)
     return unless ruby_project?(project)
     return if swept_on_date?(project)
 
     project
   end
 
-  def next_project
+  def next_project(excluding_project_ids: [])
     eligible_projects.find do |project|
-      ruby_project?(project) && !swept_on_date?(project)
+      !excluding_project_ids.include?(project.id) && ruby_project?(project) && !swept_on_date?(project)
     end
   end
 
@@ -68,7 +74,9 @@ class ScheduledMutationSweepJob < ApplicationJob
     )
   end
 
-  def enqueue_next_project
-    self.class.perform_later(sweep_date: sweep_date.iso8601) if next_project
+  def enqueue_next_project(attempted_project_ids:)
+    if next_project(excluding_project_ids: attempted_project_ids)
+      self.class.perform_later(sweep_date: sweep_date.iso8601, attempted_project_ids:)
+    end
   end
 end

--- a/app/models/quality_gate_threshold.rb
+++ b/app/models/quality_gate_threshold.rb
@@ -4,7 +4,7 @@ class QualityGateThreshold < ApplicationRecord
   has_logidze
   SEVERITIES = %w[info warning critical].freeze
   METRIC_KEYS = %w[composite_score pr_created ci_passed pr_merged iterations lint_clean
-                   tests_pass review_comment_count agent_rerun_count issue_created
+                   tests_pass mutation_kill_rate review_comment_count agent_rerun_count issue_created
                    reaction_score review_posted review_score].freeze
 
   belongs_to :project

--- a/app/models/quality_metric.rb
+++ b/app/models/quality_metric.rb
@@ -3,6 +3,9 @@
 class QualityMetric < ApplicationRecord
   METRIC_TYPES = %w[automated human].freeze
   FEEDBACK_SOURCES = %w[system pr_merge pr_reaction pr_review issue_reaction review_reaction enhance_issue_feedback webhook comment].freeze
+  SOURCES = %w[agent_run scheduled_mutation_sweep].freeze
+  AGENT_RUN_SOURCE = "agent_run"
+  SCHEDULED_MUTATION_SWEEP_SOURCE = "scheduled_mutation_sweep"
   MUTATION_KILL_RATE_WEIGHT = 0.10
 
   # Weights for composite quality score (PR creation goal).
@@ -95,6 +98,7 @@ class QualityMetric < ApplicationRecord
 
   validates :metric_type, presence: true, inclusion: { in: METRIC_TYPES }
   validates :feedback_source, inclusion: { in: FEEDBACK_SOURCES }, allow_nil: true
+  validates :source, presence: true, inclusion: { in: SOURCES }
   validates :composite_score,
     numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 1 },
     allow_nil: true
@@ -105,6 +109,8 @@ class QualityMetric < ApplicationRecord
 
   scope :automated, -> { where(metric_type: "automated") }
   scope :human, -> { where(metric_type: "human") }
+  scope :agent_run_source, -> { where(source: AGENT_RUN_SOURCE) }
+  scope :scheduled_mutation_sweep, -> { where(source: SCHEDULED_MUTATION_SWEEP_SOURCE) }
   scope :by_prompt_version, ->(prompt_version_id) { where(prompt_version_id: prompt_version_id) }
   scope :by_project, ->(project_id) { joins(:agent_run).where(agent_runs: { project_id: project_id }) }
   scope :by_time_period, ->(start_date, end_date) { where(created_at: start_date..end_date) }

--- a/app/models/quality_threshold.rb
+++ b/app/models/quality_threshold.rb
@@ -5,7 +5,7 @@ class QualityThreshold < ApplicationRecord
   DEFAULT_WINDOW_SIZE = 10
   DEFAULT_MIN_SAMPLE_SIZE = 3
   METRIC_TYPES = %w[composite_score pr_created ci_passed pr_merged iterations lint_clean
-                    tests_pass
+                    tests_pass mutation_kill_rate
                     review_comment_count agent_rerun_count issue_created
                     reaction_score review_posted review_score comment_posted
                     author_replied question_count].freeze

--- a/app/services/containers/quality_hooks.rb
+++ b/app/services/containers/quality_hooks.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "shellwords"
+
 module Containers
   module QualityHooks
     extend ActiveSupport::Concern
@@ -45,13 +47,19 @@ module Containers
     def resolve_mutation_command(project, user, language)
       return unless language == "ruby"
 
-      requirement = PreCommitRequirement
-        .resolve(project: project, user: user)
-        .find { |record| record.check_type == "mutation_test" }
+      requirement = resolve_mutation_requirement(project, user, language)
       return unless requirement
 
       warn_once_when_mutant_license_missing(project, requirement.command)
       requirement.command
+    end
+
+    def resolve_scheduled_mutation_command(project, user, language)
+      requirement = resolve_mutation_requirement(project, user, language)
+      return unless requirement
+
+      warn_once_when_mutant_license_missing(project, requirement.command)
+      scheduled_mutation_command(requirement.command)
     end
 
     def warn_once_when_mutant_license_missing(project, command)
@@ -72,6 +80,50 @@ module Containers
 
     def mutant_license_warning_cache_key(project_id)
       "quality_hooks/mutant_license_missing/#{project_id}"
+    end
+
+    private
+
+    def resolve_mutation_requirement(project, user, language)
+      return unless language == "ruby"
+
+      PreCommitRequirement
+        .resolve(project: project, user: user)
+        .find { |record| record.check_type == "mutation_test" }
+    end
+
+    def scheduled_mutation_command(command)
+      tokens = Shellwords.split(command.to_s)
+      return if tokens.empty?
+
+      normalized = []
+      jobs_overridden = false
+      index = 0
+
+      while index < tokens.length
+        token = tokens[index]
+
+        case token
+        when "--since"
+          index += 2
+        when /\A--since=/
+          index += 1
+        when "--jobs"
+          normalized.concat([ "--jobs", "1" ])
+          jobs_overridden = true
+          index += 2
+        when /\A--jobs=/
+          normalized.concat([ "--jobs", "1" ])
+          jobs_overridden = true
+          index += 1
+        else
+          normalized << token
+          index += 1
+        end
+      end
+
+      normalized.concat([ "--jobs", "1" ]) unless jobs_overridden
+      normalized.join(" ")
     end
   end
 end

--- a/app/services/containers/quality_hooks.rb
+++ b/app/services/containers/quality_hooks.rb
@@ -123,7 +123,7 @@ module Containers
       end
 
       normalized.concat([ "--jobs", "1" ]) unless jobs_overridden
-      normalized.join(" ")
+      Shellwords.join(normalized)
     end
   end
 end

--- a/app/services/mutation_sweeps/run.rb
+++ b/app/services/mutation_sweeps/run.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module MutationSweeps
+  class Run
+    include Containers::QualityHooks
+
+    SWEEP_TIMEOUT = 90.minutes
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(project:, sweep_date: Date.current)
+      @project = project
+      @sweep_date = sweep_date.to_date
+    end
+
+    def call
+      return unless command
+
+      agent_run = create_agent_run!
+
+      worktree_service.with_temporary_worktree(project.default_branch) do |worktree_path|
+        agent_run.update_columns(worktree_path: worktree_path)
+
+        Containers::Provision.with_container(agent_run:, worktree_path:) do |container|
+          container.execute(command, timeout: SWEEP_TIMEOUT, stream: true)
+        end
+
+        metric = record_metric!(agent_run:, worktree_path:)
+        finalize_agent_run!(agent_run, status: "completed")
+        metric
+      end
+    rescue StandardError => e
+      finalize_agent_run!(agent_run, status: "failed", error_message: e.message) if agent_run
+      raise
+    end
+
+    private
+
+    attr_reader :project, :sweep_date
+
+    def command
+      @command ||= resolve_scheduled_mutation_command(project, project.effective_owner, detect_language(project))
+    end
+
+    def worktree_service
+      @worktree_service ||= WorktreeService.new(project)
+    end
+
+    def create_agent_run!
+      AgentRun.create!(
+        project: project,
+        agent_type: "api",
+        status: "running",
+        goal: "create_pr",
+        focus: "general",
+        trigger_type: "automatic",
+        custom_prompt: "Scheduled mutation sweep against #{project.default_branch}",
+        started_at: Time.current
+      )
+    end
+
+    def record_metric!(agent_run:, worktree_path:)
+      results = MutantResultsReader.read(worktree_path)
+      raise "Scheduled mutation sweep produced no mutant results" unless results
+
+      total_mutations = results.fetch(:total_mutations)
+      raise "Scheduled mutation sweep reported zero total mutations" if total_mutations.zero?
+
+      killed_mutations = results.fetch(:killed_mutations)
+      kill_rate = (killed_mutations.to_f / total_mutations).round(4)
+
+      metric = QualityMetric.create!(
+        agent_run: agent_run,
+        metric_type: "automated",
+        feedback_source: "system",
+        source: QualityMetric::SCHEDULED_MUTATION_SWEEP_SOURCE,
+        mutation_kill_rate: kill_rate,
+        scores: { "mutation_kill_rate" => kill_rate },
+        metadata: {
+          "command" => command,
+          "sweep_date" => sweep_date.iso8601,
+          "total_mutations" => total_mutations,
+          "killed_mutations" => killed_mutations,
+          "source_path" => results[:source_path]
+        }
+      )
+
+      QualityMetrics::EvaluateGate.call(quality_metric: metric)
+      QualityAlerts::CheckGate.call(project: project) if project.quality_gates_enabled?
+      metric
+    end
+
+    def finalize_agent_run!(agent_run, status:, error_message: nil)
+      completed_at = Time.current
+      duration_seconds = if agent_run.started_at
+        (completed_at - agent_run.started_at).round
+      end
+
+      agent_run.update_columns(
+        status: status,
+        completed_at: completed_at,
+        duration_seconds: duration_seconds,
+        error_message: error_message
+      )
+    end
+  end
+end

--- a/app/services/mutation_sweeps/run.rb
+++ b/app/services/mutation_sweeps/run.rb
@@ -19,6 +19,7 @@ module MutationSweeps
       return unless command
 
       agent_run = create_agent_run!
+      metric_recorded = false
 
       worktree_service.with_temporary_worktree(project.default_branch) do |worktree_path|
         agent_run.update_columns(worktree_path: worktree_path)
@@ -28,10 +29,12 @@ module MutationSweeps
         end
 
         metric = record_metric!(agent_run:, worktree_path:)
+        metric_recorded = true
         finalize_agent_run!(agent_run, status: "completed")
         metric
       end
     rescue StandardError => e
+      record_failed_metric!(agent_run:, error: e) if agent_run && !metric_recorded
       finalize_agent_run!(agent_run, status: "failed", error_message: e.message) if agent_run
       raise
     end
@@ -90,6 +93,20 @@ module MutationSweeps
       QualityMetrics::EvaluateGate.call(quality_metric: metric)
       QualityAlerts::CheckGate.call(project: project) if project.quality_gates_enabled?
       metric
+    end
+
+    def record_failed_metric!(agent_run:, error:)
+      QualityMetric.find_or_create_by!(agent_run:, metric_type: "automated") do |metric|
+        metric.feedback_source = "system"
+        metric.source = QualityMetric::SCHEDULED_MUTATION_SWEEP_SOURCE
+        metric.metadata = {
+          "command" => command,
+          "sweep_date" => sweep_date.iso8601,
+          "failed" => true,
+          "error_class" => error.class.name,
+          "error_message" => error.message
+        }
+      end
     end
 
     def finalize_agent_run!(agent_run, status:, error_message: nil)

--- a/app/services/quality_metrics/collect.rb
+++ b/app/services/quality_metrics/collect.rb
@@ -40,6 +40,7 @@ module QualityMetrics
       automated_metric.assign_attributes(
         prompt_version: agent_run.prompt_version,
         feedback_source: "system",
+        source: QualityMetric::AGENT_RUN_SOURCE,
         scores: { "excluded_status" => agent_run.status },
         metadata: (automated_metric.metadata || {}).merge(
           score_metadata.merge(
@@ -60,6 +61,7 @@ module QualityMetrics
       automated_metric.assign_attributes(
         prompt_version: agent_run.prompt_version,
         feedback_source: "system",
+        source: QualityMetric::AGENT_RUN_SOURCE,
         mutation_kill_rate: mutation_kill_rate,
         scores: scores,
         metadata: (automated_metric.metadata || {}).merge(score_metadata),

--- a/app/services/quality_metrics/dashboard_stats.rb
+++ b/app/services/quality_metrics/dashboard_stats.rb
@@ -36,6 +36,7 @@ module QualityMetrics
         tier_breakdown: tier_breakdown,
         human_feedback: human_feedback,
         gate_status: gate_status,
+        mutation_testing: mutation_testing_data,
         metrics_reference: self.class.metrics_reference
       }
     end
@@ -137,7 +138,7 @@ module QualityMetrics
     private :compute_overview
 
     def export_data(limit: 10_000)
-      metrics_scope = QualityMetric.by_project(project.id)
+      metrics_scope = QualityMetric.by_project(project.id).agent_run_source
         .includes(:prompt_version, agent_run: :model_selection)
         .order(created_at: :desc)
         .limit(limit)
@@ -164,8 +165,68 @@ module QualityMetrics
     private
 
     def metrics
-      @metrics ||= QualityMetric.by_project(project.id).with_composite_score
+      @metrics ||= QualityMetric.by_project(project.id).agent_run_source.with_composite_score
         .joins(:agent_run).where(AgentRun.quality_scoreable_sql)
+    end
+
+    def mutation_testing_data
+      return unless mutation_testing_enabled?
+
+      latest_sweep = mutation_sweep_metrics.first
+
+      {
+        current_sweep_score: latest_sweep&.mutation_kill_rate&.to_f,
+        current_sweep_at: latest_sweep&.created_at,
+        trend_sparkline: mutation_sweep_trend,
+        run_histogram: agent_run_mutation_histogram
+      }
+    end
+
+    def mutation_testing_enabled?
+      @mutation_testing_enabled ||= PreCommitRequirement
+        .resolve(project: project, user: project.effective_owner)
+        .any? { |requirement| requirement.enabled? && requirement.check_type == "mutation_test" }
+    end
+
+    def mutation_sweep_metrics
+      @mutation_sweep_metrics ||= QualityMetric.by_project(project.id)
+        .scheduled_mutation_sweep
+        .automated
+        .where.not(mutation_kill_rate: nil)
+        .order(created_at: :desc)
+    end
+
+    def mutation_sweep_trend
+      mutation_sweep_metrics
+        .reorder(nil)
+        .where(created_at: 30.days.ago..)
+        .group("DATE(quality_metrics.created_at)")
+        .order(Arel.sql("DATE(quality_metrics.created_at) ASC"))
+        .average(:mutation_kill_rate)
+        .map { |date, score| [ date.iso8601, score.to_f.round(4) ] }
+    end
+
+    def agent_run_mutation_histogram
+      distribution = Array.new(10, 0)
+
+      QualityMetric.by_project(project.id)
+        .agent_run_source
+        .automated
+        .joins(:agent_run).where(AgentRun.quality_scoreable_sql)
+        .where.not(mutation_kill_rate: nil)
+        .order(created_at: :desc)
+        .limit(100)
+        .pluck(:mutation_kill_rate)
+        .each do |score|
+          bucket = [ (score.to_f * 10).floor, 9 ].min
+          distribution[bucket] += 1
+        end
+
+      distribution.each_with_index.map do |count, index|
+        lower = index * 10
+        upper = lower + 10
+        [ "#{lower}-#{upper}", count ]
+      end
     end
 
     def score_distribution

--- a/app/views/projects/quality_dashboards/show.html.erb
+++ b/app/views/projects/quality_dashboards/show.html.erb
@@ -89,6 +89,78 @@
     </div>
   </div>
 
+  <% if @stats[:mutation_testing] %>
+    <% mutation_testing = @stats[:mutation_testing] %>
+    <div class="mt-8">
+      <h2 class="text-lg font-semibold text-gray-900">Mutation kill-rate</h2>
+      <div class="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
+          <dt class="truncate text-sm font-medium text-gray-500">Current sweep score</dt>
+          <% if mutation_testing[:current_sweep_score] %>
+            <dd class="mt-1 text-3xl font-semibold tracking-tight <%= quality_score_color(mutation_testing[:current_sweep_score]) %>">
+              <%= format_quality_score(mutation_testing[:current_sweep_score]) %>
+            </dd>
+            <p class="mt-2 text-sm text-gray-500">
+              Last sweep <%= time_ago_in_words(mutation_testing[:current_sweep_at]) %> ago
+            </p>
+          <% else %>
+            <dd class="mt-2 text-sm text-gray-500">No scheduled sweep recorded yet.</dd>
+          <% end %>
+        </div>
+
+        <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6 lg:col-span-2">
+          <div class="flex items-start justify-between gap-4">
+            <div>
+              <h3 class="text-sm font-medium text-gray-500">30-day sweep trend</h3>
+              <p class="mt-1 text-sm text-gray-500">Nightly full-suite scores against <%= @project.default_branch %>.</p>
+            </div>
+          </div>
+          <div class="mt-4">
+            <% if mutation_testing[:trend_sparkline].any? %>
+              <%= line_chart mutation_testing[:trend_sparkline],
+                  id: "mutation-sweep-sparkline",
+                  height: "120px",
+                  colors: ["#0f766e"],
+                  points: false,
+                  library: {
+                    plugins: { legend: { display: false } },
+                    scales: {
+                      x: { display: false },
+                      y: { display: false, min: 0, max: 1 }
+                    }
+                  } %>
+            <% else %>
+              <p class="text-sm text-gray-500">No sweep trend available yet.</p>
+            <% end %>
+          </div>
+        </div>
+      </div>
+
+      <div class="mt-4 overflow-hidden rounded-lg bg-white shadow">
+        <div class="px-4 py-5 sm:p-6">
+          <div class="flex items-start justify-between gap-4">
+            <div>
+              <h3 class="text-sm font-medium text-gray-500">Per-agent-run distribution</h3>
+              <p class="mt-1 text-sm text-gray-500">Last 100 in-loop mutation kill-rate scores.</p>
+            </div>
+          </div>
+          <div class="mt-4">
+            <%= column_chart mutation_testing[:run_histogram],
+                id: "mutation-run-histogram",
+                height: "220px",
+                colors: ["#0f766e"],
+                library: {
+                  plugins: { legend: { display: false } },
+                  scales: {
+                    y: { beginAtZero: true, ticks: { precision: 0 } }
+                  }
+                } %>
+          </div>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
   <% overview = @stats[:overview] %>
   <% if overview[:total_metrics] > 0 %>
 

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -209,6 +209,11 @@ Rails.application.configure do
       cron: "0 4 1 */3 *",
       class: "TemporalPatchGuardSweepJob",
       description: "Audit Temporal workflow patch guards against oldest running executions (quarterly)"
+    },
+    scheduled_mutation_sweep: {
+      cron: "17 9 * * *",
+      class: "ScheduledMutationSweepJob",
+      description: "Run nightly full-suite mutation sweeps for opted-in Ruby projects"
     }
   }
 end

--- a/db/migrate/20260527084149_add_source_to_quality_metrics.rb
+++ b/db/migrate/20260527084149_add_source_to_quality_metrics.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddSourceToQualityMetrics < ActiveRecord::Migration[8.1]
+  def up
+    add_column :quality_metrics, :source, :string,
+      null: false,
+      default: "agent_run",
+      comment: "Origin of the metric row so scheduled mutation sweeps stay distinct from per-agent-run quality metrics."
+    add_index :quality_metrics, :source
+  end
+
+  def down
+    remove_index :quality_metrics, :source if index_exists?(:quality_metrics, :source)
+    remove_column :quality_metrics, :source
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_25_151229) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_27_084149) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1851,6 +1851,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_25_151229) do
     t.decimal "mutation_kill_rate", precision: 5, scale: 4, comment: "Mutant kill rate for the agent run when mutation testing executed; nil means mutant did not run or produced no score."
     t.bigint "prompt_version_id"
     t.jsonb "scores", default: {}, null: false
+    t.string "source", default: "agent_run", null: false, comment: "Origin of the metric row so scheduled mutation sweeps stay distinct from per-agent-run quality metrics."
     t.datetime "updated_at", null: false
     t.index ["agent_run_id", "metric_type"], name: "index_quality_metrics_on_agent_run_and_type", unique: true
     t.index ["agent_run_id"], name: "index_quality_metrics_on_agent_run_id"
@@ -1860,6 +1861,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_25_151229) do
     t.index ["prompt_version_id", "created_at"], name: "idx_quality_metrics_prompt_recent_composite", order: { created_at: :desc }, where: "(composite_score IS NOT NULL)"
     t.index ["prompt_version_id", "created_at"], name: "index_quality_metrics_on_prompt_version_and_created_at"
     t.index ["prompt_version_id"], name: "index_quality_metrics_on_prompt_version_id"
+    t.index ["source"], name: "index_quality_metrics_on_source"
   end
 
   create_table "quality_pause_events", comment: "Audit trail for project-level automatic pauses and resumptions caused by quality gate outcomes.", force: :cascade do |t|
@@ -3415,6 +3417,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_25_151229) do
       CREATE TRIGGER logidze_on_cost_budgets BEFORE INSERT OR UPDATE ON public.cost_budgets FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
 
+  create_trigger :logidze_on_exception_incidents, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_exception_incidents BEFORE INSERT OR UPDATE ON public.exception_incidents FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{occurrence_count,last_occurred_at,backtrace,context}')
+  SQL
+
   create_trigger :logidze_on_github_tokens, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_github_tokens BEFORE INSERT OR UPDATE ON public.github_tokens FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{token,last_used_at,repositories_synced_at,accessible_repositories}')
   SQL
@@ -3433,6 +3439,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_25_151229) do
 
   create_trigger :logidze_on_mcp_server_definitions, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_mcp_server_definitions BEFORE INSERT OR UPDATE ON public.mcp_server_definitions FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{env}')
+  SQL
+
+  create_trigger :validate_strategy_version_scope, sql_definition: <<-SQL
+      CREATE TRIGGER validate_strategy_version_scope BEFORE INSERT OR UPDATE OF project_id, strategy_version_id ON public.orchestration_decisions FOR EACH ROW EXECUTE FUNCTION validate_orchestration_decision_strategy_version_scope()
   SQL
 
   create_trigger :logidze_on_orchestration_strategies, sql_definition: <<-SQL
@@ -3497,13 +3507,5 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_25_151229) do
 
   create_trigger :logidze_on_users, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_users BEFORE INSERT OR UPDATE ON public.users FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{encrypted_password,reset_password_token,reset_password_sent_at,remember_created_at}')
-  SQL
-
-  create_trigger :logidze_on_exception_incidents, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_exception_incidents BEFORE INSERT OR UPDATE ON public.exception_incidents FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{occurrence_count,last_occurred_at,backtrace,context}')
-  SQL
-
-  create_trigger :validate_strategy_version_scope, sql_definition: <<-SQL
-      CREATE TRIGGER validate_strategy_version_scope BEFORE INSERT OR UPDATE OF project_id, strategy_version_id ON public.orchestration_decisions FOR EACH ROW EXECUTE FUNCTION validate_orchestration_decision_strategy_version_scope()
   SQL
 end

--- a/docs/rdrs/RDR-036-mutation-testing-for-ai-generated-tests.md
+++ b/docs/rdrs/RDR-036-mutation-testing-for-ai-generated-tests.md
@@ -566,6 +566,7 @@ No mutant license key, secret, or credential entry is added to Paid for its own 
 - Tier-1 incremental run on a typical Paid PR: < 5 min wall clock.
 - Container-side `mutant run --since HEAD~1 --jobs 1` on a typical agent diff: < 3 min wall clock.
 - Nightly full sweep on Paid itself: < 90 min.
+- 2026-05-27 implementation note: the recurring GoodJob sweep is serialized to one project per invocation with a hard per-project timeout of 90 minutes (`MutationSweeps::Run::SWEEP_TIMEOUT`). CI coverage validates the orchestration path with a fixture-backed mutant result and keeps the nightly scheduler from fanning out all opted-in projects at once.
 - Composite score calculation overhead from new dimension: < 10 ms per quality metric.
 
 ### Security Validation

--- a/spec/config/application_job_queue_priority_spec.rb
+++ b/spec/config/application_job_queue_priority_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe ApplicationJob, :no_db do
         AbTestAnalysisJob
         ContainerMetricsCollectionJob
         QualityMetricsCollectionJob
+        ScheduledMutationSweepJob
         ServiceContainerMetricsCollectionJob
       ],
       knowledge: %w[

--- a/spec/factories/quality_metrics.rb
+++ b/spec/factories/quality_metrics.rb
@@ -15,6 +15,7 @@ FactoryBot.define do
     end
     composite_score { 0.9813 }
     feedback_source { "system" }
+    source { QualityMetric::AGENT_RUN_SOURCE }
 
     trait :automated do
       metric_type { "automated" }

--- a/spec/jobs/scheduled_mutation_sweep_job_spec.rb
+++ b/spec/jobs/scheduled_mutation_sweep_job_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ScheduledMutationSweepJob do
+  let(:job) { described_class.new }
+  let(:account) { create(:account) }
+
+  describe "#perform" do
+    before do
+      allow(MutationSweeps::Run).to receive(:call)
+      allow(described_class).to receive(:perform_later)
+    end
+
+    it "runs the sweep for eligible ruby projects only" do
+      eligible_project = create(:project, account: account)
+      create(:pre_commit_requirement, :mutation_test, project: eligible_project, account: account, name: "mutant-eligible")
+
+      disabled_project = create(:project, account: account)
+      create(:pre_commit_requirement, :mutation_test, :disabled,
+        project: disabled_project, account: account, name: "mutant-disabled")
+
+      non_ruby_project = create(:project, account: account)
+      create(:pre_commit_requirement, :mutation_test, project: non_ruby_project, account: account, name: "mutant-js")
+      non_ruby_project.define_singleton_method(:detected_language) { "javascript" }
+
+      job.perform(sweep_date: "2026-05-27")
+
+      expect(MutationSweeps::Run).to have_received(:call).with(project: eligible_project, sweep_date: Date.new(2026, 5, 27)).once
+      expect(MutationSweeps::Run).not_to have_received(:call).with(hash_including(project: disabled_project))
+      expect(MutationSweeps::Run).not_to have_received(:call).with(hash_including(project: non_ruby_project))
+    end
+
+    it "skips projects already swept on the same date" do
+      project = create(:project, account: account)
+      create(:pre_commit_requirement, :mutation_test, project: project, account: account, name: "mutant")
+      metric_run = create(:agent_run, :completed, project: project)
+      create(:quality_metric,
+        agent_run: metric_run,
+        source: QualityMetric::SCHEDULED_MUTATION_SWEEP_SOURCE,
+        mutation_kill_rate: 0.8,
+        scores: { "mutation_kill_rate" => 0.8 },
+        created_at: Time.utc(2026, 5, 27, 6))
+
+      job.perform(sweep_date: "2026-05-27")
+
+      expect(MutationSweeps::Run).not_to have_received(:call)
+    end
+
+    it "queues a follow-up job when another eligible project remains" do
+      first_project = create(:project, account: account)
+      second_project = create(:project, account: account)
+      create(:pre_commit_requirement, :mutation_test, project: first_project, account: account, name: "mutant-1")
+      create(:pre_commit_requirement, :mutation_test, project: second_project, account: account, name: "mutant-2")
+
+      job.perform(sweep_date: "2026-05-27")
+
+      expect(described_class).to have_received(:perform_later).with(sweep_date: "2026-05-27")
+    end
+  end
+end

--- a/spec/jobs/scheduled_mutation_sweep_job_spec.rb
+++ b/spec/jobs/scheduled_mutation_sweep_job_spec.rb
@@ -47,6 +47,26 @@ RSpec.describe ScheduledMutationSweepJob do
       expect(MutationSweeps::Run).not_to have_received(:call)
     end
 
+    it "treats failed sweep markers as already attempted for the date" do
+      failed_project = create(:project, account: account)
+      next_project = create(:project, account: account)
+      create(:pre_commit_requirement, :mutation_test, project: failed_project, account: account, name: "mutant-failed")
+      create(:pre_commit_requirement, :mutation_test, project: next_project, account: account, name: "mutant-next")
+
+      failed_run = create(:agent_run, :failed, project: failed_project)
+      create(:quality_metric,
+        agent_run: failed_run,
+        source: QualityMetric::SCHEDULED_MUTATION_SWEEP_SOURCE,
+        mutation_kill_rate: nil,
+        scores: {},
+        created_at: Time.utc(2026, 5, 27, 6))
+
+      job.perform(sweep_date: "2026-05-27")
+
+      expect(MutationSweeps::Run).to have_received(:call).with(project: next_project, sweep_date: Date.new(2026, 5, 27)).once
+      expect(MutationSweeps::Run).not_to have_received(:call).with(hash_including(project: failed_project))
+    end
+
     it "queues a follow-up job when another eligible project remains" do
       first_project = create(:project, account: account)
       second_project = create(:project, account: account)
@@ -55,7 +75,20 @@ RSpec.describe ScheduledMutationSweepJob do
 
       job.perform(sweep_date: "2026-05-27")
 
-      expect(described_class).to have_received(:perform_later).with(sweep_date: "2026-05-27")
+      expect(described_class).to have_received(:perform_later).with(sweep_date: "2026-05-27", attempted_project_ids: [ first_project.id ])
+    end
+
+    it "excludes a failed project from the next job even before a marker exists" do
+      failing_project = create(:project, account: account)
+      remaining_project = create(:project, account: account)
+      create(:pre_commit_requirement, :mutation_test, project: failing_project, account: account, name: "mutant-fail")
+      create(:pre_commit_requirement, :mutation_test, project: remaining_project, account: account, name: "mutant-next")
+
+      allow(MutationSweeps::Run).to receive(:call).with(project: failing_project, sweep_date: Date.new(2026, 5, 27)).and_raise(StandardError, "boom")
+
+      job.perform(sweep_date: "2026-05-27")
+
+      expect(described_class).to have_received(:perform_later).with(sweep_date: "2026-05-27", attempted_project_ids: [ failing_project.id ])
     end
   end
 end

--- a/spec/models/quality_metric_spec.rb
+++ b/spec/models/quality_metric_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe QualityMetric do
 
     it { is_expected.to validate_presence_of(:metric_type) }
     it { is_expected.to validate_inclusion_of(:metric_type).in_array(described_class::METRIC_TYPES) }
+    it { is_expected.to validate_inclusion_of(:source).in_array(described_class::SOURCES) }
     it { is_expected.to validate_uniqueness_of(:metric_type).scoped_to(:agent_run_id) }
 
     it {

--- a/spec/models/quality_threshold_spec.rb
+++ b/spec/models/quality_threshold_spec.rb
@@ -124,6 +124,7 @@ RSpec.describe QualityThreshold do
         [ "issue_created", "create_issue" ],
         [ "reaction_score", "create_issue" ],
         [ "lint_clean", "create_pr" ],
+        [ "mutation_kill_rate", "create_pr" ],
         [ "review_comment_count", "create_pr" ],
         [ "review_posted", "review" ],
         [ "reaction_score", "review" ],

--- a/spec/requests/projects/quality_dashboards_spec.rb
+++ b/spec/requests/projects/quality_dashboards_spec.rb
@@ -87,6 +87,20 @@ RSpec.describe "Projects::QualityDashboards" do
 
         expect(response.body).to include("Export CSV")
       end
+
+      it "renders the mutation kill-rate panel only when mutation testing is enabled" do
+        create(:pre_commit_requirement, :mutation_test, project: project, account: account, name: "mutant")
+
+        get project_quality_dashboard_path(project)
+
+        expect(response.body).to include("Mutation kill-rate")
+      end
+
+      it "hides the mutation kill-rate panel when mutation testing is disabled" do
+        get project_quality_dashboard_path(project)
+
+        expect(response.body).not_to include("Mutation kill-rate")
+      end
     end
   end
 

--- a/spec/services/containers/quality_hooks_spec.rb
+++ b/spec/services/containers/quality_hooks_spec.rb
@@ -85,7 +85,22 @@ RSpec.describe Containers::QualityHooks do
 
       expect(
         host.resolve_scheduled_mutation_command(project, user, "ruby")
-      ).to eq("bundle exec mutant run --usage commercial --use rspec --jobs 1 Foo*")
+      ).to eq("bundle exec mutant run --usage commercial --use rspec --jobs 1 Foo\\*")
+    end
+
+    it "preserves shell escaping for quoted arguments" do
+      create(
+        :pre_commit_requirement,
+        :mutation_test,
+        account: account,
+        project: project,
+        name: "mutant",
+        command: 'bundle exec mutant run --since HEAD~1 --include-subject "app/models/user profile.rb"'
+      )
+
+      expect(
+        host.resolve_scheduled_mutation_command(project, user, "ruby")
+      ).to eq('bundle exec mutant run --include-subject app/models/user\ profile.rb --jobs 1')
     end
   end
 end

--- a/spec/services/containers/quality_hooks_spec.rb
+++ b/spec/services/containers/quality_hooks_spec.rb
@@ -71,4 +71,21 @@ RSpec.describe Containers::QualityHooks do
       ENV["MUTANT_LICENSE_KEY"] = original_mutant_license_key
     end
   end
+
+  describe "#resolve_scheduled_mutation_command" do
+    it "removes incremental mode and keeps jobs pinned to one worker" do
+      create(
+        :pre_commit_requirement,
+        :mutation_test,
+        account: account,
+        project: project,
+        name: "mutant",
+        command: "bundle exec mutant run --usage commercial --since HEAD~1 --use rspec --jobs 4 Foo*"
+      )
+
+      expect(
+        host.resolve_scheduled_mutation_command(project, user, "ruby")
+      ).to eq("bundle exec mutant run --usage commercial --use rspec --jobs 1 Foo*")
+    end
+  end
 end

--- a/spec/services/mutation_sweeps/run_spec.rb
+++ b/spec/services/mutation_sweeps/run_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe MutationSweeps::Run do
+  describe ".call" do
+    let(:project) { create(:project) }
+    let(:fixture_worktree) { Rails.root.join("spec/fixtures/files/mutant/worktree_with_results").to_s }
+    let(:worktree_service) { instance_double(WorktreeService) }
+    let(:container_service) { instance_double(Containers::Provision) }
+
+    before do
+      create(:pre_commit_requirement, :mutation_test, project: project, account: project.account, name: "mutant")
+      allow(WorktreeService).to receive(:new).with(project).and_return(worktree_service)
+      allow(worktree_service).to receive(:with_temporary_worktree).with(project.default_branch).and_yield(fixture_worktree)
+      allow(Containers::Provision).to receive(:with_container).and_yield(container_service)
+      allow(container_service).to receive(:execute)
+      allow(QualityMetrics::EvaluateGate).to receive(:call)
+      allow(QualityAlerts::CheckGate).to receive(:call)
+    end
+
+    it "records a scheduled mutation sweep quality metric" do
+      metric = described_class.call(project: project, sweep_date: Date.new(2026, 5, 27))
+
+      expect(metric).to be_persisted
+      expect(metric.source).to eq("scheduled_mutation_sweep")
+      expect(metric.mutation_kill_rate.to_f).to eq(0.95)
+      expect(metric.scores).to include("mutation_kill_rate" => 0.95)
+      expect(QualityMetrics::EvaluateGate).to have_received(:call).with(quality_metric: metric)
+    end
+  end
+end

--- a/spec/services/mutation_sweeps/run_spec.rb
+++ b/spec/services/mutation_sweeps/run_spec.rb
@@ -28,5 +28,29 @@ RSpec.describe MutationSweeps::Run do
       expect(metric.scores).to include("mutation_kill_rate" => 0.95)
       expect(QualityMetrics::EvaluateGate).to have_received(:call).with(quality_metric: metric)
     end
+
+    it "records a failed scheduled sweep marker when execution raises" do
+      allow(container_service).to receive(:execute).and_raise(StandardError, "mutant exploded")
+
+      expect {
+        described_class.call(project: project, sweep_date: Date.new(2026, 5, 27))
+      }.to raise_error(StandardError, "mutant exploded")
+
+      metric = QualityMetric.last
+      agent_run = AgentRun.last
+
+      expect(metric.agent_run).to eq(agent_run)
+      expect(metric.source).to eq("scheduled_mutation_sweep")
+      expect(metric.mutation_kill_rate).to be_nil
+      expect(metric.metadata).to include(
+        "failed" => true,
+        "error_class" => "StandardError",
+        "error_message" => "mutant exploded",
+        "sweep_date" => "2026-05-27"
+      )
+      expect(agent_run.reload.status).to eq("failed")
+      expect(QualityMetrics::EvaluateGate).not_to have_received(:call)
+      expect(QualityAlerts::CheckGate).not_to have_received(:call)
+    end
   end
 end

--- a/spec/services/quality_metrics/collect_spec.rb
+++ b/spec/services/quality_metrics/collect_spec.rb
@@ -50,6 +50,12 @@ RSpec.describe QualityMetrics::Collect do
       expect { described_class.call(agent_run: agent_run) }.to change(QualityMetric, :count).by(1)
     end
 
+    it "tags per-agent-run metrics with the default source" do
+      metric = described_class.call(agent_run: agent_run)
+
+      expect(metric.source).to eq("agent_run")
+    end
+
     it "checks for quality pauses after recording an eligible metric" do
       described_class.call(agent_run: agent_run)
 

--- a/spec/services/quality_metrics/dashboard_stats_spec.rb
+++ b/spec/services/quality_metrics/dashboard_stats_spec.rb
@@ -208,6 +208,39 @@ RSpec.describe QualityMetrics::DashboardStats do
       )
     end
 
+    it "hides mutation testing data when the project is not opted in" do
+      result = described_class.call(project: project)
+
+      expect(result[:mutation_testing]).to be_nil
+    end
+
+    it "returns current sweep, sparkline data, and histogram when mutation testing is enabled" do
+      create(:pre_commit_requirement, :mutation_test, project: project, account: project.account, name: "mutant")
+
+      sweep_run = create(:agent_run, :completed, project: project)
+      create(:quality_metric,
+        agent_run: sweep_run,
+        source: QualityMetric::SCHEDULED_MUTATION_SWEEP_SOURCE,
+        mutation_kill_rate: 0.91,
+        scores: { "mutation_kill_rate" => 0.91 },
+        created_at: 2.days.ago)
+
+      agent_run = create(:agent_run, :completed, project: project)
+      create(:quality_metric,
+        agent_run: agent_run,
+        source: QualityMetric::AGENT_RUN_SOURCE,
+        mutation_kill_rate: 0.72,
+        scores: { "mutation_kill_rate" => 0.72 },
+        composite_score: 0.72,
+        created_at: 1.day.ago)
+
+      result = described_class.call(project: project)[:mutation_testing]
+
+      expect(result[:current_sweep_score]).to eq(0.91)
+      expect(result[:trend_sparkline]).to all(satisfy { |point| point.is_a?(Array) && point.size == 2 })
+      expect(result[:run_histogram].sum { |(_, count)| count }).to eq(1)
+    end
+
     it "includes goal metadata for non-create_pr metrics" do
       result = described_class.call(project: project)
 


### PR DESCRIPTION
## Summary

Closes the loop on RDR-036 Phase 3b by adding a nightly full-suite mutation sweep job that catches indirect-change blind spots missed by incremental mode, and surfacing kill-rate trends on the quality dashboard so teams can monitor mutation testing health over time.

## Changes

### Database
- Add `source` column to `quality_metrics` table to distinguish scheduled sweep results (`scheduled_mutation_sweep`) from per-agent-run metrics

### Services
- New `MutationSweeps::Run` service that enumerates projects with an enabled `mutation_test` `PreCommitRequirement` for Ruby, spins up an isolated container against `main`, runs `bundle exec mutant run` (full sweep, no `--since`), and records the kill rate as a `QualityMetric`

### Jobs
- New `ScheduledMutationSweepJob` (GoodJob recurring) that iterates eligible projects nightly, throttled to one project per worker to avoid resource spikes
- Triggers `QualityAlerts::CheckGate` evaluation when the score breaches a configured threshold

### Dashboard
- Add "Mutation kill-rate" panel to `Projects::QualityDashboardsController` view showing:
  - Current sweep score from the most recent scheduled sweep metric
  - 30-day trend sparkline of sweep scores
  - Per-agent-run kill-rate distribution histogram (last 100 runs)
- Panel is conditionally rendered — hidden when the project has no enabled `mutation_test` requirement

### Specs
- Job correctly enumerates eligible projects and skips ineligible ones
- Job records `QualityMetric` with the correct `source` tag
- Dashboard view renders only for projects with mutation testing enabled
- Trend sparkline data shape matches front-end chart component expectations

## Design Decisions

- **Throttle to one project per worker per night**: avoids resource spikes from concurrent full-suite mutation runs, staying within the < 90 min per-project budget from RDR-036's validation section
- **Separate `source` tag rather than separate table**: reuses the existing `QualityMetric` pipeline and gate evaluation path while keeping scheduled sweeps distinguishable from incremental per-agent-run metrics
- **Conditional panel rendering**: projects that haven't opted into mutation testing see no empty widget, keeping the dashboard clean

## Dependencies

- Depends on #2281 (Phase 3a) which introduced `QualityMetric#mutation_kill_rate`

---

Closes #2282