### PR TITLE
chore(dev-update): ignore .worktrees/ in working tree check

### DIFF
--- a/bin/dev-update
+++ b/bin/dev-update
@@ -110,7 +110,9 @@ truncate_dev_update_logs() {
 }
 
 tree_is_dirty() {
-  [ -n "$(git status --porcelain 2>/dev/null)" ]
+  # Exclude .worktrees/ — sibling git worktrees live there and always appear
+  # untracked in the primary checkout; they are not changes to stash or commit.
+  [ -n "$(git status --porcelain -- . ':(exclude).worktrees' 2>/dev/null)" ]
 }
 
 stash_dirty_tree() {


### PR DESCRIPTION
## Summary
- `bin/dev-update`'s `tree_is_dirty` check uses `git status --porcelain`, which flags sibling git worktrees under `.worktrees/` as untracked. With the project's worktree convention, this causes dev-update to refuse to run with a misleading "uncommitted changes" error whenever any worktrees exist.
- Scope the porcelain check with a pathspec exclude (`-- . ':(exclude).worktrees'`) so `.worktrees/` is filtered out. Worktrees are no longer treated as a dirty tree; real edits still are.

## Test plan
- [x] Manually verified: with only `.worktrees/*` present and no other edits, `tree_is_dirty` returns false (`git status --porcelain -- . ':(exclude).worktrees'` produces no output).
- [x] Real edits to tracked files still trigger the dirty-tree guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)