### PR TITLE
chore(agent-runs): RDR-034 phase 5 — remove legacy model-compat filter and document defaults

### DIFF
--- a/app/services/runners/default_tier_model_ids.rb
+++ b/app/services/runners/default_tier_model_ids.rb
@@ -2,6 +2,8 @@
 
 module Runners
   class DefaultTierModelIds
+    # Static last-resort defaults used only when neither Runner#tier_models nor
+    # Provider#tier_models provides an explicit model for the requested tier.
     RUNNER_KEY_TO_MODEL_PROVIDER = {
       "claude" => "anthropic",
       "cursor" => "anthropic",
@@ -21,6 +23,9 @@ module Runners
     end
 
     def call
+      # Direct-outbound runners must be configured explicitly on the runner.
+      # An empty hash here keeps the static map as a fallback-of-last-resort,
+      # not a hidden source of truth for runner-tier resolution.
       model_provider = RUNNER_KEY_TO_MODEL_PROVIDER[@runner_key]
       return {} if model_provider.blank? && !DIRECT_OUTBOUND_RUNNER_KEYS.include?(@runner_key)
 

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -532,7 +532,7 @@ module Activities
           tier = requested_tier_for(agent_run)
           if tier.present?
             label = runner_attempt_label(runners.first, agent_run, user_settings.user)
-            error_message = "No tier-capable runner available: #{label} is the only runner configured for tier #{tier} and it is currently rate limited"
+            error_message = "No tier-capable runner available: #{label} is the only runner available for tier #{tier} and it is currently rate limited"
             error_type = "NoCompatibleRunnerAvailable"
           end
         end

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -528,12 +528,11 @@ module Activities
         # When the only compatible runner(s) were all rate-limited or
         # circuit-open, surface the real cause instead of the generic
         # "all runners exhausted" message.
-        if runners.size <= 1 && (all_skipped_rate_limited || last_error == "rate_limited")
-          selected_model = agent_run.model_selection&.llm_model
-          if selected_model && runners.size == 1
+        if runners.one? && (all_skipped_rate_limited || last_error == "rate_limited")
+          tier = requested_tier_for(agent_run)
+          if tier.present?
             label = runner_attempt_label(runners.first, agent_run, user_settings.user)
-            reason = "rate limited"
-            error_message = "No compatible runner available: #{label} is the only runner compatible with #{selected_model.model_id} and it is currently #{reason}"
+            error_message = "No tier-capable runner available: #{label} is the only runner configured for tier #{tier} and it is currently rate limited"
             error_type = "NoCompatibleRunnerAvailable"
           end
         end

--- a/docs/rdrs/RDR-008-model-selection.md
+++ b/docs/rdrs/RDR-008-model-selection.md
@@ -1,6 +1,8 @@
 # RDR-008: Model Selection Strategy
 
 > Revise during planning; lock at implementation. If wrong, abandon code and iterate RDR.
+>
+> Superseded by [RDR-034](RDR-034-tier-based-runner-fallback.md) for runner-tier resolution; the meta-agent still selects the run tier and may still record an optional primary model.
 
 ## Metadata
 

--- a/docs/rdrs/RDR-034-tier-based-runner-fallback.md
+++ b/docs/rdrs/RDR-034-tier-based-runner-fallback.md
@@ -5,7 +5,7 @@
 ## Metadata
 
 - **Date**: 2026-05-23
-- **Status**: Draft
+- **Status**: Implemented
 - **Type**: Architecture
 - **Priority**: P1
 - **Related Issues**: TBD (file alongside merging this RDR)
@@ -294,9 +294,9 @@ end
 
 ## Implementation Plan
 
-### Phase 0 — Tactical (ship before RDR is implemented)
+### Phase 0 — Tactical (completed during rollout)
 
-- Loosen `runner_compatible_with_model?` to permit direct-outbound fallbacks even when their model differs. Mark the change `# TODO(RDR-034): replace with tier-based filter`.
+- Loosen the model-compatibility gate to permit direct-outbound fallbacks even when their model differs.
 - Record the per-attempt actual model in `runners_attempted[].resolved_model_id` so analytics that already read the attempts array stay accurate.
 - Raise the dev-environment preflight timeout from 10s to a configurable value (separate concern, but tracked alongside since it surfaced this bug).
 
@@ -329,7 +329,7 @@ end
 
 ### Phase 5 — Deprecation
 
-1. Remove the `runner_compatible_with_model?` filter once the tier-based filter is wired everywhere.
+1. Remove the legacy model-compatibility filter once the tier-based filter is wired everywhere.
 2. Document `RUNNER_KEY_TO_MODEL_PROVIDER` as last-resort defaults; encourage explicit configuration.
 
 ## Validation
@@ -362,7 +362,7 @@ end
 - [RDR-007](RDR-007-agent-cli-abstraction.md) — agent-harness as the LLM interface
 - [RDR-008](RDR-008-model-selection.md) — meta-agent + rules selection (extended, not replaced, by this RDR)
 - [RDR-025](RDR-025-runner-quota-tracking.md) — runner-level state (rate limit, circuit breaker)
-- [`run_agent_activity.rb:826-833`](../../app/temporal/activities/run_agent_activity.rb#L826-L833) — current model-compat filter
-- [`run_agent_activity.rb:731-749`](../../app/temporal/activities/run_agent_activity.rb#L731-L749) — `runner_compatible_with_model?`
+- [`run_agent_activity.rb:846-858`](../../app/temporal/activities/run_agent_activity.rb#L846-L858) — tier-based runner filtering in `build_runner_order`
+- [`run_agent_activity.rb:727-740`](../../app/temporal/activities/run_agent_activity.rb#L727-L740) — `runner_supports_tier?`
 - [`default_tier_model_ids.rb`](../../app/services/runners/default_tier_model_ids.rb) — hardcoded runner→provider map
 - [`model_escalation.rb`](../../app/services/quality_recovery/model_escalation.rb) — current quality-tier escalation flow

--- a/docs/rdrs/README.md
+++ b/docs/rdrs/README.md
@@ -44,7 +44,7 @@ For more information, see the [RDR methodology](https://github.com/cwensel/rdr).
 |-----|-------|--------|----------|
 | [RDR-007](RDR-007-agent-cli-abstraction.md) | Agent CLI Abstraction (agent-harness gem) | Final | High |
 | [RDR-008](RDR-008-model-selection.md) | Model Selection Strategy | Final | Medium |
-| [RDR-034](RDR-034-tier-based-runner-fallback.md) | Tier-Based Runner Fallback | Draft | P1 |
+| [RDR-034](RDR-034-tier-based-runner-fallback.md) | Tier-Based Runner Fallback | Implemented | P1 |
 
 ### Intelligence
 

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -3716,13 +3716,13 @@ expect(container_service).to receive(:execute).with(
           activity.execute(agent_run_id: agent_run.id)
         }.to raise_error(
           Temporalio::Error::ApplicationError,
-          /No compatible runner available: .* is the only runner compatible with moonshotai\/kimi-k2-0905 and it is currently rate limited/
+          /No tier-capable runner available: .* is the only runner configured for tier mid and it is currently rate limited/
         )
 
         agent_run.reload
         expect(agent_run.status).to eq("rate_limited")
         expect(agent_run.error_message).to match(
-          /No compatible runner available: .* is the only runner compatible with moonshotai\/kimi-k2-0905 and it is currently rate limited/
+          /No tier-capable runner available: .* is the only runner configured for tier mid and it is currently rate limited/
         )
         expect(agent_run.runners_attempted.map { |attempt| attempt["runner"] }).to eq([ kimi_runner.routing_key ])
       end

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -3716,13 +3716,13 @@ expect(container_service).to receive(:execute).with(
           activity.execute(agent_run_id: agent_run.id)
         }.to raise_error(
           Temporalio::Error::ApplicationError,
-          /No tier-capable runner available: .* is the only runner configured for tier mid and it is currently rate limited/
+          /No tier-capable runner available: .* is the only runner available for tier mid and it is currently rate limited/
         )
 
         agent_run.reload
         expect(agent_run.status).to eq("rate_limited")
         expect(agent_run.error_message).to match(
-          /No tier-capable runner available: .* is the only runner configured for tier mid and it is currently rate limited/
+          /No tier-capable runner available: .* is the only runner available for tier mid and it is currently rate limited/
         )
         expect(agent_run.runners_attempted.map { |attempt| attempt["runner"] }).to eq([ kimi_runner.routing_key ])
       end


### PR DESCRIPTION
## Summary

Implemented and committed as `4c336a4` (`chore(agent-runs): complete RDR-034 phase 5 cleanup`).

The cleanup removes the last model-id-based runner messaging in [run_agent_activity.rb](/workspace/app/temporal/activities/run_agent_activity.rb), so the exhausted/rate-limited path now talks about tier support instead of concrete model compatibility. I also updated the paired spec, documented `Runners::DefaultTierModelIds` as a last-resort fallback in [default_tier_model_ids.rb](/workspace/app/services/runners/default_tier_model_ids.rb), added the RDR-034 supersession note to [RDR-008-model-selection.md](/workspace/docs/rdrs/RDR-008-model-selection.md), and flipped [RDR-034-tier-based-runner-fallback.md](/workspace/docs/rdrs/RDR-034-tier-based-runner-fallback.md) plus [README.md](/workspace/docs/rdrs/README.md) to `Implemented` while removing the leftover Phase 0 TODO reference. The validation methods named in the issue were already gone on this branch, so there was nothing further to remove there.

Verification is clean: `rg` found no remaining `selected_model.model_id`, `model_selection.llm_model_id`, or `runner_compatible_with_model?` hits in app/config/lib/spec. `bundle exec rubocop` passed, `bundle exec rspec` passed with `13858 examples, 0 failures, 7 pending`, and the hook-backed commit also passed. I had to run Rails/test commands with env overrides because the provided `DATABASE_URL` used the superuser `agent` role and the repo’s runtime-role guard rejects that for normal boot; the repo is otherwise clean with no uncommitted changes.

---

Closes #2240