### PR TITLE
fix(pr-2324): break review-goal loop — gate bypass + proxy auto-recovery

### DIFF
--- a/app/controllers/api/github_proxy_controller.rb
+++ b/app/controllers/api/github_proxy_controller.rb
@@ -8,6 +8,8 @@ module Api
     REVIEW_COMMENT_MARKER = "<!-- paid:code-review -->"
     REVIEW_HEADER = "## Code Review"
     STALE_REVIEW_DISMISSAL_MESSAGE = "Subsequent review found no remaining actionable issues."
+    PENDING_REVIEW_ERROR_PATTERN = /one pending review per pull request/i
+    GITHUB_ERROR_BODY_LOG_LIMIT = 2_000
 
     # Allowlisted GitHub API endpoints (regex with named captures for owner/repo).
     ALLOWED_ENDPOINTS = [
@@ -53,12 +55,21 @@ module Api
       end
 
       forwarded_body = maybe_prepend_review_header(path, request.raw_post)
-      response = proxy_to_github(path, github_authorization_token(path), forwarded_body)
+      authorization_token = github_authorization_token(path)
+      response = proxy_to_github(path, authorization_token, forwarded_body)
+
+      if review_creation_request?(path) && pending_review_conflict?(response)
+        recovered = recover_from_pending_review(path, authorization_token, forwarded_body, match: match)
+        response = recovered if recovered
+      end
+
       project.github_token&.touch_last_used! unless use_review_bot_token?(path)
 
       if response.status >= 200 && response.status < 300
         track_issue_creation(path, response)
         track_review_creation(path, response)
+      elsif response.status >= 400
+        log_github_error_response(path, response)
       end
 
       render body: response.body, status: response.status,
@@ -223,6 +234,83 @@ module Api
 
     def review_url_for(pr_number, review_id)
       "https://github.com/#{authenticated_project.full_name}/pull/#{pr_number}#pullrequestreview-#{review_id}"
+    end
+
+    # GitHub rejects POST /pulls/N/reviews with 422 if the authenticated user
+    # already has a PENDING review on the PR. A prior interrupted review run
+    # can leave one behind, causing every subsequent review attempt to fail
+    # the same way (#2324).
+    def pending_review_conflict?(response)
+      return false unless response.status == 422
+
+      body = parse_response_body(response.body)
+      return false unless body.is_a?(Hash)
+
+      errors = Array(body["errors"]).flat_map do |err|
+        err.is_a?(Hash) ? err.values_at("message", "code") : [ err ]
+      end
+      errors << body["message"]
+      errors.any? { |msg| msg.to_s.match?(PENDING_REVIEW_ERROR_PATTERN) }
+    end
+
+    # Find the bot's PENDING review on the target PR and DELETE it, then
+    # retry the original POST exactly once. Returns the retried response on
+    # success, or nil if recovery wasn't possible (in which case the caller
+    # keeps the original 422).
+    def recover_from_pending_review(path, authorization_token, forwarded_body, match:)
+      pending_id = find_pending_review_id(match[:owner], match[:repo], match[:number], authorization_token)
+      return nil unless pending_id
+
+      delete_response = github_api_call(:delete,
+        "repos/#{match[:owner]}/#{match[:repo]}/pulls/#{match[:number]}/reviews/#{pending_id}",
+        authorization_token, nil)
+      unless delete_response.status.between?(200, 299)
+        log_error("github_proxy.pending_review_delete_failed",
+          "status=#{delete_response.status} pending_review_id=#{pending_id}")
+        return nil
+      end
+
+      log_info("github_proxy.pending_review_recovered",
+        pending_review_id: pending_id,
+        pr_number: match[:number].to_i)
+
+      proxy_to_github(path, authorization_token, forwarded_body)
+    rescue Faraday::Error => e
+      log_error("github_proxy.pending_review_recovery_failed", e.message)
+      nil
+    end
+
+    def find_pending_review_id(owner, repo, number, authorization_token)
+      list_path = "repos/#{owner}/#{repo}/pulls/#{number}/reviews?per_page=100"
+      response = github_api_call(:get, list_path, authorization_token, nil)
+      return nil unless response.status.between?(200, 299)
+
+      reviews = parse_response_body(response.body)
+      return nil unless reviews.is_a?(Array)
+
+      pending = reviews.find { |r| r.is_a?(Hash) && r["state"].to_s.casecmp("PENDING").zero? }
+      pending&.dig("id")
+    end
+
+    def github_api_call(method, path, authorization_token, body)
+      target_url = "https://api.github.com/#{path}"
+      build_connection.run_request(
+        method, target_url, body,
+        "Authorization" => "Bearer #{authorization_token}",
+        "Accept" => "application/vnd.github+json"
+      )
+    end
+
+    def log_github_error_response(path, response)
+      Rails.logger.warn(
+        message: "github_proxy.upstream_error",
+        agent_run_id: @agent_run&.id,
+        chat_session_id: @chat_session&.id,
+        method: request.method,
+        path: path,
+        status: response.status,
+        body: response.body.to_s.truncate(GITHUB_ERROR_BODY_LOG_LIMIT)
+      )
     end
 
     def warn_if_missing_inline_comments(response_body)

--- a/app/services/automation/strategies/auto_review.rb
+++ b/app/services/automation/strategies/auto_review.rb
@@ -131,7 +131,7 @@ module Automation
         end
 
         if trigger_types.include?(Automation::ReviewMethods::PaidAgent::TRIGGER_TYPE)
-          return paid_agent_pending_decisions(plugins)
+          return paid_agent_pending_decisions(plugins, signals)
         end
 
         if trigger_types.include?(Automation::ReviewMethods::Copilot::TRIGGER_TYPE)
@@ -146,13 +146,33 @@ module Automation
         followup_decisions(signals)
       end
 
-      def paid_agent_pending_decisions(plugins)
+      def paid_agent_pending_decisions(plugins, signals)
         # paid_agent_review_pending is a hard gate: emit only the
         # queue_review_run decision and suppress create_pr follow-up runs
         # while the review is outstanding (#1135).
+        #
+        # Exception: when merge_conflicts is also present and the review
+        # isn't currently running, address the conflict via create_pr first
+        # (#2324). A review of code with conflicts can't produce meaningful
+        # feedback, and suppressing the conflict-fix leaves the PR pinned in
+        # a queue→fail→requeue loop. Active-run state still suppresses to
+        # avoid /workspace collision with the running review.
+        if !review_actively_running?(signals) && merge_conflicts_present?(signals)
+          return followup_decisions(signals)
+        end
+
         paid_plugin = plugins.find { |p| p.name == :paid_agent }
         decision = paid_plugin&.decision
         decision ? [ decision ] : []
+      end
+
+      def review_actively_running?(signals)
+        pending = signals.trigger(Automation::ReviewMethods::PaidAgent::TRIGGER_TYPE)
+        pending && pending[:active_run] == true
+      end
+
+      def merge_conflicts_present?(signals)
+        signals.triggers.any? { |t| t[:type].to_s == "merge_conflicts" }
       end
 
       def review_bot_pending_decisions(plugins, signals, trigger_types)

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -76,6 +76,12 @@ module Activities
       label_action
     ].freeze
 
+    # Triggers that bypass the paid_agent_review_pending hard gate.
+    # merge_conflicts cannot be deferred — a review of code with conflicts
+    # isn't meaningful, and leaving it suppressed lets the PR loop indefinitely
+    # while reviews keep failing on un-mergeable code (#2324).
+    PASS_THROUGH_TRIGGER_TYPES = %w[merge_conflicts].freeze
+
     def execute(input)
       @pr_progress_states = {}
       @live_pr_states = {}
@@ -514,6 +520,15 @@ module Activities
         all_triggers.concat(ci_triggers)
       end
 
+      # Surface merge_conflicts for restarted PRs so the loop can break out of
+      # a stuck review cycle (#2324). True draft PRs are work-in-progress and
+      # may carry temporary conflicts, but a "restarted" PR was previously
+      # ready and now has a real conflict the owner expects automation to fix.
+      if issue.pr_review_phase == "restarted"
+        pr_data ||= fetch_pr_data(client, project, issue)
+        all_triggers.concat(check_merge_conflicts(project, pr_data))
+      end
+
       # Only fetch conversation comments if still no triggers.
       if all_triggers.empty? && !skip_comment_signals
         all_triggers.concat(check_conversation_comments(client, project, issue, last_run))
@@ -571,11 +586,19 @@ module Activities
       # branch (WorktreeConflict). Other triggers (CI, comments, threads)
       # will be re-detected on the next scan after the review posts, when
       # the appropriate follow-up — informed by the new feedback — can run.
+      #
+      # Exception: merge_conflicts always passes through. A review of code
+      # with merge conflicts can't produce meaningful feedback, and
+      # suppressing it lets stuck-review loops keep pinning the PR (#2324).
+      # The decision-level gate in Automation::Strategies::AutoReview routes
+      # to create_pr only when the review isn't actively running, so the
+      # workspace stays single-tenant.
       review_pending = pending_review_trigger(pending_triggers + sidecar_triggers)
+      passthrough = pass_through_triggers(all_triggers)
       triggers =
         if review_pending
-          log_review_pending_gate(project, issue, suppressed: all_triggers)
-          pending_triggers + sidecar_triggers
+          log_review_pending_gate(project, issue, suppressed: all_triggers - passthrough)
+          passthrough + pending_triggers + sidecar_triggers
         else
           all_triggers + pending_triggers + sidecar_triggers
         end
@@ -589,6 +612,10 @@ module Activities
     # same cycle, since both runs would share /workspace.
     def pending_review_trigger(triggers)
       Array(triggers).find { |t| t[:type] == "paid_agent_review_pending" }
+    end
+
+    def pass_through_triggers(triggers)
+      Array(triggers).select { |t| PASS_THROUGH_TRIGGER_TYPES.include?(t[:type].to_s) }
     end
 
     # Emit a structured log when the gate suppresses other actionable
@@ -866,10 +893,14 @@ module Activities
 
       # Hard gate: a pending paid_agent review takes precedence over any
       # other actionable trigger for the PR — see scan_draft_pr for rationale.
+      # merge_conflicts is the documented exception (#2324): code with
+      # conflicts can't be meaningfully reviewed, so we let create_pr
+      # address the conflict first.
       review_pending = pending_review_trigger(triggers)
       if review_pending
-        log_review_pending_gate(project, issue, suppressed: triggers - [ review_pending ])
-        return [ review_pending ]
+        passthrough = pass_through_triggers(triggers)
+        log_review_pending_gate(project, issue, suppressed: triggers - [ review_pending ] - passthrough)
+        return [ review_pending ] + passthrough
       end
 
       triggers

--- a/spec/requests/api/github_proxy_spec.rb
+++ b/spec/requests/api/github_proxy_spec.rb
@@ -646,6 +646,99 @@ RSpec.describe "Api::GithubProxy" do
         expect(JSON.parse(response.body)["error"]).to include("not configured")
       end
 
+      context "when a stale PENDING review blocks the POST with 422 (#2324)" do
+        before do
+          conflict_body = {
+            message: "Unprocessable Entity",
+            errors: [ "User can only have one pending review per pull request" ],
+            status: "422"
+          }.to_json
+          stub_request(:post, target_url)
+            .to_return(
+              { status: 422, body: conflict_body, headers: { "Content-Type" => "application/json" } },
+              { status: 200, body: review_response_body, headers: { "Content-Type" => "application/json" } }
+            )
+          stub_request(:get, "https://api.github.com/repos/testowner/testrepo/pulls/10/reviews?per_page=100")
+            .to_return(
+              status: 200,
+              body: [
+                { id: 4380830777, state: "PENDING", user: { login: "paid-code-reviewer[bot]" } },
+                { id: 4376258909, state: "COMMENTED", user: { login: "paid-code-reviewer[bot]" } }
+              ].to_json,
+              headers: { "Content-Type" => "application/json" }
+            )
+          stub_request(:delete, "https://api.github.com/repos/testowner/testrepo/pulls/10/reviews/4380830777")
+            .to_return(status: 200, body: { id: 4380830777 }.to_json, headers: { "Content-Type" => "application/json" })
+          allow(Rails.logger).to receive(:info)
+        end
+
+        it "deletes the stale pending review and retries the POST once" do
+          post "/api/proxy/github/repos/testowner/testrepo/pulls/10/reviews",
+            params: { body: "Looks good", event: "COMMENT" }.to_json,
+            headers: valid_headers
+
+          expect(WebMock).to have_requested(:delete, "https://api.github.com/repos/testowner/testrepo/pulls/10/reviews/4380830777").once
+          expect(WebMock).to have_requested(:post, target_url).twice
+          expect(response).to have_http_status(:ok)
+          expect(Rails.logger).to have_received(:info).with(
+            hash_including(message: "github_proxy.pending_review_recovered",
+                           pending_review_id: 4380830777,
+                           pr_number: 10)
+          )
+          agent_run.reload
+          expect(agent_run.review_posted_at).to be_present
+        end
+
+        it "leaves the original 422 in place when no PENDING review is present" do
+          stub_request(:get, "https://api.github.com/repos/testowner/testrepo/pulls/10/reviews?per_page=100")
+            .to_return(
+              status: 200,
+              body: [ { id: 1, state: "COMMENTED", user: { login: "paid-code-reviewer[bot]" } } ].to_json,
+              headers: { "Content-Type" => "application/json" }
+            )
+
+          post "/api/proxy/github/repos/testowner/testrepo/pulls/10/reviews",
+            params: { body: "Looks good", event: "COMMENT" }.to_json,
+            headers: valid_headers
+
+          expect(WebMock).not_to have_requested(:delete, "https://api.github.com/repos/testowner/testrepo/pulls/10/reviews/4380830777")
+          expect(WebMock).to have_requested(:post, target_url).once
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+
+        it "leaves the original 422 in place when the DELETE fails" do
+          stub_request(:delete, "https://api.github.com/repos/testowner/testrepo/pulls/10/reviews/4380830777")
+            .to_return(status: 500, body: {}.to_json, headers: { "Content-Type" => "application/json" })
+
+          post "/api/proxy/github/repos/testowner/testrepo/pulls/10/reviews",
+            params: { body: "Looks good", event: "COMMENT" }.to_json,
+            headers: valid_headers
+
+          expect(WebMock).to have_requested(:post, target_url).once
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+      end
+
+      it "logs the upstream response body when GitHub rejects the review POST" do
+        validation_body = { message: "Validation Failed",
+                            errors: [ { resource: "PullRequestReviewComment", code: "missing_field", field: "path" } ] }.to_json
+        stub_request(:post, target_url)
+          .to_return(status: 422, body: validation_body, headers: { "Content-Type" => "application/json" })
+        allow(Rails.logger).to receive(:warn)
+
+        post "/api/proxy/github/repos/testowner/testrepo/pulls/10/reviews",
+          params: { body: "Looks good", event: "COMMENT" }.to_json,
+          headers: valid_headers
+
+        expect(Rails.logger).to have_received(:warn).with(
+          hash_including(
+            message: "github_proxy.upstream_error",
+            status: 422,
+            agent_run_id: agent_run.id
+          )
+        )
+      end
+
       it "logs a warning when a non-clean review body is posted without inline comments" do
         allow(Rails.logger).to receive(:warn)
 

--- a/spec/services/automation/strategies/auto_review_spec.rb
+++ b/spec/services/automation/strategies/auto_review_spec.rb
@@ -81,6 +81,24 @@ RSpec.describe Automation::Strategies::AutoReview do
       expect(types).not_to include("record_pr_followup")
     end
 
+    it "routes to create_pr when paid_agent review is pending but not running and merge_conflicts is present (#2324)" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "ready",
+        current_followup_count: 0,
+        labels_to_remove: [],
+        triggers: [
+          { type: "paid_agent_review_pending" },
+          { type: "merge_conflicts", details: "PR has merge conflicts" }
+        ]
+      })
+
+      types = result.to_h[:decisions].map { |d| d[:type] }
+      expect(types).to include("queue_create_pr_run")
+      expect(types).not_to include("queue_review_run")
+    end
+
     it "routes review_bot_review_pending to a request_review decision for the trigger login" do
       result = evaluate(scan: {
         issue_id: pull_request.id,

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -2470,6 +2470,22 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         expect(trigger_types).to eq([ "paid_agent_review_pending" ])
       end
 
+      it "lets merge_conflicts pass through the gate alongside paid_agent_review_pending (#2324)" do
+        project.update!(auto_fix_merge_conflicts: true)
+        stub_github_for_pr(
+          checks: [ { name: "rspec", conclusion: "success" } ],
+          reviews: [],
+          mergeable: false
+        )
+
+        result = activity.execute(project_id: project.id)
+
+        expect(automation_scan_results(result).size).to eq(1)
+        trigger_types = automation_scan_results(result).first[:triggers].map { |t| t[:type] }
+        expect(trigger_types).to include("paid_agent_review_pending")
+        expect(trigger_types).to include("merge_conflicts")
+      end
+
       it "does not gate when there is no paid_agent review pending (review already complete)" do
         # A subsequent completed review with no new code changes clears the
         # pending trigger, so ci_failure should pass through unimpeded.


### PR DESCRIPTION
## Summary

PR 2324 (`feat(interop): Phase 7.2`) was stuck in a review-goal loop for hours: 30+ review runs failed back-to-back with "No review was posted on PR #2324", while the agent kept consuming 3–10M input tokens per attempt. This PR fixes two distinct root causes uncovered while debugging it.

### 1. Stuck-review loop in the scan/decision gate

`paid_agent_review_pending` was a hard gate: when present, `scan_paid_prs_activity` suppressed every other trigger (CI failures, merge conflicts, comments) and `Automation::Strategies::AutoReview#paid_agent_pending_decisions` emitted only `queue_review_run`. With `paid_agent` as the sole reviewer on a PR with merge conflicts, no `create_pr` run could ever be queued to fix the conflict — review queued → failed → escalated → user-restarted → review queued again.

- `scan_paid_prs_activity.rb`: `merge_conflicts` now bypasses the gate in both `scan_draft_pr` (around the `pending_review_trigger` check) and `detect_ready_triggers`. `scan_draft_pr` also surfaces `merge_conflicts` for `restarted`-phase PRs; true draft PRs (WIP) are untouched.
- `auto_review.rb`: `paid_agent_pending_decisions` routes to `followup_decisions` when `paid_agent_review_pending` is pending-but-not-running and `merge_conflicts` is in the trigger set. **Active-run state still suppresses** to preserve /workspace single-tenancy.

### 2. Stale PENDING review wedging every POST with 422

Every review POST returned `422 {"errors":["User can only have one pending review per pull request"]}` — an earlier interrupted run left a PENDING review by `paid-code-reviewer[bot]` on the PR. The proxy passed the 422 through without logging the body, so operators saw only the generic "No review was posted" error on the agent run.

- `github_proxy_controller.rb`:
  - Log GitHub 4xx/5xx response bodies on review POSTs as `github_proxy.upstream_error` (truncated to 2KB) so the next failure mode surfaces in logs immediately.
  - Auto-recover from the specific "one pending review" 422: list the bot's pending reviews using the same App token, DELETE the stale one, retry the original POST once. If listing or deletion fails, the original 422 is preserved so the agent sees the same error.

## Why two changes in one PR

Both surfaced from the same debugging session on PR 2324 and each individually was insufficient. The gate fix unblocks the loop pattern for future PRs that hit blocking signals while reviews are pending; the proxy fix prevents this specific class of stale-state wedge from going invisible and self-heals it.

## Operational state of PR 2324

- Stuck review run 21245 was cancelled (released /workspace).
- Stale PENDING review (id 4380830777) was deleted via the App token.
- Reviews were temporarily disabled on the project to unwedge orchestration; a `create_pr` run (21248) is now running with focus=`review_feedback`.
- **Action item after merge**: re-enable `project.review_settings["enabled"] = true` on project 19.

## Test plan

- [x] `bundle exec rspec spec/services/automation/strategies/auto_review_spec.rb` — 22 examples pass (includes new `#2324` regression spec)
- [x] `bundle exec rspec spec/temporal/activities/scan_paid_prs_activity_spec.rb` — 367 examples pass (includes new `#2324` gate pass-through spec)
- [x] `bundle exec rspec spec/requests/api/github_proxy_spec.rb spec/controllers/api/github_proxy_controller_spec.rb` — 61 examples pass (includes 3 new pending-review recovery specs + new logging spec)
- [x] `bundle exec rubocop` on all touched files — clean
- [ ] Verify on a fresh review run after merge that pending-review recovery fires + the gate doesn't suppress merge_conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)