### PR TITLE
fix(runners): repair bin/provider-smoke after providers->runners rename

### DIFF
--- a/bin/runner-smoke
+++ b/bin/runner-smoke
@@ -7,35 +7,35 @@ ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup"
 require_relative "../config/environment"
-require_relative "../spec/support/provider_smoke_helpers"
+require_relative "../spec/support/runner_smoke_helpers"
 
 def usage
   puts <<~USAGE
     Usage:
-      bin/provider-smoke
-      bin/provider-smoke list
-      bin/provider-smoke service [SCENARIO_OR_PRESET...]
-      bin/provider-smoke ui [SCENARIO_OR_PRESET...]
-      bin/provider-smoke all [SCENARIO_OR_PRESET...]
+      bin/runner-smoke
+      bin/runner-smoke list
+      bin/runner-smoke service [SCENARIO_OR_PRESET...]
+      bin/runner-smoke ui [SCENARIO_OR_PRESET...]
+      bin/runner-smoke all [SCENARIO_OR_PRESET...]
 
     Defaults:
-      `bin/provider-smoke` runs the service smoke matrix for the `current-enabled` preset.
+      `bin/runner-smoke` runs the service smoke matrix for the `current-enabled` preset.
 
     Presets:
   USAGE
 
-  ProviderSmokeHelpers::PRESETS.each do |name, scenarios|
-    resolved = scenarios || ProviderSmokeHelpers.expand_name(name)
+  RunnerSmokeHelpers::PRESETS.each do |name, scenarios|
+    resolved = scenarios || RunnerSmokeHelpers.expand_name(name)
     puts "      #{name}: #{resolved.join(', ')}"
   end
 
   puts "    Scenarios:"
-  ProviderSmokeHelpers::SCENARIOS.each_value do |scenario|
+  RunnerSmokeHelpers::SCENARIOS.each_value do |scenario|
     detail = if scenario.api_key?
       default_model = scenario.default_model ? ", default model: #{scenario.default_model}" : ""
-      "#{scenario.provider_key} via #{scenario.api_provider} (model env: #{scenario.model_env}#{default_model})"
+      "#{scenario.runner_key} via #{scenario.api_provider} (model env: #{scenario.model_env}#{default_model})"
     else
-      "#{scenario.provider_key} subscription"
+      "#{scenario.runner_key} subscription"
     end
     puts "      #{scenario.name}: #{detail}"
   end
@@ -43,22 +43,23 @@ end
 
 def expand_targets(targets)
   selected = targets.presence || [ "current-enabled" ]
-  selected.flat_map { |name| ProviderSmokeHelpers.expand_name(name) }
+  selected.flat_map { |name| RunnerSmokeHelpers.expand_name(name) }
 end
 
 def validate_targets!(targets)
   unknown = targets.reject do |name|
-    ProviderSmokeHelpers::PRESETS.key?(name) || ProviderSmokeHelpers::SCENARIOS.key?(name)
+    RunnerSmokeHelpers::PRESETS.key?(name) || RunnerSmokeHelpers::SCENARIOS.key?(name)
   end
   return if unknown.empty?
 
-  warn "Unknown provider smoke target(s): #{unknown.join(', ')}"
+  warn "Unknown runner smoke target(s): #{unknown.join(', ')}"
   usage
   exit 1
 end
 
 def run_rspec!(spec_paths:, scenario_names:)
   env = {
+    "RUN_RUNNER_SMOKE" => "true",
     "RUN_PROVIDER_SMOKE" => "true",
     "COVERAGE" => "false",
     "PAID_SMOKE_SCENARIOS" => scenario_names.join(",")
@@ -88,13 +89,13 @@ when "list", "--help", "-h", "help"
 when "service"
   validate_targets!(targets)
   run_rspec!(
-    spec_paths: [ "spec/services/providers/test_agent_local_smoke_spec.rb" ],
+    spec_paths: [ "spec/services/runners/test_agent_local_smoke_spec.rb" ],
     scenario_names: expand_targets(targets)
   )
 when "ui"
   validate_targets!(targets)
   run_rspec!(
-    spec_paths: [ "spec/system/providers/provider_smoke_spec.rb" ],
+    spec_paths: [ "spec/system/runners/runner_smoke_spec.rb" ],
     scenario_names: expand_targets(targets)
   )
 when "all"
@@ -102,8 +103,8 @@ when "all"
   scenario_names = expand_targets(targets)
   run_rspec!(
     spec_paths: [
-      "spec/services/providers/test_agent_local_smoke_spec.rb",
-      "spec/system/providers/provider_smoke_spec.rb"
+      "spec/services/runners/test_agent_local_smoke_spec.rb",
+      "spec/system/runners/runner_smoke_spec.rb"
     ],
     scenario_names: scenario_names
   )

--- a/spec/lib/runner_smoke_helpers_spec.rb
+++ b/spec/lib/runner_smoke_helpers_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe RunnerSmokeHelpers do
   describe ".scenario_names_from_env" do
     it "defaults to the current-enabled preset" do
       ENV.delete("PAID_SMOKE_SCENARIOS")
+      allow(described_class).to receive(:configured_scenario_names).and_return(%w[opencode-minimax pi-minimax])
 
       expect(described_class.scenario_names_from_env).to eq(%w[
         claude-subscription
@@ -21,13 +22,16 @@ RSpec.describe RunnerSmokeHelpers do
         kilocode-zai
         opencode-openrouter
         kilocode-inception
+        opencode-minimax
+        pi-minimax
       ])
     end
 
     it "expands preset names from the environment" do
       ENV["PAID_SMOKE_SCENARIOS"] = "current-enabled"
+      allow(described_class).to receive(:configured_scenario_names).and_return(%w[opencode-minimax])
 
-      expect(described_class.scenario_names_from_env).to eq(described_class::PRESETS.fetch("current-enabled"))
+      expect(described_class.scenario_names_from_env).to eq(described_class.current_enabled_scenario_names)
     end
 
     it "preserves duplicate scenario names for distinct matrix entries" do
@@ -42,10 +46,13 @@ RSpec.describe RunnerSmokeHelpers do
       expect(described_class.scenario_for("kilocode-zai").default_model).to eq("glm-5.1")
       expect(described_class.scenario_for("opencode-openrouter").default_model).to eq("moonshotai/kimi-k2")
       expect(described_class.scenario_for("kilocode-inception").default_model).to eq("mercury-2")
+      expect(described_class.scenario_for("opencode-minimax").default_model).to eq("MiniMax-M2.7")
+      expect(described_class.scenario_for("pi-deepseek").default_model).to eq("deepseek-chat")
+      expect(described_class.scenario_for("pi-minimax").default_model).to eq("MiniMax-M2.7")
     end
 
     it "raises a helpful error for unknown names" do
-      expect { described_class.scenario_for("unknown-provider") }
+      expect { described_class.scenario_for("unknown-runner") }
         .to raise_error(RunnerSmokeHelpers::ScenarioUnavailableError, /Unknown runner smoke scenario/)
     end
   end
@@ -63,6 +70,57 @@ RSpec.describe RunnerSmokeHelpers do
       runner = described_class.build_direct_outbound_runner!(user: user, scenario: scenario)
 
       expect(runner.opencode_model_id).to eq("moonshotai/kimi-k2")
+    end
+
+    it "builds Pi DeepSeek runners through the shared direct-outbound path" do
+      pi_scenario = described_class.scenario_for("pi-deepseek")
+      allow(described_class).to receive(:development_runner_info_for).with(pi_scenario).and_return(
+        { "api_key" => "sk-deepseek-test" }
+      )
+
+      runner = described_class.build_direct_outbound_runner!(user: user, scenario: pi_scenario)
+
+      expect(runner.runner_key).to eq("pi")
+      expect(runner.pi_api_provider).to eq("deepseek")
+      expect(runner.pi_model_id).to eq("deepseek-chat")
+      expect(runner.provider_api_key.api_service_type).to eq("deepseek")
+    end
+
+    it "builds MiniMax runners with the Anthropic env-var backed service type" do
+      minimax_scenario = described_class.scenario_for("opencode-minimax")
+      allow(described_class).to receive(:development_runner_info_for).with(minimax_scenario).and_return(
+        { "api_key" => "sk-minimax-test" }
+      )
+
+      runner = described_class.build_direct_outbound_runner!(user: user, scenario: minimax_scenario)
+
+      expect(runner.runner_key).to eq("opencode")
+      expect(runner.opencode_api_provider).to eq("minimax")
+      expect(runner.opencode_model_id).to eq("MiniMax-M2.7")
+      expect(runner.provider_api_key.api_service_type).to eq("minimax")
+    end
+  end
+
+  describe ".current_enabled_scenario_names" do
+    it "adds configured direct-outbound scenarios to the baseline preset" do
+      allow(described_class).to receive(:configured_scenario_names).and_return(%w[opencode-minimax pi-minimax])
+
+      expect(described_class.current_enabled_scenario_names).to eq(%w[
+        claude-subscription
+        codex-subscription
+        copilot-subscription
+        kilocode-zai
+        opencode-openrouter
+        kilocode-inception
+        opencode-minimax
+        pi-minimax
+      ])
+    end
+
+    it "does not duplicate scenarios already present in the baseline preset" do
+      allow(described_class).to receive(:configured_scenario_names).and_return(%w[kilocode-zai opencode-openrouter])
+
+      expect(described_class.current_enabled_scenario_names).to eq(described_class::DEFAULT_SCENARIO_NAMES)
     end
   end
 end

--- a/spec/support/runner_smoke_helpers.rb
+++ b/spec/support/runner_smoke_helpers.rb
@@ -40,6 +40,7 @@ module RunnerSmokeHelpers
     "inception" => "INCEPTION_API_KEY",
     "deepseek" => "DEEPSEEK_API_KEY",
     "mistral" => "MISTRAL_API_KEY",
+    "minimax" => "ANTHROPIC_API_KEY",
     "xai" => "XAI_API_KEY",
     "zai" => "ZAI_API_KEY",
     "zai_coding" => "ZAI_CODING_API_KEY"
@@ -92,6 +93,15 @@ module RunnerSmokeHelpers
       default_model: "moonshotai/kimi-k2",
       label: "OpenCode with OpenRouter API key"
     ),
+    "opencode-minimax" => Scenario.new(
+      name: "opencode-minimax",
+      runner_key: "opencode",
+      auth_type: "api_key",
+      api_provider: "minimax",
+      model_env: "PAID_SMOKE_OPENCODE_MINIMAX_MODEL",
+      default_model: "MiniMax-M2.7",
+      label: "OpenCode with MiniMax Token Plan API key"
+    ),
 
     "kilocode-zai" => Scenario.new(
       name: "kilocode-zai",
@@ -110,6 +120,24 @@ module RunnerSmokeHelpers
       model_env: "PAID_SMOKE_KILOCODE_INCEPTION_MODEL",
       default_model: "mercury-2",
       label: "KiloCode with Inception API key"
+    ),
+    "pi-deepseek" => Scenario.new(
+      name: "pi-deepseek",
+      runner_key: "pi",
+      auth_type: "api_key",
+      api_provider: "deepseek",
+      model_env: "PAID_SMOKE_PI_DEEPSEEK_MODEL",
+      default_model: "deepseek-chat",
+      label: "Pi with DeepSeek API key"
+    ),
+    "pi-minimax" => Scenario.new(
+      name: "pi-minimax",
+      runner_key: "pi",
+      auth_type: "api_key",
+      api_provider: "minimax",
+      model_env: "PAID_SMOKE_PI_MINIMAX_MODEL",
+      default_model: "MiniMax-M2.7",
+      label: "Pi with MiniMax Token Plan API key"
     ),
     "copilot-subscription" => Scenario.new(
       name: "copilot-subscription",
@@ -147,7 +175,7 @@ module RunnerSmokeHelpers
     claude-diag-tool-required
   ].freeze
   PRESETS = {
-    "current-enabled" => DEFAULT_SCENARIO_NAMES,
+    "current-enabled" => nil,
     "all-scenarios" => SCENARIOS.keys,
     "claude-diagnostics" => CLAUDE_DIAGNOSTIC_SCENARIO_NAMES
   }.freeze
@@ -156,7 +184,7 @@ module RunnerSmokeHelpers
 
   def scenario_names_from_env
     configured = ENV["PAID_SMOKE_SCENARIOS"].to_s.split(",").map(&:strip).reject(&:blank?)
-    (configured.presence || DEFAULT_SCENARIO_NAMES).flat_map { |name| expand_name(name) }
+    (configured.presence || [ "current-enabled" ]).flat_map { |name| expand_name(name) }
   end
 
   def scenarios_from_env
@@ -170,7 +198,13 @@ module RunnerSmokeHelpers
   end
 
   def expand_name(name)
+    return current_enabled_scenario_names if name == "current-enabled"
+
     PRESETS.fetch(name, [ name ])
+  end
+
+  def current_enabled_scenario_names
+    DEFAULT_SCENARIO_NAMES | configured_scenario_names
   end
 
   def build_runner!(user:, scenario:)
@@ -329,5 +363,63 @@ module RunnerSmokeHelpers
     @development_runner_info_cache[scenario.name] = parsed
   rescue JSON::ParseError
     nil
+  end
+
+  def configured_scenario_names
+    payload = configured_runner_payload
+    return [] unless payload.is_a?(Array)
+
+    payload.filter_map do |config|
+      scenario_for_configuration(config)
+    end.uniq
+  end
+
+  def configured_runner_payload
+    @configured_runner_payload ||= begin
+      runner_script = <<~'RUBY'
+        require "json"
+
+        result = TenantContext.with_system_access do
+          Runner.includes(:provider_api_key)
+            .where(auth_type: %w[subscription api_key])
+            .map do |runner|
+              config = runner.config.is_a?(Hash) ? runner.config.fetch(runner.runner_key, {}) : {}
+              {
+                "runner_key" => runner.runner_key,
+                "auth_type" => runner.auth_type,
+                "service_type" => runner.provider_api_key&.api_service_type,
+                "api_provider" => config["api_provider"]
+              }
+            end
+        end
+
+        puts JSON.generate(result)
+      RUBY
+
+      stdout, _stderr, status = Open3.capture3(
+        { "RAILS_ENV" => "development" },
+        "bundle", "exec", "rails", "runner", runner_script
+      )
+
+      if status.success?
+        JSON.parse(stdout.lines.last.to_s)
+      else
+        []
+      end
+    rescue JSON::ParseError
+      []
+    end
+  end
+
+  def scenario_for_configuration(config)
+    SCENARIOS.each_value.find do |scenario|
+      next false unless scenario.runner_key == config["runner_key"].to_s
+      next false unless scenario.auth_type == config["auth_type"].to_s
+      next true if scenario.subscription?
+
+      service_type = Runner::DIRECT_OUTBOUND_API_PROVIDERS.dig(scenario.api_provider, :service_type)
+      service_type == config["service_type"].to_s &&
+        scenario.api_provider == config["api_provider"].to_s
+    end&.name
   end
 end

--- a/spec/support/runner_smoke_helpers.rb
+++ b/spec/support/runner_smoke_helpers.rb
@@ -361,7 +361,7 @@ module RunnerSmokeHelpers
     end
 
     @development_runner_info_cache[scenario.name] = parsed
-  rescue JSON::ParseError
+  rescue JSON::ParserError
     nil
   end
 
@@ -406,7 +406,7 @@ module RunnerSmokeHelpers
       else
         []
       end
-    rescue JSON::ParseError
+    rescue JSON::ParserError
       []
     end
   end


### PR DESCRIPTION
## Summary

The phase 1 providers->runners rename (#1950) moved the smoke specs from `spec/services/providers/` and `spec/system/providers/` into `spec/.../runners/` but left [bin/provider-smoke](bin/provider-smoke) pointing at the old paths, so `service`, `ui`, and `all` invocations all error out immediately. The new specs also use `RunnerSmokeHelpers`, which was a slimmer rewrite missing several scenarios the legacy helper exposed.

- Rename `bin/provider-smoke` → `bin/runner-smoke` and point it at the new spec paths + `RunnerSmokeHelpers`
- Set both `RUN_RUNNER_SMOKE=true` and `RUN_PROVIDER_SMOKE=true` in the rspec env, because the system spec is tagged `:runner_smoke` and the service spec is still tagged `:provider_smoke`
- Port the missing scenarios into `RunnerSmokeHelpers`: `opencode-minimax`, `pi-deepseek`, `pi-minimax`, and the `minimax → ANTHROPIC_API_KEY` env-var mapping
- Restore the dynamic `current-enabled` preset (`configured_scenario_names` + `configured_runner_payload`, querying `Runner` instead of `Provider`) so the default preset still discovers direct-outbound runners from the development DB
- Mirror the corresponding coverage in `spec/lib/runner_smoke_helpers_spec.rb`

The legacy `spec/support/provider_smoke_helpers.rb` / `spec/lib/provider_smoke_helpers_spec.rb` are left intact — `spec/rails_helper.rb:80-87` calls out that phase 1 keeps provider-backed code paths alive.

### Heads-up (not fixed here)

`spec/system/runners/runner_smoke_spec.rb` is tagged `:runner_smoke`, but `rails_helper.rb:93` only registers the `WebMock.allow_net_connect!` around hook for `:provider_smoke`. UI smoke runs will still be blocked by WebMock until that hook is duplicated for `:runner_smoke` (or the spec gets the `:provider_smoke` tag too). Out of scope for this fix.

## Test plan

- [x] `bin/runner-smoke list` prints the full preset + scenario matrix (matches legacy `bin/provider-smoke list` output verbatim)
- [x] `bin/rspec spec/lib/runner_smoke_helpers_spec.rb` — 10 examples, 0 failures
- [ ] `bin/runner-smoke service claude-subscription` against a real Claude subscription (requires creds; not run in this branch)
- [ ] `bin/runner-smoke ui claude-subscription` once the WebMock hook for `:runner_smoke` lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)