### PR TITLE
feat(self-heal): widen failure-pattern detection to read per-attempt errors

### DIFF
--- a/app/services/agent_run_patterns/detect.rb
+++ b/app/services/agent_run_patterns/detect.rb
@@ -8,6 +8,11 @@ module AgentRunPatterns
     ERROR_CLUSTER_MIN_SIZE = 3
     DEFAULT_WINDOW_HOURS = 6
     BASELINE_WINDOW_DAYS = 30
+    EVIDENCE_LOG_TAIL_LINE_LIMIT = 20
+    EVIDENCE_MESSAGE_LIMIT = 5
+    EVIDENCE_RUNNER_ATTEMPT_LIMIT = 10
+    EVIDENCE_RUNNER_CONFIG_LIMIT = 5
+    EVIDENCE_SAFE_RUNNER_CONFIG_FIELDS = %w[runner_key auth_type tier_model_ids].freeze
     DETECTION_FINISHED_STATUSES = (AgentRun::FINISHED_STATUSES - [ "retried" ]).freeze
 
     Pattern = Data.define(:type, :goal, :severity, :details)
@@ -42,7 +47,8 @@ module AgentRunPatterns
     attr_reader :account, :window_hours
 
     def fetch_recent_finished_runs
-      AgentRun.joins(:project)
+      AgentRun.includes(:runner, :agent_run_logs)
+        .joins(:project)
         .where(projects: { account_id: account.id })
         .where(status: DETECTION_FINISHED_STATUSES)
         .where(completed_at: window_hours.hours.ago..)
@@ -64,6 +70,7 @@ module AgentRunPatterns
           total_runs: runs.size,
           failure_rate: streak.size.to_f / runs.size,
           error_messages: streak.filter_map(&:error_message).first(5),
+          evidence_bundle: build_evidence_bundle(streak),
           run_ids: streak.map(&:id),
           started_at: streak.last.completed_at,
           ended_at: streak.first.completed_at
@@ -92,6 +99,7 @@ module AgentRunPatterns
           baseline_rate: baseline&.round(4),
           error_messages: runs.select { |r| AgentRun::FAILURE_STATUSES.include?(r.status) }
                               .filter_map(&:error_message).first(5),
+          evidence_bundle: build_evidence_bundle(runs.select { |r| AgentRun::FAILURE_STATUSES.include?(r.status) }),
           run_ids: runs.select { |r| AgentRun::FAILURE_STATUSES.include?(r.status) }.map(&:id)
         }
       ) ]
@@ -118,6 +126,7 @@ module AgentRunPatterns
             occurrence_count: error_runs.size,
             total_failures: failed_runs.size,
             sample_messages: error_runs.map(&:error_message).compact.uniq.first(3),
+            evidence_bundle: build_evidence_bundle(error_runs),
             run_ids: error_runs.map(&:id),
             statuses: error_runs.group_by(&:status).transform_values(&:count)
           }
@@ -134,6 +143,142 @@ module AgentRunPatterns
         .gsub(/\b(?:[0-9a-f]{8,}|(?=[A-Za-z0-9_-]{8,}\b)(?=[A-Za-z0-9_-]*\d)[A-Za-z0-9_-]+)\b/i, "<ID>")
         .gsub(/\b\d+(?:\.\d+)?[a-z]*\b/i, "<N>")
         .truncate(200)
+    end
+
+    def build_evidence_bundle(runs)
+      EvidenceBundle.new(
+        outer_errors: sanitize_strings(runs.filter_map { |run| run.try(:error_message) }.uniq.first(EVIDENCE_MESSAGE_LIMIT)),
+        runner_attempts: runner_attempt_evidence(runs),
+        log_tails: log_tail_evidence(runs),
+        runner_configs: runner_config_evidence(runs),
+        aggregate_stats: aggregate_stats_for(runs)
+      ).to_payload
+    end
+
+    def runner_attempt_evidence(runs)
+      Array(runs).flat_map do |run|
+        Array(read_attribute(run, :runners_attempted)).filter_map do |attempt|
+          build_attempt_evidence(attempt)
+        end
+      end.first(EVIDENCE_RUNNER_ATTEMPT_LIMIT)
+    end
+
+    def build_attempt_evidence(attempt)
+      value = attempt.to_h.deep_symbolize_keys
+      evidence = {
+        runner: sanitize_text(value[:runner]),
+        error_type: sanitize_text(value[:error_type]),
+        error_message: sanitize_text(value[:error_message]),
+        diagnostics: sanitize_free_text(value[:diagnostics])
+      }.compact
+
+      evidence = evidence.except(:diagnostics) if evidence[:diagnostics].blank?
+      evidence.presence
+    end
+
+    def log_tail_evidence(runs)
+      Array(runs).first(EVIDENCE_MESSAGE_LIMIT).filter_map do |run|
+        evidence = {
+          run_id: read_attribute(run, :id),
+          stdout: extract_log_tail(run, "stdout"),
+          stderr: extract_log_tail(run, "stderr")
+        }.compact
+
+        evidence.except(:run_id).presence ? evidence : nil
+      end
+    end
+
+    def extract_log_tail(run, log_type)
+      logs = if run.respond_to?(:agent_run_logs)
+        Array(run.agent_run_logs).select { |log| read_attribute(log, :log_type) == log_type }
+      else
+        []
+      end
+
+      content = logs.sort_by { |log| read_attribute(log, :created_at) || Time.at(0) }
+        .filter_map { |log| read_attribute(log, :content) }
+        .join("\n")
+      return if content.blank?
+
+      sanitize_text(content.lines.last(EVIDENCE_LOG_TAIL_LINE_LIMIT).join.strip)
+    end
+
+    def runner_config_evidence(runs)
+      Array(runs).filter_map do |run|
+        snapshot_runner_config(run.respond_to?(:runner) ? run.runner : nil)
+      end.uniq.first(EVIDENCE_RUNNER_CONFIG_LIMIT)
+    end
+
+    def snapshot_runner_config(runner)
+      return if runner.blank?
+
+      EVIDENCE_SAFE_RUNNER_CONFIG_FIELDS.each_with_object({}) do |field, snapshot|
+        snapshot[field.to_sym] = sanitize_free_text(read_attribute(runner, field))
+      end.merge(
+        provider_api_key_configured: read_attribute(runner, :provider_api_key_id).present?
+      ).compact
+    end
+
+    def aggregate_stats_for(runs)
+      completed_at_values = Array(runs).filter_map { |run| read_attribute(run, :completed_at) }
+
+      {
+        run_count: runs.size,
+        distinct_runners: Array(runs).flat_map { |run| distinct_runner_names_for(run) }.uniq.sort,
+        statuses: Array(runs).group_by { |run| read_attribute(run, :status) }.transform_values(&:count),
+        time_window: {
+          started_at: completed_at_values.min&.iso8601,
+          ended_at: completed_at_values.max&.iso8601,
+          detector_window_hours: window_hours
+        }
+      }
+    end
+
+    def distinct_runner_names_for(run)
+      names = Array(read_attribute(run, :runners_attempted)).filter_map do |attempt|
+        sanitize_text(attempt.to_h["runner"] || attempt.to_h[:runner])
+      end
+      names << sanitize_text(read_attribute(run, :final_runner))
+      names.compact.uniq
+    end
+
+    def sanitize_strings(values)
+      values.filter_map { |value| sanitize_text(value) }
+    end
+
+    def sanitize_free_text(value)
+      case value
+      when Hash
+        value.to_h.deep_symbolize_keys.each_with_object({}) do |(key, entry), sanitized|
+          cleaned = sanitize_free_text(entry)
+          sanitized[key] = cleaned if cleaned.present?
+        end
+      when Array
+        value.filter_map { |entry| sanitize_free_text(entry) }.presence
+      when String
+        sanitize_text(value)
+      else
+        value
+      end
+    end
+
+    def sanitize_text(value)
+      return if value.blank?
+
+      normalized = value.to_s
+      normalized = normalized.delete("\x00") if normalized.encoding == Encoding::UTF_8 && normalized.valid_encoding?
+      normalized = normalized.dup.force_encoding(Encoding::UTF_8).scrub.delete("\x00") unless normalized.valid_encoding?
+
+      redacted = Knowledge::Redaction::Redactor.call(text: normalized).clean_text
+      AgentRun::RUNNER_ATTEMPT_SECRET_PATTERNS.reduce(redacted) do |result, (pattern, replacement)|
+        result.gsub(pattern, replacement)
+      end
+    end
+
+    def read_attribute(record, attribute)
+      return unless record.respond_to?(attribute)
+
+      record.public_send(attribute)
     end
 
     def load_baseline_rate(goal)

--- a/app/services/agent_run_patterns/detect.rb
+++ b/app/services/agent_run_patterns/detect.rb
@@ -24,6 +24,7 @@ module AgentRunPatterns
     def initialize(account:, window_hours: DEFAULT_WINDOW_HOURS)
       @account = account
       @window_hours = window_hours
+      @log_tail_cache = {}
     end
 
     def call
@@ -196,14 +197,34 @@ module AgentRunPatterns
       run_ids = Array(runs).filter_map { |run| read_attribute(run, :id) }
       return {} if run_ids.empty?
 
-      AgentRunLog.where(agent_run_id: run_ids, log_type: %w[stdout stderr])
-        .select(:agent_run_id, :log_type, :content)
-        .order(:agent_run_id, :log_type, :created_at)
-        .each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |log, grouped_logs|
+      @log_tail_cache[run_ids.sort] ||= begin
+        tail_rows_for(run_ids).each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |log, grouped_logs|
           key = [ read_attribute(log, :agent_run_id), read_attribute(log, :log_type) ]
           grouped_logs[key] << read_attribute(log, :content)
-          grouped_logs[key].shift while grouped_logs[key].size > EVIDENCE_LOG_TAIL_LINE_LIMIT
         end
+      end
+    end
+
+    def tail_rows_for(run_ids)
+      ranked_logs = AgentRunLog.where(agent_run_id: run_ids, log_type: %w[stdout stderr])
+        .select(
+          :agent_run_id,
+          :log_type,
+          :content,
+          :created_at,
+          :id,
+          <<~SQL.squish
+            ROW_NUMBER() OVER (
+              PARTITION BY agent_run_id, log_type
+              ORDER BY created_at DESC, id DESC
+            ) AS row_number
+          SQL
+        )
+
+      AgentRunLog.from("(#{ranked_logs.to_sql}) agent_run_log_tails")
+        .where("row_number <= ?", EVIDENCE_LOG_TAIL_LINE_LIMIT)
+        .select(:agent_run_id, :log_type, :content)
+        .order(:agent_run_id, :log_type, created_at: :asc, id: :asc)
     end
 
     def sanitize_log_tail(log_lines)

--- a/app/services/agent_run_patterns/detect.rb
+++ b/app/services/agent_run_patterns/detect.rb
@@ -47,7 +47,7 @@ module AgentRunPatterns
     attr_reader :account, :window_hours
 
     def fetch_recent_finished_runs
-      AgentRun.includes(:runner, :agent_run_logs)
+      AgentRun.includes(:runner)
         .joins(:project)
         .where(projects: { account_id: account.id })
         .where(status: DETECTION_FINISHED_STATUSES)
@@ -79,7 +79,8 @@ module AgentRunPatterns
     end
 
     def detect_high_failure_rate(goal, runs)
-      failed = runs.count { |r| AgentRun::FAILURE_STATUSES.include?(r.status) }
+      failed_runs = runs.select { |r| AgentRun::FAILURE_STATUSES.include?(r.status) }
+      failed = failed_runs.size
       failure_rate = failed.to_f / runs.size
 
       return [] unless runs.size >= HIGH_FAILURE_MIN_SAMPLE
@@ -97,10 +98,9 @@ module AgentRunPatterns
           total_count: runs.size,
           failure_rate: failure_rate.round(4),
           baseline_rate: baseline&.round(4),
-          error_messages: runs.select { |r| AgentRun::FAILURE_STATUSES.include?(r.status) }
-                              .filter_map(&:error_message).first(5),
-          evidence_bundle: build_evidence_bundle(runs.select { |r| AgentRun::FAILURE_STATUSES.include?(r.status) }),
-          run_ids: runs.select { |r| AgentRun::FAILURE_STATUSES.include?(r.status) }.map(&:id)
+          error_messages: failed_runs.filter_map(&:error_message).first(5),
+          evidence_bundle: build_evidence_bundle(failed_runs),
+          run_ids: failed_runs.map(&:id)
         }
       ) ]
     end
@@ -189,14 +189,11 @@ module AgentRunPatterns
     end
 
     def extract_log_tail(run, log_type)
-      logs = if run.respond_to?(:agent_run_logs)
-        Array(run.agent_run_logs).select { |log| read_attribute(log, :log_type) == log_type }
-      else
-        []
-      end
+      logs = AgentRunLog.where(agent_run_id: read_attribute(run, :id), log_type: log_type)
+        .order(created_at: :asc)
+        .last(EVIDENCE_LOG_TAIL_LINE_LIMIT)
 
-      content = logs.sort_by { |log| read_attribute(log, :created_at) || Time.at(0) }
-        .filter_map { |log| read_attribute(log, :content) }
+      content = logs.filter_map { |log| read_attribute(log, :content) }
         .join("\n")
       return if content.blank?
 

--- a/app/services/agent_run_patterns/detect.rb
+++ b/app/services/agent_run_patterns/detect.rb
@@ -177,24 +177,37 @@ module AgentRunPatterns
     end
 
     def log_tail_evidence(runs)
-      Array(runs).first(EVIDENCE_MESSAGE_LIMIT).filter_map do |run|
+      sampled_runs = Array(runs).first(EVIDENCE_MESSAGE_LIMIT)
+      log_tails = load_log_tails(sampled_runs)
+
+      sampled_runs.filter_map do |run|
+        run_id = read_attribute(run, :id)
         evidence = {
-          run_id: read_attribute(run, :id),
-          stdout: extract_log_tail(run, "stdout"),
-          stderr: extract_log_tail(run, "stderr")
+          run_id: run_id,
+          stdout: sanitize_log_tail(log_tails[[ run_id, "stdout" ]]),
+          stderr: sanitize_log_tail(log_tails[[ run_id, "stderr" ]])
         }.compact
 
         evidence.except(:run_id).presence ? evidence : nil
       end
     end
 
-    def extract_log_tail(run, log_type)
-      logs = AgentRunLog.where(agent_run_id: read_attribute(run, :id), log_type: log_type)
-        .order(created_at: :asc)
-        .last(EVIDENCE_LOG_TAIL_LINE_LIMIT)
+    def load_log_tails(runs)
+      run_ids = Array(runs).filter_map { |run| read_attribute(run, :id) }
+      return {} if run_ids.empty?
 
-      content = logs.filter_map { |log| read_attribute(log, :content) }
-        .join("\n")
+      AgentRunLog.where(agent_run_id: run_ids, log_type: %w[stdout stderr])
+        .select(:agent_run_id, :log_type, :content)
+        .order(:agent_run_id, :log_type, :created_at)
+        .each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |log, grouped_logs|
+          key = [ read_attribute(log, :agent_run_id), read_attribute(log, :log_type) ]
+          grouped_logs[key] << read_attribute(log, :content)
+          grouped_logs[key].shift while grouped_logs[key].size > EVIDENCE_LOG_TAIL_LINE_LIMIT
+        end
+    end
+
+    def sanitize_log_tail(log_lines)
+      content = Array(log_lines).compact.join("\n")
       return if content.blank?
 
       sanitize_text(content.lines.last(EVIDENCE_LOG_TAIL_LINE_LIMIT).join.strip)

--- a/app/services/agent_run_patterns/diagnose.rb
+++ b/app/services/agent_run_patterns/diagnose.rb
@@ -101,7 +101,7 @@ module AgentRunPatterns
 
       evidence_documents.each do |document|
         ROOT_CAUSE_CATEGORIES.each do |category_key, config|
-          score = config[:patterns].count { |pat| document.match?(pat) }
+          score = config[:patterns].any? { |pat| document.match?(pat) } ? 1 : 0
           matches[category_key] += score if score.positive?
         end
       end

--- a/app/services/agent_run_patterns/diagnose.rb
+++ b/app/services/agent_run_patterns/diagnose.rb
@@ -66,20 +66,20 @@ module AgentRunPatterns
     end
 
     def call
-      error_messages = extract_error_messages
-      return unknown_diagnosis if error_messages.empty?
+      evidence_documents = extract_evidence_documents
+      return unknown_diagnosis if evidence_documents.empty?
 
-      matches = classify_errors(error_messages)
+      matches = classify_errors(evidence_documents)
       return unknown_diagnosis if matches.empty?
 
-      best_match = matches.max_by { |_, count| count }
+      best_match = matches.max_by { |_, score| score }
       category_key = best_match.first
       category = ROOT_CAUSE_CATEGORIES[category_key]
 
       Diagnosis.new(
         root_cause: category[:label],
         category: category_key.to_s,
-        confidence: best_match.last.to_f / error_messages.size,
+        confidence: [ best_match.last.to_f / evidence_documents.size, 1.0 ].min,
         remediation: category[:remediation]
       )
     end
@@ -88,19 +88,21 @@ module AgentRunPatterns
 
     attr_reader :pattern
 
-    def extract_error_messages
+    def extract_evidence_documents
+      evidence_bundle = pattern.details[:evidence_bundle]
+      return EvidenceBundle.from_payload(evidence_bundle).documents if evidence_bundle.present?
+
       details = pattern.details
       Array(details[:error_messages] || details[:sample_messages])
     end
 
-    def classify_errors(error_messages)
+    def classify_errors(evidence_documents)
       matches = Hash.new(0)
 
-      error_messages.each do |msg|
+      evidence_documents.each do |document|
         ROOT_CAUSE_CATEGORIES.each do |category_key, config|
-          if config[:patterns].any? { |pat| msg.match?(pat) }
-            matches[category_key] += 1
-          end
+          score = config[:patterns].count { |pat| document.match?(pat) }
+          matches[category_key] += score if score.positive?
         end
       end
 

--- a/app/services/agent_run_patterns/evidence_bundle.rb
+++ b/app/services/agent_run_patterns/evidence_bundle.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module AgentRunPatterns
+  class EvidenceBundle < Data.define(
+    :outer_errors,
+    :runner_attempts,
+    :log_tails,
+    :runner_configs,
+    :aggregate_stats
+  )
+    def self.from_payload(payload)
+      value = payload.respond_to?(:to_h) ? payload.to_h.deep_symbolize_keys : {}
+
+      new(
+        outer_errors: Array(value[:outer_errors]),
+        runner_attempts: Array(value[:runner_attempts]),
+        log_tails: Array(value[:log_tails]),
+        runner_configs: Array(value[:runner_configs]),
+        aggregate_stats: value[:aggregate_stats].is_a?(Hash) ? value[:aggregate_stats] : {}
+      )
+    end
+
+    def to_payload
+      {
+        outer_errors: outer_errors,
+        runner_attempts: runner_attempts,
+        log_tails: log_tails,
+        runner_configs: runner_configs,
+        aggregate_stats: aggregate_stats
+      }
+    end
+
+    def documents
+      [].tap do |docs|
+        outer_errors.each do |message|
+          docs << message if message.present?
+        end
+
+        runner_attempts.each do |attempt|
+          docs << [
+            attempt[:runner],
+            attempt[:error_type],
+            attempt[:error_message],
+            attempt[:diagnostics].presence&.to_json
+          ].compact.join("\n")
+        end
+
+        log_tails.each do |tail|
+          docs << [ tail[:stdout], tail[:stderr] ].compact.join("\n")
+        end
+
+        runner_configs.each do |config|
+          docs << [
+            config[:runner_key],
+            config[:auth_type],
+            ("provider_api_key_configured" if config[:provider_api_key_configured]),
+            config[:tier_model_ids].presence&.to_json
+          ].compact.join("\n")
+        end
+      end.reject(&:blank?)
+    end
+  end
+end

--- a/app/services/agent_run_patterns/evidence_bundle.rb
+++ b/app/services/agent_run_patterns/evidence_bundle.rb
@@ -49,14 +49,8 @@ module AgentRunPatterns
           docs << [ tail[:stdout], tail[:stderr] ].compact.join("\n")
         end
 
-        runner_configs.each do |config|
-          docs << [
-            config[:runner_key],
-            config[:auth_type],
-            ("provider_api_key_configured" if config[:provider_api_key_configured]),
-            config[:tier_model_ids].presence&.to_json
-          ].compact.join("\n")
-        end
+        # Runner configs remain available via `to_payload`, but excluding them
+        # here prevents contextual metadata from diluting diagnosis confidence.
       end.reject(&:blank?)
     end
   end

--- a/spec/fixtures/files/agent_run_patterns/model_metadata_not_found_runners_attempted.json
+++ b/spec/fixtures/files/agent_run_patterns/model_metadata_not_found_runners_attempted.json
@@ -1,0 +1,14 @@
+[
+  {
+    "runner": "runner:42",
+    "success": false,
+    "error_type": "provider_error",
+    "error_message": "Model metadata for `gpt-4o` not found",
+    "diagnostics": {
+      "details": [
+        "Bearer sk-secret-secret-secret-secret",
+        "github_pat_abcdefghijklmnopqrstuvwxyz1234567890"
+      ]
+    }
+  }
+]

--- a/spec/services/agent_run_patterns/detect_spec.rb
+++ b/spec/services/agent_run_patterns/detect_spec.rb
@@ -195,6 +195,27 @@ RSpec.describe AgentRunPatterns::Detect do
         expect_redacted_evidence_bundle(cluster.details[:evidence_bundle])
       end
 
+      it "loads stdout and stderr tails for sampled runs in one query" do
+        runs = create_list(
+          :agent_run,
+          3,
+          :failed,
+          project: project,
+          goal: "enhance_issue",
+          error_message: "All runners exhausted: Codex, Claude",
+          completed_at: Time.current
+        )
+
+        runs.each do |run|
+          create(:agent_run_log, agent_run: run, log_type: "stdout", content: "stdout line")
+          create(:agent_run_log, agent_run: run, log_type: "stderr", content: "stderr line")
+        end
+
+        detector = described_class.new(account: account)
+
+        expect(count_queries { detector.send(:log_tail_evidence, runs) }).to eq(1)
+      end
+
       def build_evidence_cluster
         runs = create_list(
           :agent_run,

--- a/spec/services/agent_run_patterns/detect_spec.rb
+++ b/spec/services/agent_run_patterns/detect_spec.rb
@@ -127,6 +127,23 @@ RSpec.describe AgentRunPatterns::Detect do
     end
 
     context "with error clusters" do
+      let(:fixture_attempts) do
+        JSON.parse(file_fixture("agent_run_patterns/model_metadata_not_found_runners_attempted.json").read)
+      end
+
+      let(:evidence_runner) do
+        create(:llm_model, model_id: "gpt-4o", provider: "openai", tier: "high")
+        create(
+          :runner,
+          user: project.created_by,
+          runner_key: "kilocode",
+          auth_type: "api_key",
+          provider_api_key: create(:provider_api_key, user: project.created_by, api_service_type: "openai"),
+          config: { "kilocode" => { "api_provider" => "openai", "model" => "gpt-4o" } },
+          tier_model_ids: { "low" => "gpt-4o", "mid" => "gpt-4o", "high" => "gpt-4o" }
+        )
+      end
+
       it "detects multiple failures sharing the same error pattern" do
         create_list(:agent_run, 3, :failed, project: project, goal: "analyze_issue",
           error_message: "No LLM provider produced an issue analysis",
@@ -169,6 +186,60 @@ RSpec.describe AgentRunPatterns::Detect do
         expect(clusters.map { |pattern| pattern.details[:error_pattern] }).to contain_exactly(
           "GitHub API error: <N> Forbidden",
           "Container error: OCI runtime exec format error"
+        )
+      end
+
+      it "includes a redacted evidence bundle assembled from attempts, logs, config, and aggregate stats" do
+        cluster = build_evidence_cluster
+        expect(cluster).to be_present
+        expect_redacted_evidence_bundle(cluster.details[:evidence_bundle])
+      end
+
+      def build_evidence_cluster
+        runs = create_list(
+          :agent_run,
+          3,
+          :failed,
+          project: project,
+          runner: evidence_runner,
+          goal: "enhance_issue",
+          error_message: "All runners exhausted: Codex, Claude",
+          runners_attempted: fixture_attempts,
+          completed_at: Time.current
+        )
+
+        runs.each do |run|
+          create(:agent_run_log, agent_run: run, log_type: "stdout",
+            content: "Provider says Bearer sk-live-secret-token is invalid")
+          create(:agent_run_log, agent_run: run, log_type: "stderr",
+            content: "GitHub helper used github_pat_abcdefghijklmnopqrstuvwxyz1234567890")
+        end
+
+        described_class.call(account: account).find { |pattern| pattern.type == :error_cluster }
+      end
+
+      def expect_redacted_evidence_bundle(bundle)
+        expect(bundle[:outer_errors]).to include("All runners exhausted: Codex, Claude")
+        expect(bundle[:runner_attempts].first).to include(
+          runner: "runner:42",
+          error_type: "provider_error",
+          error_message: "Model metadata for `gpt-4o` not found"
+        )
+        expect(bundle[:runner_attempts].first[:diagnostics].to_json).to include("[REDACTED:api_key]")
+        expect(bundle[:runner_attempts].first[:diagnostics].to_json).not_to include("github_pat_abcdefghijklmnopqrstuvwxyz1234567890")
+        expect(bundle[:log_tails].first[:stdout]).to include("[REDACTED:api_key]")
+        expect(bundle[:log_tails].first[:stderr]).to include("[REDACTED:github_token]")
+        expect(bundle[:runner_configs]).to contain_exactly(
+          {
+            runner_key: "kilocode",
+            auth_type: "api_key",
+            tier_model_ids: { low: "gpt-4o", mid: "gpt-4o", high: "gpt-4o" },
+            provider_api_key_configured: true
+          }
+        )
+        expect(bundle[:aggregate_stats]).to include(
+          run_count: 3,
+          distinct_runners: contain_exactly("runner:42")
         )
       end
     end

--- a/spec/services/agent_run_patterns/detect_spec.rb
+++ b/spec/services/agent_run_patterns/detect_spec.rb
@@ -216,6 +216,53 @@ RSpec.describe AgentRunPatterns::Detect do
         expect(count_queries { detector.send(:log_tail_evidence, runs) }).to eq(1)
       end
 
+      it "reuses cached log tails when the same sampled runs are inspected again" do
+        runs = create_list(
+          :agent_run,
+          3,
+          :failed,
+          project: project,
+          goal: "enhance_issue",
+          error_message: "All runners exhausted: Codex, Claude",
+          completed_at: Time.current
+        )
+
+        runs.each do |run|
+          create(:agent_run_log, agent_run: run, log_type: "stdout", content: "stdout line")
+          create(:agent_run_log, agent_run: run, log_type: "stderr", content: "stderr line")
+        end
+
+        detector = described_class.new(account: account)
+        detector.send(:log_tail_evidence, runs)
+
+        expect(count_queries { detector.send(:log_tail_evidence, runs.reverse) }).to eq(0)
+      end
+
+      it "limits each sampled log tail to the most recent lines in SQL order" do
+        run = create(
+          :agent_run,
+          :failed,
+          project: project,
+          goal: "enhance_issue",
+          error_message: "All runners exhausted: Codex, Claude",
+          completed_at: Time.current
+        )
+
+        25.times do |index|
+          create(:agent_run_log, agent_run: run, log_type: "stdout", content: "stdout line #{index}")
+        end
+
+        detector = described_class.new(account: account)
+        tails = detector.send(:log_tail_evidence, [ run ])
+
+        expect(tails).to contain_exactly(
+          include(
+            run_id: run.id,
+            stdout: (5..24).map { |index| "stdout line #{index}" }.join("\n")
+          )
+        )
+      end
+
       def build_evidence_cluster
         runs = create_list(
           :agent_run,

--- a/spec/services/agent_run_patterns/diagnose_spec.rb
+++ b/spec/services/agent_run_patterns/diagnose_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe AgentRunPatterns::Diagnose, :no_db do
 
         expect(result.root_cause).to eq("LLM Provider Error")
         expect(result.category).to eq("llm_provider")
-        expect(result.confidence).to be > 0.0
+        expect(result.confidence).to eq(0.5)
       end
     end
 

--- a/spec/services/agent_run_patterns/diagnose_spec.rb
+++ b/spec/services/agent_run_patterns/diagnose_spec.rb
@@ -129,5 +129,49 @@ RSpec.describe AgentRunPatterns::Diagnose, :no_db do
         expect(result.root_cause).to eq("LLM Provider Error")
       end
     end
+
+    context "with evidence bundle sourced from per-attempt failures" do
+      let(:pattern) do
+        AgentRunPatterns::Detect::Pattern.new(
+          type: :error_cluster,
+          goal: "enhance_issue",
+          severity: :error,
+          details: {
+            error_pattern: "All runners exhausted: Codex, Claude",
+            evidence_bundle: AgentRunPatterns::EvidenceBundle.new(
+              outer_errors: [ "All runners exhausted: Codex, Claude" ],
+              runner_attempts: [
+                {
+                  runner: "runner:42",
+                  error_type: "provider_error",
+                  error_message: "Model metadata for `gpt-4o` not found",
+                  diagnostics: { details: [ "Model metadata for `gpt-4o` not found" ] }
+                }
+              ],
+              log_tails: [],
+              runner_configs: [
+                {
+                  runner_key: "cursor",
+                  auth_type: "api_key",
+                  tier_model_ids: { low: "gpt-4o" },
+                  provider_api_key_configured: true
+                }
+              ],
+              aggregate_stats: { run_count: 3 }
+            ).to_payload
+          }
+        )
+      end
+
+      let(:error_messages) { [] }
+
+      it "classifies from per-attempt evidence instead of the outer wrapper alone" do
+        result = described_class.call(pattern)
+
+        expect(result.root_cause).to eq("LLM Provider Error")
+        expect(result.category).to eq("llm_provider")
+        expect(result.confidence).to be > 0.0
+      end
+    end
   end
 end

--- a/spec/services/agent_run_patterns/diagnose_spec.rb
+++ b/spec/services/agent_run_patterns/diagnose_spec.rb
@@ -173,5 +173,37 @@ RSpec.describe AgentRunPatterns::Diagnose, :no_db do
         expect(result.confidence).to be > 0.0
       end
     end
+
+    context "when one document matches multiple patterns in the same category" do
+      let(:pattern) do
+        AgentRunPatterns::Detect::Pattern.new(
+          type: :error_cluster,
+          goal: "enhance_issue",
+          severity: :error,
+          details: {
+            evidence_bundle: AgentRunPatterns::EvidenceBundle.new(
+              outer_errors: [
+                "Provider error: model not found and api key invalid",
+                "Something completely unrelated happened"
+              ],
+              runner_attempts: [],
+              log_tails: [],
+              runner_configs: [],
+              aggregate_stats: { run_count: 2 }
+            ).to_payload
+          }
+        )
+      end
+
+      let(:error_messages) { [] }
+
+      it "counts the document once when computing confidence" do
+        result = described_class.call(pattern)
+
+        expect(result.root_cause).to eq("LLM Provider Error")
+        expect(result.category).to eq("llm_provider")
+        expect(result.confidence).to eq(0.5)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Implemented the self-heal refactor for #2321 and committed it as `7b9bcf5` with message `feat(self-heal): widen failure pattern evidence collection`.

`AgentRunPatterns::Detect` now attaches a sanitized `details[:evidence_bundle]` built from wrapper errors, `runners_attempted`, stdout/stderr tails, an explicit safe runner-config snapshot, and aggregate cluster stats. `AgentRunPatterns::Diagnose` now classifies against that richer bundle through the new [`app/services/agent_run_patterns/evidence_bundle.rb`](/workspace/app/services/agent_run_patterns/evidence_bundle.rb), which lets existing regex categories match per-attempt provider failures instead of only the outer wrapper.

I added regression coverage for the `Model metadata for \`gpt-4o\` not found` case and redaction coverage using a fixture at [`spec/fixtures/files/agent_run_patterns/model_metadata_not_found_runners_attempted.json`](/workspace/spec/fixtures/files/agent_run_patterns/model_metadata_not_found_runners_attempted.json). Verification completed with `bundle exec rubocop` clean and `bundle exec rspec` passing: `13897 examples, 0 failures, 7 pending`.

---

Closes #2321