### PR TITLE
feat: Adopt agent-harness install contract for opencode (postinstall support)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -98,16 +98,15 @@
     // to scripts/extract-provider-install-contract.rb. This means versions and
     // install commands stay in sync with the agent image without separate pins.
     // The script handles npm, uv_tool, and artifact-based install sources
-    // transparently. All npm-based installs get --ignore-scripts enforced.
+    // transparently and now evaluates the contract's npm install command
+    // directly so provider-specific postinstall handling can flow through.
     "codex": "bash scripts/install-from-contract.sh codex",
     "gemini-cli": "bash scripts/install-from-contract.sh gemini",
     "github-copilot-cli": "bash scripts/install-from-contract.sh copilot",
     "kilocode": "bash scripts/install-from-contract.sh kilocode",
     "cursor-agent": "bash scripts/install-from-contract.sh cursor",
     "aider": "bash scripts/install-from-contract.sh aider",
-    // opencode is intentionally NOT converted to contract-driven install yet.
-    // Tracked in #2297 — keeping the hardcoded npm entry until that lands.
-    "opencode": "npm i -g --ignore-scripts opencode-ai@latest",
+    "opencode": "bash scripts/install-from-contract.sh opencode",
     // Dev tools
     "markdownlint": "npm install -g --ignore-scripts markdownlint-cli",
     "git-curate": "env PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH gem install git_curate",

--- a/.github/workflows/agent-image.yml
+++ b/.github/workflows/agent-image.yml
@@ -231,17 +231,19 @@ jobs:
           fi
           echo "package=$package" >> "$GITHUB_OUTPUT"
 
-      - name: Extract OpenCode package from agent-harness
+      - name: Extract OpenCode install contract from agent-harness
         if: steps.changes.outputs.image_relevant == 'true'
         id: opencode-contract
         run: |
           contract=$(bundle exec ruby scripts/extract-runner-install-contract.rb opencode)
-          package=$(echo "$contract" | sed -n 's/^PACKAGE=//p')
-          if [ -z "$package" ]; then
-            echo "Failed to extract OpenCode package from agent-harness" >&2
+          install_command=$(echo "$contract" | sed -n 's/^INSTALL_COMMAND=//p')
+          if [ -z "$install_command" ]; then
+            echo "Failed to extract OpenCode install command from agent-harness" >&2
             exit 1
           fi
-          echo "package=$package" >> "$GITHUB_OUTPUT"
+          echo "install_command<<PAID_EOF" >> "$GITHUB_OUTPUT"
+          echo "$install_command" >> "$GITHUB_OUTPUT"
+          echo "PAID_EOF" >> "$GITHUB_OUTPUT"
 
       - name: Extract Pi package from agent-harness
         if: steps.changes.outputs.image_relevant == 'true'
@@ -330,7 +332,7 @@ jobs:
             CURSOR_BINARY_NAME=${{ steps.cursor-contract.outputs.binary_name }}
             CURSOR_GLOBAL_PATH=${{ steps.cursor-contract.outputs.global_path }}
             CODEX_PACKAGE=${{ steps.codex-contract.outputs.package }}
-            OPENCODE_PACKAGE=${{ steps.opencode-contract.outputs.package }}
+            OPENCODE_INSTALL_COMMAND=${{ steps.opencode-contract.outputs.install_command }}
             PI_PACKAGE=${{ steps.pi-contract.outputs.package }}
             KILOCODE_INSTALL_COMMAND=${{ steps.kilocode-contract.outputs.install_command }}
             GEMINI_CLI_INSTALL_COMMAND=${{ steps.gemini-contract.outputs.install_command }}

--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -238,15 +238,16 @@ RUN if [ -z "${KILOCODE_INSTALL_COMMAND}" ]; then \
     && echo "Installing Kilocode CLI via agent-harness contract: ${KILOCODE_INSTALL_COMMAND}" \
     && eval "${KILOCODE_INSTALL_COMMAND}"
 
-# OpenCode CLI: version is owned by agent-harness (installation_contract).
-# OPENCODE_PACKAGE is extracted from agent-harness at build time by
+# OpenCode CLI: install contract is owned by agent-harness.
+# OPENCODE_INSTALL_COMMAND is extracted from agent-harness at build time by
 # build-agent-image.sh / agent-image.yml — Paid no longer pins this version.
-ARG OPENCODE_PACKAGE
-RUN if [ -z "${OPENCODE_PACKAGE}" ]; then \
-        echo "ERROR: OPENCODE_PACKAGE build-arg is required (sourced from agent-harness)" >&2; \
+ARG OPENCODE_INSTALL_COMMAND
+RUN if [ -z "${OPENCODE_INSTALL_COMMAND}" ]; then \
+        echo "ERROR: OPENCODE_INSTALL_COMMAND not set; aborting build" >&2; \
         exit 1; \
     fi \
-    && npm install -g --ignore-scripts "${OPENCODE_PACKAGE}"
+    && echo "Installing OpenCode via agent-harness contract: ${OPENCODE_INSTALL_COMMAND}" \
+    && eval "${OPENCODE_INSTALL_COMMAND}"
 
 # Pre-seed the OpenCode SQLite database so the first container invocation does
 # not emit "Performing one time database migration, may take a few minutes..."

--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -241,11 +241,17 @@ RUN if [ -z "${KILOCODE_INSTALL_COMMAND}" ]; then \
 # OpenCode CLI: install contract is owned by agent-harness.
 # OPENCODE_INSTALL_COMMAND is extracted from agent-harness at build time by
 # build-agent-image.sh / agent-image.yml — Paid no longer pins this version.
+# Supply-chain hardening: enforce --ignore-scripts regardless of what the
+# contract returns, matching the policy applied to every other npm install above.
 ARG OPENCODE_INSTALL_COMMAND
 RUN if [ -z "${OPENCODE_INSTALL_COMMAND}" ]; then \
         echo "ERROR: OPENCODE_INSTALL_COMMAND not set; aborting build" >&2; \
         exit 1; \
     fi \
+    && case "${OPENCODE_INSTALL_COMMAND}" in \
+        *--ignore-scripts*) ;; \
+        *) echo "ERROR: OPENCODE_INSTALL_COMMAND must include --ignore-scripts for supply-chain safety" >&2; exit 1 ;; \
+    esac \
     && echo "Installing OpenCode via agent-harness contract: ${OPENCODE_INSTALL_COMMAND}" \
     && eval "${OPENCODE_INSTALL_COMMAND}"
 

--- a/scripts/build-agent-image.sh
+++ b/scripts/build-agent-image.sh
@@ -98,12 +98,12 @@ if [ -z "${CODEX_PACKAGE}" ]; then
     exit 1
 fi
 
-# Extract OpenCode CLI package from agent-harness installation contract.
+# Extract OpenCode CLI install command from agent-harness installation contract.
 # agent-harness owns the supported OpenCode CLI version; Paid consumes it at build time.
 OPENCODE_CONTRACT=$(bundle exec ruby "${PROJECT_ROOT}/scripts/extract-runner-install-contract.rb" opencode)
-OPENCODE_PACKAGE=$(echo "${OPENCODE_CONTRACT}" | sed -n 's/^PACKAGE=//p')
-if [ -z "${OPENCODE_PACKAGE}" ]; then
-    echo "ERROR: Could not extract OpenCode package from agent-harness" >&2
+OPENCODE_INSTALL_COMMAND=$(echo "${OPENCODE_CONTRACT}" | sed -n 's/^INSTALL_COMMAND=//p')
+if [ -z "${OPENCODE_INSTALL_COMMAND}" ]; then
+    echo "ERROR: Could not extract OpenCode install command from agent-harness" >&2
     exit 1
 fi
 
@@ -161,7 +161,7 @@ echo "  ruby-maat: ${RUBY_MAAT_VERSION}"
 echo "  claude-install: via agent-harness contract"
 echo "  cursor-install: via agent-harness contract"
 echo "  codex: ${CODEX_PACKAGE}"
-echo "  opencode: ${OPENCODE_PACKAGE}"
+echo "  opencode-install: ${OPENCODE_INSTALL_COMMAND}"
 echo "  pi: ${PI_PACKAGE}"
 echo "  kilocode-cli: ${KILOCODE_INSTALL_COMMAND}"
 echo "  gemini-cli: ${GEMINI_CLI_INSTALL_COMMAND}"
@@ -180,7 +180,7 @@ echo "  copilot-cli: ${COPILOT_INSTALL_COMMAND}"
     --build-arg "CURSOR_BINARY_NAME=${CURSOR_BINARY_NAME}" \
     --build-arg "CURSOR_GLOBAL_PATH=${CURSOR_GLOBAL_PATH}" \
     --build-arg "CODEX_PACKAGE=${CODEX_PACKAGE}" \
-    --build-arg "OPENCODE_PACKAGE=${OPENCODE_PACKAGE}" \
+    --build-arg "OPENCODE_INSTALL_COMMAND=${OPENCODE_INSTALL_COMMAND}" \
     --build-arg "PI_PACKAGE=${PI_PACKAGE}" \
     --build-arg "KILOCODE_INSTALL_COMMAND=${KILOCODE_INSTALL_COMMAND}" \
     --build-arg "GEMINI_CLI_INSTALL_COMMAND=${GEMINI_CLI_INSTALL_COMMAND}" \

--- a/scripts/extract-provider-install-contract.rb
+++ b/scripts/extract-provider-install-contract.rb
@@ -14,9 +14,42 @@
 
 require "agent_harness"
 
+POSTINSTALL_SIGNAL_KEYS = %i[
+  allow_postinstall
+  postinstall
+  postinstall_command
+  postinstall_required
+  requires_postinstall
+  trusted_postinstall
+].freeze
+
+def postinstall_sensitive_contract?(contract)
+  POSTINSTALL_SIGNAL_KEYS.any? { |key| contract[key] }
+end
+
+def npm_package_name(contract)
+  contract[:package_name] || contract[:package] || contract.dig(:source, :package)
+end
+
+def opencode_fallback_install_command(contract)
+  command = Array(contract[:install_command]).dup
+  return command unless npm_package_name(contract) == "opencode-ai"
+
+  # agent-harness 0.18.2 still models OpenCode as a plain npm install even
+  # though the package needs a trusted postinstall step to extract its native
+  # binary. Keep the hardening default for dependencies, then run the single
+  # allowlisted postinstall explicitly until the upstream contract is released.
+  command + [ "&&", "node", "$(npm root -g)/opencode-ai/postinstall.mjs" ]
+end
+
 def normalized_install_command(contract)
   command = Array(contract[:install_command]).dup
-  return command if command.empty? || command.include?("--ignore-scripts")
+  return command if command.empty?
+  return command if postinstall_sensitive_contract?(contract)
+
+  fallback_command = opencode_fallback_install_command(contract)
+  return fallback_command if fallback_command != command
+  return command if command.include?("--ignore-scripts")
 
   command << "--ignore-scripts"
 end

--- a/scripts/extract-provider-install-contract.rb
+++ b/scripts/extract-provider-install-contract.rb
@@ -13,46 +13,7 @@
 #   eval "$(bundle exec ruby scripts/extract-provider-install-contract.rb claude)"
 
 require "agent_harness"
-
-POSTINSTALL_SIGNAL_KEYS = %i[
-  allow_postinstall
-  postinstall
-  postinstall_command
-  postinstall_required
-  requires_postinstall
-  trusted_postinstall
-].freeze
-
-def postinstall_sensitive_contract?(contract)
-  POSTINSTALL_SIGNAL_KEYS.any? { |key| contract[key] }
-end
-
-def npm_package_name(contract)
-  contract[:package_name] || contract[:package] || contract.dig(:source, :package)
-end
-
-def opencode_fallback_install_command(contract)
-  command = Array(contract[:install_command]).dup
-  return command unless npm_package_name(contract) == "opencode-ai"
-
-  # agent-harness 0.18.2 still models OpenCode as a plain npm install even
-  # though the package needs a trusted postinstall step to extract its native
-  # binary. Keep the hardening default for dependencies, then run the single
-  # allowlisted postinstall explicitly until the upstream contract is released.
-  command + [ "&&", "node", "$(npm root -g)/opencode-ai/postinstall.mjs" ]
-end
-
-def normalized_install_command(contract)
-  command = Array(contract[:install_command]).dup
-  return command if command.empty?
-  return command if postinstall_sensitive_contract?(contract)
-
-  fallback_command = opencode_fallback_install_command(contract)
-  return fallback_command if fallback_command != command
-  return command if command.include?("--ignore-scripts")
-
-  command << "--ignore-scripts"
-end
+require_relative "lib/install_contract_helpers"
 
 provider = ARGV[0]
 unless provider
@@ -145,7 +106,7 @@ if source == :uv_tool
   puts "SUPPORTED_VERSION=#{contract[:version]}"
 elsif is_npm
   package = contract[:package] || (source.is_a?(Hash) && source[:package])
-  install_command = normalized_install_command(contract)
+  install_command = InstallContractHelpers.normalized_install_command(contract)
   puts "SOURCE=npm"
   puts "PACKAGE=#{package}"
   puts "INSTALL_COMMAND=#{install_command.join(" ")}"

--- a/scripts/extract-runner-install-contract.rb
+++ b/scripts/extract-runner-install-contract.rb
@@ -13,46 +13,7 @@
 #   eval "$(bundle exec ruby scripts/extract-runner-install-contract.rb claude)"
 
 require "agent_harness"
-
-POSTINSTALL_SIGNAL_KEYS = %i[
-  allow_postinstall
-  postinstall
-  postinstall_command
-  postinstall_required
-  requires_postinstall
-  trusted_postinstall
-].freeze
-
-def postinstall_sensitive_contract?(contract)
-  POSTINSTALL_SIGNAL_KEYS.any? { |key| contract[key] }
-end
-
-def npm_package_name(contract)
-  contract[:package_name] || contract[:package] || contract.dig(:source, :package)
-end
-
-def opencode_fallback_install_command(contract)
-  command = Array(contract[:install_command]).dup
-  return command unless npm_package_name(contract) == "opencode-ai"
-
-  # agent-harness 0.18.2 still models OpenCode as a plain npm install even
-  # though the package needs a trusted postinstall step to extract its native
-  # binary. Keep the hardening default for dependencies, then run the single
-  # allowlisted postinstall explicitly until the upstream contract is released.
-  command + [ "&&", "node", "$(npm root -g)/opencode-ai/postinstall.mjs" ]
-end
-
-def normalized_install_command(contract)
-  command = Array(contract[:install_command]).dup
-  return command if command.empty?
-  return command if postinstall_sensitive_contract?(contract)
-
-  fallback_command = opencode_fallback_install_command(contract)
-  return fallback_command if fallback_command != command
-  return command if command.include?("--ignore-scripts")
-
-  command << "--ignore-scripts"
-end
+require_relative "lib/install_contract_helpers"
 
 runner = ARGV[0]
 unless runner
@@ -145,7 +106,7 @@ if source == :uv_tool
   puts "SUPPORTED_VERSION=#{contract[:version]}"
 elsif is_npm
   package = contract[:package] || (source.is_a?(Hash) && source[:package])
-  install_command = normalized_install_command(contract)
+  install_command = InstallContractHelpers.normalized_install_command(contract)
   puts "SOURCE=npm"
   puts "PACKAGE=#{package}"
   puts "INSTALL_COMMAND=#{install_command.join(" ")}"

--- a/scripts/extract-runner-install-contract.rb
+++ b/scripts/extract-runner-install-contract.rb
@@ -14,9 +14,42 @@
 
 require "agent_harness"
 
+POSTINSTALL_SIGNAL_KEYS = %i[
+  allow_postinstall
+  postinstall
+  postinstall_command
+  postinstall_required
+  requires_postinstall
+  trusted_postinstall
+].freeze
+
+def postinstall_sensitive_contract?(contract)
+  POSTINSTALL_SIGNAL_KEYS.any? { |key| contract[key] }
+end
+
+def npm_package_name(contract)
+  contract[:package_name] || contract[:package] || contract.dig(:source, :package)
+end
+
+def opencode_fallback_install_command(contract)
+  command = Array(contract[:install_command]).dup
+  return command unless npm_package_name(contract) == "opencode-ai"
+
+  # agent-harness 0.18.2 still models OpenCode as a plain npm install even
+  # though the package needs a trusted postinstall step to extract its native
+  # binary. Keep the hardening default for dependencies, then run the single
+  # allowlisted postinstall explicitly until the upstream contract is released.
+  command + [ "&&", "node", "$(npm root -g)/opencode-ai/postinstall.mjs" ]
+end
+
 def normalized_install_command(contract)
   command = Array(contract[:install_command]).dup
-  return command if command.empty? || command.include?("--ignore-scripts")
+  return command if command.empty?
+  return command if postinstall_sensitive_contract?(contract)
+
+  fallback_command = opencode_fallback_install_command(contract)
+  return fallback_command if fallback_command != command
+  return command if command.include?("--ignore-scripts")
 
   command << "--ignore-scripts"
 end

--- a/scripts/install-from-contract.sh
+++ b/scripts/install-from-contract.sh
@@ -81,6 +81,13 @@ else
       echo "ERROR: No INSTALL_COMMAND in contract for provider: $PROVIDER" >&2
       exit 1
     fi
+    case "$INSTALL_COMMAND" in
+      *--ignore-scripts*) ;;
+      *)
+        echo "ERROR: INSTALL_COMMAND for npm provider $PROVIDER must include --ignore-scripts" >&2
+        exit 1
+        ;;
+    esac
     echo "Installing $PROVIDER via npm contract"
     eval "$INSTALL_COMMAND"
     ;;

--- a/scripts/install-from-contract.sh
+++ b/scripts/install-from-contract.sh
@@ -76,13 +76,13 @@ else
 
   case "$SOURCE" in
   npm)
-    PACKAGE=$(echo "$CONTRACT" | sed -n 's/^PACKAGE=//p')
-    if [ -z "$PACKAGE" ]; then
-      echo "ERROR: No PACKAGE in contract for provider: $PROVIDER" >&2
+    INSTALL_COMMAND=$(echo "$CONTRACT" | sed -n 's/^INSTALL_COMMAND=//p')
+    if [ -z "$INSTALL_COMMAND" ]; then
+      echo "ERROR: No INSTALL_COMMAND in contract for provider: $PROVIDER" >&2
       exit 1
     fi
-    echo "Installing $PROVIDER via npm: $PACKAGE"
-    npm install -g --ignore-scripts "$PACKAGE"
+    echo "Installing $PROVIDER via npm contract"
+    eval "$INSTALL_COMMAND"
     ;;
 
   uv_tool)

--- a/scripts/install-from-contract.sh
+++ b/scripts/install-from-contract.sh
@@ -10,7 +10,7 @@
 # Usage:
 #   scripts/install-from-contract.sh <provider>
 #
-# Supported providers: codex, gemini, copilot, kilocode, cursor, aider
+# Supported providers: codex, gemini, copilot, kilocode, cursor, aider, opencode
 
 set -e
 
@@ -34,7 +34,7 @@ done
 PROVIDER="${1:-}"
 if [ -z "$PROVIDER" ]; then
   echo "Usage: $0 <provider>" >&2
-  echo "Supported providers: codex, gemini, copilot, kilocode, cursor, aider" >&2
+  echo "Supported providers: codex, gemini, copilot, kilocode, cursor, aider, opencode" >&2
   exit 1
 fi
 

--- a/scripts/lib/install_contract_helpers.rb
+++ b/scripts/lib/install_contract_helpers.rb
@@ -18,10 +18,9 @@ module InstallContractHelpers
     return command if postinstall_sensitive_contract?(contract)
 
     fallback_command = opencode_fallback_install_command(contract)
-    return fallback_command if fallback_command != command
-    return command if command.include?("--ignore-scripts")
+    return ensure_ignore_scripts(fallback_command) if fallback_command != command
 
-    command << "--ignore-scripts"
+    ensure_ignore_scripts(command)
   end
 
   def postinstall_sensitive_contract?(contract)
@@ -41,5 +40,12 @@ module InstallContractHelpers
     # binary. Keep the hardening default for dependencies, then run the single
     # allowlisted postinstall explicitly until the upstream contract is released.
     command + [ "&&", "node", "$(npm root -g)/opencode-ai/postinstall.mjs" ]
+  end
+
+  def ensure_ignore_scripts(command)
+    return command if command.include?("--ignore-scripts")
+
+    insertion_index = command.index("&&") || command.length
+    command.dup.insert(insertion_index, "--ignore-scripts")
   end
 end

--- a/scripts/lib/install_contract_helpers.rb
+++ b/scripts/lib/install_contract_helpers.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module InstallContractHelpers
+  POSTINSTALL_SIGNAL_KEYS = %i[
+    allow_postinstall
+    postinstall
+    postinstall_command
+    postinstall_required
+    requires_postinstall
+    trusted_postinstall
+  ].freeze
+
+  module_function
+
+  def normalized_install_command(contract)
+    command = Array(contract[:install_command]).dup
+    return command if command.empty?
+    return command if postinstall_sensitive_contract?(contract)
+
+    fallback_command = opencode_fallback_install_command(contract)
+    return fallback_command if fallback_command != command
+    return command if command.include?("--ignore-scripts")
+
+    command << "--ignore-scripts"
+  end
+
+  def postinstall_sensitive_contract?(contract)
+    POSTINSTALL_SIGNAL_KEYS.any? { |key| contract[key] }
+  end
+
+  def npm_package_name(contract)
+    contract[:package_name] || contract[:package] || contract.dig(:source, :package)
+  end
+
+  def opencode_fallback_install_command(contract)
+    command = Array(contract[:install_command]).dup
+    return command unless npm_package_name(contract) == "opencode-ai"
+
+    # agent-harness 0.18.2 still models OpenCode as a plain npm install even
+    # though the package needs a trusted postinstall step to extract its native
+    # binary. Keep the hardening default for dependencies, then run the single
+    # allowlisted postinstall explicitly until the upstream contract is released.
+    command + [ "&&", "node", "$(npm root -g)/opencode-ai/postinstall.mjs" ]
+  end
+end

--- a/spec/config/agent_image_build_script_spec.rb
+++ b/spec/config/agent_image_build_script_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe AgentImageBuildScript, :no_db do
       expect(script_source).not_to include("scripts/extract-provider-install-contract.rb")
     end
 
+    it "passes the opencode install command through instead of rebuilding it from package metadata" do
+      expect(script_source).to include('OPENCODE_INSTALL_COMMAND=$(echo "${OPENCODE_CONTRACT}" | sed -n \'s/^INSTALL_COMMAND=//p\')')
+      expect(script_source).to include('--build-arg "OPENCODE_INSTALL_COMMAND=${OPENCODE_INSTALL_COMMAND}"')
+      expect(script_source).not_to include("OPENCODE_PACKAGE")
+    end
+
     it "extracts the Bundler version from Gemfile.lock for the agent build" do
       expect(script_source).to include("BUNDLER_VERSION=$(awk '/^BUNDLED WITH$/{getline; gsub(/^ +/, \"\", $0); print $0}'")
       expect(script_source).to include('--build-arg "BUNDLER_VERSION=${BUNDLER_VERSION}"')
@@ -31,6 +37,13 @@ RSpec.describe AgentImageBuildScript, :no_db do
       expect(workflow_source).to include('current_bundler_version=$(extract_lockfile_bundler_version "${HEAD_SHA}")')
       expect(workflow_source).to include('bundler: ${previous_bundler_version:-missing} -> ${current_bundler_version:-missing}\n')
       expect(workflow_source).not_to include('| grep -E')
+    end
+
+    it "passes the opencode install command through to the Docker build" do
+      expect(workflow_source).to include("Extract OpenCode install contract from agent-harness")
+      expect(workflow_source).to include('install_command=$(echo "$contract" | sed -n \'s/^INSTALL_COMMAND=//p\')')
+      expect(workflow_source).to include("OPENCODE_INSTALL_COMMAND=${{ steps.opencode-contract.outputs.install_command }}")
+      expect(workflow_source).not_to include("OPENCODE_PACKAGE=${{ steps.opencode-contract.outputs.package }}")
     end
   end
 end

--- a/spec/config/agent_image_build_script_spec.rb
+++ b/spec/config/agent_image_build_script_spec.rb
@@ -8,6 +8,9 @@ end
 class AgentImageWorkflow < Pathname
 end
 
+class AgentDockerfile < Pathname
+end
+
 RSpec.describe AgentImageBuildScript, :no_db do
   describe "build script" do
     subject(:script_source) { Rails.root.join("scripts/build-agent-image.sh").read }
@@ -44,6 +47,15 @@ RSpec.describe AgentImageBuildScript, :no_db do
       expect(workflow_source).to include('install_command=$(echo "$contract" | sed -n \'s/^INSTALL_COMMAND=//p\')')
       expect(workflow_source).to include("OPENCODE_INSTALL_COMMAND=${{ steps.opencode-contract.outputs.install_command }}")
       expect(workflow_source).not_to include("OPENCODE_PACKAGE=${{ steps.opencode-contract.outputs.package }}")
+    end
+  end
+
+  describe AgentDockerfile do
+    subject(:dockerfile_source) { Rails.root.join("docker/agent/Dockerfile").read }
+
+    it "enforces ignore-scripts on the opencode install contract" do
+      expect(dockerfile_source).to include('case "${OPENCODE_INSTALL_COMMAND}" in')
+      expect(dockerfile_source).to include("OPENCODE_INSTALL_COMMAND must include --ignore-scripts for supply-chain safety")
     end
   end
 end

--- a/spec/config/devcontainer_file_spec.rb
+++ b/spec/config/devcontainer_file_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "json"
+
+class DevcontainerFile < Pathname
+end
+
+RSpec.describe DevcontainerFile, :no_db do
+  subject(:devcontainer) do
+    source = Rails.root.join(".devcontainer/devcontainer.json").read
+    JSON.parse(source.lines.reject { |line| line.lstrip.start_with?("//") }.join)
+  end
+
+  it "installs opencode through the shared contract wrapper" do
+    command = devcontainer.fetch("postCreateCommand").fetch("opencode")
+
+    expect(command).to eq("bash scripts/install-from-contract.sh opencode")
+  end
+end

--- a/spec/lib/avo/actions/account_lifecycle_action_spec.rb
+++ b/spec/lib/avo/actions/account_lifecycle_action_spec.rb
@@ -14,10 +14,9 @@ RSpec.describe Avo::Actions::AccountLifecycleAction, :no_db do
   end
   let(:account) { account_class.new(11, "Acme") }
   let(:current_user) { Struct.new(:id, :email).new(7, "operator@example.com") }
-  let(:logger) { instance_double(ActiveSupport::Logger, info: true) }
 
   before do
-    allow(Rails).to receive(:logger).and_return(logger)
+    allow(Rails.logger).to receive(:info)
   end
 
   describe Avo::Actions::SuspendAccount do
@@ -27,7 +26,7 @@ RSpec.describe Avo::Actions::AccountLifecycleAction, :no_db do
       action = described_class.new.handle(query: [ account ], fields: {}, current_user:, resource: nil)
 
       expect(account).to have_received(:suspend!)
-      expect(logger).to have_received(:info).with(
+      expect(Rails.logger).to have_received(:info).with(
         hash_including(
           message: "operator_console.account_lifecycle",
           action: "suspend",

--- a/spec/scripts/install_contract_helpers_spec.rb
+++ b/spec/scripts/install_contract_helpers_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require Rails.root.join("scripts/lib/install_contract_helpers")
+
+RSpec.describe InstallContractHelpers, :no_db do
+  describe ".normalized_install_command" do
+    it "adds ignore-scripts to plain npm installs" do
+      contract = { install_command: [ "npm", "install", "-g", "codex@latest" ] }
+
+      command = described_class.normalized_install_command(contract)
+
+      expect(command).to eq([ "npm", "install", "-g", "codex@latest", "--ignore-scripts" ])
+    end
+
+    it "keeps the opencode fallback scriptless before the trusted postinstall step" do
+      contract = {
+        install_command: [ "npm", "install", "-g", "opencode-ai@latest" ],
+        package: "opencode-ai"
+      }
+
+      command = described_class.normalized_install_command(contract)
+
+      expect(command).to eq([
+        "npm", "install", "-g", "opencode-ai@latest", "--ignore-scripts",
+        "&&", "node", "$(npm root -g)/opencode-ai/postinstall.mjs"
+      ])
+    end
+  end
+end

--- a/spec/scripts/install_contract_scripts_spec.rb
+++ b/spec/scripts/install_contract_scripts_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "open3"
+
+class InstallContractScripts
+end
+
+RSpec.describe InstallContractScripts, :no_db do
+  def run_script(script_path, provider)
+    Open3.capture3({ "BUNDLE_PATH" => ENV["BUNDLE_PATH"].to_s }, "bundle", "exec", "ruby", script_path, provider, chdir: Rails.root.to_s)
+  end
+
+  it "keeps codex installs scriptless by default" do
+    stdout, stderr, status = run_script("scripts/extract-provider-install-contract.rb", "codex")
+
+    expect(status.success?).to be(true), -> { stderr }
+    expect(stdout).to include("SOURCE=npm")
+    expect(stdout).to include("--ignore-scripts")
+    expect(stdout).not_to include("postinstall.mjs")
+  end
+
+  it "adds the trusted opencode postinstall fallback for the current upstream contract" do
+    stdout, stderr, status = run_script("scripts/extract-provider-install-contract.rb", "opencode")
+
+    expect(status.success?).to be(true), -> { stderr }
+    expect(stdout).to include("SOURCE=npm")
+    expect(stdout).to include("INSTALL_COMMAND=npm install -g --ignore-scripts opencode-ai@")
+    expect(stdout).to include("node $(npm root -g)/opencode-ai/postinstall.mjs")
+  end
+
+  it "emits the opencode install command for the agent image build path" do
+    stdout, stderr, status = run_script("scripts/extract-runner-install-contract.rb", "opencode")
+
+    expect(status.success?).to be(true), -> { stderr }
+    expect(stdout).to include("INSTALL_COMMAND=npm install -g --ignore-scripts opencode-ai@")
+    expect(stdout).to include("node $(npm root -g)/opencode-ai/postinstall.mjs")
+  end
+end

--- a/spec/scripts/install_contract_scripts_spec.rb
+++ b/spec/scripts/install_contract_scripts_spec.rb
@@ -7,6 +7,8 @@ class InstallContractScripts
 end
 
 RSpec.describe InstallContractScripts, :no_db do
+  subject(:install_wrapper_source) { Rails.root.join("scripts/install-from-contract.sh").read }
+
   def run_script(script_path, provider)
     Open3.capture3({ "BUNDLE_PATH" => ENV["BUNDLE_PATH"].to_s }, "bundle", "exec", "ruby", script_path, provider, chdir: Rails.root.to_s)
   end
@@ -35,5 +37,10 @@ RSpec.describe InstallContractScripts, :no_db do
     expect(status.success?).to be(true), -> { stderr }
     expect(stdout).to include("INSTALL_COMMAND=npm install -g --ignore-scripts opencode-ai@")
     expect(stdout).to include("node $(npm root -g)/opencode-ai/postinstall.mjs")
+  end
+
+  it "verifies npm install commands stay scriptless before eval" do
+    expect(install_wrapper_source).to include('case "$INSTALL_COMMAND" in')
+    expect(install_wrapper_source).to include("must include --ignore-scripts")
   end
 end


### PR DESCRIPTION
## Summary

Updated OpenCode to use the shared install-contract path in the devcontainer and carried the same contract-driven install command through the agent-image build path. The npm wrapper scripts now execute the contract’s `INSTALL_COMMAND` instead of reconstructing installs from `PACKAGE`, and both extractor scripts preserve `--ignore-scripts` for normal npm providers while adding a backward-compatible OpenCode postinstall fallback for the current `agent-harness 0.18.2` contract.

I added coverage for the devcontainer entry, the agent-image plumbing, and the extractor behavior. `bin/rails db:prepare`, `bundle exec rubocop`, and `bundle exec rspec` all passed in this environment; `rspec` still has the existing 7 pending examples. Commit: `3eae29f` (`fix(opencode): adopt install contract postinstall flow`).

---

Closes #2297