### PR TITLE
feat(self-heal): ZFC-based Diagnose with proposed-action enum + RemediationDecision audit table

### DIFF
--- a/app/controllers/remediation_decisions_controller.rb
+++ b/app/controllers/remediation_decisions_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RemediationDecisionsController < ApplicationController
+  def show
+    @remediation_decision = policy_scope(RemediationDecision).find(params[:id])
+    authorize @remediation_decision
+  end
+end

--- a/app/jobs/agent_run_pattern_detector_job.rb
+++ b/app/jobs/agent_run_pattern_detector_job.rb
@@ -20,8 +20,13 @@ class AgentRunPatternDetectorJob < ApplicationJob
         patterns = AgentRunPatterns::Detect.call(account: account)
         total_patterns += patterns.size
 
-        diagnoses = build_diagnoses(patterns)
-        AgentRunPatterns::Notify.call(account: account, patterns: patterns, diagnoses: diagnoses)
+        results = build_diagnoses(account, patterns)
+        AgentRunPatterns::Notify.call(
+          account: account,
+          patterns: patterns,
+          diagnoses: results[:diagnoses],
+          decisions: results[:decisions]
+        )
 
         next if patterns.empty?
 
@@ -51,23 +56,30 @@ class AgentRunPatternDetectorJob < ApplicationJob
 
   private
 
-  def build_diagnoses(patterns)
-    patterns.each_with_object({}) do |pattern, hash|
-      diagnosis = AgentRunPatterns::Diagnose.call(pattern)
-      existing = hash[pattern.goal]
+  def build_diagnoses(account, patterns)
+    remaining_budget = AgentRunPatterns::DailyDiagnosisBudget.remaining_for(account: account)
 
-      hash[pattern.goal] = if existing.nil? || better_diagnosis?(diagnosis, existing)
-        diagnosis
-      else
-        existing
-      end
+    patterns.each_with_object({ diagnoses: {}, decisions: {} }) do |pattern, result|
+      allow_llm = remaining_budget.positive?
+      remaining_budget -= 1 if allow_llm
+
+      diagnosis = AgentRunPatterns::Diagnose.call(
+        pattern,
+        account: account,
+        allow_llm: allow_llm
+      )
+      decision = AgentRunPatterns::RecordRemediationDecision.call(
+        account: account,
+        pattern: pattern,
+        diagnosis: diagnosis
+      )
+
+      result[:diagnoses][fingerprint(pattern)] = diagnosis
+      result[:decisions][fingerprint(pattern)] = decision
     end
   end
 
-  def better_diagnosis?(candidate, existing)
-    return true if existing.category == "unknown" && candidate.category != "unknown"
-    return false if candidate.category == "unknown" && existing.category != "unknown"
-
-    candidate.confidence > existing.confidence
+  def fingerprint(pattern)
+    pattern.details[:fingerprint].to_s
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -27,6 +27,7 @@ class Account < ApplicationRecord
   has_many :mcp_server_definitions, dependent: :destroy
   has_many :marketplace_entries, dependent: :destroy
   has_many :notifications, dependent: :destroy
+  has_many :remediation_decisions, dependent: :destroy
   has_many :pre_commit_requirements, dependent: :destroy
   has_one :tracker_configuration, as: :configurable, dependent: :destroy
   has_one :tenant_setting, dependent: :destroy

--- a/app/models/remediation_decision.rb
+++ b/app/models/remediation_decision.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class RemediationDecision < ApplicationRecord
+  PROPOSED_ACTIONS = %w[
+    notify
+    file_issue
+    mark_runner_unavailable
+    clear_runner_field
+    disable_runner_fallback
+  ].freeze
+  STATUSES = %w[proposed approved applied skipped failed reverted].freeze
+  OUTCOMES = %w[improved unchanged regressed].freeze
+
+  belongs_to :account
+  belongs_to :applied_by, class_name: "User", optional: true
+
+  validates :fingerprint, presence: true
+  validates :root_cause, presence: true
+  validates :confidence, numericality: { greater_than_or_equal_to: 0.0, less_than_or_equal_to: 1.0 }
+  validates :proposed_action, presence: true, inclusion: { in: PROPOSED_ACTIONS }
+  validates :action_target_type, presence: true
+  validates :status, presence: true, inclusion: { in: STATUSES }
+  validates :outcome, inclusion: { in: OUTCOMES }, allow_nil: true
+  validates :occurrence_count, numericality: { only_integer: true, greater_than_or_equal_to: 1 }
+  validates :pre_remediation_failure_count, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :post_remediation_failure_count, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
+
+  scope :recent, -> { order(created_at: :desc, id: :desc) }
+
+  def action_target_label
+    case action_target_type
+    when "account"
+      "Account ##{action_target_id}"
+    when "project"
+      "Project ##{action_target_id}"
+    when "runner"
+      "Runner ##{action_target_id}"
+    when "runner_field"
+      "Runner ##{action_target_id} field #{action_target_metadata["field_name"]}"
+    else
+      "#{action_target_type}:#{action_target_id}"
+    end
+  end
+end

--- a/app/models/remediation_decision.rb
+++ b/app/models/remediation_decision.rb
@@ -22,6 +22,9 @@ class RemediationDecision < ApplicationRecord
   validates :status, presence: true, inclusion: { in: STATUSES }
   validates :outcome, inclusion: { in: OUTCOMES }, allow_nil: true
   validates :occurrence_count, numericality: { only_integer: true, greater_than_or_equal_to: 1 }
+  validates :diagnosis_attempted_on, presence: true
+  validates :diagnosis_attempt_count_on_day, numericality: { only_integer: true, greater_than_or_equal_to: 1 }
+  validates :last_diagnosis_attempt_at, presence: true
   validates :pre_remediation_failure_count, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
   validates :post_remediation_failure_count, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,7 @@ class User < ApplicationRecord
   has_many :providers, class_name: "Provider", dependent: :destroy
   has_many :provider_api_keys, dependent: :destroy
   has_many :account_activity_events, foreign_key: :actor_id, dependent: :nullify, inverse_of: :actor
+  has_many :applied_remediation_decisions, class_name: "RemediationDecision", foreign_key: :applied_by_id, dependent: :nullify, inverse_of: :applied_by
   has_many :pre_commit_requirements, dependent: :destroy
   has_many :initiated_agent_runs, class_name: "AgentRun", foreign_key: :initiating_user_id, dependent: :nullify, inverse_of: :initiating_user
   has_one :tracker_configuration, as: :configurable, dependent: :destroy

--- a/app/policies/remediation_decision_policy.rb
+++ b/app/policies/remediation_decision_policy.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class RemediationDecisionPolicy < ApplicationPolicy
+end

--- a/app/services/agent_run_patterns/daily_diagnosis_budget.rb
+++ b/app/services/agent_run_patterns/daily_diagnosis_budget.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module AgentRunPatterns
+  class DailyDiagnosisBudget
+    DEFAULT_DAILY_CAP = 20
+
+    def self.remaining_for(...)
+      new(...).remaining_for
+    end
+
+    def initialize(account:)
+      @account = account
+    end
+
+    def remaining_for
+      [ daily_cap - decisions_created_today, 0 ].max
+    end
+
+    private
+
+    attr_reader :account
+
+    def daily_cap
+      configured = account.tenant_setting&.features&.dig("self_heal", "diagnosis_daily_cap")
+      value = configured.to_i
+      value.positive? ? value : DEFAULT_DAILY_CAP
+    end
+
+    def decisions_created_today
+      RemediationDecision.where(account: account, created_at: Time.current.all_day).count
+    end
+  end
+end

--- a/app/services/agent_run_patterns/daily_diagnosis_budget.rb
+++ b/app/services/agent_run_patterns/daily_diagnosis_budget.rb
@@ -13,7 +13,7 @@ module AgentRunPatterns
     end
 
     def remaining_for
-      [ daily_cap - decisions_created_today, 0 ].max
+      [ daily_cap - diagnoses_attempted_today, 0 ].max
     end
 
     private
@@ -26,8 +26,10 @@ module AgentRunPatterns
       value.positive? ? value : DEFAULT_DAILY_CAP
     end
 
-    def decisions_created_today
-      RemediationDecision.where(account: account, created_at: Time.current.all_day).count
+    def diagnoses_attempted_today
+      RemediationDecision
+        .where(account: account, diagnosis_attempted_on: Date.current)
+        .sum(:diagnosis_attempt_count_on_day)
     end
   end
 end

--- a/app/services/agent_run_patterns/detect.rb
+++ b/app/services/agent_run_patterns/detect.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "digest"
+
 module AgentRunPatterns
   class Detect
     FAILURE_STREAK_THRESHOLD = 3
@@ -66,7 +68,9 @@ module AgentRunPatterns
         type: :failure_streak,
         goal: goal,
         severity: :error,
-        details: {
+        details: with_fingerprint(
+          goal: goal,
+          type: :failure_streak,
           streak_length: streak.size,
           total_runs: runs.size,
           failure_rate: streak.size.to_f / runs.size,
@@ -75,7 +79,7 @@ module AgentRunPatterns
           run_ids: streak.map(&:id),
           started_at: streak.last.completed_at,
           ended_at: streak.first.completed_at
-        }
+        )
       ) ]
     end
 
@@ -94,7 +98,9 @@ module AgentRunPatterns
         type: :high_failure_rate,
         goal: goal,
         severity: severity,
-        details: {
+        details: with_fingerprint(
+          goal: goal,
+          type: :high_failure_rate,
           failure_count: failed,
           total_count: runs.size,
           failure_rate: failure_rate.round(4),
@@ -102,7 +108,7 @@ module AgentRunPatterns
           error_messages: failed_runs.filter_map(&:error_message).first(5),
           evidence_bundle: build_evidence_bundle(failed_runs),
           run_ids: failed_runs.map(&:id)
-        }
+        )
       ) ]
     end
 
@@ -122,7 +128,9 @@ module AgentRunPatterns
           type: :error_cluster,
           goal: goal,
           severity: :error,
-          details: {
+          details: with_fingerprint(
+            goal: goal,
+            type: :error_cluster,
             error_pattern: normalized_msg,
             occurrence_count: error_runs.size,
             total_failures: failed_runs.size,
@@ -130,7 +138,7 @@ module AgentRunPatterns
             evidence_bundle: build_evidence_bundle(error_runs),
             run_ids: error_runs.map(&:id),
             statuses: error_runs.group_by(&:status).transform_values(&:count)
-          }
+          )
         )
       end
 
@@ -255,6 +263,8 @@ module AgentRunPatterns
 
       {
         run_count: runs.size,
+        distinct_project_ids: Array(runs).filter_map { |run| read_attribute(run, :project_id) }.uniq.sort,
+        distinct_runner_ids: Array(runs).filter_map { |run| read_attribute(run, :runner_id) }.uniq.sort,
         distinct_runners: Array(runs).flat_map { |run| distinct_runner_names_for(run) }.uniq.sort,
         statuses: Array(runs).group_by { |run| read_attribute(run, :status) }.transform_values(&:count),
         time_window: {
@@ -369,6 +379,18 @@ module AgentRunPatterns
       return pattern.details[:error_pattern] if pattern.type == :error_cluster
 
       nil
+    end
+
+    def with_fingerprint(goal:, type:, **details)
+      details.merge(
+        fingerprint: Digest::SHA256.hexdigest({
+          goal: goal,
+          type: type,
+          error_pattern: details[:error_pattern],
+          error_messages: Array(details[:error_messages]).sort,
+          sample_messages: Array(details[:sample_messages]).sort
+        }.to_json)
+      )
     end
   end
 end

--- a/app/services/agent_run_patterns/detect.rb
+++ b/app/services/agent_run_patterns/detect.rb
@@ -382,13 +382,17 @@ module AgentRunPatterns
     end
 
     def with_fingerprint(goal:, type:, **details)
+      aggregate_stats = details[:evidence_bundle].to_h.deep_symbolize_keys[:aggregate_stats] || {}
+
       details.merge(
         fingerprint: Digest::SHA256.hexdigest({
           goal: goal,
           type: type,
           error_pattern: details[:error_pattern],
           error_messages: Array(details[:error_messages]).sort,
-          sample_messages: Array(details[:sample_messages]).sort
+          sample_messages: Array(details[:sample_messages]).sort,
+          distinct_project_ids: Array(aggregate_stats[:distinct_project_ids]).sort,
+          distinct_runner_ids: Array(aggregate_stats[:distinct_runner_ids]).sort
         }.to_json)
       )
     end

--- a/app/services/agent_run_patterns/diagnose.rb
+++ b/app/services/agent_run_patterns/diagnose.rb
@@ -1,7 +1,43 @@
 # frozen_string_literal: true
 
+require "json"
+
 module AgentRunPatterns
   class Diagnose
+    DEFAULT_MODEL = "claude-sonnet-4-6"
+    MIN_CONFIDENCE = 0.55
+    TIMEOUT = 45
+    PROMPT = <<~PROMPT
+      You are diagnosing recurring Paid agent-run failures.
+
+      Return exactly one JSON object with these keys:
+      - root_cause: short free-text string for humans
+      - confidence: number between 0.0 and 1.0
+      - proposed_action: one of %{actions}
+      - action_target: object with:
+        - type: one of "account", "project", "runner", "runner_field"
+        - id: string or null
+        - field_name: string or null
+      - evidence_pointers: array of pointer strings copied exactly from the evidence list
+
+      Rules:
+      - Choose only from the allowed proposed_action enum.
+      - Use only the provided evidence.
+      - If evidence is weak, lower confidence.
+      - Prefer the narrowest valid target.
+      - For clear_runner_field, set action_target.type to "runner_field" and include field_name.
+      - Do not include markdown, prose, or extra keys.
+
+      Pattern context:
+      %{pattern_context}
+
+      Available target ids:
+      %{target_context}
+
+      Evidence:
+      %{evidence_lines}
+    PROMPT
+
     ROOT_CAUSE_CATEGORIES = {
       llm_provider: {
         patterns: [
@@ -14,8 +50,7 @@ module AgentRunPatterns
           /context.*length.*exceed/i,
           /token.*limit.*exceed/i
         ],
-        label: "LLM Provider Error",
-        remediation: "Check provider health and credentials. Consider retrying with an alternate transport or model."
+        label: "LLM Provider Error"
       },
       github_api: {
         patterns: [
@@ -27,8 +62,7 @@ module AgentRunPatterns
           /branch.*protection/i,
           /merge.*conflict/i
         ],
-        label: "GitHub API Error",
-        remediation: "Check GitHub token health, rate limit status, and repository permissions."
+        label: "GitHub API Error"
       },
       container: {
         patterns: [
@@ -40,8 +74,7 @@ module AgentRunPatterns
           /container.*exit/i,
           /exec format error/i
         ],
-        label: "Container Error",
-        remediation: "Check Docker availability, resource limits, and container image integrity."
+        label: "Container Error"
       },
       timeout: {
         patterns: [
@@ -50,72 +83,254 @@ module AgentRunPatterns
           /deadline.*exceeded/i,
           /execution.*expired/i
         ],
-        label: "Timeout",
-        remediation: "Check queue depth, resource contention, and whether the task scope is too large."
+        label: "Timeout"
       }
     }.freeze
 
-    Diagnosis = Data.define(:root_cause, :category, :confidence, :remediation)
-
-    def self.call(pattern)
-      new(pattern).call
+    class Diagnosis < Data.define(
+      :root_cause,
+      :confidence,
+      :proposed_action,
+      :action_target,
+      :evidence_pointers
+    )
+      def unknown?
+        root_cause == "Unknown"
+      end
     end
 
-    def initialize(pattern)
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(pattern, account:, allow_llm: true)
       @pattern = pattern
+      @account = account
+      @allow_llm = allow_llm
     end
 
     def call
-      evidence_documents = extract_evidence_documents
-      return unknown_diagnosis if evidence_documents.empty?
+      evidence_entries = extract_evidence_entries
+      return fallback_diagnosis(evidence_entries) if evidence_entries.empty?
+      return fallback_diagnosis(evidence_entries) unless allow_llm
 
-      matches = classify_errors(evidence_documents)
-      return unknown_diagnosis if matches.empty?
-
-      best_match = matches.max_by { |_, score| score }
-      category_key = best_match.first
-      category = ROOT_CAUSE_CATEGORIES[category_key]
-
-      Diagnosis.new(
-        root_cause: category[:label],
-        category: category_key.to_s,
-        confidence: [ best_match.last.to_f / evidence_documents.size, 1.0 ].min,
-        remediation: category[:remediation]
+      llm_diagnosis = diagnose_with_llm(evidence_entries)
+      llm_diagnosis || fallback_diagnosis(evidence_entries)
+    rescue AgentHarness::Error => e
+      Rails.logger.warn(
+        message: "agent_run_patterns.diagnose_llm_failed",
+        account_id: account.id,
+        fingerprint: fingerprint,
+        error_class: e.class.name,
+        error: e.message
       )
+      fallback_diagnosis(evidence_entries)
     end
 
     private
 
-    attr_reader :pattern
+    attr_reader :account, :allow_llm, :pattern
 
-    def extract_evidence_documents
-      evidence_bundle = pattern.details[:evidence_bundle]
-      return EvidenceBundle.from_payload(evidence_bundle).documents if evidence_bundle.present?
+    def diagnose_with_llm(evidence_entries)
+      response = AgentHarness.send_message(
+        prompt_for(evidence_entries),
+        provider: :claude,
+        model: DEFAULT_MODEL,
+        timeout: TIMEOUT,
+        tools: :none,
+        **Llm::TextMode.options
+      )
 
-      details = pattern.details
-      Array(details[:error_messages] || details[:sample_messages])
+      return log_and_fallback("llm_unsuccessful_response") unless response.success?
+
+      parsed = parse_json(response.output)
+      return log_and_fallback("invalid_json_output", raw_output: response.output) unless parsed
+
+      validate_llm_diagnosis(parsed)
     end
 
-    def classify_errors(evidence_documents)
-      matches = Hash.new(0)
+    def parse_json(output)
+      cleaned = output.to_s.gsub(/\A```(?:json)?\s*/, "").gsub(/\s*```\z/, "").strip
+      return if cleaned.blank?
 
-      evidence_documents.each do |document|
-        ROOT_CAUSE_CATEGORIES.each do |category_key, config|
-          score = config[:patterns].any? { |pat| document.match?(pat) } ? 1 : 0
-          matches[category_key] += score if score.positive?
-        end
+      JSON.parse(cleaned)
+    rescue JSON::ParserError
+      nil
+    end
+
+    def validate_llm_diagnosis(payload)
+      confidence = Float(payload.fetch("confidence"))
+      return log_and_fallback("invalid_confidence", raw_output: payload) unless confidence.between?(0.0, 1.0)
+      return log_and_fallback("low_confidence", raw_output: payload) if confidence < MIN_CONFIDENCE
+
+      action = payload.fetch("proposed_action").to_s
+      unless RemediationDecision::PROPOSED_ACTIONS.include?(action)
+        return log_and_fallback("invalid_proposed_action", raw_output: payload)
       end
 
-      matches
+      evidence_pointers = Array(payload["evidence_pointers"]).map(&:to_s).reject(&:blank?)
+      if evidence_pointers.empty? || (evidence_pointers - allowed_pointers).any?
+        return log_and_fallback("invalid_evidence_pointers", raw_output: payload)
+      end
+
+      root_cause = payload.fetch("root_cause").to_s.strip
+      return log_and_fallback("blank_root_cause", raw_output: payload) if root_cause.blank?
+
+      action_target = normalize_action_target(action, payload["action_target"])
+      return log_and_fallback("invalid_action_target", raw_output: payload) unless action_target
+
+      Diagnosis.new(
+        root_cause: root_cause,
+        confidence: confidence.round(3),
+        proposed_action: action,
+        action_target: action_target,
+        evidence_pointers: evidence_pointers
+      )
+    rescue KeyError, ArgumentError, TypeError
+      log_and_fallback("invalid_structured_output", raw_output: payload)
+    end
+
+    def normalize_action_target(action, raw_target)
+      target = raw_target.is_a?(Hash) ? raw_target.deep_stringify_keys : {}
+
+      case action
+      when "notify"
+        { "type" => "account", "id" => account.id.to_s }
+      when "file_issue"
+        project_id = validated_id(target["id"], available_project_ids)
+        return unless project_id
+
+        { "type" => "project", "id" => project_id }
+      when "mark_runner_unavailable", "disable_runner_fallback"
+        runner_id = validated_id(target["id"], available_runner_ids)
+        return unless runner_id
+
+        { "type" => "runner", "id" => runner_id }
+      when "clear_runner_field"
+        runner_id = validated_id(target["id"], available_runner_ids)
+        field_name = target["field_name"].to_s.strip
+        return if runner_id.blank? || field_name.blank?
+
+        { "type" => "runner_field", "id" => runner_id, "field_name" => field_name }
+      end
+    end
+
+    def validated_id(value, allowed_ids)
+      candidate = value.to_s
+      return if candidate.blank?
+
+      candidate if allowed_ids.include?(candidate)
+    end
+
+    def fallback_diagnosis(evidence_entries)
+      matches = classify_errors(evidence_entries)
+      return unknown_diagnosis if matches.empty?
+
+      best_match = matches.max_by { |_, data| data[:score] }
+      category_key = best_match.first
+      category = ROOT_CAUSE_CATEGORIES.fetch(category_key)
+
+      Diagnosis.new(
+        root_cause: category[:label],
+        confidence: [ best_match.last[:score].to_f / evidence_entries.size, 1.0 ].min.round(3),
+        proposed_action: "notify",
+        action_target: { "type" => "account", "id" => account.id.to_s },
+        evidence_pointers: Array(matches[category_key][:pointers]).presence || [ evidence_entries.first.fetch(:pointer) ]
+      )
     end
 
     def unknown_diagnosis
       Diagnosis.new(
         root_cause: "Unknown",
-        category: "unknown",
         confidence: 0.0,
-        remediation: "Manual investigation required. Review individual agent run logs for details."
+        proposed_action: "notify",
+        action_target: { "type" => "account", "id" => account.id.to_s },
+        evidence_pointers: []
       )
+    end
+
+    def classify_errors(evidence_entries)
+      matches = Hash.new { |hash, key| hash[key] = { score: 0, pointers: [] } }
+
+      evidence_entries.each do |entry|
+        ROOT_CAUSE_CATEGORIES.each do |category_key, config|
+          next unless config[:patterns].any? { |pattern_match| entry[:text].match?(pattern_match) }
+
+          matches[category_key][:score] += 1
+          matches[category_key][:pointers] << entry[:pointer]
+        end
+      end
+
+      matches.transform_values { |data| data[:score].positive? ? data : nil }.compact
+    end
+
+    def extract_evidence_entries
+      evidence_bundle = EvidenceBundle.from_payload(pattern.details[:evidence_bundle])
+      entries = evidence_bundle.documents_with_pointers
+      return entries if entries.any?
+
+      legacy_messages(pattern.details).filter_map.with_index do |message, index|
+        next if message.blank?
+
+        { pointer: "legacy_messages[#{index}]", text: message }
+      end
+    end
+
+    def allowed_pointers
+      @allowed_pointers ||= extract_evidence_entries.map { |entry| entry[:pointer] }
+    end
+
+    def legacy_messages(details)
+      Array(details[:error_messages] || details[:sample_messages])
+    end
+
+    def prompt_for(evidence_entries)
+      format(
+        PROMPT,
+        actions: RemediationDecision::PROPOSED_ACTIONS.to_json,
+        pattern_context: {
+          fingerprint: fingerprint,
+          goal: pattern.goal,
+          type: pattern.type,
+          severity: pattern.severity,
+          details: pattern.details.except(:evidence_bundle)
+        }.to_json,
+        target_context: {
+          account_id: account.id.to_s,
+          project_ids: available_project_ids,
+          runner_ids: available_runner_ids
+        }.to_json,
+        evidence_lines: evidence_entries.map { |entry|
+          "#{entry[:pointer]}: #{entry[:text].truncate(500)}"
+        }.join("\n")
+      )
+    end
+
+    def fingerprint
+      pattern.details[:fingerprint].to_s
+    end
+
+    def available_project_ids
+      Array(evidence_bundle.aggregate_stats[:distinct_project_ids]).map(&:to_s)
+    end
+
+    def available_runner_ids
+      Array(evidence_bundle.aggregate_stats[:distinct_runner_ids]).map(&:to_s)
+    end
+
+    def evidence_bundle
+      @evidence_bundle ||= EvidenceBundle.from_payload(pattern.details[:evidence_bundle])
+    end
+
+    def log_and_fallback(reason, raw_output: nil)
+      Rails.logger.warn(
+        message: "agent_run_patterns.diagnose_fell_back",
+        account_id: account.id,
+        fingerprint: fingerprint,
+        reason: reason,
+        raw_output: raw_output
+      )
+      nil
     end
   end
 end

--- a/app/services/agent_run_patterns/evidence_bundle.rb
+++ b/app/services/agent_run_patterns/evidence_bundle.rb
@@ -31,27 +31,67 @@ module AgentRunPatterns
     end
 
     def documents
-      [].tap do |docs|
-        outer_errors.each do |message|
-          docs << message if message.present?
+      documents_with_pointers.map { |document| document[:text] }
+    end
+
+    def documents_with_pointers
+      [].tap do |documents|
+        outer_errors.each_with_index do |message, index|
+          next if message.blank?
+
+          documents << { pointer: "outer_errors[#{index}]", text: message }
         end
 
-        runner_attempts.each do |attempt|
-          docs << [
-            attempt[:runner],
-            attempt[:error_type],
-            attempt[:error_message],
-            attempt[:diagnostics].presence&.to_json
-          ].compact.join("\n")
+        runner_attempts.each_with_index do |attempt, index|
+          add_attempt_document(documents, attempt, index)
         end
 
-        log_tails.each do |tail|
-          docs << [ tail[:stdout], tail[:stderr] ].compact.join("\n")
+        log_tails.each_with_index do |tail, index|
+          add_log_documents(documents, tail, index)
         end
 
         # Runner configs remain available via `to_payload`, but excluding them
         # here prevents contextual metadata from diluting diagnosis confidence.
-      end.reject(&:blank?)
+      end
+    end
+
+    def allowed_pointers
+      documents_with_pointers.map { |document| document[:pointer] }
+    end
+
+    def text_for_pointer(pointer)
+      documents_with_pointers.find { |document| document[:pointer] == pointer }&.dig(:text)
+    end
+
+    private
+
+    def add_attempt_document(documents, attempt, index)
+      {
+        "runner_attempts[#{index}].error_message" => attempt[:error_message],
+        "runner_attempts[#{index}].diagnostics" => attempt[:diagnostics].presence&.to_json
+      }.each do |pointer, value|
+        next if value.blank?
+
+        documents << {
+          pointer: pointer,
+          text: [
+            attempt[:runner],
+            attempt[:error_type],
+            value
+          ].compact.join("\n")
+        }
+      end
+    end
+
+    def add_log_documents(documents, tail, index)
+      {
+        "log_tails[#{index}].stdout" => tail[:stdout],
+        "log_tails[#{index}].stderr" => tail[:stderr]
+      }.each do |pointer, value|
+        next if value.blank?
+
+        documents << { pointer: pointer, text: value }
+      end
     end
   end
 end

--- a/app/services/agent_run_patterns/notify.rb
+++ b/app/services/agent_run_patterns/notify.rb
@@ -8,10 +8,11 @@ module AgentRunPatterns
       new(...).call
     end
 
-    def initialize(account:, patterns:, diagnoses:)
+    def initialize(account:, patterns:, diagnoses:, decisions:)
       @account = account
       @patterns = patterns
       @diagnoses = diagnoses
+      @decisions = decisions
     end
 
     def call
@@ -21,7 +22,7 @@ module AgentRunPatterns
 
     private
 
-    attr_reader :account, :patterns, :diagnoses
+    attr_reader :account, :patterns, :diagnoses, :decisions
 
     def ordered_patterns
       @ordered_patterns ||= patterns.sort_by do |pattern|
@@ -36,7 +37,8 @@ module AgentRunPatterns
 
     def publish_in_app_notification
       worst = worst_pattern
-      diagnosis = diagnoses[worst.goal]
+      diagnosis = diagnosis_for(worst)
+      decision = decision_for(worst)
 
       Notifications::Publish.call(
         account: account,
@@ -45,8 +47,8 @@ module AgentRunPatterns
         severity: notification_severity(worst),
         title: notification_title(worst, diagnosis),
         description: notification_description(worst, diagnosis),
-        metadata: build_metadata,
-        action_url: "/dashboard",
+        metadata: build_metadata(decision),
+        action_url: decision ? "/remediation_decisions/#{decision.id}" : "/dashboard",
         nav_section: "dashboard"
       )
     end
@@ -99,7 +101,13 @@ module AgentRunPatterns
       if diagnosis
         parts << ""
         parts << "Root cause: #{diagnosis.root_cause}"
-        parts << "Remediation: #{diagnosis.remediation}"
+        parts << "Proposed action: #{human_action(diagnosis)}"
+
+        evidence_lines = evidence_lines_for(worst, diagnosis)
+        if evidence_lines.any?
+          parts << "Why:"
+          parts.concat(evidence_lines)
+        end
       end
 
       parts.join("\n")
@@ -121,13 +129,14 @@ module AgentRunPatterns
       end
     end
 
-    def build_metadata
+    def build_metadata(decision)
       {
         pattern_count: ordered_patterns.size,
         pattern_types: ordered_patterns.map { |p| "#{p.goal}:#{p.type}" },
         goals: ordered_patterns.map(&:goal).uniq,
         worst_goal: worst_pattern.goal,
-        diagnosed_root_cause: diagnoses.values.filter_map(&:root_cause).first
+        diagnosed_root_cause: diagnosis_for(worst_pattern)&.root_cause,
+        remediation_decision_id: decision&.id
       }
     end
 
@@ -145,6 +154,39 @@ module AgentRunPatterns
     def metadata_value(notification, key)
       metadata = notification.metadata
       Array(metadata&.dig(key.to_s) || metadata&.dig(key)).presence
+    end
+
+    def diagnosis_for(pattern)
+      diagnoses[fingerprint(pattern)]
+    end
+
+    def decision_for(pattern)
+      decisions[fingerprint(pattern)]
+    end
+
+    def fingerprint(pattern)
+      pattern.details[:fingerprint].to_s
+    end
+
+    def human_action(diagnosis)
+      target = diagnosis.action_target.deep_stringify_keys
+      label = diagnosis.proposed_action.humanize
+      return label if target["type"] == "account"
+      return "#{label} (runner ##{target["id"]})" if target["type"] == "runner"
+      return "#{label} (project ##{target["id"]})" if target["type"] == "project"
+
+      "#{label} (runner ##{target["id"]}, field #{target["field_name"]})"
+    end
+
+    def evidence_lines_for(pattern, diagnosis)
+      bundle = AgentRunPatterns::EvidenceBundle.from_payload(pattern.details[:evidence_bundle])
+
+      diagnosis.evidence_pointers.filter_map do |pointer|
+        snippet = bundle.text_for_pointer(pointer)
+        next "- #{pointer}" if snippet.blank?
+
+        "- #{pointer}: #{snippet.tr("\n", " ").truncate(120)}"
+      end
     end
   end
 end

--- a/app/services/agent_run_patterns/record_remediation_decision.rb
+++ b/app/services/agent_run_patterns/record_remediation_decision.rb
@@ -25,7 +25,7 @@ module AgentRunPatterns
     def call
       RemediationDecision.transaction do
         existing = RemediationDecision
-          .where(account: account, fingerprint: fingerprint)
+          .where(account: account, fingerprint: fingerprint, status: "proposed")
           .where("created_at >= ?", DEDUPE_WINDOW.ago)
           .order(created_at: :desc)
           .lock

--- a/app/services/agent_run_patterns/record_remediation_decision.rb
+++ b/app/services/agent_run_patterns/record_remediation_decision.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module AgentRunPatterns
+  class RecordRemediationDecision
+    DEDUPE_WINDOW = 24.hours
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(account:, pattern:, diagnosis:)
+      @account = account
+      @pattern = pattern
+      @diagnosis = diagnosis
+    end
+
+    def call
+      RemediationDecision.transaction do
+        existing = RemediationDecision
+          .where(account: account, fingerprint: fingerprint)
+          .where("created_at >= ?", DEDUPE_WINDOW.ago)
+          .order(created_at: :desc)
+          .lock
+          .first
+
+        if existing
+          update_existing_decision(existing)
+        else
+          RemediationDecision.create!(decision_attributes)
+        end
+      end
+    end
+
+    private
+
+    attr_reader :account, :diagnosis, :pattern
+
+    def update_existing_decision(decision)
+      decision.assign_attributes(
+        decision_attributes.except(:status, :occurrence_count, :created_at)
+      )
+      decision.occurrence_count += 1
+      decision.save!
+      decision
+    end
+
+    def decision_attributes
+      target = diagnosis.action_target.deep_stringify_keys
+
+      {
+        account: account,
+        fingerprint: fingerprint,
+        root_cause: diagnosis.root_cause,
+        confidence: diagnosis.confidence,
+        evidence_pointers: diagnosis.evidence_pointers,
+        proposed_action: diagnosis.proposed_action,
+        action_target_type: target["type"],
+        action_target_id: target["id"],
+        action_target_metadata: target.except("type", "id"),
+        status: "proposed",
+        revert_data: {},
+        pre_remediation_failure_count: failure_count,
+        post_remediation_failure_count: nil,
+        outcome: nil,
+        occurrence_count: 1
+      }
+    end
+
+    def failure_count
+      pattern.details[:streak_length] ||
+        pattern.details[:failure_count] ||
+        pattern.details[:occurrence_count] ||
+        0
+    end
+
+    def fingerprint
+      pattern.details[:fingerprint].to_s
+    end
+  end
+end

--- a/app/services/agent_run_patterns/record_remediation_decision.rb
+++ b/app/services/agent_run_patterns/record_remediation_decision.rb
@@ -3,6 +3,14 @@
 module AgentRunPatterns
   class RecordRemediationDecision
     DEDUPE_WINDOW = 24.hours
+    DEDUPE_PROTECTED_FIELDS = %i[
+      status
+      occurrence_count
+      created_at
+      revert_data
+      outcome
+      post_remediation_failure_count
+    ].freeze
 
     def self.call(...)
       new(...).call
@@ -37,7 +45,7 @@ module AgentRunPatterns
 
     def update_existing_decision(decision)
       decision.assign_attributes(
-        decision_attributes.except(:status, :occurrence_count, :created_at)
+        decision_attributes.except(*DEDUPE_PROTECTED_FIELDS)
       )
       decision.occurrence_count += 1
       decision.save!

--- a/app/services/agent_run_patterns/record_remediation_decision.rb
+++ b/app/services/agent_run_patterns/record_remediation_decision.rb
@@ -6,6 +6,9 @@ module AgentRunPatterns
     DEDUPE_PROTECTED_FIELDS = %i[
       status
       occurrence_count
+      diagnosis_attempted_on
+      diagnosis_attempt_count_on_day
+      last_diagnosis_attempt_at
       created_at
       revert_data
       outcome
@@ -23,18 +26,21 @@ module AgentRunPatterns
     end
 
     def call
+      recorded_at = Time.current
+
       RemediationDecision.transaction do
         existing = RemediationDecision
-          .where(account: account, fingerprint: fingerprint, status: "proposed")
+          .where(dedupe_scope)
+          .where(status: "proposed")
           .where("created_at >= ?", DEDUPE_WINDOW.ago)
           .order(created_at: :desc)
           .lock
           .first
 
         if existing
-          update_existing_decision(existing)
+          update_existing_decision(existing, recorded_at)
         else
-          RemediationDecision.create!(decision_attributes)
+          RemediationDecision.create!(decision_attributes(recorded_at))
         end
       end
     end
@@ -43,16 +49,17 @@ module AgentRunPatterns
 
     attr_reader :account, :diagnosis, :pattern
 
-    def update_existing_decision(decision)
+    def update_existing_decision(decision, recorded_at)
       decision.assign_attributes(
-        decision_attributes.except(*DEDUPE_PROTECTED_FIELDS)
+        decision_attributes(recorded_at).except(*DEDUPE_PROTECTED_FIELDS)
       )
       decision.occurrence_count += 1
+      record_attempt!(decision, recorded_at)
       decision.save!
       decision
     end
 
-    def decision_attributes
+    def decision_attributes(recorded_at)
       target = diagnosis.action_target.deep_stringify_keys
 
       {
@@ -70,7 +77,33 @@ module AgentRunPatterns
         pre_remediation_failure_count: failure_count,
         post_remediation_failure_count: nil,
         outcome: nil,
-        occurrence_count: 1
+        occurrence_count: 1,
+        diagnosis_attempted_on: recorded_at.to_date,
+        diagnosis_attempt_count_on_day: 1,
+        last_diagnosis_attempt_at: recorded_at
+      }
+    end
+
+    def record_attempt!(decision, recorded_at)
+      if decision.diagnosis_attempted_on == recorded_at.to_date
+        decision.diagnosis_attempt_count_on_day += 1
+      else
+        decision.diagnosis_attempted_on = recorded_at.to_date
+        decision.diagnosis_attempt_count_on_day = 1
+      end
+
+      decision.last_diagnosis_attempt_at = recorded_at
+    end
+
+    def dedupe_scope
+      target = diagnosis.action_target.deep_stringify_keys
+
+      {
+        account: account,
+        fingerprint: fingerprint,
+        action_target_type: target["type"],
+        action_target_id: target["id"],
+        action_target_metadata: target.except("type", "id")
       }
     end
 

--- a/app/services/screenshots/capture_targets.rb
+++ b/app/services/screenshots/capture_targets.rb
@@ -33,6 +33,7 @@ module Screenshots
       account
       account_roi_dashboard
       account_audit_logs
+      remediation_decision_show
       quality_dashboard
       chat_sessions
       ab_tests
@@ -89,6 +90,11 @@ module Screenshots
       account_roi_dashboard: Target.new(slug: "account_roi_dashboard", path_builder: "/account_roi_dashboard", requires_auth: true),
       account_compliance_dashboard: Target.new(slug: "account_compliance_dashboard", path_builder: "/account_compliance_dashboard", requires_auth: true),
       account_audit_logs: Target.new(slug: "account_audit_logs", path_builder: "/account_audit_logs", requires_auth: true),
+      remediation_decision_show: Target.new(
+        slug: "remediation_decision_show",
+        path_builder: ->(seed_data) { "/remediation_decisions/#{seed_data.fetch(:remediation_decision).id}" },
+        requires_auth: true
+      ),
       tenant_configuration: Target.new(slug: "tenant_configuration", path_builder: "/tenant_configuration/edit", requires_auth: true),
       providers: Target.new(slug: "providers", path_builder: "/runners", requires_auth: true),
       providers_new: Target.new(slug: "providers_new", path_builder: "/runners/new?form_variant=subscription", requires_auth: true),
@@ -231,6 +237,7 @@ module Screenshots
       "user_settings_controller.rb" => [ :user_settings ],
       "accounts_controller.rb" => [ :account ],
       "account_audit_logs_controller.rb" => [ :account_audit_logs ],
+      "remediation_decisions_controller.rb" => [ :remediation_decision_show ],
       "account_memberships_controller.rb" => [ :account ],
       "account_ownership_transfers_controller.rb" => [ :account ],
       "account_lifecycles_controller.rb" => [ :account ],

--- a/app/services/screenshots/capture_targets.rb
+++ b/app/services/screenshots/capture_targets.rb
@@ -375,6 +375,7 @@ module Screenshots
       when /\Aaccounts\/roi_dashboards\// then [ :account_roi_dashboard ]
       when /\Aaccounts\// then [ :account ]
       when /\Aaccount_audit_logs\// then [ :account_audit_logs ]
+      when /\Aremediation_decisions\// then [ :remediation_decision_show ]
       when /\Atenant_configurations\// then [ :tenant_configuration ]
       when /\Aprovider_api_keys\// then rest_resource_targets(relative_path, "provider_api_keys", index: :provider_api_keys, new: :provider_api_key_new, show: :provider_api_key_show, edit: :provider_api_key_edit)
       when /\Aproviders\// then providers_targets(relative_path.delete_prefix("providers/"))

--- a/app/services/screenshots/seed_data/paid.rb
+++ b/app/services/screenshots/seed_data/paid.rb
@@ -267,6 +267,20 @@ module Screenshots
             record.evidence = { reason: "Collector has produced no artifacts in 30 days" }
           end
 
+          remediation_decision = RemediationDecision.find_or_create_by!(account: account, fingerprint: "screenshots-remediation-fingerprint") do |record|
+            record.root_cause = "Runner fallback exhausted after repeated GitHub API rate limits"
+            record.confidence = 0.88
+            record.evidence_pointers = [ "runner_attempts[0].error_message" ]
+            record.proposed_action = "disable_runner_fallback"
+            record.action_target_type = "runner"
+            record.action_target_id = provider.id.to_s
+            record.action_target_metadata = {}
+            record.status = "proposed"
+            record.revert_data = {}
+            record.pre_remediation_failure_count = 3
+            record.occurrence_count = 1
+          end
+
           WorkflowState.find_or_create_by!(temporal_workflow_id: "github-poll-#{project.id}") do |record|
             record.project = project
             record.workflow_type = "GitHubPollWorkflow"
@@ -295,6 +309,7 @@ module Screenshots
             "style_guide" => { "id" => style_guide.id, "name" => style_guide.name },
             "chat_session" => { "id" => chat_session.id, "name" => chat_session.title },
             "knowledge_artifact" => { "id" => knowledge_artifact.id },
+            "remediation_decision" => { "id" => remediation_decision.id },
             "installation_project" => { "id" => installation_project.id, "name" => installation_project.name }
           }
         end

--- a/app/services/screenshots/seed_data/paid.rb
+++ b/app/services/screenshots/seed_data/paid.rb
@@ -267,6 +267,7 @@ module Screenshots
             record.evidence = { reason: "Collector has produced no artifacts in 30 days" }
           end
 
+          diagnosis_attempted_at = Time.current
           remediation_decision = RemediationDecision.find_or_create_by!(account: account, fingerprint: "screenshots-remediation-fingerprint") do |record|
             record.root_cause = "Runner fallback exhausted after repeated GitHub API rate limits"
             record.confidence = 0.88
@@ -279,6 +280,9 @@ module Screenshots
             record.revert_data = {}
             record.pre_remediation_failure_count = 3
             record.occurrence_count = 1
+            record.diagnosis_attempted_on = diagnosis_attempted_at.to_date
+            record.diagnosis_attempt_count_on_day = 1
+            record.last_diagnosis_attempt_at = diagnosis_attempted_at
           end
 
           WorkflowState.find_or_create_by!(temporal_workflow_id: "github-poll-#{project.id}") do |record|

--- a/app/views/remediation_decisions/show.html.erb
+++ b/app/views/remediation_decisions/show.html.erb
@@ -1,0 +1,51 @@
+<% content_for(:title) { "Remediation Decision ##{@remediation_decision.id} - Paid" } %>
+
+<div class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+  <div class="rounded-xl border border-gray-200 bg-white shadow-sm">
+    <div class="border-b border-gray-200 px-6 py-5">
+      <p class="text-sm font-medium text-indigo-600">Self-heal diagnosis</p>
+      <h1 class="mt-1 text-2xl font-semibold text-gray-900">Remediation Decision #<%= @remediation_decision.id %></h1>
+      <p class="mt-2 text-sm text-gray-600"><%= @remediation_decision.root_cause %></p>
+    </div>
+
+    <dl class="grid gap-6 px-6 py-6 sm:grid-cols-2">
+      <div>
+        <dt class="text-sm font-medium text-gray-500">Proposed action</dt>
+        <dd class="mt-1 text-sm text-gray-900"><%= @remediation_decision.proposed_action.humanize %></dd>
+      </div>
+      <div>
+        <dt class="text-sm font-medium text-gray-500">Target</dt>
+        <dd class="mt-1 text-sm text-gray-900"><%= @remediation_decision.action_target_label %></dd>
+      </div>
+      <div>
+        <dt class="text-sm font-medium text-gray-500">Confidence</dt>
+        <dd class="mt-1 text-sm text-gray-900"><%= number_to_percentage(@remediation_decision.confidence * 100, precision: 0) %></dd>
+      </div>
+      <div>
+        <dt class="text-sm font-medium text-gray-500">Status</dt>
+        <dd class="mt-1 text-sm text-gray-900"><%= @remediation_decision.status.humanize %></dd>
+      </div>
+      <div>
+        <dt class="text-sm font-medium text-gray-500">Fingerprint</dt>
+        <dd class="mt-1 break-all font-mono text-xs text-gray-900"><%= @remediation_decision.fingerprint %></dd>
+      </div>
+      <div>
+        <dt class="text-sm font-medium text-gray-500">Occurrences in window</dt>
+        <dd class="mt-1 text-sm text-gray-900"><%= @remediation_decision.occurrence_count %></dd>
+      </div>
+    </dl>
+
+    <div class="border-t border-gray-200 px-6 py-6">
+      <h2 class="text-sm font-medium text-gray-500">Why</h2>
+      <% if @remediation_decision.evidence_pointers.any? %>
+        <ul class="mt-3 space-y-2 text-sm text-gray-900">
+          <% @remediation_decision.evidence_pointers.each do |pointer| %>
+            <li class="rounded-md bg-gray-50 px-3 py-2 font-mono text-xs"><%= pointer %></li>
+          <% end %>
+        </ul>
+      <% else %>
+        <p class="mt-3 text-sm text-gray-600">No evidence pointers were captured for this decision.</p>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
     patch :dismiss, on: :member
     post :mark_all_read, on: :collection
   end
+  resources :remediation_decisions, only: [ :show ]
 
   # Onboarding wizard
   resource :onboarding, only: [ :show, :update ], controller: "onboarding" do

--- a/db/migrate/20260528111011_create_remediation_decisions.rb
+++ b/db/migrate/20260528111011_create_remediation_decisions.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class CreateRemediationDecisions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :remediation_decisions,
+      comment: "Audits self-heal diagnoses and proposed remediation actions for recurring agent-run failure fingerprints." do |t|
+      t.references :account, null: false, foreign_key: true, comment: "Owning account for tenant isolation and auditing."
+      t.string :fingerprint, null: false, comment: "Stable pattern fingerprint used to dedupe recurring diagnoses."
+      t.text :root_cause, null: false, comment: "Human-readable diagnosis summary shown in notifications and audits."
+      t.decimal :confidence, precision: 4, scale: 3, null: false, default: 0.0,
+        comment: "Model confidence score from 0.0 to 1.0 for the proposed action."
+      t.jsonb :evidence_pointers, null: false, default: [], comment: "Pointers into the sanitized evidence bundle that support the diagnosis."
+      t.string :proposed_action, null: false, comment: "Frozen action enum proposed by the diagnosis pipeline."
+      t.string :action_target_type, null: false, comment: "Normalized target category such as account, project, runner, or runner_field."
+      t.string :action_target_id, comment: "Opaque target identifier for the proposed action."
+      t.jsonb :action_target_metadata, null: false, default: {}, comment: "Extra target details such as a runner field name."
+      t.string :status, null: false, default: "proposed", comment: "Lifecycle state: proposed, approved, applied, skipped, failed, or reverted."
+      t.datetime :applied_at, comment: "When the remediation action was applied."
+      t.references :applied_by, foreign_key: { to_table: :users }, comment: "User who approved or applied the action when it was manual."
+      t.jsonb :revert_data, null: false, default: {}, comment: "Structured data needed to reverse an applied remediation unambiguously."
+      t.integer :pre_remediation_failure_count, comment: "Observed failure count for the fingerprint before remediation was proposed."
+      t.integer :post_remediation_failure_count, comment: "Observed failure count for the fingerprint after remediation evaluation."
+      t.string :outcome, comment: "Evaluation result for the remediation: improved, unchanged, or regressed."
+      t.integer :occurrence_count, null: false, default: 1, comment: "How many detections collapsed into this deduped decision row."
+      t.timestamps
+    end
+
+    add_index :remediation_decisions, [ :account_id, :fingerprint, :created_at ], name: "idx_remediation_decisions_dedup_lookup"
+    add_index :remediation_decisions, [ :account_id, :status, :created_at ], name: "idx_remediation_decisions_account_status_created"
+    add_index :remediation_decisions, :proposed_action
+  end
+end

--- a/db/migrate/20260528111015_enable_rls_on_remediation_decisions.rb
+++ b/db/migrate/20260528111015_enable_rls_on_remediation_decisions.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class EnableRlsOnRemediationDecisions < ActiveRecord::Migration[8.1]
+  def up
+    safety_assured do
+      execute <<~SQL
+        ALTER TABLE remediation_decisions ENABLE ROW LEVEL SECURITY;
+        ALTER TABLE remediation_decisions FORCE ROW LEVEL SECURITY;
+
+        CREATE POLICY tenant_isolation ON remediation_decisions
+        AS PERMISSIVE
+        FOR ALL
+        USING (
+          paid_tenant_bypass()
+          OR remediation_decisions.account_id = paid_current_account_id()
+        )
+        WITH CHECK (
+          paid_tenant_bypass()
+          OR remediation_decisions.account_id = paid_current_account_id()
+        );
+      SQL
+    end
+  end
+
+  def down
+    safety_assured do
+      execute "DROP POLICY IF EXISTS tenant_isolation ON remediation_decisions"
+      execute "ALTER TABLE remediation_decisions NO FORCE ROW LEVEL SECURITY"
+      execute "ALTER TABLE remediation_decisions DISABLE ROW LEVEL SECURITY"
+    end
+  end
+end

--- a/db/migrate/20260528133444_add_diagnosis_attempt_tracking_to_remediation_decisions.rb
+++ b/db/migrate/20260528133444_add_diagnosis_attempt_tracking_to_remediation_decisions.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class AddDiagnosisAttemptTrackingToRemediationDecisions < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  class MigrationRemediationDecision < ActiveRecord::Base
+    self.table_name = "remediation_decisions"
+  end
+
+  def up
+    add_column :remediation_decisions, :diagnosis_attempted_on, :date,
+      comment: "UTC day when this fingerprint last consumed diagnosis budget."
+    add_column :remediation_decisions, :diagnosis_attempt_count_on_day, :integer, default: 1, null: false,
+      comment: "How many diagnosis attempts for this fingerprint consumed budget on diagnosis_attempted_on."
+    add_column :remediation_decisions, :last_diagnosis_attempt_at, :datetime,
+      comment: "Timestamp of the most recent diagnosis attempt recorded for this audit row."
+    add_index :remediation_decisions, [ :account_id, :diagnosis_attempted_on ],
+      name: "idx_remediation_decisions_budget_lookup", algorithm: :concurrently
+
+    MigrationRemediationDecision.reset_column_information
+    MigrationRemediationDecision.find_each do |decision|
+      attempted_at = decision.created_at || Time.current
+      decision.update_columns(
+        diagnosis_attempted_on: attempted_at.to_date,
+        diagnosis_attempt_count_on_day: 1,
+        last_diagnosis_attempt_at: attempted_at
+      )
+    end
+  end
+
+  def down
+    remove_index :remediation_decisions, name: "idx_remediation_decisions_budget_lookup", algorithm: :concurrently
+    remove_column :remediation_decisions, :last_diagnosis_attempt_at
+    remove_column :remediation_decisions, :diagnosis_attempt_count_on_day
+    remove_column :remediation_decisions, :diagnosis_attempted_on
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_27_113550) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_28_111015) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1944,6 +1944,33 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_113550) do
     t.index ["project_id"], name: "index_quality_thresholds_on_project_id"
   end
 
+  create_table "remediation_decisions", comment: "Audits self-heal diagnoses and proposed remediation actions for recurring agent-run failure fingerprints.", force: :cascade do |t|
+    t.bigint "account_id", null: false, comment: "Owning account for tenant isolation and auditing."
+    t.string "action_target_id", comment: "Opaque target identifier for the proposed action."
+    t.jsonb "action_target_metadata", default: {}, null: false, comment: "Extra target details such as a runner field name."
+    t.string "action_target_type", null: false, comment: "Normalized target category such as account, project, runner, or runner_field."
+    t.datetime "applied_at", comment: "When the remediation action was applied."
+    t.bigint "applied_by_id", comment: "User who approved or applied the action when it was manual."
+    t.decimal "confidence", precision: 4, scale: 3, default: "0.0", null: false, comment: "Model confidence score from 0.0 to 1.0 for the proposed action."
+    t.datetime "created_at", null: false
+    t.jsonb "evidence_pointers", default: [], null: false, comment: "Pointers into the sanitized evidence bundle that support the diagnosis."
+    t.string "fingerprint", null: false, comment: "Stable pattern fingerprint used to dedupe recurring diagnoses."
+    t.integer "occurrence_count", default: 1, null: false, comment: "How many detections collapsed into this deduped decision row."
+    t.string "outcome", comment: "Evaluation result for the remediation: improved, unchanged, or regressed."
+    t.integer "post_remediation_failure_count", comment: "Observed failure count for the fingerprint after remediation evaluation."
+    t.integer "pre_remediation_failure_count", comment: "Observed failure count for the fingerprint before remediation was proposed."
+    t.string "proposed_action", null: false, comment: "Frozen action enum proposed by the diagnosis pipeline."
+    t.jsonb "revert_data", default: {}, null: false, comment: "Structured data needed to reverse an applied remediation unambiguously."
+    t.text "root_cause", null: false, comment: "Human-readable diagnosis summary shown in notifications and audits."
+    t.string "status", default: "proposed", null: false, comment: "Lifecycle state: proposed, approved, applied, skipped, failed, or reverted."
+    t.datetime "updated_at", null: false
+    t.index ["account_id", "fingerprint", "created_at"], name: "idx_remediation_decisions_dedup_lookup"
+    t.index ["account_id", "status", "created_at"], name: "idx_remediation_decisions_account_status_created"
+    t.index ["account_id"], name: "index_remediation_decisions_on_account_id"
+    t.index ["applied_by_id"], name: "index_remediation_decisions_on_applied_by_id"
+    t.index ["proposed_action"], name: "index_remediation_decisions_on_proposed_action"
+  end
+
   create_table "roi_benchmarks", comment: "Customer-specific comparison baselines used in ROI dashboards and pilot reports.", force: :cascade do |t|
     t.integer "accepted_pr_count", default: 0, null: false, comment: "Accepted pull requests included in this benchmark window."
     t.decimal "average_cycle_time_hours", precision: 10, scale: 2, comment: "Average elapsed hours from issue intake to accepted pull request."
@@ -2610,6 +2637,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_113550) do
   add_foreign_key "quality_recovery_actions", "prompt_versions", on_delete: :nullify
   add_foreign_key "quality_thresholds", "accounts"
   add_foreign_key "quality_thresholds", "projects"
+  add_foreign_key "remediation_decisions", "accounts"
+  add_foreign_key "remediation_decisions", "users", column: "applied_by_id"
   add_foreign_key "roi_benchmarks", "projects", on_delete: :cascade
   add_foreign_key "runner_states", "users", on_delete: :cascade
   add_foreign_key "runners", "integration_credentials", on_delete: :restrict
@@ -3466,6 +3495,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_113550) do
       CREATE TRIGGER logidze_on_cost_budgets BEFORE INSERT OR UPDATE ON public.cost_budgets FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
 
+  create_trigger :logidze_on_exception_incidents, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_exception_incidents BEFORE INSERT OR UPDATE ON public.exception_incidents FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{occurrence_count,last_occurred_at,backtrace,context}')
+  SQL
+
   create_trigger :logidze_on_github_tokens, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_github_tokens BEFORE INSERT OR UPDATE ON public.github_tokens FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{token,last_used_at,repositories_synced_at,accessible_repositories}')
   SQL
@@ -3484,6 +3517,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_113550) do
 
   create_trigger :logidze_on_mcp_server_definitions, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_mcp_server_definitions BEFORE INSERT OR UPDATE ON public.mcp_server_definitions FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{env}')
+  SQL
+
+  create_trigger :validate_strategy_version_scope, sql_definition: <<-SQL
+      CREATE TRIGGER validate_strategy_version_scope BEFORE INSERT OR UPDATE OF project_id, strategy_version_id ON public.orchestration_decisions FOR EACH ROW EXECUTE FUNCTION validate_orchestration_decision_strategy_version_scope()
   SQL
 
   create_trigger :logidze_on_orchestration_strategies, sql_definition: <<-SQL
@@ -3548,13 +3585,5 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_113550) do
 
   create_trigger :logidze_on_users, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_users BEFORE INSERT OR UPDATE ON public.users FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{encrypted_password,reset_password_token,reset_password_sent_at,remember_created_at}')
-  SQL
-
-  create_trigger :logidze_on_exception_incidents, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_exception_incidents BEFORE INSERT OR UPDATE ON public.exception_incidents FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{occurrence_count,last_occurred_at,backtrace,context}')
-  SQL
-
-  create_trigger :validate_strategy_version_scope, sql_definition: <<-SQL
-      CREATE TRIGGER validate_strategy_version_scope BEFORE INSERT OR UPDATE OF project_id, strategy_version_id ON public.orchestration_decisions FOR EACH ROW EXECUTE FUNCTION validate_orchestration_decision_strategy_version_scope()
   SQL
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_28_111015) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_28_133444) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1953,8 +1953,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_28_111015) do
     t.bigint "applied_by_id", comment: "User who approved or applied the action when it was manual."
     t.decimal "confidence", precision: 4, scale: 3, default: "0.0", null: false, comment: "Model confidence score from 0.0 to 1.0 for the proposed action."
     t.datetime "created_at", null: false
+    t.integer "diagnosis_attempt_count_on_day", default: 1, null: false, comment: "How many diagnosis attempts for this fingerprint consumed budget on diagnosis_attempted_on."
+    t.date "diagnosis_attempted_on", comment: "UTC day when this fingerprint last consumed diagnosis budget."
     t.jsonb "evidence_pointers", default: [], null: false, comment: "Pointers into the sanitized evidence bundle that support the diagnosis."
     t.string "fingerprint", null: false, comment: "Stable pattern fingerprint used to dedupe recurring diagnoses."
+    t.datetime "last_diagnosis_attempt_at", comment: "Timestamp of the most recent diagnosis attempt recorded for this audit row."
     t.integer "occurrence_count", default: 1, null: false, comment: "How many detections collapsed into this deduped decision row."
     t.string "outcome", comment: "Evaluation result for the remediation: improved, unchanged, or regressed."
     t.integer "post_remediation_failure_count", comment: "Observed failure count for the fingerprint after remediation evaluation."
@@ -1964,6 +1967,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_28_111015) do
     t.text "root_cause", null: false, comment: "Human-readable diagnosis summary shown in notifications and audits."
     t.string "status", default: "proposed", null: false, comment: "Lifecycle state: proposed, approved, applied, skipped, failed, or reverted."
     t.datetime "updated_at", null: false
+    t.index ["account_id", "diagnosis_attempted_on"], name: "idx_remediation_decisions_budget_lookup"
     t.index ["account_id", "fingerprint", "created_at"], name: "idx_remediation_decisions_dedup_lookup"
     t.index ["account_id", "status", "created_at"], name: "idx_remediation_decisions_account_status_created"
     t.index ["account_id"], name: "index_remediation_decisions_on_account_id"

--- a/spec/factories/remediation_decisions.rb
+++ b/spec/factories/remediation_decisions.rb
@@ -15,5 +15,8 @@ FactoryBot.define do
     revert_data { {} }
     pre_remediation_failure_count { 3 }
     occurrence_count { 1 }
+    diagnosis_attempted_on { Date.current }
+    diagnosis_attempt_count_on_day { 1 }
+    last_diagnosis_attempt_at { Time.current }
   end
 end

--- a/spec/factories/remediation_decisions.rb
+++ b/spec/factories/remediation_decisions.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :remediation_decision do
+    account
+    sequence(:fingerprint) { |n| "fingerprint-#{n}" }
+    root_cause { "GitHub API rate limit exhausted" }
+    confidence { 0.91 }
+    evidence_pointers { [ "outer_errors[0]" ] }
+    proposed_action { "notify" }
+    action_target_type { "account" }
+    action_target_id { account.id.to_s }
+    action_target_metadata { {} }
+    status { "proposed" }
+    revert_data { {} }
+    pre_remediation_failure_count { 3 }
+    occurrence_count { 1 }
+  end
+end

--- a/spec/jobs/agent_run_pattern_detector_job_spec.rb
+++ b/spec/jobs/agent_run_pattern_detector_job_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe AgentRunPatternDetectorJob, :no_db do
       end)
       allow(AgentRunPatterns::Detect).to receive(:call).and_return([])
       allow(AgentRunPatterns::Diagnose).to receive(:call)
+      allow(AgentRunPatterns::DailyDiagnosisBudget).to receive(:remaining_for).and_return(5)
+      allow(AgentRunPatterns::RecordRemediationDecision).to receive(:call).and_return(double(id: 99))
       allow(AgentRunPatterns::Notify).to receive(:call)
       allow(TenantContext).to receive(:with_system_access).and_yield
       allow(Account).to receive(:find_each).and_yield(account)
@@ -51,7 +53,13 @@ RSpec.describe AgentRunPatternDetectorJob, :no_db do
           type: :failure_streak,
           goal: "enhance_issue",
           severity: :error,
-          details: { streak_length: 3, total_runs: 3, failure_rate: 1.0, error_messages: [ "Error" ] }
+          details: {
+            fingerprint: "fp-1",
+            streak_length: 3,
+            total_runs: 3,
+            failure_rate: 1.0,
+            error_messages: [ "Error" ]
+          }
         )
       end
       let(:follow_up_pattern) do
@@ -59,57 +67,73 @@ RSpec.describe AgentRunPatternDetectorJob, :no_db do
           type: :error_cluster,
           goal: "enhance_issue",
           severity: :error,
-          details: { sample_messages: [ "GitHub API error: 403 Forbidden" ] }
+          details: {
+            fingerprint: "fp-2",
+            sample_messages: [ "GitHub API error: 403 Forbidden" ]
+          }
         )
       end
-      let(:unknown_diagnosis) do
-        AgentRunPatterns::Diagnose::Diagnosis.new(
-          root_cause: "Unknown",
-          category: "unknown",
-          confidence: 0.0,
-          remediation: "Investigate manually."
-        )
-      end
-      let(:github_diagnosis) do
+      let(:diagnosis) do
         AgentRunPatterns::Diagnose::Diagnosis.new(
           root_cause: "GitHub API Error",
-          category: "github_api",
           confidence: 1.0,
-          remediation: "Check GitHub token health."
+          proposed_action: "file_issue",
+          action_target: { "type" => "project", "id" => "7" },
+          evidence_pointers: [ "legacy_messages[0]" ]
         )
       end
 
       before do
         allow(AgentRunPatterns::Detect).to receive(:call).with(account: account).and_return([ pattern ])
+        allow(AgentRunPatterns::Diagnose).to receive(:call).and_return(diagnosis)
       end
 
-      it "diagnoses each detected pattern" do
+      it "diagnoses each detected pattern with account context" do
         described_class.perform_now
 
-        expect(AgentRunPatterns::Diagnose).to have_received(:call).with(pattern)
+        expect(AgentRunPatterns::Diagnose).to have_received(:call).with(
+          pattern,
+          account: account,
+          allow_llm: true
+        )
       end
 
-      it "notifies for the account" do
+      it "records a remediation decision for each fingerprint" do
+        described_class.perform_now
+
+        expect(AgentRunPatterns::RecordRemediationDecision).to have_received(:call).with(
+          account: account,
+          pattern: pattern,
+          diagnosis: diagnosis
+        )
+      end
+
+      it "notifies for the account with fingerprint-keyed diagnoses and decisions" do
         described_class.perform_now
 
         expect(AgentRunPatterns::Notify).to have_received(:call).with(
           account: account,
           patterns: [ pattern ],
-          diagnoses: hash_including("enhance_issue")
+          diagnoses: hash_including("fp-1" => diagnosis),
+          decisions: hash_including("fp-1")
         )
       end
 
-      it "prefers the strongest diagnosis for each goal" do
+      it "stops issuing LLM diagnoses after the daily budget is exhausted" do
         allow(AgentRunPatterns::Detect).to receive(:call).with(account: account).and_return([ pattern, follow_up_pattern ])
-        allow(AgentRunPatterns::Diagnose).to receive(:call).with(pattern).and_return(unknown_diagnosis)
-        allow(AgentRunPatterns::Diagnose).to receive(:call).with(follow_up_pattern).and_return(github_diagnosis)
+        allow(AgentRunPatterns::DailyDiagnosisBudget).to receive(:remaining_for).and_return(1)
 
         described_class.perform_now
 
-        expect(AgentRunPatterns::Notify).to have_received(:call).with(
+        expect(AgentRunPatterns::Diagnose).to have_received(:call).with(
+          pattern,
           account: account,
-          patterns: [ pattern, follow_up_pattern ],
-          diagnoses: hash_including("enhance_issue" => github_diagnosis)
+          allow_llm: true
+        )
+        expect(AgentRunPatterns::Diagnose).to have_received(:call).with(
+          follow_up_pattern,
+          account: account,
+          allow_llm: false
         )
       end
     end
@@ -122,7 +146,8 @@ RSpec.describe AgentRunPatternDetectorJob, :no_db do
         expect(AgentRunPatterns::Notify).to have_received(:call).with(
           account: account,
           patterns: [],
-          diagnoses: {}
+          diagnoses: {},
+          decisions: {}
         )
       end
     end

--- a/spec/requests/remediation_decisions_spec.rb
+++ b/spec/requests/remediation_decisions_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "RemediationDecisions" do
+  let(:account) { create(:account) }
+  let(:user) { create(:user, account: account) }
+  let(:decision) do
+    create(
+      :remediation_decision,
+      account: account,
+      proposed_action: "disable_runner_fallback",
+      action_target_type: "runner",
+      action_target_id: "42"
+    )
+  end
+
+  before { sign_in user }
+
+  describe "GET /remediation_decisions/:id" do
+    it "renders the remediation decision details" do
+      get remediation_decision_path(decision)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Remediation Decision ##{decision.id}")
+      expect(response.body).to include("Disable runner fallback")
+      expect(response.body).to include("Runner #42")
+      expect(response.body).to include(decision.root_cause)
+    end
+  end
+end

--- a/spec/services/agent_run_patterns/daily_diagnosis_budget_spec.rb
+++ b/spec/services/agent_run_patterns/daily_diagnosis_budget_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AgentRunPatterns::DailyDiagnosisBudget do
+  let(:account) { create(:account) }
+
+  it "counts diagnosis attempts recorded today instead of raw decision rows" do
+    create(
+      :remediation_decision,
+      account: account,
+      diagnosis_attempted_on: Date.current,
+      diagnosis_attempt_count_on_day: 4
+    )
+    create(
+      :remediation_decision,
+      account: account,
+      diagnosis_attempted_on: 1.day.ago.to_date,
+      diagnosis_attempt_count_on_day: 9
+    )
+
+    expect(described_class.new(account: account).send(:diagnoses_attempted_today)).to eq(4)
+    expect(described_class.remaining_for(account: account)).to eq(16)
+  end
+end

--- a/spec/services/agent_run_patterns/detect_spec.rb
+++ b/spec/services/agent_run_patterns/detect_spec.rb
@@ -419,6 +419,13 @@ RSpec.describe AgentRunPatterns::Detect do
       )
     end
 
+    it "changes the fingerprint when the candidate project set changes" do
+      first = fingerprint_for(project_ids: [ 7 ], runner_ids: [ 42 ])
+      second = fingerprint_for(project_ids: [ 8 ], runner_ids: [ 42 ])
+
+      expect(first[:fingerprint]).not_to eq(second[:fingerprint])
+    end
+
     def deterministic_runs
       [
         run_class.new(1, "enhance_issue", "failed", "No LLM provider produced an issue enhancement", 30.seconds.ago),
@@ -428,6 +435,22 @@ RSpec.describe AgentRunPatterns::Detect do
         run_class.new(5, "create_pr", "failed", "GitHub API error: 403 Forbidden", 2.minutes.ago),
         run_class.new(6, "create_pr", "failed", "GitHub API error: 403 Forbidden", 1.minute.ago)
       ]
+    end
+
+    def fingerprint_for(project_ids:, runner_ids:)
+      described_class.new(account: account).send(
+        :with_fingerprint,
+        goal: "enhance_issue",
+        type: :error_cluster,
+        error_pattern: "GitHub API error: <N> Forbidden",
+        sample_messages: [ "GitHub API error: 403 Forbidden" ],
+        evidence_bundle: {
+          aggregate_stats: {
+            distinct_project_ids: project_ids,
+            distinct_runner_ids: runner_ids
+          }
+        }
+      )
     end
   end
 end

--- a/spec/services/agent_run_patterns/diagnose_spec.rb
+++ b/spec/services/agent_run_patterns/diagnose_spec.rb
@@ -3,207 +3,131 @@
 require "rails_helper"
 
 RSpec.describe AgentRunPatterns::Diagnose, :no_db do
+  let(:account) { Struct.new(:id).new(42) }
+  let(:pattern) do
+    AgentRunPatterns::Detect::Pattern.new(
+      type: :error_cluster,
+      goal: "enhance_issue",
+      severity: :error,
+      details: {
+        fingerprint: "fp-123",
+        error_pattern: "All runners exhausted: Codex, Claude",
+        evidence_bundle: evidence_bundle.to_payload
+      }
+    )
+  end
+  let(:evidence_bundle) do
+    AgentRunPatterns::EvidenceBundle.new(
+      outer_errors: [ "All runners exhausted after retries" ],
+      runner_attempts: [
+        {
+          runner: "runner:42",
+          error_type: "provider_error",
+          error_message: "GitHub API error: 403 Forbidden",
+          diagnostics: { details: [ "rate limit remaining: 0" ] }
+        }
+      ],
+      log_tails: [],
+      runner_configs: [],
+      aggregate_stats: {
+        distinct_project_ids: [ 7 ],
+        distinct_runner_ids: [ 42 ]
+      }
+    )
+  end
+  let(:llm_response) do
+    {
+      root_cause: "GitHub API quota exhausted on runner fallback",
+      confidence: 0.92,
+      proposed_action: "mark_runner_unavailable",
+      action_target: { type: "runner", id: "42" },
+      evidence_pointers: [ "runner_attempts[0].error_message" ]
+    }
+  end
+
+  before do
+    allow(Llm::TextMode).to receive(:options).and_return({})
+  end
+
   describe ".call" do
-    let(:pattern) do
-      AgentRunPatterns::Detect::Pattern.new(
+    it "returns a validated LLM diagnosis when the output matches the enum" do
+      allow(AgentHarness).to receive(:send_message).and_return(
+        AgentHarness::Response.new(
+          output: llm_response.to_json,
+          exit_code: 0,
+          duration: 2.0,
+          provider: :claude,
+          model: "claude-sonnet-4-6",
+          tokens: { input: 100, output: 40, total: 140 }
+        )
+      )
+
+      result = described_class.call(pattern, account: account)
+
+      expect(result.root_cause).to eq("GitHub API quota exhausted on runner fallback")
+      expect(result.confidence).to eq(0.92)
+      expect(result.proposed_action).to eq("mark_runner_unavailable")
+      expect(result.action_target).to eq({ "type" => "runner", "id" => "42" })
+      expect(result.evidence_pointers).to eq([ "runner_attempts[0].error_message" ])
+    end
+
+    context "when the LLM proposes an out-of-enum action" do
+      before do
+        allow(AgentHarness).to receive(:send_message).and_return(
+          AgentHarness::Response.new(
+            output: llm_response.merge(
+              root_cause: "GitHub rate limit issue",
+              confidence: 0.95,
+              proposed_action: "restart_everything"
+            ).to_json,
+            exit_code: 0,
+            duration: 2.0,
+            provider: :claude,
+            model: "claude-sonnet-4-6",
+            tokens: { input: 100, output: 40, total: 140 }
+          )
+        )
+        allow(Rails.logger).to receive(:warn)
+      end
+
+      it "falls back to regex classification" do
+        result = described_class.call(pattern, account: account)
+
+        expect(result.root_cause).to eq("LLM Provider Error")
+        expect(result.proposed_action).to eq("notify")
+        expect(result.action_target).to eq({ "type" => "account", "id" => "42" })
+        expect(result.evidence_pointers).to include("runner_attempts[0].error_message")
+        expect(Rails.logger).to have_received(:warn).with(
+          hash_including(
+            message: "agent_run_patterns.diagnose_fell_back",
+            reason: "invalid_proposed_action",
+            fingerprint: "fp-123"
+          )
+        )
+      end
+    end
+
+    it "falls back to regex classification when LLM usage is disabled" do
+      result = described_class.call(pattern, account: account, allow_llm: false)
+
+      expect(result.root_cause).to eq("LLM Provider Error")
+      expect(result.proposed_action).to eq("notify")
+      expect(result.action_target).to eq({ "type" => "account", "id" => "42" })
+    end
+
+    it "returns unknown when there is no usable evidence" do
+      empty_pattern = AgentRunPatterns::Detect::Pattern.new(
         type: :failure_streak,
         goal: "enhance_issue",
         severity: :error,
-        details: { error_messages: error_messages, streak_length: 3, total_runs: 3, failure_rate: 1.0 }
+        details: { fingerprint: "fp-empty", error_messages: [] }
       )
-    end
 
-    context "with LLM provider errors" do
-      let(:error_messages) do
-        [
-          "No LLM provider produced an issue enhancement",
-          "No LLM provider produced an issue enhancement",
-          "No LLM provider produced an issue enhancement"
-        ]
-      end
+      result = described_class.call(empty_pattern, account: account, allow_llm: false)
 
-      it "diagnoses LLM provider error" do
-        result = described_class.call(pattern)
-
-        expect(result.root_cause).to eq("LLM Provider Error")
-        expect(result.category).to eq("llm_provider")
-        expect(result.confidence).to be > 0.5
-        expect(result.remediation).to include("provider")
-      end
-    end
-
-    context "with GitHub API errors" do
-      let(:error_messages) do
-        [
-          "GitHub API error: 403 Forbidden",
-          "GitHub API error: 403 Forbidden"
-        ]
-      end
-
-      it "diagnoses GitHub API error" do
-        result = described_class.call(pattern)
-
-        expect(result.root_cause).to eq("GitHub API Error")
-        expect(result.category).to eq("github_api")
-      end
-    end
-
-    context "with timeout errors" do
-      let(:error_messages) do
-        [
-          "Execution timed out after 3600s",
-          "Timeout waiting for container response"
-        ]
-      end
-
-      it "diagnoses timeout" do
-        result = described_class.call(pattern)
-
-        expect(result.root_cause).to eq("Timeout")
-        expect(result.category).to eq("timeout")
-      end
-    end
-
-    context "with container errors" do
-      let(:error_messages) do
-        [
-          "Container error: OCI runtime exec format error",
-          "Docker error: cannot allocate memory"
-        ]
-      end
-
-      it "diagnoses container error" do
-        result = described_class.call(pattern)
-
-        expect(result.root_cause).to eq("Container Error")
-        expect(result.category).to eq("container")
-      end
-    end
-
-    context "with unknown errors" do
-      let(:error_messages) do
-        [ "Something completely unexpected happened" ]
-      end
-
-      it "returns unknown diagnosis" do
-        result = described_class.call(pattern)
-
-        expect(result.root_cause).to eq("Unknown")
-        expect(result.category).to eq("unknown")
-        expect(result.confidence).to eq(0.0)
-      end
-    end
-
-    context "with empty error messages" do
-      let(:error_messages) { [] }
-
-      it "returns unknown diagnosis" do
-        result = described_class.call(pattern)
-
-        expect(result.root_cause).to eq("Unknown")
-        expect(result.category).to eq("unknown")
-      end
-    end
-
-    context "with error cluster pattern" do
-      let(:pattern) do
-        AgentRunPatterns::Detect::Pattern.new(
-          type: :error_cluster,
-          goal: "enhance_issue",
-          severity: :error,
-          details: {
-            sample_messages: [
-              "No LLM provider produced an issue enhancement",
-              "No LLM provider produced an issue enhancement"
-            ],
-            error_pattern: "No LLM provider..."
-          }
-        )
-      end
-
-      let(:error_messages) { [] }
-
-      it "uses sample_messages from error cluster details" do
-        result = described_class.call(pattern)
-
-        expect(result.root_cause).to eq("LLM Provider Error")
-      end
-    end
-
-    context "with evidence bundle sourced from per-attempt failures" do
-      let(:pattern) do
-        AgentRunPatterns::Detect::Pattern.new(
-          type: :error_cluster,
-          goal: "enhance_issue",
-          severity: :error,
-          details: {
-            error_pattern: "All runners exhausted: Codex, Claude",
-            evidence_bundle: AgentRunPatterns::EvidenceBundle.new(
-              outer_errors: [ "All runners exhausted: Codex, Claude" ],
-              runner_attempts: [
-                {
-                  runner: "runner:42",
-                  error_type: "provider_error",
-                  error_message: "Model metadata for `gpt-4o` not found",
-                  diagnostics: { details: [ "Model metadata for `gpt-4o` not found" ] }
-                }
-              ],
-              log_tails: [],
-              runner_configs: [
-                {
-                  runner_key: "cursor",
-                  auth_type: "api_key",
-                  tier_model_ids: { low: "gpt-4o" },
-                  provider_api_key_configured: true
-                }
-              ],
-              aggregate_stats: { run_count: 3 }
-            ).to_payload
-          }
-        )
-      end
-
-      let(:error_messages) { [] }
-
-      it "classifies from per-attempt evidence instead of the outer wrapper alone" do
-        result = described_class.call(pattern)
-
-        expect(result.root_cause).to eq("LLM Provider Error")
-        expect(result.category).to eq("llm_provider")
-        expect(result.confidence).to eq(0.5)
-      end
-    end
-
-    context "when one document matches multiple patterns in the same category" do
-      let(:pattern) do
-        AgentRunPatterns::Detect::Pattern.new(
-          type: :error_cluster,
-          goal: "enhance_issue",
-          severity: :error,
-          details: {
-            evidence_bundle: AgentRunPatterns::EvidenceBundle.new(
-              outer_errors: [
-                "Provider error: model not found and api key invalid",
-                "Something completely unrelated happened"
-              ],
-              runner_attempts: [],
-              log_tails: [],
-              runner_configs: [],
-              aggregate_stats: { run_count: 2 }
-            ).to_payload
-          }
-        )
-      end
-
-      let(:error_messages) { [] }
-
-      it "counts the document once when computing confidence" do
-        result = described_class.call(pattern)
-
-        expect(result.root_cause).to eq("LLM Provider Error")
-        expect(result.category).to eq("llm_provider")
-        expect(result.confidence).to eq(0.5)
-      end
+      expect(result.root_cause).to eq("Unknown")
+      expect(result.confidence).to eq(0.0)
+      expect(result.proposed_action).to eq("notify")
     end
   end
 end

--- a/spec/services/agent_run_patterns/notify_spec.rb
+++ b/spec/services/agent_run_patterns/notify_spec.rb
@@ -5,13 +5,13 @@ require "rails_helper"
 RSpec.describe AgentRunPatterns::Notify do
   describe ".call" do
     let(:account) { create(:account) }
-
     let(:pattern) do
       AgentRunPatterns::Detect::Pattern.new(
         type: :failure_streak,
         goal: "enhance_issue",
         severity: :error,
         details: {
+          fingerprint: "fp-1",
           streak_length: 5,
           total_runs: 5,
           failure_rate: 1.0,
@@ -19,17 +19,18 @@ RSpec.describe AgentRunPatterns::Notify do
         }
       )
     end
-
     let(:diagnosis) do
       AgentRunPatterns::Diagnose::Diagnosis.new(
         root_cause: "LLM Provider Error",
-        category: "llm_provider",
         confidence: 1.0,
-        remediation: "Check provider health and credentials."
+        proposed_action: "notify",
+        action_target: { "type" => "account", "id" => account.id.to_s },
+        evidence_pointers: [ "legacy_messages[0]" ]
       )
     end
-
-    let(:diagnoses) { { "enhance_issue" => diagnosis } }
+    let(:decision) { create(:remediation_decision, account: account, fingerprint: "fp-1") }
+    let(:diagnoses) { { "fp-1" => diagnosis } }
+    let(:decisions) { { "fp-1" => decision } }
 
     before do
       allow(Turbo::StreamsChannel).to receive(:broadcast_replace_to)
@@ -37,12 +38,9 @@ RSpec.describe AgentRunPatterns::Notify do
 
     context "with detected patterns" do
       it "publishes an in-app notification" do
-        described_class.call(account: account, patterns: [ pattern ], diagnoses: diagnoses)
+        described_class.call(account: account, patterns: [ pattern ], diagnoses: diagnoses, decisions: decisions)
 
-        notification = Notification.find_by(
-          account: account,
-          source: "agent_run_pattern_detector"
-        )
+        notification = Notification.find_by(account: account, source: "agent_run_pattern_detector")
         expect(notification).to be_present
         expect(notification.severity).to eq("error")
         expect(notification.title).to include("Enhance issue")
@@ -50,34 +48,30 @@ RSpec.describe AgentRunPatterns::Notify do
       end
 
       it "includes pattern metadata" do
-        described_class.call(account: account, patterns: [ pattern ], diagnoses: diagnoses)
+        described_class.call(account: account, patterns: [ pattern ], diagnoses: diagnoses, decisions: decisions)
 
-        notification = Notification.find_by(
-          account: account,
-          source: "agent_run_pattern_detector"
-        )
+        notification = Notification.find_by(account: account, source: "agent_run_pattern_detector")
         expect(notification.metadata).to include(
           "pattern_count" => 1,
           "goals" => [ "enhance_issue" ],
-          "worst_goal" => "enhance_issue"
+          "worst_goal" => "enhance_issue",
+          "remediation_decision_id" => decision.id
         )
       end
 
-      it "includes root cause in description" do
-        described_class.call(account: account, patterns: [ pattern ], diagnoses: diagnoses)
+      it "includes root cause, proposed action, and a decision link" do
+        described_class.call(account: account, patterns: [ pattern ], diagnoses: diagnoses, decisions: decisions)
 
-        notification = Notification.find_by(
-          account: account,
-          source: "agent_run_pattern_detector"
-        )
+        notification = Notification.find_by(account: account, source: "agent_run_pattern_detector")
         expect(notification.description).to include("LLM Provider Error")
-        expect(notification.description).to include("Check provider health")
+        expect(notification.description).to include("Proposed action: Notify")
+        expect(notification.action_url).to eq("/remediation_decisions/#{decision.id}")
       end
     end
 
     context "with no patterns" do
       it "does not publish a notification" do
-        described_class.call(account: account, patterns: [], diagnoses: {})
+        described_class.call(account: account, patterns: [], diagnoses: {}, decisions: {})
 
         expect(Notification.where(account: account, source: "agent_run_pattern_detector")).not_to exist
       end
@@ -90,6 +84,7 @@ RSpec.describe AgentRunPatterns::Notify do
           goal: "create_pr",
           severity: :warning,
           details: {
+            fingerprint: "fp-warning",
             failure_count: 4,
             total_count: 5,
             failure_rate: 0.8
@@ -98,12 +93,9 @@ RSpec.describe AgentRunPatterns::Notify do
       end
 
       it "publishes a warning notification" do
-        described_class.call(account: account, patterns: [ warning_pattern ], diagnoses: {})
+        described_class.call(account: account, patterns: [ warning_pattern ], diagnoses: {}, decisions: {})
 
-        notification = Notification.find_by(
-          account: account,
-          source: "agent_run_pattern_detector"
-        )
+        notification = Notification.find_by(account: account, source: "agent_run_pattern_detector")
         expect(notification.severity).to eq("warning")
         expect(notification.description).to include("80% rate")
       end
@@ -116,6 +108,7 @@ RSpec.describe AgentRunPatterns::Notify do
           goal: "enhance_issue",
           severity: :error,
           details: {
+            fingerprint: "fp-rate",
             streak_length: 4,
             total_runs: 5,
             failure_rate: 0.8,
@@ -125,23 +118,20 @@ RSpec.describe AgentRunPatterns::Notify do
       end
 
       it "displays the failure rate as a correct percentage" do
-        described_class.call(account: account, patterns: [ streak_pattern ], diagnoses: diagnoses)
+        described_class.call(account: account, patterns: [ streak_pattern ], diagnoses: diagnoses, decisions: decisions)
 
-        notification = Notification.find_by(
-          account: account,
-          source: "agent_run_pattern_detector"
-        )
+        notification = Notification.find_by(account: account, source: "agent_run_pattern_detector")
         expect(notification.description).to include("80%")
       end
     end
 
     context "when patterns clear" do
       it "resolves notifications for goals no longer failing" do
-        described_class.call(account: account, patterns: [ pattern ], diagnoses: diagnoses)
+        described_class.call(account: account, patterns: [ pattern ], diagnoses: diagnoses, decisions: decisions)
 
         expect(Notification.where(account: account, source: "agent_run_pattern_detector").active.count).to eq(1)
 
-        described_class.call(account: account, patterns: [], diagnoses: {})
+        described_class.call(account: account, patterns: [], diagnoses: {}, decisions: {})
 
         remaining = Notification.where(account: account, source: "agent_run_pattern_detector").active
         expect(remaining.count).to eq(0)
@@ -152,18 +142,19 @@ RSpec.describe AgentRunPatterns::Notify do
           type: :failure_streak,
           goal: "create_pr",
           severity: :error,
-          details: { streak_length: 3, total_runs: 3, failure_rate: 1.0, error_messages: [ "Error" ] }
+          details: { fingerprint: "fp-2", streak_length: 3, total_runs: 3, failure_rate: 1.0, error_messages: [ "Error" ] }
         )
+
         described_class.call(
           account: account,
           patterns: [ pattern, second_pattern ],
-          diagnoses: diagnoses
+          diagnoses: diagnoses,
+          decisions: decisions
         )
 
         expect(Notification.where(account: account, source: "agent_run_pattern_detector").active.count).to eq(1)
 
-        # Only enhance_issue still failing; create_pr cleared
-        described_class.call(account: account, patterns: [ pattern ], diagnoses: diagnoses)
+        described_class.call(account: account, patterns: [ pattern ], diagnoses: diagnoses, decisions: decisions)
 
         remaining = Notification.where(account: account, source: "agent_run_pattern_detector").active
         expect(remaining.count).to eq(1)
@@ -179,7 +170,7 @@ RSpec.describe AgentRunPatterns::Notify do
           metadata: { goals: [ "enhance_issue", "create_pr" ] }
         )
 
-        described_class.call(account: account, patterns: [ pattern ], diagnoses: diagnoses)
+        described_class.call(account: account, patterns: [ pattern ], diagnoses: diagnoses, decisions: decisions)
 
         expect(notification.reload).to be_active
       end
@@ -188,14 +179,14 @@ RSpec.describe AgentRunPatterns::Notify do
 
   describe "#pattern_summary", :no_db do
     let(:account) { Struct.new(:id).new(1) }
-    let(:service) { described_class.new(account: account, patterns: [], diagnoses: {}) }
+    let(:service) { described_class.new(account: account, patterns: [], diagnoses: {}, decisions: {}) }
 
     it "renders failure streak rates as percentages before rounding" do
       pattern = AgentRunPatterns::Detect::Pattern.new(
         type: :failure_streak,
         goal: "enhance_issue",
         severity: :error,
-        details: { streak_length: 4, total_runs: 5, failure_rate: 0.8 }
+        details: { fingerprint: "fp-summary", streak_length: 4, total_runs: 5, failure_rate: 0.8 }
       )
 
       expect(service.send(:pattern_summary, pattern)).to include("80% of 5 runs")
@@ -209,10 +200,10 @@ RSpec.describe AgentRunPatterns::Notify do
         type: :failure_streak,
         goal: "enhance_issue",
         severity: :error,
-        details: { streak_length: 3, total_runs: 3, failure_rate: 1.0 }
+        details: { fingerprint: "fp-active", streak_length: 3, total_runs: 3, failure_rate: 1.0 }
       )
     end
-    let(:service) { described_class.new(account: account, patterns: [ active_pattern ], diagnoses: {}) }
+    let(:service) { described_class.new(account: account, patterns: [ active_pattern ], diagnoses: {}, decisions: {}) }
 
     before do
       stub_const("Notification", Class.new do
@@ -300,20 +291,20 @@ RSpec.describe AgentRunPatterns::Notify do
           type: :failure_streak,
           goal: "enhance_issue",
           severity: :error,
-          details: { streak_length: 3, total_runs: 3, failure_rate: 1.0 }
+          details: { fingerprint: "fp-meta-1", streak_length: 3, total_runs: 3, failure_rate: 1.0 }
         ),
         AgentRunPatterns::Detect::Pattern.new(
           type: :error_cluster,
           goal: "create_pr",
           severity: :error,
-          details: { error_pattern: "GitHub API error: <N> Forbidden", occurrence_count: 3 }
+          details: { fingerprint: "fp-meta-2", error_pattern: "GitHub API error: <N> Forbidden", occurrence_count: 3 }
         )
       ]
     end
-    let(:service) { described_class.new(account: account, patterns: patterns, diagnoses: {}) }
+    let(:service) { described_class.new(account: account, patterns: patterns, diagnoses: {}, decisions: {}) }
 
     it "orders metadata deterministically when multiple patterns are active" do
-      metadata = service.send(:build_metadata)
+      metadata = service.send(:build_metadata, nil)
 
       expect(metadata[:goals]).to eq([ "create_pr", "enhance_issue" ])
       expect(metadata[:pattern_types]).to eq([

--- a/spec/services/agent_run_patterns/record_remediation_decision_spec.rb
+++ b/spec/services/agent_run_patterns/record_remediation_decision_spec.rb
@@ -37,7 +37,9 @@ RSpec.describe AgentRunPatterns::RecordRemediationDecision do
       action_target_id: "42",
       status: "proposed",
       occurrence_count: 1,
-      pre_remediation_failure_count: 3
+      pre_remediation_failure_count: 3,
+      diagnosis_attempted_on: Date.current,
+      diagnosis_attempt_count_on_day: 1
     )
   end
 
@@ -48,6 +50,50 @@ RSpec.describe AgentRunPatterns::RecordRemediationDecision do
 
     expect(second.id).to eq(first.id)
     expect(second.reload.occurrence_count).to eq(2)
+    expect(second.diagnosis_attempt_count_on_day).to eq(2)
+  end
+
+  it "creates a separate decision when the repeated fingerprint targets a different runner" do
+    described_class.call(account: account, pattern: pattern, diagnosis: diagnosis)
+
+    other_diagnosis = diagnosis.with(action_target: { "type" => "runner", "id" => "43" })
+
+    expect {
+      described_class.call(account: account, pattern: pattern, diagnosis: other_diagnosis)
+    }.to change(RemediationDecision, :count).by(1)
+  end
+
+  it "creates a separate decision when the repeated fingerprint targets a different runner field" do
+    field_diagnosis = diagnosis.with(
+      proposed_action: "clear_runner_field",
+      action_target: { "type" => "runner_field", "id" => "42", "field_name" => "model" }
+    )
+    described_class.call(account: account, pattern: pattern, diagnosis: field_diagnosis)
+
+    other_field_diagnosis = field_diagnosis.with(
+      action_target: { "type" => "runner_field", "id" => "42", "field_name" => "fallback_runner" }
+    )
+
+    expect {
+      described_class.call(account: account, pattern: pattern, diagnosis: other_field_diagnosis)
+    }.to change(RemediationDecision, :count).by(1)
+  end
+
+  it "resets the per-day diagnosis attempt counter on a new day" do
+    freeze_time do
+      decision = described_class.call(account: account, pattern: pattern, diagnosis: diagnosis)
+
+      travel 1.day
+
+      repeated = described_class.call(account: account, pattern: pattern, diagnosis: diagnosis)
+
+      expect(repeated.id).to eq(decision.id)
+      expect(repeated.reload).to have_attributes(
+        occurrence_count: 2,
+        diagnosis_attempted_on: Date.current,
+        diagnosis_attempt_count_on_day: 1
+      )
+    end
   end
 
   it "creates a new decision after the prior one moves past proposed" do

--- a/spec/services/agent_run_patterns/record_remediation_decision_spec.rb
+++ b/spec/services/agent_run_patterns/record_remediation_decision_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AgentRunPatterns::RecordRemediationDecision do
+  let(:account) { create(:account) }
+  let(:pattern) do
+    AgentRunPatterns::Detect::Pattern.new(
+      type: :error_cluster,
+      goal: "enhance_issue",
+      severity: :error,
+      details: {
+        fingerprint: "fingerprint-1",
+        occurrence_count: 3
+      }
+    )
+  end
+  let(:diagnosis) do
+    AgentRunPatterns::Diagnose::Diagnosis.new(
+      root_cause: "GitHub API quota exhausted",
+      confidence: 0.9,
+      proposed_action: "mark_runner_unavailable",
+      action_target: { "type" => "runner", "id" => "42" },
+      evidence_pointers: [ "runner_attempts[0].error_message" ]
+    )
+  end
+
+  it "creates a proposed remediation decision" do
+    decision = described_class.call(account: account, pattern: pattern, diagnosis: diagnosis)
+
+    expect(decision).to have_attributes(
+      account: account,
+      fingerprint: "fingerprint-1",
+      root_cause: "GitHub API quota exhausted",
+      proposed_action: "mark_runner_unavailable",
+      action_target_type: "runner",
+      action_target_id: "42",
+      status: "proposed",
+      occurrence_count: 1,
+      pre_remediation_failure_count: 3
+    )
+  end
+
+  it "dedupes the same fingerprint within 24 hours and increments occurrence_count" do
+    first = described_class.call(account: account, pattern: pattern, diagnosis: diagnosis)
+
+    second = described_class.call(account: account, pattern: pattern, diagnosis: diagnosis)
+
+    expect(second.id).to eq(first.id)
+    expect(second.reload.occurrence_count).to eq(2)
+  end
+end

--- a/spec/services/agent_run_patterns/record_remediation_decision_spec.rb
+++ b/spec/services/agent_run_patterns/record_remediation_decision_spec.rb
@@ -49,4 +49,25 @@ RSpec.describe AgentRunPatterns::RecordRemediationDecision do
     expect(second.id).to eq(first.id)
     expect(second.reload.occurrence_count).to eq(2)
   end
+
+  it "preserves evaluation fields when deduping an existing decision" do
+    decision = described_class.call(account: account, pattern: pattern, diagnosis: diagnosis)
+    decision.update!(
+      status: "applied",
+      revert_data: { "command" => "bin/self-heal revert 123" },
+      post_remediation_failure_count: 1,
+      outcome: "improved"
+    )
+
+    deduped = described_class.call(account: account, pattern: pattern, diagnosis: diagnosis)
+
+    expect(deduped.id).to eq(decision.id)
+    expect(deduped.reload).to have_attributes(
+      status: "applied",
+      revert_data: { "command" => "bin/self-heal revert 123" },
+      post_remediation_failure_count: 1,
+      outcome: "improved",
+      occurrence_count: 2
+    )
+  end
 end

--- a/spec/services/agent_run_patterns/record_remediation_decision_spec.rb
+++ b/spec/services/agent_run_patterns/record_remediation_decision_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe AgentRunPatterns::RecordRemediationDecision do
     expect(second.reload.occurrence_count).to eq(2)
   end
 
-  it "preserves evaluation fields when deduping an existing decision" do
+  it "creates a new decision after the prior one moves past proposed" do
     decision = described_class.call(account: account, pattern: pattern, diagnosis: diagnosis)
     decision.update!(
       status: "applied",
@@ -59,15 +59,31 @@ RSpec.describe AgentRunPatterns::RecordRemediationDecision do
       outcome: "improved"
     )
 
-    deduped = described_class.call(account: account, pattern: pattern, diagnosis: diagnosis)
-
-    expect(deduped.id).to eq(decision.id)
-    expect(deduped.reload).to have_attributes(
+    replacement = nil
+    expect {
+      replacement = described_class.call(account: account, pattern: pattern, diagnosis: diagnosis)
+    }.to change(RemediationDecision, :count).by(1)
+    expect(replacement.id).not_to eq(decision.id)
+    expect(decision.reload).to have_attributes(
       status: "applied",
       revert_data: { "command" => "bin/self-heal revert 123" },
       post_remediation_failure_count: 1,
       outcome: "improved",
-      occurrence_count: 2
+      occurrence_count: 1
     )
+  end
+
+  it "leaves non-proposed decisions immutable when recording a repeated fingerprint" do
+    decision = described_class.call(account: account, pattern: pattern, diagnosis: diagnosis)
+    decision.update!(status: "applied")
+
+    replacement = described_class.call(account: account, pattern: pattern, diagnosis: diagnosis)
+
+    expect(replacement.reload).to have_attributes(
+      status: "proposed",
+      occurrence_count: 1,
+      proposed_action: "mark_runner_unavailable"
+    )
+    expect(decision.reload).to have_attributes(status: "applied", occurrence_count: 1)
   end
 end

--- a/spec/services/screenshots/capture_targets_spec.rb
+++ b/spec/services/screenshots/capture_targets_spec.rb
@@ -114,6 +114,12 @@ RSpec.describe Screenshots::CaptureTargets, :no_db do
       expect(targets.map(&:slug)).to eq([ "account_audit_logs" ])
     end
 
+    it "maps remediation decision views to the remediation decision screenshot target" do
+      targets = described_class.call(changed_files: [ "app/views/remediation_decisions/show.html.erb" ])
+
+      expect(targets.map(&:slug)).to eq([ "remediation_decision_show" ])
+    end
+
     it "maps marketplace entry controllers to representative marketplace routes" do
       targets = described_class.call(changed_files: [ "app/controllers/marketplace_entries_controller.rb" ])
 


### PR DESCRIPTION
## Summary

Implemented the self-heal diagnosis rewrite and committed it as `1799240` with message `feat(self-heal): add audited remediation diagnoses`.

The change replaces `AgentRunPatterns::Diagnose` with an `agent-harness` LLM-backed JSON diagnosis flow, validates proposed actions against a fixed enum, falls back to the legacy regex classifier on invalid/low-confidence/unavailable LLM responses, persists proposed decisions into the new `remediation_decisions` audit table with 24-hour fingerprint dedupe and occurrence counting, adds a customer-facing decision show page and notification link, and wires the screenshot target registry for the new controller.

Verification passed: `bundle exec rubocop` and `bundle exec rspec` both completed cleanly. The full suite result was `13923 examples, 0 failures, 7 pending`.

---

Closes #2322