### PR TITLE
feat(self-heal): bounded auto-apply for reversible remediation actions + revert UI

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -34,6 +34,10 @@ class AccountsController < ApplicationController
   private
 
   def account_params
-    params.require(:account).permit(:name, :default_max_tokens_per_run)
+    params.require(:account).permit(
+      :name,
+      :default_max_tokens_per_run,
+      remediation_policy: RemediationDecision::PROPOSED_ACTIONS.index_with { %i[mode minimum_confidence filing_threshold] }
+    )
   end
 end

--- a/app/controllers/remediation_decisions_controller.rb
+++ b/app/controllers/remediation_decisions_controller.rb
@@ -5,4 +5,17 @@ class RemediationDecisionsController < ApplicationController
     @remediation_decision = policy_scope(RemediationDecision).find(params[:id])
     authorize @remediation_decision
   end
+
+  def revert
+    @remediation_decision = policy_scope(RemediationDecision).find(params[:id])
+    authorize @remediation_decision, :update?
+
+    unless @remediation_decision.revertable?
+      redirect_to remediation_decision_path(@remediation_decision), alert: "This remediation cannot be reverted."
+      return
+    end
+
+    RevertRemediationDecisionJob.perform_later(@remediation_decision.id, actor_id: current_user.id)
+    redirect_to remediation_decision_path(@remediation_decision), notice: "Revert queued."
+  end
 end

--- a/app/controllers/runners_controller.rb
+++ b/app/controllers/runners_controller.rb
@@ -59,10 +59,12 @@ class RunnersController < ApplicationController
 
   def edit
     authorize @runner
+    load_remediation_history
   end
 
   def update
     authorize @runner
+    load_remediation_history
     @runner.assign_attributes(runner_params)
     validate_container_executable!
 
@@ -250,6 +252,13 @@ class RunnersController < ApplicationController
     elsif @runner.api_key?
       @api_key_runner_options |= [ key ] unless @api_key_runner_options.include?(key)
     end
+  end
+
+  def load_remediation_history
+    @remediation_history = policy_scope(RemediationDecision)
+      .for_runner_id(@runner.id)
+      .recent
+      .limit(20)
   end
 
   def validate_runner_key_enabled!

--- a/app/jobs/agent_run_pattern_detector_job.rb
+++ b/app/jobs/agent_run_pattern_detector_job.rb
@@ -73,6 +73,10 @@ class AgentRunPatternDetectorJob < ApplicationJob
         pattern: pattern,
         diagnosis: diagnosis
       )
+      decision = AgentRunPatterns::AutoApply.call(
+        decision: decision,
+        pattern: pattern
+      )
 
       result[:diagnoses][fingerprint(pattern)] = diagnosis
       result[:decisions][fingerprint(pattern)] = decision

--- a/app/jobs/remediation_decision_outcome_job.rb
+++ b/app/jobs/remediation_decision_outcome_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class RemediationDecisionOutcomeJob < ApplicationJob
+  queue_as :maintenance
+
+  def perform
+    TenantContext.with_system_access do
+      Account.find_each do |account|
+        patterns = AgentRunPatterns::Detect.call(account: account)
+        AgentRunPatterns::UpdateOutcomes.call(account: account, patterns: patterns)
+      rescue => e
+        Rails.logger.warn(
+          message: "agent_run_patterns.outcome_update_failed_for_account",
+          account_id: account.id,
+          error_class: e.class.name,
+          error: e.message
+        )
+      end
+    end
+  end
+end

--- a/app/jobs/revert_remediation_decision_job.rb
+++ b/app/jobs/revert_remediation_decision_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class RevertRemediationDecisionJob < ApplicationJob
+  queue_as :maintenance
+
+  def perform(remediation_decision_id, actor_id: nil)
+    TenantContext.with_system_access do
+      decision = RemediationDecision.find(remediation_decision_id)
+      actor = User.find_by(id: actor_id) if actor_id.present?
+
+      AgentRunPatterns::RevertDecision.call(decision: decision, actor: actor)
+    end
+  end
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -5,6 +5,12 @@ class Account < ApplicationRecord
   MAX_SLUG_GENERATION_ATTEMPTS = 10
   PLANS = %w[trial free professional enterprise].freeze
   TRIAL_DURATION = 14.days
+  REMEDIATION_POLICY_MODES = %w[notify_only auto_apply disabled].freeze
+  DEFAULT_REMEDIATION_POLICY_ENTRY = {
+    "mode" => "notify_only",
+    "minimum_confidence" => 0.8,
+    "filing_threshold" => 1
+  }.freeze
 
   enum :status, { active: 0, suspended: 1, deactivated: 2 }
 
@@ -51,8 +57,10 @@ class Account < ApplicationRecord
     format: { with: /\A[a-z0-9-]+\z/, message: "can only contain lowercase letters, numbers, and hyphens" }
   validates :default_max_tokens_per_run,
     numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 2_147_483_647 }
+  validate :remediation_policy_must_be_valid
 
   before_validation :generate_slug, on: :create
+  before_validation :normalize_remediation_policy!
 
   def save(**options)
     super
@@ -178,7 +186,82 @@ class Account < ApplicationRecord
     primary_owner_membership&.user
   end
 
+  def effective_remediation_policy
+    actions = defined?(RemediationDecision) ? RemediationDecision::PROPOSED_ACTIONS : []
+
+    actions.index_with do |action|
+      DEFAULT_REMEDIATION_POLICY_ENTRY.merge(
+        normalized_remediation_policy.fetch(action, {})
+      )
+    end
+  end
+
+  def remediation_policy_for(action)
+    effective_remediation_policy.fetch(action.to_s, DEFAULT_REMEDIATION_POLICY_ENTRY)
+  end
+
   private
+
+  def normalized_remediation_policy
+    (remediation_policy.is_a?(Hash) ? remediation_policy : {})
+      .deep_stringify_keys
+      .slice(*(defined?(RemediationDecision) ? RemediationDecision::PROPOSED_ACTIONS : []))
+  end
+
+  def normalize_remediation_policy!
+    self.remediation_policy = normalized_remediation_policy.each_with_object({}) do |(action, settings), result|
+      next unless settings.is_a?(Hash)
+
+      normalized = settings.deep_stringify_keys.slice("mode", "minimum_confidence", "filing_threshold")
+      normalized["mode"] = normalized["mode"].to_s if normalized.key?("mode")
+
+      if normalized.key?("minimum_confidence")
+        normalized["minimum_confidence"] = normalized["minimum_confidence"].to_f
+      end
+
+      if normalized.key?("filing_threshold")
+        normalized["filing_threshold"] = normalized["filing_threshold"].to_i
+      end
+
+      result[action] = normalized
+    end
+  end
+
+  def remediation_policy_must_be_valid
+    return if remediation_policy.blank?
+    return errors.add(:remediation_policy, "must be a hash keyed by remediation action") unless remediation_policy.is_a?(Hash)
+
+    unknown_actions = remediation_policy.keys.map(&:to_s) - RemediationDecision::PROPOSED_ACTIONS
+    if unknown_actions.any?
+      errors.add(:remediation_policy, "contains unknown action(s): #{unknown_actions.join(', ')}")
+    end
+
+    normalized_remediation_policy.each do |action, settings|
+      unless settings.is_a?(Hash)
+        errors.add(:remediation_policy, "#{action} must be a hash of mode and thresholds")
+        next
+      end
+
+      mode = settings["mode"]
+      if mode.present? && !REMEDIATION_POLICY_MODES.include?(mode)
+        errors.add(:remediation_policy, "#{action} mode must be one of: #{REMEDIATION_POLICY_MODES.join(', ')}")
+      end
+
+      if settings.key?("minimum_confidence")
+        confidence = settings["minimum_confidence"]
+        unless confidence.is_a?(Numeric) && confidence.between?(0.0, 1.0)
+          errors.add(:remediation_policy, "#{action} minimum_confidence must be between 0.0 and 1.0")
+        end
+      end
+
+      if settings.key?("filing_threshold")
+        threshold = settings["filing_threshold"]
+        unless threshold.is_a?(Integer) && threshold.positive?
+          errors.add(:remediation_policy, "#{action} filing_threshold must be a positive integer")
+        end
+      end
+    end
+  end
 
   def generate_slug
     return if slug.present?

--- a/app/models/account_activity_event.rb
+++ b/app/models/account_activity_event.rb
@@ -20,6 +20,8 @@ class AccountActivityEvent < ApplicationRecord
     "runner.created" => "runner",
     "runner.updated" => "runner",
     "runner.deleted" => "runner",
+    "self_heal.remediation_applied" => "runner",
+    "self_heal.remediation_reverted" => "runner",
     "agent_run.created" => "run",
     "agent_run.cancelled" => "run",
     "agent_run.retried" => "run",
@@ -110,6 +112,10 @@ class AccountActivityEvent < ApplicationRecord
       "Updated #{metadata_value('runner_name')} runner"
     when "runner.deleted"
       "Removed #{metadata_value('runner_name')} runner"
+    when "self_heal.remediation_applied"
+      "Auto-applied #{metadata_value('remediation_action').to_s.humanize.downcase} for #{metadata_value('target_label')}"
+    when "self_heal.remediation_reverted"
+      "Reverted #{metadata_value('remediation_action').to_s.humanize.downcase} for #{metadata_value('target_label')}"
     when "agent_run.created"
       "Created agent run ##{metadata_value('agent_run_id')} on #{metadata_value('project_name')}"
     when "agent_run.cancelled"
@@ -144,6 +150,8 @@ class AccountActivityEvent < ApplicationRecord
     when "project.created"
       Array(metadata.to_h["github_url"]).compact
     when "runner.created", "runner.updated"
+      Array(metadata.to_h["details"]).compact
+    when "self_heal.remediation_applied", "self_heal.remediation_reverted"
       Array(metadata.to_h["details"]).compact
     when "agent_run.created"
       Array(metadata.to_h["details"]).compact

--- a/app/models/remediation_decision.rb
+++ b/app/models/remediation_decision.rb
@@ -29,6 +29,11 @@ class RemediationDecision < ApplicationRecord
   validates :post_remediation_failure_count, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, allow_nil: true
 
   scope :recent, -> { order(created_at: :desc, id: :desc) }
+  scope :applied, -> { where(status: "applied") }
+  scope :pending_outcome, -> { applied.where(outcome: nil) }
+  scope :for_runner_id, ->(runner_id) {
+    where(action_target_id: runner_id.to_s, action_target_type: %w[runner runner_field])
+  }
 
   def action_target_label
     case action_target_type
@@ -43,5 +48,25 @@ class RemediationDecision < ApplicationRecord
     else
       "#{action_target_type}:#{action_target_id}"
     end
+  end
+
+  def applied?
+    status == "applied"
+  end
+
+  def runner_target?
+    action_target_type.in?(%w[runner runner_field]) && action_target_id.present?
+  end
+
+  def runner_id
+    action_target_id.to_i if runner_target?
+  end
+
+  def revertable?
+    applied? && revert_data.to_h["handler"].present?
+  end
+
+  def auto_applied?
+    applied? && applied_by_id.nil?
   end
 end

--- a/app/services/agent_run_patterns/apply_decision.rb
+++ b/app/services/agent_run_patterns/apply_decision.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+module AgentRunPatterns
+  class ApplyDecision
+    ALLOWED_RUNNER_FIELDS = %w[tier_model_ids].freeze
+    RATE_LIMIT_DURATION = 1.hour
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(decision:, pattern:)
+      @decision = decision
+      @pattern = pattern
+    end
+
+    def call
+      return decision unless decision.status == "proposed"
+
+      RemediationDecision.transaction do
+        decision.lock!
+        decision.reload
+        return decision unless decision.status == "proposed"
+
+        case decision.proposed_action
+        when "mark_runner_unavailable"
+          apply_mark_runner_unavailable!
+        when "clear_runner_field"
+          apply_clear_runner_field!
+        when "disable_runner_fallback"
+          apply_disable_runner_fallback!
+        when "file_issue"
+          apply_file_issue!
+        when "notify"
+          apply_notify!
+        else
+          raise ArgumentError, "Unsupported remediation action #{decision.proposed_action.inspect}"
+        end
+
+        decision.update!(status: "applied", applied_at: Time.current)
+        record_audit_event
+      end
+
+      decision
+    rescue => e
+      decision.update!(status: "failed") if decision.persisted? && decision.status == "proposed"
+      Rails.logger.warn(
+        message: "agent_run_patterns.auto_apply_failed",
+        remediation_decision_id: decision.id,
+        proposed_action: decision.proposed_action,
+        error_class: e.class.name,
+        error: e.message
+      )
+      decision
+    end
+
+    private
+
+    attr_reader :decision, :pattern
+
+    def apply_mark_runner_unavailable!
+      runner = find_runner!
+      state = runner.user.runner_states.find_or_create_by!(runner_name: runner.state_key) do |record|
+        record.failure_count = 0
+        record.circuit_state = "closed"
+      end
+
+      decision.update!(
+        revert_data: {
+          "handler" => "mark_runner_unavailable",
+          "runner_id" => runner.id,
+          "runner_state_name" => state.runner_name,
+          "previous_rate_limited_until" => state.rate_limited_until&.iso8601
+        }
+      )
+
+      state.mark_rate_limited!(reset_at: Time.current + RATE_LIMIT_DURATION)
+    end
+
+    def apply_clear_runner_field!
+      runner = find_runner!
+      field_name = decision.action_target_metadata.fetch("field_name").to_s
+      raise ArgumentError, "Unsupported runner field #{field_name.inspect}" unless ALLOWED_RUNNER_FIELDS.include?(field_name)
+
+      previous_value = runner.public_send(field_name)
+      decision.update!(
+        revert_data: {
+          "handler" => "clear_runner_field",
+          "runner_id" => runner.id,
+          "field_name" => field_name,
+          "previous_value" => previous_value
+        }
+      )
+
+      runner.update!(field_name => nil)
+    end
+
+    def apply_disable_runner_fallback!
+      runner = find_runner!
+      decision.update!(
+        revert_data: {
+          "handler" => "disable_runner_fallback",
+          "runner_id" => runner.id,
+          "previous_enabled_for_fallback" => runner.enabled_for_fallback
+        }
+      )
+
+      runner.update!(enabled_for_fallback: false)
+    end
+
+    def apply_file_issue!
+      project = find_project!
+      incident = decision.account.exception_incidents.find_or_initialize_by(fingerprint: decision.fingerprint)
+      incident.assign_attributes(
+        project: project,
+        exception_class: "SelfHealRemediation",
+        message: decision.root_cause,
+        backtrace: decision.evidence_pointers.join("\n"),
+        subsystem: "agent_runs",
+        severity: "p2",
+        action_taken: "notified",
+        status: "open",
+        last_occurred_at: Time.current,
+        occurrence_count: [ incident.occurrence_count.to_i, decision.occurrence_count ].max,
+        context: {
+          "remediation_decision_id" => decision.id,
+          "action_target" => {
+            "type" => decision.action_target_type,
+            "id" => decision.action_target_id,
+            "metadata" => decision.action_target_metadata
+          },
+          "evidence_pointers" => decision.evidence_pointers
+        }
+      )
+      incident.save!
+
+      decision.update!(
+        revert_data: {
+          "handler" => "file_issue",
+          "project_id" => project.id,
+          "incident_id" => incident.id
+        }
+      )
+
+      ExceptionHandler::IssueFiler.call(incident: incident, project: project)
+      decision.update!(revert_data: decision.revert_data.merge(
+        "github_issue_url" => incident.reload.github_issue_url,
+        "github_issue_number" => incident.github_issue_number
+      ))
+    end
+
+    def apply_notify!
+      Notifications::Publish.call(
+        account: decision.account,
+        source: Notify::NOTIFICATION_SOURCE,
+        subject: decision.account,
+        severity: :warning,
+        title: "Self-heal notification: #{decision.root_cause}",
+        description: "Remediation action #{decision.proposed_action.humanize} was applied as notify-only.",
+        metadata: { remediation_decision_id: decision.id },
+        action_url: "/remediation_decisions/#{decision.id}",
+        nav_section: "dashboard"
+      )
+      decision.update!(revert_data: { "handler" => "notify" })
+    end
+
+    def find_runner!
+      runner = Runner.find(decision.runner_id)
+      raise ActiveRecord::RecordNotFound, "Runner does not belong to decision account" unless runner.user.account_id == decision.account_id
+
+      runner
+    end
+
+    def find_project!
+      project = Project.find(decision.action_target_id)
+      raise ActiveRecord::RecordNotFound, "Project does not belong to decision account" unless project.account_id == decision.account_id
+
+      project
+    end
+
+    def record_audit_event
+      subject = find_runner_for_audit || find_project_for_audit || decision.account
+
+      Audit::RecordEvent.call(
+        account: decision.account,
+        action: "self_heal.remediation_applied",
+        subject: subject,
+        metadata: {
+          remediation_action: decision.proposed_action,
+          remediation_decision_id: decision.id,
+          target_label: decision.action_target_label,
+          details: [
+            "Root cause: #{decision.root_cause}",
+            "Fingerprint: #{decision.fingerprint}",
+            "Confidence: #{decision.confidence}"
+          ]
+        }
+      )
+    end
+
+    def find_runner_for_audit
+      return find_runner! if decision.runner_target?
+
+      nil
+    rescue ActiveRecord::RecordNotFound
+      nil
+    end
+
+    def find_project_for_audit
+      return nil unless decision.action_target_type == "project"
+
+      find_project!
+    rescue ActiveRecord::RecordNotFound
+      nil
+    end
+  end
+end

--- a/app/services/agent_run_patterns/auto_apply.rb
+++ b/app/services/agent_run_patterns/auto_apply.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module AgentRunPatterns
+  class AutoApply
+    COOLDOWN_WINDOW = 24.hours
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(decision:, pattern:)
+      @decision = decision
+      @pattern = pattern
+    end
+
+    def call
+      return decision unless auto_apply_enabled?
+      return decision unless threshold_met?
+      return decision if auto_apply_cooldown_active?
+      return decision if downgraded_to_notify_only?
+
+      ApplyDecision.call(decision: decision, pattern: pattern)
+    end
+
+    private
+
+    attr_reader :decision, :pattern
+
+    def auto_apply_enabled?
+      policy.fetch("mode") == "auto_apply"
+    end
+
+    def threshold_met?
+      decision.confidence.to_f >= policy.fetch("minimum_confidence").to_f &&
+        decision.occurrence_count >= policy.fetch("filing_threshold").to_i
+    end
+
+    def auto_apply_cooldown_active?
+      decision.account.remediation_decisions
+        .where.not(id: decision.id)
+        .where(fingerprint: decision.fingerprint, proposed_action: decision.proposed_action, status: "applied")
+        .where("COALESCE(applied_at, created_at) >= ?", COOLDOWN_WINDOW.ago)
+        .exists?
+    end
+
+    def downgraded_to_notify_only?
+      decision.account.remediation_decisions
+        .where.not(id: decision.id)
+        .where(fingerprint: decision.fingerprint, proposed_action: decision.proposed_action)
+        .where(outcome: %w[unchanged regressed])
+        .exists?
+    end
+
+    def policy
+      @policy ||= decision.account.remediation_policy_for(decision.proposed_action)
+    end
+  end
+end

--- a/app/services/agent_run_patterns/notify.rb
+++ b/app/services/agent_run_patterns/notify.rb
@@ -46,7 +46,7 @@ module AgentRunPatterns
         subject: account,
         severity: notification_severity(worst),
         title: notification_title(worst, diagnosis),
-        description: notification_description(worst, diagnosis),
+        description: notification_description(worst, diagnosis, decision),
         metadata: build_metadata(decision),
         action_url: decision ? "/remediation_decisions/#{decision.id}" : "/dashboard",
         nav_section: "dashboard"
@@ -89,7 +89,7 @@ module AgentRunPatterns
       "#{goal} failures detected (#{count} failures) — #{root_cause}"
     end
 
-    def notification_description(worst, diagnosis)
+    def notification_description(worst, diagnosis, decision)
       parts = []
       parts << "Detected failure patterns across #{ordered_patterns.size} goal type(s):"
       parts << ""
@@ -101,7 +101,7 @@ module AgentRunPatterns
       if diagnosis
         parts << ""
         parts << "Root cause: #{diagnosis.root_cause}"
-        parts << "Proposed action: #{human_action(diagnosis)}"
+        parts << action_summary(decision, diagnosis)
 
         evidence_lines = evidence_lines_for(worst, diagnosis)
         if evidence_lines.any?
@@ -136,7 +136,9 @@ module AgentRunPatterns
         goals: ordered_patterns.map(&:goal).uniq,
         worst_goal: worst_pattern.goal,
         diagnosed_root_cause: diagnosis_for(worst_pattern)&.root_cause,
-        remediation_decision_id: decision&.id
+        remediation_decision_id: decision&.id,
+        remediation_status: decision&.status,
+        revert_url: decision&.revertable? ? "/remediation_decisions/#{decision.id}/revert" : nil
       }
     end
 
@@ -176,6 +178,14 @@ module AgentRunPatterns
       return "#{label} (project ##{target["id"]})" if target["type"] == "project"
 
       "#{label} (runner ##{target["id"]}, field #{target["field_name"]})"
+    end
+
+    def action_summary(decision, diagnosis)
+      if decision&.applied?
+        "Auto-applied action: #{human_action(diagnosis)}"
+      else
+        "Proposed action: #{human_action(diagnosis)}"
+      end
     end
 
     def evidence_lines_for(pattern, diagnosis)

--- a/app/services/agent_run_patterns/revert_decision.rb
+++ b/app/services/agent_run_patterns/revert_decision.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module AgentRunPatterns
+  class RevertDecision
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(decision:, actor: nil)
+      @decision = decision
+      @actor = actor
+    end
+
+    def call
+      return decision unless decision.revertable?
+
+      RemediationDecision.transaction do
+        decision.lock!
+        decision.reload
+        return decision unless decision.revertable?
+
+        case revert_data.fetch("handler")
+        when "mark_runner_unavailable"
+          revert_mark_runner_unavailable!
+        when "clear_runner_field"
+          revert_clear_runner_field!
+        when "disable_runner_fallback"
+          revert_disable_runner_fallback!
+        when "file_issue"
+          revert_file_issue!
+        when "notify"
+          nil
+        end
+
+        decision.update!(status: "reverted")
+        record_audit_event
+      end
+
+      decision
+    end
+
+    private
+
+    attr_reader :actor, :decision
+
+    def revert_data
+      decision.revert_data.to_h
+    end
+
+    def revert_mark_runner_unavailable!
+      runner = Runner.find(revert_data.fetch("runner_id"))
+      state = runner.user.runner_states.find_or_create_by!(runner_name: revert_data.fetch("runner_state_name")) do |record|
+        record.failure_count = 0
+        record.circuit_state = "closed"
+      end
+      previous_reset_at = revert_data["previous_rate_limited_until"]
+
+      if previous_reset_at.present?
+        state.update!(rate_limited_until: Time.zone.parse(previous_reset_at))
+      else
+        state.clear_rate_limit!
+      end
+    end
+
+    def revert_clear_runner_field!
+      runner = Runner.find(revert_data.fetch("runner_id"))
+      runner.update!(revert_data.fetch("field_name") => revert_data["previous_value"])
+    end
+
+    def revert_disable_runner_fallback!
+      runner = Runner.find(revert_data.fetch("runner_id"))
+      runner.update!(enabled_for_fallback: revert_data.fetch("previous_enabled_for_fallback"))
+    end
+
+    def revert_file_issue!
+      incident = ExceptionIncident.find_by(id: revert_data["incident_id"])
+      return unless incident
+
+      incident.update!(status: "resolved", resolved_at: Time.current)
+    end
+
+    def record_audit_event
+      subject = Runner.find_by(id: revert_data["runner_id"]) || decision.account
+
+      Audit::RecordEvent.call(
+        account: decision.account,
+        action: "self_heal.remediation_reverted",
+        actor: actor,
+        subject: subject,
+        metadata: {
+          remediation_action: decision.proposed_action,
+          remediation_decision_id: decision.id,
+          target_label: decision.action_target_label,
+          details: [
+            "Reverted remediation decision ##{decision.id}",
+            "Fingerprint: #{decision.fingerprint}"
+          ]
+        }
+      )
+    end
+  end
+end

--- a/app/services/agent_run_patterns/update_outcomes.rb
+++ b/app/services/agent_run_patterns/update_outcomes.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module AgentRunPatterns
+  class UpdateOutcomes
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(account:, patterns:)
+      @account = account
+      @patterns = patterns
+    end
+
+    def call
+      account.remediation_decisions.pending_outcome.find_each do |decision|
+        post_count = pattern_counts.fetch(decision.fingerprint, 0)
+
+        decision.update!(
+          post_remediation_failure_count: post_count,
+          outcome: outcome_for(decision, post_count)
+        )
+      end
+    end
+
+    private
+
+    attr_reader :account, :patterns
+
+    def pattern_counts
+      @pattern_counts ||= patterns.each_with_object({}) do |pattern, result|
+        result[pattern.details[:fingerprint].to_s] = failure_count(pattern)
+      end
+    end
+
+    def failure_count(pattern)
+      pattern.details[:streak_length] ||
+        pattern.details[:failure_count] ||
+        pattern.details[:occurrence_count] ||
+        0
+    end
+
+    def outcome_for(decision, post_count)
+      return "regressed" if post_count > decision.pre_remediation_failure_count.to_i
+      return "unchanged" if post_count >= decision.pre_remediation_failure_count.to_i
+
+      "improved"
+    end
+  end
+end

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -79,6 +79,63 @@
       </section>
 
       <section class="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <div class="flex items-center justify-between gap-4">
+          <div>
+            <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Self-Heal Policy</h2>
+            <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">Opt each remediation action into auto-apply independently and tune the thresholds used before Paid mutates runner state.</p>
+          </div>
+        </div>
+
+        <%= form_with model: current_account, url: account_path, method: :patch, class: "mt-6 space-y-4" do |form| %>
+          <div class="overflow-hidden rounded-2xl border border-gray-200 dark:border-gray-700">
+            <table class="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-700">
+              <thead class="bg-gray-50 dark:bg-gray-900/60">
+                <tr>
+                  <th class="px-4 py-3 text-left font-medium text-gray-700 dark:text-gray-200">Action</th>
+                  <th class="px-4 py-3 text-left font-medium text-gray-700 dark:text-gray-200">Mode</th>
+                  <th class="px-4 py-3 text-left font-medium text-gray-700 dark:text-gray-200">Min confidence</th>
+                  <th class="px-4 py-3 text-left font-medium text-gray-700 dark:text-gray-200">Occurrence threshold</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-800">
+                <% current_account.effective_remediation_policy.each do |action, policy| %>
+                  <tr>
+                    <td class="px-4 py-4 font-medium text-gray-900 dark:text-white"><%= action.humanize %></td>
+                    <td class="px-4 py-4">
+                      <%= select_tag "account[remediation_policy][#{action}][mode]",
+                            options_for_select(Account::REMEDIATION_POLICY_MODES.map { |mode| [mode.humanize, mode] }, policy["mode"]),
+                            class: "w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+                    </td>
+                    <td class="px-4 py-4">
+                      <%= number_field_tag "account[remediation_policy][#{action}][minimum_confidence]",
+                            policy["minimum_confidence"],
+                            min: 0,
+                            max: 1,
+                            step: 0.01,
+                            class: "w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+                    </td>
+                    <td class="px-4 py-4">
+                      <%= number_field_tag "account[remediation_policy][#{action}][filing_threshold]",
+                            policy["filing_threshold"],
+                            min: 1,
+                            step: 1,
+                            class: "w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+
+          <% if policy(current_account).update? %>
+            <div class="flex justify-end">
+              <%= form.submit "Save self-heal policy", class: "rounded-full bg-amber-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-amber-500" %>
+            </div>
+          <% end %>
+        <% end %>
+      </section>
+
+      <section class="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
         <div class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Team</h2>

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -29,6 +29,13 @@
   </td>
   <td class="whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm sm:pr-6">
     <div class="flex items-center justify-end gap-2">
+      <% if notification.metadata.to_h["revert_url"].present? %>
+        <%= button_to "Revert",
+              notification.metadata.to_h["revert_url"],
+              method: :post,
+              class: "text-red-600 hover:text-red-900 text-xs font-medium",
+              form: { data: { turbo_confirm: "Revert this remediation?" } } %>
+      <% end %>
       <% unless notification.read_at? %>
         <%= button_to "Read", read_notification_path(notification), method: :patch, class: "text-indigo-600 hover:text-indigo-900 text-xs font-medium", form: { data: { turbo_stream: true } } %>
       <% end %>

--- a/app/views/remediation_decisions/show.html.erb
+++ b/app/views/remediation_decisions/show.html.erb
@@ -3,9 +3,20 @@
 <div class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="rounded-xl border border-gray-200 bg-white shadow-sm">
     <div class="border-b border-gray-200 px-6 py-5">
-      <p class="text-sm font-medium text-indigo-600">Self-heal diagnosis</p>
-      <h1 class="mt-1 text-2xl font-semibold text-gray-900">Remediation Decision #<%= @remediation_decision.id %></h1>
-      <p class="mt-2 text-sm text-gray-600"><%= @remediation_decision.root_cause %></p>
+      <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p class="text-sm font-medium text-indigo-600">Self-heal diagnosis</p>
+          <h1 class="mt-1 text-2xl font-semibold text-gray-900">Remediation Decision #<%= @remediation_decision.id %></h1>
+          <p class="mt-2 text-sm text-gray-600"><%= @remediation_decision.root_cause %></p>
+        </div>
+        <% if @remediation_decision.revertable? %>
+          <%= button_to "Revert",
+                revert_remediation_decision_path(@remediation_decision),
+                method: :post,
+                class: "rounded-full border border-red-300 px-4 py-2 text-sm font-semibold text-red-700 hover:bg-red-50",
+                form: { data: { turbo_confirm: "Revert this remediation?" } } %>
+        <% end %>
+      </div>
     </div>
 
     <dl class="grid gap-6 px-6 py-6 sm:grid-cols-2">
@@ -26,12 +37,27 @@
         <dd class="mt-1 text-sm text-gray-900"><%= @remediation_decision.status.humanize %></dd>
       </div>
       <div>
+        <dt class="text-sm font-medium text-gray-500">Outcome</dt>
+        <dd class="mt-1 text-sm text-gray-900"><%= @remediation_decision.outcome&.humanize || "Pending" %></dd>
+      </div>
+      <div>
+        <dt class="text-sm font-medium text-gray-500">Applied at</dt>
+        <dd class="mt-1 text-sm text-gray-900"><%= @remediation_decision.applied_at ? local_time(@remediation_decision.applied_at) : "Not applied" %></dd>
+      </div>
+      <div>
         <dt class="text-sm font-medium text-gray-500">Fingerprint</dt>
         <dd class="mt-1 break-all font-mono text-xs text-gray-900"><%= @remediation_decision.fingerprint %></dd>
       </div>
       <div>
         <dt class="text-sm font-medium text-gray-500">Occurrences in window</dt>
         <dd class="mt-1 text-sm text-gray-900"><%= @remediation_decision.occurrence_count %></dd>
+      </div>
+      <div>
+        <dt class="text-sm font-medium text-gray-500">Failure counts</dt>
+        <dd class="mt-1 text-sm text-gray-900">
+          Before: <%= @remediation_decision.pre_remediation_failure_count || 0 %>,
+          After: <%= @remediation_decision.post_remediation_failure_count.nil? ? "Pending" : @remediation_decision.post_remediation_failure_count %>
+        </dd>
       </div>
     </dl>
 

--- a/app/views/runners/_remediation_history.html.erb
+++ b/app/views/runners/_remediation_history.html.erb
@@ -1,0 +1,43 @@
+<section class="rounded-lg bg-white p-6 shadow">
+  <div class="flex items-center justify-between gap-3">
+    <div>
+      <h2 class="text-lg font-semibold text-gray-900">Decision History</h2>
+      <p class="mt-1 text-sm text-gray-500">Timeline of proposed, applied, and reverted self-heal actions for this runner.</p>
+    </div>
+  </div>
+
+  <% if remediation_history.any? %>
+    <div class="mt-6 space-y-4">
+      <% remediation_history.each do |decision| %>
+        <article class="rounded-lg border border-gray-200 p-4">
+          <div class="flex items-start justify-between gap-3">
+            <div>
+              <p class="text-sm font-semibold text-gray-900"><%= decision.proposed_action.humanize %></p>
+              <p class="mt-1 text-sm text-gray-600"><%= decision.root_cause %></p>
+            </div>
+            <span class="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-700"><%= decision.status.humanize %></span>
+          </div>
+          <dl class="mt-3 grid gap-2 text-sm text-gray-600">
+            <div>
+              <dt class="inline font-medium text-gray-900">When:</dt>
+              <dd class="inline"><%= local_time(decision.created_at) %></dd>
+            </div>
+            <div>
+              <dt class="inline font-medium text-gray-900">Outcome:</dt>
+              <dd class="inline"><%= decision.outcome&.humanize || "Pending" %></dd>
+            </div>
+            <div>
+              <dt class="inline font-medium text-gray-900">Why:</dt>
+              <dd class="inline"><%= decision.evidence_pointers.join(", ").presence || "No evidence pointers recorded" %></dd>
+            </div>
+          </dl>
+          <div class="mt-3">
+            <%= link_to "Open decision", remediation_decision_path(decision), class: "text-sm font-medium text-indigo-600 hover:text-indigo-500" %>
+          </div>
+        </article>
+      <% end %>
+    </div>
+  <% else %>
+    <p class="mt-6 text-sm text-gray-500">No remediation decisions recorded for this runner yet.</p>
+  <% end %>
+</section>

--- a/app/views/runners/edit.html.erb
+++ b/app/views/runners/edit.html.erb
@@ -1,15 +1,19 @@
 <% content_for(:title) { "Edit Runner - Paid" } %>
 
-<div class="mx-auto max-w-xl px-4 py-8 sm:px-6 lg:px-8">
-  <div class="rounded-lg bg-white p-6 shadow">
-    <h1 class="text-xl font-semibold text-gray-900">Edit Runner</h1>
-    <p class="mt-1 text-sm text-gray-500">Update where this runner can be used.</p>
+<div class="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+  <div class="grid gap-6 lg:grid-cols-[minmax(0,1.3fr)_minmax(320px,0.8fr)]">
+    <div class="rounded-lg bg-white p-6 shadow">
+      <h1 class="text-xl font-semibold text-gray-900">Edit Runner</h1>
+      <p class="mt-1 text-sm text-gray-500">Update where this runner can be used.</p>
 
-    <div class="mt-6">
-      <%= render "form", runner: @runner,
-            subscription_runner_options: @subscription_runner_options,
-            api_key_runner_options: @api_key_runner_options,
-            available_api_keys: @available_api_keys %>
+      <div class="mt-6">
+        <%= render "form", runner: @runner,
+              subscription_runner_options: @subscription_runner_options,
+              api_key_runner_options: @api_key_runner_options,
+              available_api_keys: @available_api_keys %>
+      </div>
     </div>
+
+    <%= render "remediation_history", remediation_history: @remediation_history %>
   </div>
 </div>

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -205,6 +205,11 @@ Rails.application.configure do
       class: "AgentRunPatternDetectorJob",
       description: "Detect goal-level failure patterns in agent runs and notify"
     },
+    remediation_decision_outcomes: {
+      cron: "*/15 * * * *",
+      class: "RemediationDecisionOutcomeJob",
+      description: "Evaluate outcomes for auto-applied self-heal remediations"
+    },
     temporal_patch_guard_sweep: {
       cron: "0 4 1 */3 *",
       class: "TemporalPatchGuardSweepJob",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,9 @@ Rails.application.routes.draw do
     patch :dismiss, on: :member
     post :mark_all_read, on: :collection
   end
-  resources :remediation_decisions, only: [ :show ]
+  resources :remediation_decisions, only: [ :show ] do
+    post :revert, on: :member
+  end
 
   # Onboarding wizard
   resource :onboarding, only: [ :show, :update ], controller: "onboarding" do

--- a/db/migrate/20260528223650_allow_null_tier_model_ids_on_runners.rb
+++ b/db/migrate/20260528223650_allow_null_tier_model_ids_on_runners.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AllowNullTierModelIdsOnRunners < ActiveRecord::Migration[8.1]
+  def up
+    change_column_default :runners, :tier_model_ids, from: {}, to: nil
+    change_column_null :runners, :tier_model_ids, true
+    change_column_comment :runners, :tier_model_ids,
+      "Per-tier model mapping for configurable runners. Nil means no explicit mapping is stored."
+  end
+
+  def down
+    change_column_comment :runners, :tier_model_ids,
+      "Per-tier model routing for configurable runners."
+    change_column_null :runners, :tier_model_ids, false, {}
+    change_column_default :runners, :tier_model_ids, from: nil, to: {}
+  end
+end

--- a/db/migrate/20260528223651_add_remediation_policy_to_accounts.rb
+++ b/db/migrate/20260528223651_add_remediation_policy_to_accounts.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddRemediationPolicyToAccounts < ActiveRecord::Migration[8.1]
+  def change
+    add_column :accounts, :remediation_policy, :jsonb, default: {}, null: false,
+      comment: "Per-action self-heal remediation modes and thresholds for this account."
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_28_133444) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_28_223651) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -103,6 +103,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_28_133444) do
     t.string "name", null: false
     t.datetime "onboarding_completed_at"
     t.string "plan", default: "trial", null: false
+    t.jsonb "remediation_policy", default: {}, null: false, comment: "Per-action self-heal remediation modes and thresholds for this account."
     t.datetime "scheduler_paused_at"
     t.string "slug", null: false
     t.integer "status", default: 0, null: false
@@ -2026,7 +2027,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_28_133444) do
     t.bigint "provider_api_key_id"
     t.string "provider_key", limit: 50
     t.string "runner_key", limit: 50, null: false
-    t.jsonb "tier_model_ids", default: {}, null: false
+    t.jsonb "tier_model_ids", comment: "Per-tier model mapping for configurable runners. Nil means no explicit mapping is stored."
     t.jsonb "tier_models", default: {}, null: false, comment: "Per-tier model map shared by Runner and Provider records on this table. Shape: {\"low\":{\"model_id\":\"model-id\",\"provider_id\":123}} keyed by LlmModel tiers."
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
@@ -3525,10 +3526,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_28_133444) do
       CREATE TRIGGER logidze_on_mcp_server_definitions BEFORE INSERT OR UPDATE ON public.mcp_server_definitions FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{env}')
   SQL
 
-  create_trigger :validate_strategy_version_scope, sql_definition: <<-SQL
-      CREATE TRIGGER validate_strategy_version_scope BEFORE INSERT OR UPDATE OF project_id, strategy_version_id ON public.orchestration_decisions FOR EACH ROW EXECUTE FUNCTION validate_orchestration_decision_strategy_version_scope()
-  SQL
-
   create_trigger :logidze_on_orchestration_strategies, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_orchestration_strategies BEFORE INSERT OR UPDATE ON public.orchestration_strategies FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
@@ -3591,5 +3588,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_28_133444) do
 
   create_trigger :logidze_on_users, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_users BEFORE INSERT OR UPDATE ON public.users FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{encrypted_password,reset_password_token,reset_password_sent_at,remember_created_at}')
+  SQL
+
+  create_trigger :validate_strategy_version_scope, sql_definition: <<-SQL
+      CREATE TRIGGER validate_strategy_version_scope BEFORE INSERT OR UPDATE OF project_id, strategy_version_id ON public.orchestration_decisions FOR EACH ROW EXECUTE FUNCTION validate_orchestration_decision_strategy_version_scope()
   SQL
 end

--- a/spec/config/application_job_queue_priority_spec.rb
+++ b/spec/config/application_job_queue_priority_spec.rb
@@ -36,7 +36,9 @@ RSpec.describe ApplicationJob, :no_db do
         PoolReplenishmentJob
         PromptEvolutionJob
         QueueMonitorJob
+        RemediationDecisionOutcomeJob
         RecoverMissingPullRequestLabelsJob
+        RevertRemediationDecisionJob
         ScreenshotCleanupJob
         ServiceContainerReconciliationJob
         StaleRunDetectorJob

--- a/spec/jobs/agent_run_pattern_detector_job_auto_apply_spec.rb
+++ b/spec/jobs/agent_run_pattern_detector_job_auto_apply_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AgentRunPatternDetectorJob do
+  let(:account) { create(:account) }
+  let(:owner) { create(:user, :owner, account: account) }
+  let(:runner) do
+    create(
+      :runner,
+      user: owner,
+      runner_key: "cursor",
+      enabled_for_agent_runs: true,
+      enabled_for_fallback: true
+    )
+  end
+  let(:pattern) do
+    AgentRunPatterns::Detect::Pattern.new(
+      type: :error_cluster,
+      goal: "enhance_issue",
+      severity: :error,
+      details: {
+        fingerprint: "runner-rate-limit-fingerprint",
+        occurrence_count: 3
+      }
+    )
+  end
+  let(:diagnosis) do
+    AgentRunPatterns::Diagnose::Diagnosis.new(
+      root_cause: "Runner quota exhausted",
+      confidence: 0.92,
+      proposed_action: "mark_runner_unavailable",
+      action_target: { "type" => "runner", "id" => runner.id.to_s },
+      evidence_pointers: [ "runner_attempts[0].error_message" ]
+    )
+  end
+
+  before do
+    account.update!(
+      remediation_policy: {
+        "mark_runner_unavailable" => {
+          "mode" => "auto_apply",
+          "minimum_confidence" => 0.8,
+          "filing_threshold" => 1
+        }
+      }
+    )
+
+    allow(AgentRunPatterns::Detect).to receive(:call).with(account: account).and_return([ pattern ])
+    allow(AgentRunPatterns::Diagnose).to receive(:call).and_return(diagnosis)
+  end
+
+  it "auto-applies the first remediation and leaves later runs proposed after an unchanged outcome" do
+    first_decision = perform_detection_cycle
+
+    expect_first_decision_to_be_auto_applied(first_decision)
+
+    RemediationDecisionOutcomeJob.perform_now
+
+    expect_unchanged_outcome(first_decision)
+
+    follow_up_decision = perform_detection_cycle(expected_activity_delta: 0)
+
+    expect_follow_up_decision_to_remain_proposed(follow_up_decision)
+  end
+
+  def perform_detection_cycle(expected_decision_delta: 1, expected_activity_delta: 1)
+    expect {
+      described_class.perform_now
+    }.to change(RemediationDecision, :count).by(expected_decision_delta)
+      .and change(AccountActivityEvent, :count).by(expected_activity_delta)
+
+    RemediationDecision.order(:id).last
+  end
+
+  def expect_first_decision_to_be_auto_applied(decision)
+    expect(decision).to have_attributes(
+      status: "applied",
+      proposed_action: "mark_runner_unavailable",
+      outcome: nil
+    )
+    expect(owner.runner_states.find_by!(runner_name: runner.state_key)).to be_rate_limited
+    expect(decision.revert_data).to include(
+      "handler" => "mark_runner_unavailable",
+      "runner_id" => runner.id
+    )
+    expect(account.account_activity_events.recent.first.action).to eq("self_heal.remediation_applied")
+  end
+
+  def expect_unchanged_outcome(decision)
+    expect(decision.reload).to have_attributes(
+      outcome: "unchanged",
+      post_remediation_failure_count: 3
+    )
+  end
+
+  def expect_follow_up_decision_to_remain_proposed(decision)
+    expect(decision).to have_attributes(
+      status: "proposed",
+      proposed_action: "mark_runner_unavailable",
+      outcome: nil
+    )
+  end
+end

--- a/spec/jobs/agent_run_pattern_detector_job_spec.rb
+++ b/spec/jobs/agent_run_pattern_detector_job_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe AgentRunPatternDetectorJob, :no_db do
       allow(AgentRunPatterns::Diagnose).to receive(:call)
       allow(AgentRunPatterns::DailyDiagnosisBudget).to receive(:remaining_for).and_return(5)
       allow(AgentRunPatterns::RecordRemediationDecision).to receive(:call).and_return(double(id: 99))
+      allow(AgentRunPatterns::AutoApply).to receive(:call).and_return(double(id: 99))
       allow(AgentRunPatterns::Notify).to receive(:call)
       allow(TenantContext).to receive(:with_system_access).and_yield
       allow(Account).to receive(:find_each).and_yield(account)
@@ -105,6 +106,10 @@ RSpec.describe AgentRunPatternDetectorJob, :no_db do
           account: account,
           pattern: pattern,
           diagnosis: diagnosis
+        )
+        expect(AgentRunPatterns::AutoApply).to have_received(:call).with(
+          decision: anything,
+          pattern: pattern
         )
       end
 

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "Accounts" do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include(
         "Account Administration",
+        "Self-Heal Policy",
         "Team",
         "Tenant Limits and Usage",
         "ROI, Evals & Benchmarking",
@@ -105,6 +106,29 @@ RSpec.describe "Accounts" do
       event = account.account_activity_events.recent.first
       expect(event.action).to eq("account.updated")
       expect(event.metadata["changed_fields"]).to include("name", "default_max_tokens_per_run")
+    end
+
+    it "persists remediation policy settings" do
+      patch account_path, params: {
+        account: {
+          remediation_policy: {
+            mark_runner_unavailable: {
+              mode: "auto_apply",
+              minimum_confidence: "0.9",
+              filing_threshold: "2"
+            }
+          }
+        }
+      }
+
+      expect(response).to redirect_to(account_path)
+      expect(account.reload.remediation_policy).to include(
+        "mark_runner_unavailable" => {
+          "mode" => "auto_apply",
+          "minimum_confidence" => 0.9,
+          "filing_threshold" => 2
+        }
+      )
     end
 
     it "rolls back the account update when activity recording fails" do

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -17,6 +17,20 @@ RSpec.describe "Notifications" do
       expect(response.body).to include("Test alert")
     end
 
+    it "renders a revert button for applied remediation notifications" do
+      create(
+        :notification,
+        account: account,
+        title: "Self-heal alert",
+        metadata: { revert_url: "/remediation_decisions/123/revert" }
+      )
+
+      get notifications_path
+
+      expect(response.body).to include("Revert")
+      expect(response.body).to include("/remediation_decisions/123/revert")
+    end
+
     it "renders the table with mobile horizontal scrolling constraints" do
       create(:notification, account: account, title: "Scrollable alert")
 

--- a/spec/requests/remediation_decisions_spec.rb
+++ b/spec/requests/remediation_decisions_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe "RemediationDecisions" do
   let(:account) { create(:account) }
-  let(:user) { create(:user, account: account) }
+  let(:user) { create(:user, :owner, account: account) }
   let(:decision) do
     create(
       :remediation_decision,
@@ -26,6 +26,59 @@ RSpec.describe "RemediationDecisions" do
       expect(response.body).to include("Disable runner fallback")
       expect(response.body).to include("Runner #42")
       expect(response.body).to include(decision.root_cause)
+    end
+  end
+
+  describe "POST /remediation_decisions/:id/revert" do
+    include ActiveJob::TestHelper
+
+    let(:runner) { create(:runner, user: user, runner_key: "cursor", enabled_for_fallback: true) }
+    let(:tier_model_ids) do
+      {
+        "low" => "claude-haiku-4-5",
+        "mid" => "claude-sonnet-4-6",
+        "high" => "claude-opus-4-1"
+      }
+    end
+    let(:decision) do
+      create(
+        :remediation_decision,
+        account: account,
+        proposed_action: "clear_runner_field",
+        action_target_type: "runner_field",
+        action_target_id: runner.id.to_s,
+        action_target_metadata: { "field_name" => "tier_model_ids" }
+      )
+    end
+
+    before do
+      create(:llm_model, model_id: "claude-haiku-4-5", provider: "anthropic", tier: "low", capability_score: 7.0)
+      create(:llm_model, model_id: "claude-sonnet-4-6", provider: "anthropic", tier: "mid", capability_score: 8.0)
+      create(:llm_model, model_id: "claude-opus-4-1", provider: "anthropic", tier: "high", capability_score: 9.0)
+
+      runner.update!(tier_model_ids: tier_model_ids)
+      AgentRunPatterns::ApplyDecision.call(
+        decision: decision,
+        pattern: AgentRunPatterns::Detect::Pattern.new(
+          type: :error_cluster,
+          goal: "enhance_issue",
+          severity: :error,
+          details: { fingerprint: decision.fingerprint, occurrence_count: 3 }
+        )
+      )
+    end
+
+    it "enqueues a revert job and restores the cleared field" do
+      expect(decision.reload).to be_revertable
+      expect(runner.reload.tier_model_ids).to be_nil
+
+      perform_enqueued_jobs do
+        post revert_remediation_decision_path(decision)
+      end
+
+      expect(response).to redirect_to(remediation_decision_path(decision))
+      expect(runner.reload.tier_model_ids).to eq(tier_model_ids)
+      expect(decision.reload.status).to eq("reverted")
     end
   end
 end

--- a/spec/requests/runners_spec.rb
+++ b/spec/requests/runners_spec.rb
@@ -740,6 +740,24 @@ RSpec.describe "Runners" do
       expect(response.body).not_to include('name="runner[complexity_thresholds[low_max]]"')
       expect(response.body).not_to include('name="runner[complexity_thresholds[mid_max]]"')
     end
+
+    it "renders remediation decision history on the edit page" do
+      runner = user.runners.find_by!(runner_key: "claude")
+      create(
+        :remediation_decision,
+        account: user.account,
+        proposed_action: "disable_runner_fallback",
+        action_target_type: "runner",
+        action_target_id: runner.id.to_s,
+        root_cause: "Fallback runner repeatedly failed"
+      )
+
+      get edit_runner_path(runner)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Decision History")
+      expect(response.body).to include("Fallback runner repeatedly failed")
+    end
   end
 
   describe "POST /runners/:id/test_agent" do


### PR DESCRIPTION
## Summary

Implemented bounded self-heal auto-apply with reversible handlers, per-account remediation policy, revert jobs/UI, runner decision history, outcome tracking, and audit-log entries. The flow now supports auto-applying safe runner-scoped actions, downgrading repeat-unchanged fingerprints back to notify-only, and one-click reverts from notifications and decision detail pages.

Verification passed with `bundle exec rubocop` and `bundle exec rspec` under `RAILS_ENV=test` using the provided DB host/user env overrides in this workspace. Commit created: `8976440` with message `feat(self-heal): auto-apply reversible remediations`.

---

Closes #2323