### PR TITLE
feat(roi): Phase 7.1 — ROI, Evals & Benchmarking

### DIFF
--- a/app/controllers/accounts/roi_dashboards_controller.rb
+++ b/app/controllers/accounts/roi_dashboards_controller.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "csv"
+
+module Accounts
+  class RoiDashboardsController < ApplicationController
+    def show
+      authorize current_account
+      @stats = Accounts::RoiDashboardStats.call(account: current_account)
+    end
+
+    def export
+      authorize current_account, :show?
+      stats = Accounts::RoiDashboardStats.call(account: current_account)
+
+      send_data generate_csv(stats),
+        filename: "account-roi-report-#{current_account.slug}-#{Date.current}.csv",
+        type: "text/csv"
+    end
+
+    private
+
+    def generate_csv(stats)
+      CSV.generate do |csv|
+        csv << [ "Executive Summary" ]
+        stats[:executive_summary].each { |line| csv << [ line ] }
+        csv << []
+        csv << [ "Metric", "Account Current" ]
+        Roi::MetricDefinitions::ALL.each do |definition|
+          csv << [ definition[:name], stats[:summary][definition[:key]] ]
+        end
+
+        csv << []
+        csv << [ "Benchmark Rollups" ]
+        csv << [ "Label", "Type", "Accepted PRs", "Merge Rate", "Cycle Time (hrs)", "Rework Rate", "Defect Escape Rate", "Cost / Accepted PR (cents)" ]
+        stats[:benchmark_rollups].each do |benchmark|
+          csv << [
+            benchmark[:benchmark_label],
+            benchmark[:benchmark_type],
+            benchmark[:accepted_pr_count],
+            benchmark[:merge_rate],
+            benchmark[:average_cycle_time_hours],
+            benchmark[:rework_rate],
+            benchmark[:defect_escape_rate],
+            benchmark[:cost_per_accepted_pr_cents]
+          ]
+        end
+
+        csv << []
+        csv << [ "Projects" ]
+        csv << [ "Project", "Accepted PRs", "Merge Rate", "Cycle Time (hrs)", "Rework Rate", "Defect Escape Rate", "Cost / Accepted PR (cents)" ]
+        stats[:project_rows].each do |row|
+          csv << [
+            row[:project].name,
+            row[:summary][:accepted_pr_count],
+            row[:summary][:merge_rate],
+            row[:summary][:average_cycle_time_hours],
+            row[:summary][:rework_rate],
+            row[:summary][:defect_escape_rate],
+            row[:summary][:cost_per_accepted_pr_cents]
+          ]
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/projects/roi_benchmarks_controller.rb
+++ b/app/controllers/projects/roi_benchmarks_controller.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Projects
+  class RoiBenchmarksController < ApplicationController
+    before_action :set_project
+    before_action :set_roi_benchmark, only: :destroy
+
+    def create
+      authorize @project, :update?
+
+      @project.roi_benchmarks.create!(roi_benchmark_params)
+      redirect_to project_roi_dashboard_path(@project), notice: "ROI benchmark added."
+    rescue ActiveRecord::RecordInvalid => e
+      @stats = Projects::RoiDashboardStats.call(project: @project)
+      @roi_benchmark = e.record
+      flash.now[:alert] = @roi_benchmark.errors.full_messages.to_sentence
+      render "projects/roi_dashboards/show", status: :unprocessable_content
+    end
+
+    def destroy
+      authorize @project, :update?
+
+      @roi_benchmark.destroy!
+      redirect_to project_roi_dashboard_path(@project), notice: "ROI benchmark removed."
+    end
+
+    private
+
+    def set_project
+      @project = policy_scope(Project).find(params[:project_id])
+    end
+
+    def set_roi_benchmark
+      @roi_benchmark = @project.roi_benchmarks.find(params[:id])
+    end
+
+    def roi_benchmark_params
+      params.require(:roi_benchmark).permit(
+        :name,
+        :benchmark_type,
+        :tool_name,
+        :starts_at,
+        :ends_at,
+        :merge_rate,
+        :average_cycle_time_hours,
+        :rework_rate,
+        :defect_escape_rate,
+        :cost_per_accepted_pr_cents,
+        :accepted_pr_count,
+        :notes
+      )
+    end
+  end
+end

--- a/app/controllers/projects/roi_dashboards_controller.rb
+++ b/app/controllers/projects/roi_dashboards_controller.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "csv"
+
+module Projects
+  class RoiDashboardsController < ApplicationController
+    before_action :set_project
+
+    def show
+      authorize @project, :show?
+      @stats = Projects::RoiDashboardStats.call(project: @project)
+      @roi_benchmark = @project.roi_benchmarks.build
+    end
+
+    def export
+      authorize @project, :show?
+      stats = Projects::RoiDashboardStats.call(project: @project)
+
+      send_data generate_csv(stats),
+        filename: "roi-report-#{@project.name.parameterize}-#{Date.current}.csv",
+        type: "text/csv"
+    end
+
+    private
+
+    def set_project
+      @project = policy_scope(Project).find(params[:project_id])
+    end
+
+    def generate_csv(stats)
+      CSV.generate do |csv|
+        csv << [ "Executive Summary" ]
+        stats[:executive_summary].each { |line| csv << [ line ] }
+        csv << []
+        csv << [ "Metric", "Paid Current", "Benchmark" ]
+
+        Roi::MetricDefinitions::ALL.each do |definition|
+          csv << [ definition[:name], stats[:summary][definition[:key]], nil ]
+        end
+
+        csv << []
+        csv << [ "Benchmarks" ]
+        csv << [ "Label", "Type", "Accepted PRs", "Merge Rate", "Cycle Time (hrs)", "Rework Rate", "Defect Escape Rate", "Cost / Accepted PR (cents)" ]
+        stats[:benchmarks].each do |benchmark|
+          csv << [
+            benchmark[:benchmark_label],
+            benchmark[:benchmark_type],
+            benchmark[:accepted_pr_count],
+            benchmark[:merge_rate],
+            benchmark[:average_cycle_time_hours],
+            benchmark[:rework_rate],
+            benchmark[:defect_escape_rate],
+            benchmark[:cost_per_accepted_pr_cents]
+          ]
+        end
+
+        csv << []
+        csv << [ "Trend" ]
+        csv << [ "Period", "Accepted PRs", "Merge Rate", "Cycle Time (hrs)", "Rework Rate", "Defect Escape Rate", "Cost / Accepted PR (cents)" ]
+        stats[:trend].each do |row|
+          csv << [
+            row[:label],
+            row[:accepted_pr_count],
+            row[:merge_rate],
+            row[:average_cycle_time_hours],
+            row[:rework_rate],
+            row[:defect_escape_rate],
+            row[:cost_per_accepted_pr_cents]
+          ]
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/roi_dashboard_helper.rb
+++ b/app/helpers/roi_dashboard_helper.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module RoiDashboardHelper
+  INVERSE_ROI_METRICS = %i[average_cycle_time_hours rework_rate defect_escape_rate cost_per_accepted_pr_cents].freeze
+
+  def roi_metric_value(metric_key, value)
+    return "--" if value.nil?
+
+    case metric_key.to_sym
+    when :merge_rate, :rework_rate, :defect_escape_rate
+      number_to_percentage(value, precision: 1)
+    when :average_cycle_time_hours
+      "#{value.round(1)}h"
+    when :cost_per_accepted_pr_cents
+      format_cost_cents(value.to_i)
+    else
+      value
+    end
+  end
+
+  def roi_delta(metric_key, current, baseline)
+    return "--" if current.nil? || baseline.nil?
+
+    delta = current - baseline
+    if metric_key.to_sym == :cost_per_accepted_pr_cents
+      cents = delta.round
+      sign = cents.positive? ? "+" : ""
+      "#{sign}#{format_cost_cents(cents.abs)}"
+    elsif metric_key.to_sym == :average_cycle_time_hours
+      sign = delta.positive? ? "+" : ""
+      "#{sign}#{delta.round(1)}h"
+    else
+      sign = delta.positive? ? "+" : ""
+      "#{sign}#{number_to_percentage(delta, precision: 1)}"
+    end
+  end
+
+  def roi_delta_class(metric_key, current, baseline)
+    return "text-gray-400" if current.nil? || baseline.nil?
+
+    delta = current - baseline
+    favorable = INVERSE_ROI_METRICS.include?(metric_key.to_sym) ? delta.negative? : delta.positive?
+
+    if favorable
+      "text-green-600"
+    elsif delta.zero?
+      "text-gray-500"
+    else
+      "text-red-600"
+    end
+  end
+
+  def roi_benchmark_type_label(benchmark_type)
+    case benchmark_type
+    when "human_only"
+      "Human-only"
+    when "commercial_agent"
+      "Commercial agent"
+    else
+      benchmark_type.to_s.titleize
+    end
+  end
+end

--- a/app/helpers/roi_dashboard_helper.rb
+++ b/app/helpers/roi_dashboard_helper.rb
@@ -24,7 +24,7 @@ module RoiDashboardHelper
     delta = current - baseline
     if metric_key.to_sym == :cost_per_accepted_pr_cents
       cents = delta.round
-      sign = cents.positive? ? "+" : ""
+      sign = cents.positive? ? "+" : cents.negative? ? "-" : ""
       "#{sign}#{format_cost_cents(cents.abs)}"
     elsif metric_key.to_sym == :average_cycle_time_hours
       sign = delta.positive? ? "+" : ""

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -14,6 +14,7 @@ class Account < ApplicationRecord
   has_many :members, through: :account_memberships, source: :user
   has_many :provider_api_keys, through: :users
   has_many :projects, dependent: :destroy
+  has_many :roi_benchmarks, through: :projects
   has_many :github_tokens, dependent: :destroy
   has_many :github_installations, dependent: :destroy
   has_many :integration_credentials, dependent: :destroy

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -152,6 +152,7 @@ class Project < ApplicationRecord
   has_many :container_pool_entries, dependent: :destroy
   has_many :worktrees, dependent: :destroy
   has_many :cost_budgets, dependent: :destroy
+  has_many :roi_benchmarks, dependent: :destroy
   has_many :project_baselines, dependent: :destroy
   has_many :agent_run_anomalies, dependent: :destroy
   has_many :quality_recovery_actions, dependent: :destroy

--- a/app/models/roi_benchmark.rb
+++ b/app/models/roi_benchmark.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class RoiBenchmark < ApplicationRecord
+  BENCHMARK_TYPES = %w[human_only commercial_agent].freeze
+
+  belongs_to :project
+
+  validates :name, presence: true, length: { maximum: 255 }
+  validates :benchmark_type, presence: true, inclusion: { in: BENCHMARK_TYPES }
+  validates :tool_name, length: { maximum: 100 }, allow_blank: true
+  validates :accepted_pr_count, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :cost_per_accepted_pr_cents, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :average_cycle_time_hours, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :merge_rate, :rework_rate, :defect_escape_rate,
+    numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 100 },
+    allow_nil: true
+  validate :commercial_agent_requires_tool_name
+  validate :ends_at_not_before_starts_at
+
+  scope :recent, -> { order(ends_at: :desc, created_at: :desc) }
+
+  def benchmark_label
+    return "#{name} (#{tool_name})" if commercial_agent? && tool_name.present?
+
+    name
+  end
+
+  def commercial_agent?
+    benchmark_type == "commercial_agent"
+  end
+
+  private
+
+  def commercial_agent_requires_tool_name
+    return unless commercial_agent?
+    return if tool_name.present?
+
+    errors.add(:tool_name, "is required for commercial agent benchmarks")
+  end
+
+  def ends_at_not_before_starts_at
+    return if starts_at.blank? || ends_at.blank?
+    return if ends_at >= starts_at
+
+    errors.add(:ends_at, "must be on or after the start date")
+  end
+end

--- a/app/services/accounts/roi_dashboard_stats.rb
+++ b/app/services/accounts/roi_dashboard_stats.rb
@@ -46,15 +46,21 @@ module Accounts
     attr_reader :account
 
     def project_rows
-      @project_rows ||= account.projects.order(:name).map do |project|
-        {
-          project: project,
-          summary: Roi::MetricsCalculator.call(
-            agent_runs: project.agent_runs,
-            related_runs: project.agent_runs,
-            window: current_window
-          )
-        }
+      @project_rows ||= begin
+        runs_by_project = current_window_runs.group_by(&:project_id)
+
+        account.projects.order(:name).map do |project|
+          project_runs = runs_by_project.fetch(project.id, [])
+
+          {
+            project: project,
+            summary: Roi::MetricsCalculator.call(
+              agent_runs: project_runs,
+              related_runs: project_runs,
+              window: current_window
+            )
+          }
+        end
       end
     end
 
@@ -119,6 +125,16 @@ module Accounts
 
     def current_window
       WINDOW.ago..Time.current
+    end
+
+    def current_window_runs
+      @current_window_runs ||= account_runs
+        .where(goal: "create_pr", status: "completed")
+        .where.not(pull_request_number: nil)
+        .where(created_at: current_window)
+        .includes(:issue, :quality_metrics)
+        .order(:created_at)
+        .to_a
     end
   end
 end

--- a/app/services/accounts/roi_dashboard_stats.rb
+++ b/app/services/accounts/roi_dashboard_stats.rb
@@ -67,11 +67,11 @@ module Accounts
           benchmark_label: label,
           benchmark_type: benchmark_type,
           accepted_pr_count: accepted_weight,
-          merge_rate: weighted_average(rows, :merge_rate, accepted_weight),
-          average_cycle_time_hours: weighted_average(rows, :average_cycle_time_hours, accepted_weight),
-          rework_rate: weighted_average(rows, :rework_rate, accepted_weight),
-          defect_escape_rate: weighted_average(rows, :defect_escape_rate, accepted_weight),
-          cost_per_accepted_pr_cents: weighted_average(rows, :cost_per_accepted_pr_cents, accepted_weight)&.round
+          merge_rate: weighted_average(rows, :merge_rate),
+          average_cycle_time_hours: weighted_average(rows, :average_cycle_time_hours),
+          rework_rate: weighted_average(rows, :rework_rate),
+          defect_escape_rate: weighted_average(rows, :defect_escape_rate),
+          cost_per_accepted_pr_cents: weighted_average(rows, :cost_per_accepted_pr_cents)&.round
         }
       end.sort_by { |row| -row[:accepted_pr_count].to_i }
     end
@@ -95,7 +95,7 @@ module Accounts
       end
     end
 
-    def weighted_average(rows, field, accepted_weight)
+    def weighted_average(rows, field)
       values = rows.filter_map do |row|
         value = row.public_send(field)
         next if value.nil?
@@ -107,7 +107,7 @@ module Accounts
       end
       return nil if values.empty?
 
-      divisor = accepted_weight.positive? ? accepted_weight : values.sum { |(_, weight)| weight }
+      divisor = values.sum { |(_, weight)| weight }
       return nil if divisor.zero?
 
       (values.sum { |(value, weight)| value * weight } / divisor.to_f).round(2)

--- a/app/services/accounts/roi_dashboard_stats.rb
+++ b/app/services/accounts/roi_dashboard_stats.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+module Accounts
+  class RoiDashboardStats
+    WINDOW = 90.days
+    TREND_MONTHS = 6
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def self.overview(...)
+      new(...).summary
+    end
+
+    def initialize(account:)
+      @account = account
+    end
+
+    def call
+      {
+        summary: summary,
+        trend: trend,
+        benchmark_rollups: benchmark_rollups,
+        project_rows: project_rows,
+        executive_summary: Roi::ExecutiveSummary.call(
+          scope_label: account.name,
+          summary: summary,
+          benchmarks: benchmark_rollups
+        ),
+        metric_definitions: Roi::MetricDefinitions::ALL,
+        templates: Roi::ExperimentTemplates::ALL
+      }
+    end
+
+    def summary
+      @summary ||= Roi::MetricsCalculator.call(
+        agent_runs: account_runs,
+        related_runs: account_runs,
+        window: current_window
+      )
+    end
+
+    private
+
+    attr_reader :account
+
+    def project_rows
+      @project_rows ||= account.projects.order(:name).map do |project|
+        {
+          project: project,
+          summary: Roi::MetricsCalculator.call(
+            agent_runs: project.agent_runs,
+            related_runs: project.agent_runs,
+            window: current_window
+          )
+        }
+      end
+    end
+
+    def benchmark_rollups
+      @benchmark_rollups ||= account.roi_benchmarks.recent.group_by do |benchmark|
+        [ benchmark.benchmark_type, benchmark.tool_name.presence || benchmark.name ]
+      end.map do |(benchmark_type, label), rows|
+        accepted_weight = rows.sum(&:accepted_pr_count)
+        {
+          benchmark_label: label,
+          benchmark_type: benchmark_type,
+          accepted_pr_count: accepted_weight,
+          merge_rate: weighted_average(rows, :merge_rate, accepted_weight),
+          average_cycle_time_hours: weighted_average(rows, :average_cycle_time_hours, accepted_weight),
+          rework_rate: weighted_average(rows, :rework_rate, accepted_weight),
+          defect_escape_rate: weighted_average(rows, :defect_escape_rate, accepted_weight),
+          cost_per_accepted_pr_cents: weighted_average(rows, :cost_per_accepted_pr_cents, accepted_weight)&.round
+        }
+      end.sort_by { |row| -row[:accepted_pr_count].to_i }
+    end
+
+    def trend
+      TREND_MONTHS.times.map do |offset|
+        start_time = (TREND_MONTHS - offset - 1).months.ago.beginning_of_month
+        end_time = start_time.end_of_month
+        snapshot = Roi::MetricsCalculator.call(
+          agent_runs: account_runs,
+          related_runs: account_runs,
+          window: start_time..end_time
+        )
+
+        {
+          label: start_time.strftime("%b %Y"),
+          starts_at: start_time,
+          ends_at: end_time,
+          **snapshot
+        }
+      end
+    end
+
+    def weighted_average(rows, field, accepted_weight)
+      values = rows.filter_map do |row|
+        value = row.public_send(field)
+        next if value.nil?
+
+        weight = row.accepted_pr_count
+        next if weight.zero?
+
+        [ value.to_f, weight ]
+      end
+      return nil if values.empty?
+
+      divisor = accepted_weight.positive? ? accepted_weight : values.sum { |(_, weight)| weight }
+      return nil if divisor.zero?
+
+      (values.sum { |(value, weight)| value * weight } / divisor.to_f).round(2)
+    end
+
+    def account_runs
+      @account_runs ||= AgentRun.joins(:project).where(projects: { account_id: account.id })
+    end
+
+    def current_window
+      WINDOW.ago..Time.current
+    end
+  end
+end

--- a/app/services/projects/roi_dashboard_stats.rb
+++ b/app/services/projects/roi_dashboard_stats.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module Projects
+  class RoiDashboardStats
+    WINDOW = 90.days
+    TREND_MONTHS = 6
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(project:)
+      @project = project
+    end
+
+    def call
+      {
+        summary: summary,
+        trend: trend,
+        benchmarks: benchmarks,
+        executive_summary: Roi::ExecutiveSummary.call(
+          scope_label: project.name,
+          summary: summary,
+          benchmarks: benchmarks
+        ),
+        metric_definitions: Roi::MetricDefinitions::ALL,
+        templates: Roi::ExperimentTemplates::ALL
+      }
+    end
+
+    private
+
+    attr_reader :project
+
+    def summary
+      @summary ||= Roi::MetricsCalculator.call(
+        agent_runs: project.agent_runs,
+        related_runs: project.agent_runs,
+        window: current_window
+      )
+    end
+
+    def benchmarks
+      @benchmarks ||= project.roi_benchmarks.recent.map do |benchmark|
+        {
+          id: benchmark.id,
+          benchmark_label: benchmark.benchmark_label,
+          benchmark_type: benchmark.benchmark_type,
+          tool_name: benchmark.tool_name,
+          starts_at: benchmark.starts_at,
+          ends_at: benchmark.ends_at,
+          accepted_pr_count: benchmark.accepted_pr_count,
+          merge_rate: benchmark.merge_rate&.to_f,
+          average_cycle_time_hours: benchmark.average_cycle_time_hours&.to_f,
+          rework_rate: benchmark.rework_rate&.to_f,
+          defect_escape_rate: benchmark.defect_escape_rate&.to_f,
+          cost_per_accepted_pr_cents: benchmark.cost_per_accepted_pr_cents,
+          notes: benchmark.notes
+        }
+      end
+    end
+
+    def trend
+      TREND_MONTHS.times.map do |offset|
+        start_time = (TREND_MONTHS - offset - 1).months.ago.beginning_of_month
+        end_time = start_time.end_of_month
+        snapshot = Roi::MetricsCalculator.call(
+          agent_runs: project.agent_runs,
+          related_runs: project.agent_runs,
+          window: start_time..end_time
+        )
+
+        {
+          label: start_time.strftime("%b %Y"),
+          starts_at: start_time,
+          ends_at: end_time,
+          **snapshot
+        }
+      end
+    end
+
+    def current_window
+      WINDOW.ago..Time.current
+    end
+  end
+end

--- a/app/services/roi/executive_summary.rb
+++ b/app/services/roi/executive_summary.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Roi
+  class ExecutiveSummary
+    WINDOW_LABEL = "last 90 days".freeze
+    INVERSE_METRICS = %i[average_cycle_time_hours rework_rate defect_escape_rate cost_per_accepted_pr_cents].freeze
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(scope_label:, summary:, benchmarks:)
+      @scope_label = scope_label
+      @summary = summary
+      @benchmarks = benchmarks
+    end
+
+    def call
+      [ production_line, comparison_line ].compact
+    end
+
+    private
+
+    attr_reader :scope_label, :summary, :benchmarks
+
+    def production_line
+      if summary[:accepted_pr_count].zero?
+        "#{scope_label} has no accepted PR evidence in the #{WINDOW_LABEL} yet. Start with a pilot template and add a baseline benchmark to quantify progress."
+      else
+        "#{scope_label} produced #{summary[:accepted_pr_count]} accepted PRs from #{summary[:created_pr_count]} created PRs in the #{WINDOW_LABEL}, with a #{summary[:merge_rate]}% merge rate, #{summary[:average_cycle_time_hours]}h average cycle time, and #{currency(summary[:cost_per_accepted_pr_cents])} cost per accepted PR."
+      end
+    end
+
+    def comparison_line
+      benchmark = benchmarks.max_by { |row| row[:accepted_pr_count].to_i }
+      return "Add a human-only or commercial benchmark to produce a procurement-ready side-by-side comparison." if benchmark.nil?
+      return unless summary[:accepted_pr_count].positive?
+
+      comparisons = Roi::MetricDefinitions::ALL.filter_map do |definition|
+        current = summary[definition[:key]]
+        baseline = benchmark[definition[:key]]
+        next if current.nil? || baseline.nil?
+
+        delta = current - baseline
+        favorable = INVERSE_METRICS.include?(definition[:key]) ? delta.negative? : delta.positive?
+        next unless favorable
+
+        {
+          name: definition[:name],
+          delta: delta,
+          inverse: INVERSE_METRICS.include?(definition[:key])
+        }
+      end
+      strongest = comparisons.max_by { |comparison| comparison[:delta].abs }
+      return "Paid is being measured against #{benchmark[:benchmark_label]} across the full ROI framework." if strongest.nil?
+
+      "#{scope_label} currently outperforms #{benchmark[:benchmark_label]} most clearly on #{strongest[:name].downcase} (#{delta_label(strongest[:delta], inverse: strongest[:inverse])})."
+    end
+
+    def delta_label(delta, inverse:)
+      if inverse
+        if delta.negative?
+          magnitude = -delta
+          magnitude.is_a?(Float) ? "#{magnitude.round(1)} lower" : "#{magnitude} lower"
+        else
+          "#{delta.round(1)} higher"
+        end
+      else
+        "#{delta.round(1)} points"
+      end
+    end
+
+    def currency(cents)
+      return "--" if cents.nil?
+
+      format("$%.2f", cents / 100.0)
+    end
+  end
+end

--- a/app/services/roi/experiment_templates.rb
+++ b/app/services/roi/experiment_templates.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Roi
+  class ExperimentTemplates
+    ALL = [
+      {
+        key: "two_week_bug_fix_pilot",
+        name: "2-week bug-fix pilot",
+        duration: "14 days",
+        motion: "Route a bounded stream of bug tickets through Paid and compare against the current human-only lane.",
+        success_criteria: [
+          "Higher merge rate on bug tickets",
+          "Lower cycle time from issue open to accepted PR",
+          "Lower cost per accepted PR than the current delivery path"
+        ],
+        benchmark_plan: "Capture one human-only benchmark entry before launch, then update weekly."
+      },
+      {
+        key: "backlog_burndown_pilot",
+        name: "Backlog burn-down pilot",
+        duration: "21 days",
+        motion: "Run Paid against a curated queue of aging backlog issues while maintaining a matched human baseline cohort.",
+        success_criteria: [
+          "More accepted PRs per week",
+          "Stable or lower rework and defect escape rates",
+          "Clear payback narrative for procurement and expansion review"
+        ],
+        benchmark_plan: "Track benchmark entries for the human lane and any commercial-agent comparison in the same period."
+      }
+    ].freeze
+  end
+end

--- a/app/services/roi/metric_definitions.rb
+++ b/app/services/roi/metric_definitions.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Roi
+  class MetricDefinitions
+    ALL = [
+      {
+        key: :merge_rate,
+        name: "Merge rate",
+        objective: "maximize",
+        description: "Accepted pull requests divided by created pull requests in the measurement window."
+      },
+      {
+        key: :average_cycle_time_hours,
+        name: "Cycle time",
+        objective: "minimize",
+        description: "Average elapsed hours from issue intake to accepted pull request."
+      },
+      {
+        key: :rework_rate,
+        name: "Rework rate",
+        objective: "minimize",
+        description: "Accepted pull requests that needed reruns, retries, or follow-up work."
+      },
+      {
+        key: :defect_escape_rate,
+        name: "Defect escape rate",
+        objective: "minimize",
+        description: "Accepted pull requests followed by additional issue work after acceptance."
+      },
+      {
+        key: :cost_per_accepted_pr_cents,
+        name: "Cost per accepted PR",
+        objective: "minimize",
+        description: "Total create-PR spend divided by accepted pull requests."
+      }
+    ].freeze
+  end
+end

--- a/app/services/roi/metrics_calculator.rb
+++ b/app/services/roi/metrics_calculator.rb
@@ -44,10 +44,11 @@ module Roi
     attr_reader :agent_runs, :related_runs, :window
 
     def scoped_runs
-      scope = agent_runs.where(goal: "create_pr", status: "completed").where.not(pull_request_number: nil)
-      scope = scope.where(created_at: window) if window
-
-      scope.includes(:issue, :quality_metrics).order(:created_at).to_a
+      @scoped_runs ||= if relation_like?(agent_runs)
+        scoped_relation(agent_runs).includes(:issue, :quality_metrics).order(:created_at).to_a
+      else
+        scoped_array(agent_runs)
+      end
     end
 
     def accepted_snapshot_for(run)
@@ -94,12 +95,42 @@ module Roi
       issue_ids = accepted_runs.map { |snapshot| snapshot[:run].issue_id }.compact.uniq
       return {} if issue_ids.empty?
 
-      scope = related_runs.where(issue_id: issue_ids).where.not(goal: "create_issue")
-      scope = scope.where(created_at: window) if window
+      if relation_like?(related_runs)
+        scope = related_runs.where(issue_id: issue_ids).where.not(goal: "create_issue")
+        scope = scope.where(created_at: window) if window
 
-      scope.pluck(:issue_id, :created_at).each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |(issue_id, created_at), memo|
-        memo[issue_id] << created_at
+        scope.pluck(:issue_id, :created_at).each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |(issue_id, created_at), memo|
+          memo[issue_id] << created_at
+        end
+      else
+        related_runs
+          .select { |run| issue_ids.include?(run.issue_id) && run.goal != "create_issue" }
+          .select { |run| window.nil? || window.cover?(run.created_at) }
+          .each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |run, memo|
+            memo[run.issue_id] << run.created_at
+          end
       end
+    end
+
+    def relation_like?(runs)
+      runs.respond_to?(:where)
+    end
+
+    def scoped_relation(runs)
+      scope = runs.where(goal: "create_pr", status: "completed").where.not(pull_request_number: nil)
+      scope = scope.where(created_at: window) if window
+      scope
+    end
+
+    def scoped_array(runs)
+      runs
+        .select do |run|
+          run.goal == "create_pr" &&
+            run.status == "completed" &&
+            run.pull_request_number.present? &&
+            (window.nil? || window.cover?(run.created_at))
+        end
+        .sort_by(&:created_at)
     end
 
     def average(values)

--- a/app/services/roi/metrics_calculator.rb
+++ b/app/services/roi/metrics_calculator.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+module Roi
+  class MetricsCalculator
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(agent_runs:, related_runs: agent_runs, window: nil)
+      @agent_runs = agent_runs
+      @related_runs = related_runs
+      @window = window
+    end
+
+    def call
+      runs = scoped_runs
+      return empty_summary if runs.empty?
+
+      accepted_runs = runs.filter_map { |run| accepted_snapshot_for(run) }
+      total_cost_cents = runs.sum { |run| run.cost_cents.to_i }
+      issue_run_counts = runs.group_by(&:issue_id).transform_values(&:size)
+      later_run_times_by_issue = load_later_run_times(accepted_runs)
+
+      cycle_times = accepted_runs.filter_map { |snapshot| cycle_time_hours_for(snapshot) }
+      rework_count = accepted_runs.count { |snapshot| rework?(snapshot, issue_run_counts:) }
+      defect_escape_count = accepted_runs.count { |snapshot| defect_escape?(snapshot, later_run_times_by_issue:) }
+      accepted_count = accepted_runs.size
+      created_count = runs.size
+
+      {
+        created_pr_count: created_count,
+        accepted_pr_count: accepted_count,
+        total_cost_cents: total_cost_cents,
+        merge_rate: percentage(accepted_count, created_count),
+        average_cycle_time_hours: average(cycle_times),
+        rework_rate: percentage(rework_count, accepted_count),
+        defect_escape_rate: percentage(defect_escape_count, accepted_count),
+        cost_per_accepted_pr_cents: accepted_count.zero? ? nil : (total_cost_cents.to_f / accepted_count).round
+      }
+    end
+
+    private
+
+    attr_reader :agent_runs, :related_runs, :window
+
+    def scoped_runs
+      scope = agent_runs.where(goal: "create_pr", status: "completed").where.not(pull_request_number: nil)
+      scope = scope.where(created_at: window) if window
+
+      scope.includes(:issue, :quality_metrics).order(:created_at).to_a
+    end
+
+    def accepted_snapshot_for(run)
+      merged_metric = run.quality_metrics
+        .select { |metric| metric.metric_type == "human" && metric.scores&.key?("pr_merged") }
+        .max_by(&:created_at)
+      return unless merged_metric
+      return unless merged_metric.scores["pr_merged"].to_f >= 1.0
+
+      {
+        run: run,
+        issue: run.issue,
+        accepted_at: merged_metric.created_at || run.completed_at || run.updated_at
+      }
+    end
+
+    def cycle_time_hours_for(snapshot)
+      started_at = snapshot[:issue]&.github_created_at || snapshot[:run].created_at
+      accepted_at = snapshot[:accepted_at]
+      return if started_at.blank? || accepted_at.blank?
+
+      ((accepted_at - started_at) / 1.hour).round(2)
+    end
+
+    def rework?(snapshot, issue_run_counts:)
+      issue = snapshot[:issue]
+      run = snapshot[:run]
+
+      run.iterations.to_i > 1 ||
+        issue_run_counts.fetch(run.issue_id, 0) > 1 ||
+        issue&.pr_followup_count.to_i.positive? ||
+        issue&.review_goal_retry_count.to_i.positive? ||
+        issue&.draft_review_count.to_i.positive?
+    end
+
+    def defect_escape?(snapshot, later_run_times_by_issue:)
+      issue_id = snapshot[:run].issue_id
+      return false if issue_id.blank?
+
+      later_run_times_by_issue.fetch(issue_id, []).any? { |created_at| created_at > snapshot[:accepted_at] }
+    end
+
+    def load_later_run_times(accepted_runs)
+      issue_ids = accepted_runs.map { |snapshot| snapshot[:run].issue_id }.compact.uniq
+      return {} if issue_ids.empty?
+
+      scope = related_runs.where(issue_id: issue_ids).where.not(goal: "create_issue")
+      scope = scope.where(created_at: window) if window
+
+      scope.pluck(:issue_id, :created_at).each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |(issue_id, created_at), memo|
+        memo[issue_id] << created_at
+      end
+    end
+
+    def average(values)
+      return nil if values.empty?
+
+      (values.sum.to_f / values.size).round(2)
+    end
+
+    def percentage(numerator, denominator)
+      return nil if denominator.zero?
+
+      (numerator.to_f / denominator * 100).round(1)
+    end
+
+    def empty_summary
+      {
+        created_pr_count: 0,
+        accepted_pr_count: 0,
+        total_cost_cents: 0,
+        merge_rate: nil,
+        average_cycle_time_hours: nil,
+        rework_rate: nil,
+        defect_escape_rate: nil,
+        cost_per_accepted_pr_cents: nil
+      }
+    end
+  end
+end

--- a/app/services/screenshots/capture_targets.rb
+++ b/app/services/screenshots/capture_targets.rb
@@ -49,6 +49,7 @@ module Screenshots
       "integrations" => %i[integrations integrations_new],
       "knowledge" => %i[knowledge_search project_knowledge_search project_knowledge_browse project_context_intake project_knowledge_recommendations],
       "quality_metrics" => %i[quality_dashboard project_quality_dashboard],
+      "roi_dashboard" => %i[account_roi_dashboard project_roi_dashboard],
       "workflow" => [ :workflow_status ]
     }.freeze
 

--- a/app/services/screenshots/capture_targets.rb
+++ b/app/services/screenshots/capture_targets.rb
@@ -31,6 +31,7 @@ module Screenshots
       onboarding
       user_settings
       account
+      account_roi_dashboard
       account_audit_logs
       quality_dashboard
       chat_sessions
@@ -84,6 +85,7 @@ module Screenshots
       provider_api_key_edit: Target.new(slug: "provider_api_key_edit", path_builder: ->(seed_data) { "/provider_api_keys/#{seed_data.fetch(:provider_api_key).id}/edit" }, requires_auth: true),
       user_settings: Target.new(slug: "user_settings", path_builder: "/user_settings/edit", requires_auth: true),
       account: Target.new(slug: "account", path_builder: "/account", requires_auth: true),
+      account_roi_dashboard: Target.new(slug: "account_roi_dashboard", path_builder: "/account_roi_dashboard", requires_auth: true),
       account_compliance_dashboard: Target.new(slug: "account_compliance_dashboard", path_builder: "/account_compliance_dashboard", requires_auth: true),
       account_audit_logs: Target.new(slug: "account_audit_logs", path_builder: "/account_audit_logs", requires_auth: true),
       tenant_configuration: Target.new(slug: "tenant_configuration", path_builder: "/tenant_configuration/edit", requires_auth: true),
@@ -154,6 +156,7 @@ module Screenshots
         requires_auth: true
       ),
       project_quality_dashboard: Target.new(slug: "project_quality_dashboard", path_builder: ->(seed_data) { "/projects/#{seed_data.fetch(:project).id}/quality_dashboard" }, requires_auth: true),
+      project_roi_dashboard: Target.new(slug: "project_roi_dashboard", path_builder: ->(seed_data) { "/projects/#{seed_data.fetch(:project).id}/roi_dashboard" }, requires_auth: true),
       project_convention_settings: Target.new(slug: "project_convention_settings", path_builder: ->(seed_data) { "/projects/#{seed_data.fetch(:project).id}/convention_settings" }, requires_auth: true),
       project_bundle_performance_dashboard: Target.new(slug: "project_bundle_performance_dashboard", path_builder: ->(seed_data) { "/projects/#{seed_data.fetch(:project).id}/bundle_performance_dashboard" }, requires_auth: true),
       project_cost_snapshot: Target.new(slug: "project_cost_snapshot", path_builder: ->(seed_data) { "/projects/#{seed_data.fetch(:project).id}/cost_snapshot" }, requires_auth: true),
@@ -250,11 +253,14 @@ module Screenshots
     NESTED_CONTROLLER_TARGETS = {
       "users/registrations_controller.rb" => [ :sign_up ],
       "accounts/compliance_dashboards_controller.rb" => [ :account_compliance_dashboard ],
+      "accounts/roi_dashboards_controller.rb" => [ :account_roi_dashboard ],
       "projects/agent_runs_controller.rb" => %i[project_agent_runs project_agent_run_new project_agent_run_show project_agent_run_provenance],
       "projects/bundle_performance_dashboards_controller.rb" => [ :project_bundle_performance_dashboard ],
       "projects/cost_dashboards_controller.rb" => [ :project_cost_dashboard ],
       "projects/cost_snapshots_controller.rb" => [ :project_cost_snapshot ],
       "projects/quality_dashboards_controller.rb" => [ :project_quality_dashboard ],
+      "projects/roi_dashboards_controller.rb" => [ :project_roi_dashboard ],
+      "projects/roi_benchmarks_controller.rb" => [ :project_roi_dashboard ],
       "knowledge/search_controller.rb" => %i[knowledge_search project_knowledge_search],
       "knowledge/browse_controller.rb" => %i[project_knowledge_browse project_knowledge_browse_show],
       "knowledge/artifacts_controller.rb" => [ :project_knowledge_artifact_show ],
@@ -358,6 +364,7 @@ module Screenshots
       when /\Alinear_tokens\// then rest_resource_targets(relative_path, "linear_tokens", index: :linear_tokens, new: :linear_token_new, show: :linear_token_show, edit: :linear_token_show)
       when /\Auser_settings\// then [ :user_settings ]
       when /\Aaccounts\/compliance_dashboards\// then [ :account_compliance_dashboard ]
+      when /\Aaccounts\/roi_dashboards\// then [ :account_roi_dashboard ]
       when /\Aaccounts\// then [ :account ]
       when /\Aaccount_audit_logs\// then [ :account_audit_logs ]
       when /\Atenant_configurations\// then [ :tenant_configuration ]
@@ -391,6 +398,7 @@ module Screenshots
       when /\Aprojects\/cost_snapshots\// then [ :project_cost_snapshot ]
       when /\Aworkflow_statuses\// then [ :workflow_status ]
       when /\Aprojects\/quality_dashboards\// then [ :project_quality_dashboard ]
+      when /\Aprojects\/roi_dashboards\// then [ :project_roi_dashboard ]
       when /\Aprojects\/convention_settings\// then [ :project_convention_settings ]
       when /\Aprojects\/knowledge_recommendations\// then [ :project_knowledge_recommendations ]
       when /\Aprojects\// then projects_targets(relative_path.delete_prefix("projects/"))

--- a/app/views/accounts/roi_dashboards/show.html.erb
+++ b/app/views/accounts/roi_dashboards/show.html.erb
@@ -1,0 +1,156 @@
+<% content_for :title, "Account ROI Dashboard" %>
+
+<div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+  <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+    <div>
+      <p class="text-sm font-medium uppercase tracking-[0.2em] text-amber-700">Account ROI Dashboard</p>
+      <h1 class="mt-2 text-3xl font-semibold text-gray-900"><%= current_account.name %></h1>
+      <p class="mt-2 text-sm text-gray-600">Account-wide evaluation, benchmarking, and pilot evidence across the rolling 90-day window.</p>
+    </div>
+    <div class="flex flex-wrap gap-3">
+      <%= link_to "Back to account", account_path, class: "rounded-full border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50" %>
+      <%= link_to "Export CSV", export_account_roi_dashboard_path(format: :csv), class: "rounded-full bg-amber-600 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-500" %>
+    </div>
+  </div>
+
+  <% summary = @stats[:summary] %>
+  <div class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-6">
+    <div class="rounded-lg bg-white px-4 py-5 shadow">
+      <dt class="truncate text-sm font-medium text-gray-500">Accepted PRs</dt>
+      <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900"><%= summary[:accepted_pr_count] %></dd>
+    </div>
+    <% @stats[:metric_definitions].each do |definition| %>
+      <div class="rounded-lg bg-white px-4 py-5 shadow">
+        <dt class="truncate text-sm font-medium text-gray-500"><%= definition[:name] %></dt>
+        <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900"><%= roi_metric_value(definition[:key], summary[definition[:key]]) %></dd>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="mt-8 rounded-lg bg-amber-50 px-5 py-5 shadow-sm ring-1 ring-inset ring-amber-200">
+    <h2 class="text-lg font-semibold text-gray-900">Executive Summary</h2>
+    <div class="mt-3 space-y-2 text-sm text-gray-700">
+      <% @stats[:executive_summary].each do |line| %>
+        <p><%= line %></p>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="mt-8 grid gap-8 xl:grid-cols-2">
+    <section class="rounded-lg bg-white shadow">
+      <div class="border-b border-gray-200 px-5 py-4">
+        <h2 class="text-lg font-semibold text-gray-900">Benchmark Rollups</h2>
+        <p class="mt-1 text-sm text-gray-500">Weighted account-level comparisons built from project benchmark entries.</p>
+      </div>
+      <% if @stats[:benchmark_rollups].any? %>
+        <div class="overflow-x-auto">
+          <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+              <tr>
+                <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Benchmark</th>
+                <% @stats[:metric_definitions].each do |definition| %>
+                  <th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500"><%= definition[:name] %></th>
+                <% end %>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 bg-white">
+              <% @stats[:benchmark_rollups].each do |benchmark| %>
+                <tr>
+                  <td class="px-4 py-3 text-sm">
+                    <div class="font-medium text-gray-900"><%= benchmark[:benchmark_label] %></div>
+                    <div class="text-xs text-gray-500"><%= roi_benchmark_type_label(benchmark[:benchmark_type]) %> • <%= benchmark[:accepted_pr_count] %> accepted PRs</div>
+                  </td>
+                  <% @stats[:metric_definitions].each do |definition| %>
+                    <td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-700"><%= roi_metric_value(definition[:key], benchmark[definition[:key]]) %></td>
+                  <% end %>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      <% else %>
+        <div class="px-5 py-5 text-sm text-gray-500">No project benchmarks have been recorded yet.</div>
+      <% end %>
+    </section>
+
+    <section class="rounded-lg bg-white shadow">
+      <div class="border-b border-gray-200 px-5 py-4">
+        <h2 class="text-lg font-semibold text-gray-900">Pilot Templates</h2>
+        <p class="mt-1 text-sm text-gray-500">Standard motions customer success can reuse during pilots and expansion reviews.</p>
+      </div>
+      <div class="space-y-4 px-5 py-5">
+        <% @stats[:templates].each do |template| %>
+          <div class="rounded-lg border border-gray-200 p-4">
+            <div class="flex items-center justify-between gap-4">
+              <h3 class="text-sm font-semibold text-gray-900"><%= template[:name] %></h3>
+              <span class="text-xs font-medium uppercase tracking-wide text-gray-500"><%= template[:duration] %></span>
+            </div>
+            <p class="mt-2 text-sm text-gray-600"><%= template[:motion] %></p>
+            <p class="mt-3 text-sm text-gray-500"><%= template[:benchmark_plan] %></p>
+          </div>
+        <% end %>
+      </div>
+    </section>
+  </div>
+
+  <section class="mt-8 rounded-lg bg-white shadow">
+    <div class="border-b border-gray-200 px-5 py-4">
+      <h2 class="text-lg font-semibold text-gray-900">Project Rollup</h2>
+      <p class="mt-1 text-sm text-gray-500">Which projects are producing the clearest ROI evidence.</p>
+    </div>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+          <tr>
+            <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Project</th>
+            <th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Accepted PRs</th>
+            <% @stats[:metric_definitions].each do |definition| %>
+              <th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500"><%= definition[:name] %></th>
+            <% end %>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200 bg-white">
+          <% @stats[:project_rows].each do |row| %>
+            <tr>
+              <td class="px-4 py-3 text-sm font-medium text-gray-900"><%= link_to row[:project].name, project_roi_dashboard_path(row[:project]), class: "text-indigo-600 hover:text-indigo-500" %></td>
+              <td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-700"><%= row[:summary][:accepted_pr_count] %></td>
+              <% @stats[:metric_definitions].each do |definition| %>
+                <td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-700"><%= roi_metric_value(definition[:key], row[:summary][definition[:key]]) %></td>
+              <% end %>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="mt-8 rounded-lg bg-white shadow">
+    <div class="border-b border-gray-200 px-5 py-4">
+      <h2 class="text-lg font-semibold text-gray-900">Trend Analysis</h2>
+    </div>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+          <tr>
+            <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Period</th>
+            <th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Accepted PRs</th>
+            <% @stats[:metric_definitions].each do |definition| %>
+              <th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500"><%= definition[:name] %></th>
+            <% end %>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200 bg-white">
+          <% @stats[:trend].each do |row| %>
+            <tr>
+              <td class="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900"><%= row[:label] %></td>
+              <td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-700"><%= row[:accepted_pr_count] %></td>
+              <% @stats[:metric_definitions].each do |definition| %>
+                <td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-700"><%= roi_metric_value(definition[:key], row[definition[:key]]) %></td>
+              <% end %>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</div>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -212,6 +212,19 @@
       <section class="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
         <div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
           <div>
+            <h2 class="text-xl font-semibold text-gray-900 dark:text-white">ROI, Evals & Benchmarking</h2>
+            <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">Track account-wide pilot outcomes, benchmark Paid against your current workflow, and export procurement-ready ROI evidence.</p>
+          </div>
+          <div class="flex flex-wrap gap-3">
+            <%= link_to "Open ROI dashboard", account_roi_dashboard_path, class: "rounded-full bg-amber-600 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-500" %>
+            <%= link_to "Export ROI report", export_account_roi_dashboard_path(format: :csv), class: "rounded-full border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-900" %>
+          </div>
+        </div>
+      </section>
+
+      <section class="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div>
             <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Compliance & Deployment Assurance</h2>
             <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">Track hardened deployment posture, export compliance evidence, and surface operational gaps for security review.</p>
           </div>

--- a/app/views/projects/_stats.html.erb
+++ b/app/views/projects/_stats.html.erb
@@ -44,5 +44,8 @@
         <%= link_to "Cost Details", project_cost_dashboard_path(project), class: "text-indigo-600 hover:text-indigo-900 font-medium" %>
       </div>
     <% end %>
+    <div class="flex items-center gap-1.5 px-4 py-3">
+      <%= link_to "ROI Dashboard", project_roi_dashboard_path(project), class: "text-indigo-600 hover:text-indigo-900 font-medium" %>
+    </div>
   </div>
 </div>

--- a/app/views/projects/roi_dashboards/show.html.erb
+++ b/app/views/projects/roi_dashboards/show.html.erb
@@ -1,0 +1,264 @@
+<% content_for(:title) { "ROI Dashboard - #{@project.name} - Paid" } %>
+
+<div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+  <div class="mb-6">
+    <%= link_to back_link_path(project_path(@project)), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
+      <svg class="mr-1 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
+      </svg>
+      Back to <%= @project.name %>
+    <% end %>
+  </div>
+
+  <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+    <div>
+      <h1 class="text-2xl font-semibold text-gray-900">ROI, Evals & Benchmarking</h1>
+      <p class="mt-1 text-sm text-gray-500"><%= @project.name %> • rolling 90-day evidence window</p>
+    </div>
+    <%= link_to export_project_roi_dashboard_path(@project, format: :csv), class: "inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" do %>
+      Export CSV
+    <% end %>
+  </div>
+
+  <% summary = @stats[:summary] %>
+  <div class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-6">
+    <div class="rounded-lg bg-white px-4 py-5 shadow">
+      <dt class="truncate text-sm font-medium text-gray-500">Accepted PRs</dt>
+      <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900"><%= summary[:accepted_pr_count] %></dd>
+    </div>
+    <% @stats[:metric_definitions].each do |definition| %>
+      <div class="rounded-lg bg-white px-4 py-5 shadow">
+        <dt class="truncate text-sm font-medium text-gray-500"><%= definition[:name] %></dt>
+        <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-900"><%= roi_metric_value(definition[:key], summary[definition[:key]]) %></dd>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="mt-8 rounded-lg bg-amber-50 px-5 py-5 shadow-sm ring-1 ring-inset ring-amber-200">
+    <h2 class="text-lg font-semibold text-gray-900">Executive Summary</h2>
+    <div class="mt-3 space-y-2 text-sm text-gray-700">
+      <% @stats[:executive_summary].each do |line| %>
+        <p><%= line %></p>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="mt-8 grid gap-8 xl:grid-cols-[minmax(0,1.4fr)_minmax(320px,0.9fr)]">
+    <section class="rounded-lg bg-white shadow">
+      <div class="border-b border-gray-200 px-5 py-4">
+        <h2 class="text-lg font-semibold text-gray-900">Benchmark Comparison</h2>
+        <p class="mt-1 text-sm text-gray-500">Compare Paid against the baseline human-only flow and commercial agent pilots.</p>
+      </div>
+      <% if @stats[:benchmarks].any? %>
+        <div class="overflow-x-auto">
+          <table class="min-w-full divide-y divide-gray-200">
+            <thead class="bg-gray-50">
+              <tr>
+                <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Benchmark</th>
+                <% @stats[:metric_definitions].each do |definition| %>
+                  <th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500"><%= definition[:name] %></th>
+                <% end %>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 bg-white">
+              <tr class="bg-emerald-50/50">
+                <td class="whitespace-nowrap px-4 py-3 text-sm font-semibold text-gray-900">Paid Current</td>
+                <% @stats[:metric_definitions].each do |definition| %>
+                  <td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-700"><%= roi_metric_value(definition[:key], summary[definition[:key]]) %></td>
+                <% end %>
+              </tr>
+              <% @stats[:benchmarks].each do |benchmark| %>
+                <tr>
+                  <td class="px-4 py-3 text-sm">
+                    <div class="font-medium text-gray-900"><%= benchmark[:benchmark_label] %></div>
+                    <div class="text-xs text-gray-500"><%= roi_benchmark_type_label(benchmark[:benchmark_type]) %> • <%= benchmark[:accepted_pr_count] %> accepted PRs</div>
+                  </td>
+                  <% @stats[:metric_definitions].each do |definition| %>
+                    <% current = summary[definition[:key]] %>
+                    <% baseline = benchmark[definition[:key]] %>
+                    <td class="whitespace-nowrap px-4 py-3 text-right text-sm">
+                      <div class="text-gray-900"><%= roi_metric_value(definition[:key], baseline) %></div>
+                      <div class="<%= roi_delta_class(definition[:key], current, baseline) %>"><%= roi_delta(definition[:key], current, baseline) %></div>
+                    </td>
+                  <% end %>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      <% else %>
+        <div class="px-5 py-5 text-sm text-gray-500">No benchmarks yet. Add a human-only or commercial benchmark to produce side-by-side ROI evidence.</div>
+      <% end %>
+    </section>
+
+    <section class="rounded-lg bg-white shadow">
+      <div class="border-b border-gray-200 px-5 py-4">
+        <h2 class="text-lg font-semibold text-gray-900">Add Benchmark</h2>
+        <p class="mt-1 text-sm text-gray-500">Capture the comparison cohort used in pilot and procurement reviews.</p>
+      </div>
+      <div class="px-5 py-5">
+        <% if @roi_benchmark.errors.any? %>
+          <div class="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm text-red-700"><%= @roi_benchmark.errors.full_messages.to_sentence %></div>
+        <% end %>
+
+        <%= form_with model: [@project, @roi_benchmark], class: "space-y-4" do |form| %>
+          <div>
+            <%= form.label :name, class: "block text-sm font-medium text-gray-700" %>
+            <%= form.text_field :name, class: "mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm" %>
+          </div>
+          <div class="grid gap-4 sm:grid-cols-2">
+            <div>
+              <%= form.label :benchmark_type, class: "block text-sm font-medium text-gray-700" %>
+              <%= form.select :benchmark_type, RoiBenchmark::BENCHMARK_TYPES.map { |value| [roi_benchmark_type_label(value), value] }, {}, class: "mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm" %>
+            </div>
+            <div>
+              <%= form.label :tool_name, class: "block text-sm font-medium text-gray-700" %>
+              <%= form.text_field :tool_name, class: "mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm" %>
+            </div>
+          </div>
+          <div class="grid gap-4 sm:grid-cols-2">
+            <div>
+              <%= form.label :starts_at, "Start date", class: "block text-sm font-medium text-gray-700" %>
+              <%= form.date_field :starts_at, class: "mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm" %>
+            </div>
+            <div>
+              <%= form.label :ends_at, "End date", class: "block text-sm font-medium text-gray-700" %>
+              <%= form.date_field :ends_at, class: "mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm" %>
+            </div>
+          </div>
+          <div class="grid gap-4 sm:grid-cols-2">
+            <div>
+              <%= form.label :merge_rate, "Merge rate (%)", class: "block text-sm font-medium text-gray-700" %>
+              <%= form.number_field :merge_rate, step: 0.1, min: 0, max: 100, class: "mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm" %>
+            </div>
+            <div>
+              <%= form.label :average_cycle_time_hours, "Cycle time (hours)", class: "block text-sm font-medium text-gray-700" %>
+              <%= form.number_field :average_cycle_time_hours, step: 0.1, min: 0, class: "mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm" %>
+            </div>
+            <div>
+              <%= form.label :rework_rate, "Rework rate (%)", class: "block text-sm font-medium text-gray-700" %>
+              <%= form.number_field :rework_rate, step: 0.1, min: 0, max: 100, class: "mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm" %>
+            </div>
+            <div>
+              <%= form.label :defect_escape_rate, "Defect escape rate (%)", class: "block text-sm font-medium text-gray-700" %>
+              <%= form.number_field :defect_escape_rate, step: 0.1, min: 0, max: 100, class: "mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm" %>
+            </div>
+            <div>
+              <%= form.label :cost_per_accepted_pr_cents, "Cost / accepted PR (cents)", class: "block text-sm font-medium text-gray-700" %>
+              <%= form.number_field :cost_per_accepted_pr_cents, step: 1, min: 0, class: "mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm" %>
+            </div>
+            <div>
+              <%= form.label :accepted_pr_count, class: "block text-sm font-medium text-gray-700" %>
+              <%= form.number_field :accepted_pr_count, step: 1, min: 0, class: "mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm" %>
+            </div>
+          </div>
+          <div>
+            <%= form.label :notes, class: "block text-sm font-medium text-gray-700" %>
+            <%= form.text_area :notes, rows: 3, class: "mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm" %>
+          </div>
+          <div class="flex justify-end">
+            <%= form.submit "Save benchmark", class: "rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500" %>
+          </div>
+        <% end %>
+      </div>
+    </section>
+  </div>
+
+  <section class="mt-8 rounded-lg bg-white shadow">
+    <div class="border-b border-gray-200 px-5 py-4">
+      <h2 class="text-lg font-semibold text-gray-900">Trend Analysis</h2>
+      <p class="mt-1 text-sm text-gray-500">Monthly movement across the ROI framework.</p>
+    </div>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+          <tr>
+            <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Period</th>
+            <th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Accepted PRs</th>
+            <% @stats[:metric_definitions].each do |definition| %>
+              <th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500"><%= definition[:name] %></th>
+            <% end %>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200 bg-white">
+          <% @stats[:trend].each do |row| %>
+            <tr>
+              <td class="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900"><%= row[:label] %></td>
+              <td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-700"><%= row[:accepted_pr_count] %></td>
+              <% @stats[:metric_definitions].each do |definition| %>
+                <td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-700"><%= roi_metric_value(definition[:key], row[definition[:key]]) %></td>
+              <% end %>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <div class="mt-8 grid gap-8 xl:grid-cols-2">
+    <section class="rounded-lg bg-white shadow">
+      <div class="border-b border-gray-200 px-5 py-4">
+        <h2 class="text-lg font-semibold text-gray-900">Evaluation Framework</h2>
+        <p class="mt-1 text-sm text-gray-500">Standard definitions used across pilot reviews and expansion decisions.</p>
+      </div>
+      <div class="divide-y divide-gray-200">
+        <% @stats[:metric_definitions].each do |definition| %>
+          <div class="px-5 py-4">
+            <div class="flex items-center justify-between gap-4">
+              <h3 class="text-sm font-semibold text-gray-900"><%= definition[:name] %></h3>
+              <span class="inline-flex rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-700"><%= definition[:objective].titleize %></span>
+            </div>
+            <p class="mt-2 text-sm text-gray-600"><%= definition[:description] %></p>
+          </div>
+        <% end %>
+      </div>
+    </section>
+
+    <section class="rounded-lg bg-white shadow">
+      <div class="border-b border-gray-200 px-5 py-4">
+        <h2 class="text-lg font-semibold text-gray-900">Pilot Templates</h2>
+        <p class="mt-1 text-sm text-gray-500">Repeatable experiments for sales, customer success, and procurement motions.</p>
+      </div>
+      <div class="space-y-4 px-5 py-5">
+        <% @stats[:templates].each do |template| %>
+          <div class="rounded-lg border border-gray-200 p-4">
+            <div class="flex items-center justify-between gap-4">
+              <h3 class="text-sm font-semibold text-gray-900"><%= template[:name] %></h3>
+              <span class="text-xs font-medium uppercase tracking-wide text-gray-500"><%= template[:duration] %></span>
+            </div>
+            <p class="mt-2 text-sm text-gray-600"><%= template[:motion] %></p>
+            <p class="mt-3 text-xs font-semibold uppercase tracking-wide text-gray-500">Success Criteria</p>
+            <ul class="mt-2 list-disc pl-5 text-sm text-gray-600">
+              <% template[:success_criteria].each do |criterion| %>
+                <li><%= criterion %></li>
+              <% end %>
+            </ul>
+            <p class="mt-3 text-sm text-gray-500"><%= template[:benchmark_plan] %></p>
+          </div>
+        <% end %>
+      </div>
+    </section>
+  </div>
+
+  <% if @stats[:benchmarks].any? %>
+    <section class="mt-8 rounded-lg bg-white shadow">
+      <div class="border-b border-gray-200 px-5 py-4">
+        <h2 class="text-lg font-semibold text-gray-900">Saved Benchmarks</h2>
+      </div>
+      <div class="divide-y divide-gray-200">
+        <% @stats[:benchmarks].each do |benchmark| %>
+          <div class="flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <div class="text-sm font-semibold text-gray-900"><%= benchmark[:benchmark_label] %></div>
+              <div class="text-sm text-gray-500"><%= roi_benchmark_type_label(benchmark[:benchmark_type]) %> • <%= benchmark[:starts_at]&.to_date || "N/A" %> to <%= benchmark[:ends_at]&.to_date || "N/A" %></div>
+              <% if benchmark[:notes].present? %>
+                <div class="mt-1 text-sm text-gray-600"><%= benchmark[:notes] %></div>
+              <% end %>
+            </div>
+            <%= button_to "Delete", project_roi_benchmark_path(@project, benchmark[:id]), method: :delete, class: "rounded-md border border-red-300 px-3 py-2 text-sm font-semibold text-red-700 hover:bg-red-50", form: { data: { turbo_confirm: "Delete this benchmark?" } } %>
+          </div>
+        <% end %>
+      </div>
+    </section>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,9 @@ Rails.application.routes.draw do
 
   # Customer-facing account administration
   resource :account, only: [ :show, :update ]
+  resource :account_roi_dashboard, only: [ :show ], controller: "accounts/roi_dashboards" do
+    get :export
+  end
   resource :account_compliance_dashboard, only: [ :show, :update ], controller: "accounts/compliance_dashboards" do
     get :export
   end
@@ -181,9 +184,13 @@ Rails.application.routes.draw do
       get :export
     end
     resource :bundle_performance_dashboard, only: [ :show ], controller: "projects/bundle_performance_dashboards"
+    resource :roi_dashboard, only: [ :show ], controller: "projects/roi_dashboards" do
+      get :export
+    end
     resource :quality_thresholds, only: [ :update ], controller: "projects/quality_thresholds"
     resource :cost_snapshot, only: [ :show ], controller: "projects/cost_snapshots"
     resource :cost_dashboard, only: [ :show ], controller: "projects/cost_dashboards"
+    resources :roi_benchmarks, only: [ :create, :destroy ], controller: "projects/roi_benchmarks"
     resource :screenshot_config, only: [], controller: "projects/screenshot_configs" do
       post :detect
     end

--- a/db/migrate/20260527113550_create_roi_benchmarks.rb
+++ b/db/migrate/20260527113550_create_roi_benchmarks.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+class CreateRoiBenchmarks < ActiveRecord::Migration[8.1]
+  def up
+    create_table :roi_benchmarks,
+      comment: "Customer-specific comparison baselines used in ROI dashboards and pilot reports." do |t|
+      t.references :project,
+        null: false,
+        index: false,
+        foreign_key: { on_delete: :cascade },
+        comment: "Owning project for tenant isolation and benchmark segmentation."
+      t.string :name,
+        null: false,
+        limit: 255,
+        comment: "Human-readable benchmark label such as Human-only Baseline or Cursor Pilot."
+      t.string :benchmark_type,
+        null: false,
+        limit: 50,
+        comment: "Supported comparison class: human_only or commercial_agent."
+      t.string :tool_name,
+        limit: 100,
+        comment: "Specific vendor or tool name when benchmark_type is commercial_agent."
+      t.datetime :starts_at,
+        comment: "Inclusive start of the benchmark measurement window."
+      t.datetime :ends_at,
+        comment: "Inclusive end of the benchmark measurement window."
+      t.decimal :merge_rate,
+        precision: 5,
+        scale: 2,
+        comment: "Accepted pull requests divided by created pull requests, stored as a percentage."
+      t.decimal :average_cycle_time_hours,
+        precision: 10,
+        scale: 2,
+        comment: "Average elapsed hours from issue intake to accepted pull request."
+      t.decimal :rework_rate,
+        precision: 5,
+        scale: 2,
+        comment: "Share of accepted pull requests requiring follow-up work, stored as a percentage."
+      t.decimal :defect_escape_rate,
+        precision: 5,
+        scale: 2,
+        comment: "Share of accepted pull requests followed by post-acceptance fix work, stored as a percentage."
+      t.integer :cost_per_accepted_pr_cents,
+        comment: "Blended cost for each accepted pull request in cents."
+      t.integer :accepted_pr_count,
+        null: false,
+        default: 0,
+        comment: "Accepted pull requests included in this benchmark window."
+      t.text :notes,
+        comment: "Free-form implementation notes captured for stakeholder review."
+
+      t.timestamps
+    end
+
+    add_index :roi_benchmarks,
+      [ :project_id, :benchmark_type, :ends_at ],
+      name: "idx_roi_benchmarks_project_type_ends_at"
+    add_index :roi_benchmarks,
+      [ :project_id, :name ],
+      name: "idx_roi_benchmarks_project_name"
+
+    safety_assured do
+      execute <<~SQL
+        ALTER TABLE roi_benchmarks ENABLE ROW LEVEL SECURITY;
+        ALTER TABLE roi_benchmarks FORCE ROW LEVEL SECURITY;
+        CREATE POLICY tenant_isolation ON roi_benchmarks
+        AS PERMISSIVE
+        FOR ALL
+        USING (
+          paid_tenant_bypass() OR EXISTS (
+            SELECT 1 FROM projects
+            WHERE projects.id = roi_benchmarks.project_id
+              AND projects.account_id = paid_current_account_id()
+          )
+        )
+        WITH CHECK (
+          paid_tenant_bypass() OR EXISTS (
+            SELECT 1 FROM projects
+            WHERE projects.id = roi_benchmarks.project_id
+              AND projects.account_id = paid_current_account_id()
+          )
+        );
+      SQL
+    end
+  end
+
+  def down
+    safety_assured do
+      execute "DROP POLICY IF EXISTS tenant_isolation ON roi_benchmarks"
+      execute "ALTER TABLE roi_benchmarks NO FORCE ROW LEVEL SECURITY"
+      execute "ALTER TABLE roi_benchmarks DISABLE ROW LEVEL SECURITY"
+    end
+
+    drop_table :roi_benchmarks
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_25_151229) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_27_113550) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1915,6 +1915,26 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_25_151229) do
     t.index ["project_id"], name: "index_quality_thresholds_on_project_id"
   end
 
+  create_table "roi_benchmarks", comment: "Customer-specific comparison baselines used in ROI dashboards and pilot reports.", force: :cascade do |t|
+    t.integer "accepted_pr_count", default: 0, null: false, comment: "Accepted pull requests included in this benchmark window."
+    t.decimal "average_cycle_time_hours", precision: 10, scale: 2, comment: "Average elapsed hours from issue intake to accepted pull request."
+    t.string "benchmark_type", limit: 50, null: false, comment: "Supported comparison class: human_only or commercial_agent."
+    t.integer "cost_per_accepted_pr_cents", comment: "Blended cost for each accepted pull request in cents."
+    t.datetime "created_at", null: false
+    t.decimal "defect_escape_rate", precision: 5, scale: 2, comment: "Share of accepted pull requests followed by post-acceptance fix work, stored as a percentage."
+    t.datetime "ends_at", comment: "Inclusive end of the benchmark measurement window."
+    t.decimal "merge_rate", precision: 5, scale: 2, comment: "Accepted pull requests divided by created pull requests, stored as a percentage."
+    t.string "name", limit: 255, null: false, comment: "Human-readable benchmark label such as Human-only Baseline or Cursor Pilot."
+    t.text "notes", comment: "Free-form implementation notes captured for stakeholder review."
+    t.bigint "project_id", null: false, comment: "Owning project for tenant isolation and benchmark segmentation."
+    t.decimal "rework_rate", precision: 5, scale: 2, comment: "Share of accepted pull requests requiring follow-up work, stored as a percentage."
+    t.datetime "starts_at", comment: "Inclusive start of the benchmark measurement window."
+    t.string "tool_name", limit: 100, comment: "Specific vendor or tool name when benchmark_type is commercial_agent."
+    t.datetime "updated_at", null: false
+    t.index ["project_id", "benchmark_type", "ends_at"], name: "idx_roi_benchmarks_project_type_ends_at"
+    t.index ["project_id", "name"], name: "idx_roi_benchmarks_project_name"
+  end
+
   create_table "runner_states", force: :cascade do |t|
     t.datetime "circuit_opened_at"
     t.string "circuit_state", limit: 20, default: "closed", null: false
@@ -2560,6 +2580,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_25_151229) do
   add_foreign_key "quality_recovery_actions", "prompt_versions", on_delete: :nullify
   add_foreign_key "quality_thresholds", "accounts"
   add_foreign_key "quality_thresholds", "projects"
+  add_foreign_key "roi_benchmarks", "projects", on_delete: :cascade
   add_foreign_key "runner_states", "users", on_delete: :cascade
   add_foreign_key "runners", "integration_credentials", on_delete: :restrict
   add_foreign_key "runners", "provider_api_keys", on_delete: :restrict
@@ -3415,6 +3436,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_25_151229) do
       CREATE TRIGGER logidze_on_cost_budgets BEFORE INSERT OR UPDATE ON public.cost_budgets FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
 
+  create_trigger :logidze_on_exception_incidents, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_exception_incidents BEFORE INSERT OR UPDATE ON public.exception_incidents FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{occurrence_count,last_occurred_at,backtrace,context}')
+  SQL
+
   create_trigger :logidze_on_github_tokens, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_github_tokens BEFORE INSERT OR UPDATE ON public.github_tokens FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{token,last_used_at,repositories_synced_at,accessible_repositories}')
   SQL
@@ -3433,6 +3458,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_25_151229) do
 
   create_trigger :logidze_on_mcp_server_definitions, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_mcp_server_definitions BEFORE INSERT OR UPDATE ON public.mcp_server_definitions FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{env}')
+  SQL
+
+  create_trigger :validate_strategy_version_scope, sql_definition: <<-SQL
+      CREATE TRIGGER validate_strategy_version_scope BEFORE INSERT OR UPDATE OF project_id, strategy_version_id ON public.orchestration_decisions FOR EACH ROW EXECUTE FUNCTION validate_orchestration_decision_strategy_version_scope()
   SQL
 
   create_trigger :logidze_on_orchestration_strategies, sql_definition: <<-SQL
@@ -3497,13 +3526,5 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_25_151229) do
 
   create_trigger :logidze_on_users, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_users BEFORE INSERT OR UPDATE ON public.users FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{encrypted_password,reset_password_token,reset_password_sent_at,remember_created_at}')
-  SQL
-
-  create_trigger :logidze_on_exception_incidents, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_exception_incidents BEFORE INSERT OR UPDATE ON public.exception_incidents FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{occurrence_count,last_occurred_at,backtrace,context}')
-  SQL
-
-  create_trigger :validate_strategy_version_scope, sql_definition: <<-SQL
-      CREATE TRIGGER validate_strategy_version_scope BEFORE INSERT OR UPDATE OF project_id, strategy_version_id ON public.orchestration_decisions FOR EACH ROW EXECUTE FUNCTION validate_orchestration_decision_strategy_version_scope()
   SQL
 end

--- a/spec/factories/roi_benchmarks.rb
+++ b/spec/factories/roi_benchmarks.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :roi_benchmark do
+    project
+    name { "Human-only baseline" }
+    benchmark_type { "human_only" }
+    starts_at { 30.days.ago }
+    ends_at { Time.current }
+    merge_rate { 45.0 }
+    average_cycle_time_hours { 72.0 }
+    rework_rate { 28.0 }
+    defect_escape_rate { 9.0 }
+    cost_per_accepted_pr_cents { 18_000 }
+    accepted_pr_count { 8 }
+    notes { "Captured from a matched manual cohort." }
+
+    trait :commercial_agent do
+      name { "Commercial agent baseline" }
+      benchmark_type { "commercial_agent" }
+      tool_name { "Cursor" }
+    end
+  end
+end

--- a/spec/requests/accounts/roi_dashboards_spec.rb
+++ b/spec/requests/accounts/roi_dashboards_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Accounts::RoiDashboards" do
+  let(:account) { create(:account) }
+  let(:user) { create(:user, account: account) }
+
+  describe "GET /account_roi_dashboard" do
+    it "redirects unauthenticated users" do
+      get account_roi_dashboard_path
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "renders the account ROI dashboard for authenticated users" do
+      sign_in user
+
+      get account_roi_dashboard_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Account ROI Dashboard")
+      expect(response.body).to include("Project Rollup")
+      expect(response.body).to include("Trend Analysis")
+    end
+  end
+
+  describe "GET /account_roi_dashboard/export" do
+    it "returns a CSV report" do
+      sign_in user
+
+      get export_account_roi_dashboard_path(format: :csv)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to include("text/csv")
+      expect(response.body).to include("Account Current")
+      expect(response.body).to include("Projects")
+    end
+  end
+end

--- a/spec/requests/projects/roi_dashboards_spec.rb
+++ b/spec/requests/projects/roi_dashboards_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Projects::RoiDashboards" do
+  let(:account) { create(:account) }
+  let(:user) { create(:user, account: account) }
+  let(:project) { create(:project, account: account) }
+
+  describe "GET /projects/:project_id/roi_dashboard" do
+    it "redirects unauthenticated users" do
+      get project_roi_dashboard_path(project)
+
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "renders the ROI dashboard for authenticated users" do
+      sign_in user
+
+      get project_roi_dashboard_path(project)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("ROI, Evals & Benchmarking")
+      expect(response.body).to include("Evaluation Framework")
+      expect(response.body).to include("Add Benchmark")
+    end
+  end
+
+  describe "POST /projects/:project_id/roi_benchmarks" do
+    it "creates a benchmark entry" do
+      sign_in user
+
+      post project_roi_benchmarks_path(project), params: {
+        roi_benchmark: {
+          name: "Manual baseline",
+          benchmark_type: "human_only",
+          merge_rate: "52.5",
+          average_cycle_time_hours: "48",
+          rework_rate: "12.0",
+          defect_escape_rate: "4.0",
+          cost_per_accepted_pr_cents: "14000",
+          accepted_pr_count: "5"
+        }
+      }
+
+      expect(response).to redirect_to(project_roi_dashboard_path(project))
+      expect(project.roi_benchmarks.find_by!(name: "Manual baseline")).to have_attributes(
+        merge_rate: BigDecimal("52.5"),
+        accepted_pr_count: 5
+      )
+    end
+  end
+
+  describe "DELETE /projects/:project_id/roi_benchmarks/:id" do
+    it "removes a benchmark entry" do
+      sign_in user
+      benchmark = create(:roi_benchmark, project: project)
+
+      delete project_roi_benchmark_path(project, benchmark)
+
+      expect(response).to redirect_to(project_roi_dashboard_path(project))
+      expect(project.roi_benchmarks.where(id: benchmark.id)).to be_empty
+    end
+  end
+
+  describe "GET /projects/:project_id/roi_dashboard/export" do
+    it "returns a CSV report" do
+      sign_in user
+
+      get export_project_roi_dashboard_path(project, format: :csv)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to include("text/csv")
+      expect(response.body).to include("Executive Summary")
+      expect(response.body).to include("Merge rate")
+    end
+  end
+end

--- a/spec/services/accounts/roi_dashboard_stats_spec.rb
+++ b/spec/services/accounts/roi_dashboard_stats_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Accounts::RoiDashboardStats do
+  describe ".call" do
+    let(:account) { create(:account) }
+    let(:project) { create(:project, account: account) }
+
+    it "rolls up benchmark averages using only rows with metric values" do
+      create(:roi_benchmark,
+        project: project,
+        benchmark_type: "human_only",
+        name: "Human-only baseline",
+        accepted_pr_count: 2,
+        merge_rate: 50.0)
+      create(:roi_benchmark,
+        project: project,
+        benchmark_type: "human_only",
+        name: "Human-only baseline",
+        accepted_pr_count: 8,
+        merge_rate: nil)
+
+      stats = described_class.call(account: account)
+
+      expect(stats[:benchmark_rollups].first).to include(
+        benchmark_label: "Human-only baseline",
+        accepted_pr_count: 10,
+        merge_rate: 50.0
+      )
+    end
+
+    it "returns nil rollup metrics when all benchmark rows have zero accepted PRs" do
+      create(:roi_benchmark,
+        project: project,
+        accepted_pr_count: 0,
+        merge_rate: 40.0,
+        average_cycle_time_hours: 24.0,
+        rework_rate: 15.0,
+        defect_escape_rate: 5.0,
+        cost_per_accepted_pr_cents: 12_000)
+
+      stats = described_class.call(account: account)
+
+      expect(stats[:benchmark_rollups].first).to include(
+        accepted_pr_count: 0,
+        merge_rate: nil,
+        average_cycle_time_hours: nil,
+        rework_rate: nil,
+        defect_escape_rate: nil,
+        cost_per_accepted_pr_cents: nil
+      )
+    end
+  end
+end

--- a/spec/services/accounts/roi_dashboard_stats_spec.rb
+++ b/spec/services/accounts/roi_dashboard_stats_spec.rb
@@ -51,5 +51,34 @@ RSpec.describe Accounts::RoiDashboardStats do
         cost_per_accepted_pr_cents: nil
       )
     end
+
+    it "builds per-project summaries from a single preloaded run set" do
+      other_project = create(:project, account: account, name: "Beta")
+
+      create_accepted_run(project:, issue_created_at: 5.days.ago, run_created_at: 4.days.ago, merged_at: 2.days.ago, cost_cents: 6_000,
+        pull_request_number: 11)
+      create_accepted_run(project: other_project, issue_created_at: 4.days.ago, run_created_at: 3.days.ago, merged_at: 1.day.ago,
+        cost_cents: 4_000, pull_request_number: 12)
+
+      stats = described_class.call(account: account)
+
+      expect(stats[:project_rows].map { |row| [ row[:project].name, row[:summary][:cost_per_accepted_pr_cents] ] }).to eq([
+        [ "Beta", 4_000 ],
+        [ project.name, 6_000 ]
+      ])
+    end
+  end
+
+  def create_accepted_run(project:, issue_created_at:, run_created_at:, merged_at:, cost_cents:, pull_request_number:)
+    issue = create(:issue, project:, github_created_at: issue_created_at)
+    run = create(:agent_run, :completed,
+      project:,
+      issue:,
+      created_at: run_created_at,
+      completed_at: run_created_at + 1.day,
+      cost_cents:,
+      goal: "create_pr",
+      pull_request_number:)
+    create(:quality_metric, :human, agent_run: run, created_at: merged_at, scores: { "pr_merged" => 1.0 })
   end
 end

--- a/spec/services/projects/roi_dashboard_stats_spec.rb
+++ b/spec/services/projects/roi_dashboard_stats_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Projects::RoiDashboardStats do
+  describe ".call" do
+    let(:account) { create(:account) }
+    let(:project) { create(:project, account: account) }
+
+    it "computes ROI metrics, benchmarks, templates, and summary text" do
+      issue = create(:issue, project: project, github_created_at: 4.days.ago)
+      run = create(:agent_run, :completed, project: project, issue: issue, created_at: 3.days.ago, completed_at: 2.days.ago,
+        cost_cents: 9_000, iterations: 2, goal: "create_pr", pull_request_number: 15)
+      create(:quality_metric, :human, agent_run: run, created_at: 1.day.ago, scores: { "pr_merged" => 1.0 })
+      create(:roi_benchmark, project: project, merge_rate: 55.0, cost_per_accepted_pr_cents: 12_000)
+
+      stats = described_class.call(project: project)
+
+      expect(stats[:summary]).to include(
+        accepted_pr_count: 1,
+        created_pr_count: 1,
+        merge_rate: 100.0,
+        cost_per_accepted_pr_cents: 9_000
+      )
+      expect(stats[:summary][:average_cycle_time_hours]).to be > 0
+      expect(stats[:summary][:rework_rate]).to eq(100.0)
+      expect(stats[:benchmarks].first).to include(benchmark_label: "Human-only baseline")
+      expect(stats[:trend].size).to eq(6)
+      expect(stats[:templates].map { |template| template[:name] }).to include("2-week bug-fix pilot", "Backlog burn-down pilot")
+      expect(stats[:executive_summary].join(" ")).to include(project.name)
+    end
+  end
+end

--- a/spec/services/screenshots/capture_targets_spec.rb
+++ b/spec/services/screenshots/capture_targets_spec.rb
@@ -66,6 +66,12 @@ RSpec.describe Screenshots::CaptureTargets, :no_db do
       expect(targets.map(&:slug)).to eq([ "workflow_status" ])
     end
 
+    it "maps ROI helper changes to the ROI dashboard screenshot targets" do
+      targets = described_class.call(changed_files: [ "app/helpers/roi_dashboard_helper.rb" ])
+
+      expect(targets.map(&:slug)).to contain_exactly("account_roi_dashboard", "project_roi_dashboard")
+    end
+
     it "maps component files to shared UI targets" do
       targets = described_class.call(changed_files: [ "app/components/sidebar_component.rb" ])
 


### PR DESCRIPTION
## Summary

Implemented ROI/evals/benchmarking for Phase 7.1 and committed it as `663321c` with `feat(roi): add ROI dashboards and benchmark tracking`.

The change adds project/account ROI dashboards, benchmark tracking against human-only and commercial-agent baselines, exportable reports, executive summaries, pilot templates, and the underlying ROI metric framework/services. It also adds the `roi_benchmarks` model + migration, routes/controllers/views, and request/service coverage.

Verification completed:
- `bin/rails db:prepare`
- `bundle exec rubocop`
- `bundle exec rspec`
- pre-commit hook passed on commit
- final `git status --short` is clean

RSpec finished with `13894 examples, 0 failures, 7 pending`; the pending items are pre-existing migration/Qdrant specs.

---

Closes #2313