### PR TITLE
feat(platform): Phase 8.1 — Managed Deployment Models

### DIFF
--- a/app/controllers/accounts/compliance_dashboards_controller.rb
+++ b/app/controllers/accounts/compliance_dashboards_controller.rb
@@ -65,9 +65,15 @@ module Accounts
     def deployment_assurance_params
       params.fetch(:deployment_assurance, ActionController::Parameters.new).permit(
         :deployment_model,
+        :tenant_isolation,
         :network_boundary,
         :reference_architecture,
         :operations_owner,
+        monitoring: %i[
+          provider
+          escalation_owner
+          last_reviewed_at
+        ],
         customer_managed_keys: %i[
           enabled
           provider
@@ -86,9 +92,21 @@ module Accounts
           backup_last_verified_at
           restore_last_tested_at
           upgrade_last_validated_at
-          air_gap_package_validated_at
+          reference_stack_last_validated_at
           rpo_hours
           rto_hours
+        ],
+        release_management: %i[
+          upgrade_channel
+          maintenance_window
+          maintenance_timezone
+          version_support_policy
+          support_window_days
+        ],
+        byoc: %i[
+          cloud_provider
+          automation_stack
+          reference_stack
         ]
       ).to_h
     end

--- a/app/models/tenant_setting.rb
+++ b/app/models/tenant_setting.rb
@@ -78,9 +78,18 @@ class TenantSetting < ApplicationRecord
     }
   }.freeze
   DEPLOYMENT_ASSURANCE_MODELS = %w[managed_cloud private_saas byoc].freeze
-  DEPLOYMENT_ASSURANCE_TENANT_ISOLATION = %w[multi_tenant_rls single_tenant customer_cloud].freeze
+  LEGACY_DEPLOYMENT_ASSURANCE_MODELS = %w[self_hosted private_vpc air_gapped].freeze
+  VALID_DEPLOYMENT_ASSURANCE_MODELS =
+    (DEPLOYMENT_ASSURANCE_MODELS + LEGACY_DEPLOYMENT_ASSURANCE_MODELS).freeze
   DEPLOYMENT_ASSURANCE_NETWORK_BOUNDARIES = %w[paid_managed private_connect customer_vpc].freeze
+  LEGACY_DEPLOYMENT_ASSURANCE_NETWORK_BOUNDARIES = %w[private_vpc public_ingress offline].freeze
+  VALID_DEPLOYMENT_ASSURANCE_NETWORK_BOUNDARIES =
+    (DEPLOYMENT_ASSURANCE_NETWORK_BOUNDARIES + LEGACY_DEPLOYMENT_ASSURANCE_NETWORK_BOUNDARIES).freeze
   DEPLOYMENT_ASSURANCE_REFERENCE_ARCHITECTURES = %w[managed_control_plane dedicated_hosted_stack customer_cloud_stack].freeze
+  LEGACY_DEPLOYMENT_ASSURANCE_REFERENCE_ARCHITECTURES = %w[single_tenant private_services offline_promotion].freeze
+  VALID_DEPLOYMENT_ASSURANCE_REFERENCE_ARCHITECTURES =
+    (DEPLOYMENT_ASSURANCE_REFERENCE_ARCHITECTURES + LEGACY_DEPLOYMENT_ASSURANCE_REFERENCE_ARCHITECTURES).freeze
+  DEPLOYMENT_ASSURANCE_TENANT_ISOLATION = %w[multi_tenant_rls single_tenant customer_cloud].freeze
   DEPLOYMENT_ASSURANCE_BACKUP_CADENCES = %w[hourly daily weekly].freeze
   DEPLOYMENT_ASSURANCE_UPGRADE_CHANNELS = %w[stable extended_support preview].freeze
   DEPLOYMENT_ASSURANCE_VERSION_SUPPORT_POLICIES = %w[latest n_minus_one lts].freeze
@@ -369,13 +378,13 @@ class TenantSetting < ApplicationRecord
   def validate_deployment_assurance
     return unless features.is_a?(Hash)
 
-    assurance = features.fetch("deployment_assurance", nil)
+    assurance = deployment_assurance_configuration
     return unless assurance.is_a?(Hash)
 
     validate_deployment_assurance_option(
       assurance["deployment_model"],
       path: "deployment_model",
-      allowed_values: DEPLOYMENT_ASSURANCE_MODELS
+      allowed_values: VALID_DEPLOYMENT_ASSURANCE_MODELS
     )
     validate_deployment_assurance_option(
       assurance["tenant_isolation"],
@@ -385,12 +394,12 @@ class TenantSetting < ApplicationRecord
     validate_deployment_assurance_option(
       assurance["network_boundary"],
       path: "network_boundary",
-      allowed_values: DEPLOYMENT_ASSURANCE_NETWORK_BOUNDARIES
+      allowed_values: VALID_DEPLOYMENT_ASSURANCE_NETWORK_BOUNDARIES
     )
     validate_deployment_assurance_option(
       assurance["reference_architecture"],
       path: "reference_architecture",
-      allowed_values: DEPLOYMENT_ASSURANCE_REFERENCE_ARCHITECTURES
+      allowed_values: VALID_DEPLOYMENT_ASSURANCE_REFERENCE_ARCHITECTURES
     )
     validate_deployment_assurance_option(
       assurance.dig("disaster_recovery", "backup_cadence"),

--- a/app/models/tenant_setting.rb
+++ b/app/models/tenant_setting.rb
@@ -32,10 +32,16 @@ class TenantSetting < ApplicationRecord
     "auto_continue" => true
   }.freeze
   DEFAULT_DEPLOYMENT_ASSURANCE = {
-    "deployment_model" => "self_hosted",
-    "network_boundary" => "private_vpc",
-    "reference_architecture" => "single_tenant",
+    "deployment_model" => "managed_cloud",
+    "tenant_isolation" => "multi_tenant_rls",
+    "network_boundary" => "paid_managed",
+    "reference_architecture" => "managed_control_plane",
     "operations_owner" => "",
+    "monitoring" => {
+      "provider" => "",
+      "escalation_owner" => "",
+      "last_reviewed_at" => ""
+    },
     "customer_managed_keys" => {
       "enabled" => false,
       "provider" => "",
@@ -54,15 +60,30 @@ class TenantSetting < ApplicationRecord
       "backup_last_verified_at" => "",
       "restore_last_tested_at" => "",
       "upgrade_last_validated_at" => "",
-      "air_gap_package_validated_at" => "",
+      "reference_stack_last_validated_at" => "",
       "rpo_hours" => 24,
       "rto_hours" => 8
+    },
+    "release_management" => {
+      "upgrade_channel" => "stable",
+      "maintenance_window" => "",
+      "maintenance_timezone" => "UTC",
+      "version_support_policy" => "n_minus_one",
+      "support_window_days" => 30
+    },
+    "byoc" => {
+      "cloud_provider" => "",
+      "automation_stack" => "",
+      "reference_stack" => ""
     }
   }.freeze
-  DEPLOYMENT_ASSURANCE_MODELS = %w[self_hosted private_vpc air_gapped].freeze
-  DEPLOYMENT_ASSURANCE_NETWORK_BOUNDARIES = %w[private_vpc public_ingress offline].freeze
-  DEPLOYMENT_ASSURANCE_REFERENCE_ARCHITECTURES = %w[single_tenant private_services offline_promotion].freeze
+  DEPLOYMENT_ASSURANCE_MODELS = %w[managed_cloud private_saas byoc].freeze
+  DEPLOYMENT_ASSURANCE_TENANT_ISOLATION = %w[multi_tenant_rls single_tenant customer_cloud].freeze
+  DEPLOYMENT_ASSURANCE_NETWORK_BOUNDARIES = %w[paid_managed private_connect customer_vpc].freeze
+  DEPLOYMENT_ASSURANCE_REFERENCE_ARCHITECTURES = %w[managed_control_plane dedicated_hosted_stack customer_cloud_stack].freeze
   DEPLOYMENT_ASSURANCE_BACKUP_CADENCES = %w[hourly daily weekly].freeze
+  DEPLOYMENT_ASSURANCE_UPGRADE_CHANNELS = %w[stable extended_support preview].freeze
+  DEPLOYMENT_ASSURANCE_VERSION_SUPPORT_POLICIES = %w[latest n_minus_one lts].freeze
   DEFAULT_WORKER_SETTINGS = {
     "temporal_workflow_slots" => 20,
     "temporal_activity_slots" => 4,
@@ -357,6 +378,11 @@ class TenantSetting < ApplicationRecord
       allowed_values: DEPLOYMENT_ASSURANCE_MODELS
     )
     validate_deployment_assurance_option(
+      assurance["tenant_isolation"],
+      path: "tenant_isolation",
+      allowed_values: DEPLOYMENT_ASSURANCE_TENANT_ISOLATION
+    )
+    validate_deployment_assurance_option(
       assurance["network_boundary"],
       path: "network_boundary",
       allowed_values: DEPLOYMENT_ASSURANCE_NETWORK_BOUNDARIES
@@ -370,6 +396,16 @@ class TenantSetting < ApplicationRecord
       assurance.dig("disaster_recovery", "backup_cadence"),
       path: "disaster_recovery.backup_cadence",
       allowed_values: DEPLOYMENT_ASSURANCE_BACKUP_CADENCES
+    )
+    validate_deployment_assurance_option(
+      assurance.dig("release_management", "upgrade_channel"),
+      path: "release_management.upgrade_channel",
+      allowed_values: DEPLOYMENT_ASSURANCE_UPGRADE_CHANNELS
+    )
+    validate_deployment_assurance_option(
+      assurance.dig("release_management", "version_support_policy"),
+      path: "release_management.version_support_policy",
+      allowed_values: DEPLOYMENT_ASSURANCE_VERSION_SUPPORT_POLICIES
     )
     validate_deployment_assurance_integer(
       assurance.dig("customer_managed_keys", "rotation_interval_days"),
@@ -386,6 +422,10 @@ class TenantSetting < ApplicationRecord
     validate_deployment_assurance_integer(
       assurance.dig("disaster_recovery", "rto_hours"),
       path: "disaster_recovery.rto_hours"
+    )
+    validate_deployment_assurance_integer(
+      assurance.dig("release_management", "support_window_days"),
+      path: "release_management.support_window_days"
     )
   end
 
@@ -475,6 +515,11 @@ class TenantSetting < ApplicationRecord
       %w[rpo_hours rto_hours].each do |key|
         normalized["disaster_recovery"][key] =
           normalize_integer_value(normalized.dig("disaster_recovery", key))
+      end
+
+      %w[support_window_days].each do |key|
+        normalized["release_management"][key] =
+          normalize_integer_value(normalized.dig("release_management", key))
       end
     end
   end

--- a/app/services/accounts/compliance/dashboard.rb
+++ b/app/services/accounts/compliance/dashboard.rb
@@ -368,6 +368,10 @@ module Accounts
       end
 
       def byoc_reference_stack_control
+        if deployment_assurance["deployment_model"] == "air_gapped"
+          return air_gapped_reference_stack_control
+        end
+
         unless deployment_assurance["deployment_model"] == "byoc"
           return control(
             :byoc_reference_stack,
@@ -396,6 +400,29 @@ module Accounts
             "Cloud provider: #{byoc['cloud_provider'].presence || 'Not recorded'}",
             "Automation stack: #{byoc['automation_stack'].presence || 'Not recorded'}",
             "Reference stack: #{byoc['reference_stack'].presence || 'Not recorded'}",
+            "Last validated: #{display_date(recovery['reference_stack_last_validated_at'])}"
+          ]
+        )
+      end
+
+      def air_gapped_reference_stack_control
+        recovery = deployment_assurance["disaster_recovery"]
+        status =
+          if fresh_within?(recovery["reference_stack_last_validated_at"], days: 90)
+            :compliant
+          elsif parse_date(recovery["reference_stack_last_validated_at"])
+            :warning
+          else
+            :gap
+          end
+
+        control(
+          :byoc_reference_stack,
+          status: status,
+          evidence: [
+            "Legacy air-gapped deployment retained until migration completes",
+            "Reference architecture: #{deployment_assurance['reference_architecture'].humanize}",
+            "Network boundary: #{deployment_assurance['network_boundary'].humanize}",
             "Last validated: #{display_date(recovery['reference_stack_last_validated_at'])}"
           ]
         )

--- a/app/services/accounts/compliance/dashboard.rb
+++ b/app/services/accounts/compliance/dashboard.rb
@@ -5,22 +5,22 @@ module Accounts
     class Dashboard
       REFERENCE_ARCHITECTURES = [
         {
-          key: "self_hosted",
-          name: "Self-hosted",
-          summary: "Single-tenant deployment with isolated Rails, PostgreSQL, Redis, and object storage.",
-          doc_path: "docs/compliance/reference-architectures.md#self-hosted-reference-architecture"
+          key: "managed_cloud",
+          name: "Managed cloud",
+          summary: "Paid-operated multi-tenant control plane with tenant isolation, backups, monitoring, and managed upgrades.",
+          doc_path: "docs/compliance/reference-architectures.md#managed-cloud-reference-architecture"
         },
         {
-          key: "private_vpc",
-          name: "Private VPC",
-          summary: "Private-network deployment with controlled ingress, egress, and managed persistence services.",
-          doc_path: "docs/compliance/reference-architectures.md#private-vpc-reference-architecture"
+          key: "private_saas",
+          name: "Private SaaS",
+          summary: "Single-tenant hosted stack for enterprise buyers that need dedicated infrastructure with Paid-operated updates.",
+          doc_path: "docs/compliance/reference-architectures.md#private-saas-reference-architecture"
         },
         {
-          key: "air_gapped",
-          name: "Air-gapped",
-          summary: "Offline package promotion model for environments that prohibit direct internet connectivity.",
-          doc_path: "docs/compliance/reference-architectures.md#air-gapped-reference-architecture"
+          key: "byoc",
+          name: "Bring your own cloud",
+          summary: "Customer-cloud deployment automation with validated reference stacks and customer-owned network boundaries.",
+          doc_path: "docs/compliance/reference-architectures.md#bring-your-own-cloud-reference-architecture"
         }
       ].freeze
 
@@ -33,8 +33,8 @@ module Accounts
         },
         {
           key: "upgrade_validation",
-          name: "Upgrade Validation",
-          summary: "Pre-upgrade checks, rollback planning, and post-upgrade verification.",
+          name: "Upgrade and Support Policy",
+          summary: "Upgrade channels, maintenance windows, rollback planning, and version-support expectations.",
           doc_path: "docs/compliance/operational-assurance-runbooks.md#upgrade-validation"
         },
         {
@@ -42,15 +42,21 @@ module Accounts
           name: "Secret Rotation",
           summary: "Customer-managed key rotation and provider credential renewal workflow.",
           doc_path: "docs/compliance/operational-assurance-runbooks.md#secret-rotation"
+        },
+        {
+          key: "byoc_reference_stack",
+          name: "BYOC Reference Stack Validation",
+          summary: "Reference-stack automation, cloud-provider ownership, and validation evidence for customer-cloud deployments.",
+          doc_path: "docs/compliance/operational-assurance-runbooks.md#byoc-reference-stack-validation"
         }
       ].freeze
 
       CONTROL_MAPPINGS = {
         deployment_topology: {
-          title: "Deployment topology documented",
-          requirement: "Reference architecture, network boundary, and operator ownership are recorded.",
+          title: "Deployment operating model documented",
+          requirement: "Deployment model, tenant isolation, reference architecture, and operator ownership are recorded.",
           mappings: [ "SOC 2 CC1.2", "SOC 2 CC6.6", "ISO 27001 A.5.8" ],
-          guidance: "Capture the deployment model and operations owner used for this tenant."
+          guidance: "Capture the operating model and the owner accountable for this tenant's production posture."
         },
         configuration_snapshot: {
           title: "Configuration snapshot exportable",
@@ -63,6 +69,12 @@ module Accounts
           requirement: "Administrative actions are recorded and can be exported for review.",
           mappings: [ "SOC 2 CC7.2", "ISO 27001 A.8.15" ],
           guidance: "Generate an evidence pack after lifecycle, membership, or tenant configuration changes."
+        },
+        monitoring_coverage: {
+          title: "Monitoring ownership documented",
+          requirement: "The deployment lists the monitoring provider, escalation owner, and recent review evidence.",
+          mappings: [ "SOC 2 CC7.1", "ISO 27001 A.8.16" ],
+          guidance: "Record who receives production alerts and when the monitoring configuration was last reviewed."
         },
         customer_managed_keys: {
           title: "Customer-managed key posture",
@@ -89,16 +101,16 @@ module Accounts
           guidance: "Run and record a restore exercise at least once per quarter."
         },
         upgrade_validation: {
-          title: "Upgrade validation",
-          requirement: "Upgrades are rehearsed with rollback planning before production rollout.",
+          title: "Upgrade and support policy",
+          requirement: "Every deployment model declares an upgrade channel, maintenance window, and supported version policy.",
           mappings: [ "SOC 2 CC8.1", "ISO 27001 A.8.32" ],
-          guidance: "Record the most recent validated upgrade rehearsal and expected rollback window."
+          guidance: "Record the supported release channel, maintenance window, and the most recent validated upgrade rehearsal."
         },
-        air_gap_validation: {
-          title: "Air-gap package validation",
-          requirement: "Offline deployment packages are validated when the tenant uses an air-gapped model.",
-          mappings: [ "SOC 2 CC6.7", "ISO 27001 A.5.14" ],
-          guidance: "Re-validate offline artifacts whenever the deployment package or dependencies change."
+        byoc_reference_stack: {
+          title: "BYOC reference stack validated",
+          requirement: "Customer-cloud deployments identify their cloud provider, automation stack, and recent validation evidence.",
+          mappings: [ "SOC 2 CC6.6", "ISO 27001 A.5.23" ],
+          guidance: "Re-validate the approved reference stack whenever the automation or managed dependencies change."
         }
       }.freeze
 
@@ -117,12 +129,13 @@ module Accounts
           deployment_topology_control,
           configuration_snapshot_control,
           audit_export_control,
+          monitoring_coverage_control,
           customer_managed_keys_control,
           secret_rotation_control,
           backup_verification_control,
           restore_validation_control,
           upgrade_validation_control,
-          air_gap_validation_control
+          byoc_reference_stack_control
         ]
 
         applicable_controls = controls.reject { |control| control[:status] == :not_applicable }
@@ -172,9 +185,34 @@ module Accounts
           status: status,
           evidence: [
             "Deployment model: #{deployment_assurance['deployment_model'].humanize}",
+            "Tenant isolation: #{deployment_assurance['tenant_isolation'].humanize}",
             "Network boundary: #{deployment_assurance['network_boundary'].humanize}",
             "Reference architecture: #{deployment_assurance['reference_architecture'].humanize}",
             owner.presence ? "Operations owner: #{owner}" : "Operations owner missing"
+          ]
+        )
+      end
+
+      def monitoring_coverage_control
+        monitoring = deployment_assurance["monitoring"]
+        status =
+          if monitoring["provider"].present? && monitoring["escalation_owner"].present?
+            if fresh_within?(monitoring["last_reviewed_at"], days: 90)
+              :compliant
+            else
+              :warning
+            end
+          else
+            :gap
+          end
+
+        control(
+          :monitoring_coverage,
+          status: status,
+          evidence: [
+            "Monitoring provider: #{monitoring['provider'].presence || 'Not recorded'}",
+            "Escalation owner: #{monitoring['escalation_owner'].presence || 'Not recorded'}",
+            "Last reviewed: #{display_date(monitoring['last_reviewed_at'])}"
           ]
         )
       end
@@ -304,10 +342,11 @@ module Accounts
 
       def upgrade_validation_control
         recovery = deployment_assurance["disaster_recovery"]
+        release_management = deployment_assurance["release_management"]
         status =
-          if fresh_within?(recovery["upgrade_last_validated_at"], days: 90)
+          if release_management["maintenance_window"].present? && fresh_within?(recovery["upgrade_last_validated_at"], days: 90)
             :compliant
-          elsif parse_date(recovery["upgrade_last_validated_at"])
+          elsif release_management["maintenance_window"].present? || parse_date(recovery["upgrade_last_validated_at"])
             :warning
           else
             :gap
@@ -317,36 +356,47 @@ module Accounts
           :upgrade_validation,
           status: status,
           evidence: [
+            "Upgrade channel: #{release_management['upgrade_channel'].humanize}",
+            "Maintenance window: #{release_management['maintenance_window'].presence || 'Not recorded'}",
+            "Maintenance timezone: #{release_management['maintenance_timezone'].presence || 'Not recorded'}",
+            "Support policy: #{release_management['version_support_policy'].humanize}",
+            "Support window: #{release_management['support_window_days']} days",
             "Last validated upgrade: #{display_date(recovery['upgrade_last_validated_at'])}",
             "Rollback planning documented in runbook"
           ]
         )
       end
 
-      def air_gap_validation_control
-        unless deployment_assurance["deployment_model"] == "air_gapped"
+      def byoc_reference_stack_control
+        unless deployment_assurance["deployment_model"] == "byoc"
           return control(
-            :air_gap_validation,
+            :byoc_reference_stack,
             status: :not_applicable,
-            evidence: [ "Tenant is not using an air-gapped deployment model" ]
+            evidence: [ "Tenant is not using a bring-your-own-cloud deployment model" ]
           )
         end
 
+        byoc = deployment_assurance["byoc"]
         recovery = deployment_assurance["disaster_recovery"]
         status =
-          if fresh_within?(recovery["air_gap_package_validated_at"], days: 90)
-            :compliant
-          elsif parse_date(recovery["air_gap_package_validated_at"])
-            :warning
+          if byoc["cloud_provider"].present? && byoc["automation_stack"].present? && byoc["reference_stack"].present?
+            if fresh_within?(recovery["reference_stack_last_validated_at"], days: 90)
+              :compliant
+            else
+              :warning
+            end
           else
             :gap
           end
 
         control(
-          :air_gap_validation,
+          :byoc_reference_stack,
           status: status,
           evidence: [
-            "Offline package validated: #{display_date(recovery['air_gap_package_validated_at'])}"
+            "Cloud provider: #{byoc['cloud_provider'].presence || 'Not recorded'}",
+            "Automation stack: #{byoc['automation_stack'].presence || 'Not recorded'}",
+            "Reference stack: #{byoc['reference_stack'].presence || 'Not recorded'}",
+            "Last validated: #{display_date(recovery['reference_stack_last_validated_at'])}"
           ]
         )
       end

--- a/app/services/accounts/compliance/evidence_pack.rb
+++ b/app/services/accounts/compliance/evidence_pack.rb
@@ -15,7 +15,7 @@ module Accounts
 
       def call
         {
-          schema_version: "2026-05-24",
+          schema_version: "2026-05-29",
           generated_at: Time.current.iso8601,
           account: {
             id: account.id,

--- a/app/views/accounts/compliance_dashboards/show.html.erb
+++ b/app/views/accounts/compliance_dashboards/show.html.erb
@@ -2,9 +2,12 @@
 
 <% can_manage_compliance = policy(current_account).update? %>
 <% deployment_assurance = @compliance_dashboard[:deployment_assurance] %>
+<% monitoring = deployment_assurance["monitoring"] %>
 <% customer_managed_keys = deployment_assurance["customer_managed_keys"] %>
 <% secret_rotation = deployment_assurance["secret_rotation"] %>
 <% disaster_recovery = deployment_assurance["disaster_recovery"] %>
+<% release_management = deployment_assurance["release_management"] %>
+<% byoc = deployment_assurance["byoc"] %>
 
 <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
@@ -12,7 +15,7 @@
       <p class="text-sm font-medium uppercase tracking-[0.2em] text-amber-700 dark:text-amber-300">Compliance</p>
       <h1 class="mt-2 text-3xl font-semibold text-gray-900 dark:text-white">Deployment Assurance</h1>
       <p class="mt-2 max-w-3xl text-sm text-gray-600 dark:text-gray-300">
-        Capture deployment posture, customer-managed key status, rotation evidence, and operational runbook validation in one place.
+        Capture deployment model choices, operating ownership, and upgrade policy evidence in one place for buyer and security review.
       </p>
     </div>
 
@@ -106,19 +109,45 @@
           <section class="grid gap-4 md:grid-cols-2">
             <div>
               <%= label_tag "deployment_assurance_deployment_model", "Deployment model", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
-              <%= select_tag "deployment_assurance[deployment_model]", options_for_select([["Self hosted", "self_hosted"], ["Private VPC", "private_vpc"], ["Air gapped", "air_gapped"]], deployment_assurance["deployment_model"]), id: "deployment_assurance_deployment_model", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              <%= select_tag "deployment_assurance[deployment_model]", options_for_select([["Managed cloud", "managed_cloud"], ["Private SaaS", "private_saas"], ["Bring your own cloud", "byoc"]], deployment_assurance["deployment_model"]), id: "deployment_assurance_deployment_model", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+            </div>
+            <div>
+              <%= label_tag "deployment_assurance_tenant_isolation", "Tenant isolation", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+              <%= select_tag "deployment_assurance[tenant_isolation]", options_for_select([["Multi-tenant RLS", "multi_tenant_rls"], ["Single tenant", "single_tenant"], ["Customer cloud", "customer_cloud"]], deployment_assurance["tenant_isolation"]), id: "deployment_assurance_tenant_isolation", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
             </div>
             <div>
               <%= label_tag "deployment_assurance_network_boundary", "Network boundary", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
-              <%= select_tag "deployment_assurance[network_boundary]", options_for_select([["Private VPC", "private_vpc"], ["Controlled public ingress", "public_ingress"], ["Offline", "offline"]], deployment_assurance["network_boundary"]), id: "deployment_assurance_network_boundary", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              <%= select_tag "deployment_assurance[network_boundary]", options_for_select([["Paid-managed", "paid_managed"], ["Private connect", "private_connect"], ["Customer VPC", "customer_vpc"]], deployment_assurance["network_boundary"]), id: "deployment_assurance_network_boundary", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
             </div>
             <div>
               <%= label_tag "deployment_assurance_reference_architecture", "Reference architecture", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
-              <%= select_tag "deployment_assurance[reference_architecture]", options_for_select([["Single tenant", "single_tenant"], ["Private services", "private_services"], ["Offline promotion", "offline_promotion"]], deployment_assurance["reference_architecture"]), id: "deployment_assurance_reference_architecture", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              <%= select_tag "deployment_assurance[reference_architecture]", options_for_select([["Managed control plane", "managed_control_plane"], ["Dedicated hosted stack", "dedicated_hosted_stack"], ["Customer cloud stack", "customer_cloud_stack"]], deployment_assurance["reference_architecture"]), id: "deployment_assurance_reference_architecture", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
             </div>
             <div>
               <%= label_tag "deployment_assurance_operations_owner", "Operations owner", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
               <%= text_field_tag "deployment_assurance[operations_owner]", deployment_assurance["operations_owner"], id: "deployment_assurance_operations_owner", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white", placeholder: "platform-team@example.com" %>
+            </div>
+          </section>
+
+          <section class="rounded-2xl border border-gray-200 p-4 dark:border-gray-700">
+            <div>
+              <h3 class="text-lg font-semibold text-gray-900 dark:text-white">Monitoring coverage</h3>
+              <p class="text-sm text-gray-600 dark:text-gray-300">Record the monitoring provider, escalation owner, and last review used for this deployment model.</p>
+            </div>
+
+            <div class="mt-4 grid gap-4 md:grid-cols-3">
+              <div>
+                <%= label_tag "deployment_assurance_monitoring_provider", "Monitoring provider", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= text_field_tag "deployment_assurance[monitoring][provider]", monitoring["provider"], id: "deployment_assurance_monitoring_provider", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white", placeholder: "Datadog" %>
+              </div>
+              <div>
+                <%= label_tag "deployment_assurance_monitoring_escalation_owner", "Escalation owner", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= text_field_tag "deployment_assurance[monitoring][escalation_owner]", monitoring["escalation_owner"], id: "deployment_assurance_monitoring_escalation_owner", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white", placeholder: "sre@example.com" %>
+              </div>
+              <div>
+                <%= label_tag "deployment_assurance_monitoring_last_reviewed_at", "Last reviewed", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= date_field_tag "deployment_assurance[monitoring][last_reviewed_at]", monitoring["last_reviewed_at"], id: "deployment_assurance_monitoring_last_reviewed_at", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
             </div>
           </section>
 
@@ -186,8 +215,8 @@
 
           <section class="rounded-2xl border border-gray-200 p-4 dark:border-gray-700">
             <div>
-              <h3 class="text-lg font-semibold text-gray-900 dark:text-white">Disaster recovery and upgrades</h3>
-              <p class="text-sm text-gray-600 dark:text-gray-300">Record the most recent backup verification, restore rehearsal, upgrade validation, and offline package test.</p>
+              <h3 class="text-lg font-semibold text-gray-900 dark:text-white">Disaster recovery</h3>
+              <p class="text-sm text-gray-600 dark:text-gray-300">Record the most recent backup verification, restore rehearsal, upgrade validation, and reference-stack validation evidence.</p>
             </div>
 
             <div class="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
@@ -216,8 +245,60 @@
                 <%= date_field_tag "deployment_assurance[disaster_recovery][upgrade_last_validated_at]", disaster_recovery["upgrade_last_validated_at"], id: "deployment_assurance_disaster_recovery_upgrade_last_validated_at", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
               </div>
               <div>
-                <%= label_tag "deployment_assurance_disaster_recovery_air_gap_package_validated_at", "Air-gap package validated", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
-                <%= date_field_tag "deployment_assurance[disaster_recovery][air_gap_package_validated_at]", disaster_recovery["air_gap_package_validated_at"], id: "deployment_assurance_disaster_recovery_air_gap_package_validated_at", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+                <%= label_tag "deployment_assurance_disaster_recovery_reference_stack_last_validated_at", "Reference stack validated", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= date_field_tag "deployment_assurance[disaster_recovery][reference_stack_last_validated_at]", disaster_recovery["reference_stack_last_validated_at"], id: "deployment_assurance_disaster_recovery_reference_stack_last_validated_at", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+            </div>
+          </section>
+
+          <section class="rounded-2xl border border-gray-200 p-4 dark:border-gray-700">
+            <div>
+              <h3 class="text-lg font-semibold text-gray-900 dark:text-white">Upgrade and support policy</h3>
+              <p class="text-sm text-gray-600 dark:text-gray-300">Define the release channel, maintenance window, and version-support promise for the selected deployment model.</p>
+            </div>
+
+            <div class="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+              <div>
+                <%= label_tag "deployment_assurance_release_management_upgrade_channel", "Upgrade channel", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= select_tag "deployment_assurance[release_management][upgrade_channel]", options_for_select([["Stable", "stable"], ["Extended support", "extended_support"], ["Preview", "preview"]], release_management["upgrade_channel"]), id: "deployment_assurance_release_management_upgrade_channel", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+              <div>
+                <%= label_tag "deployment_assurance_release_management_maintenance_window", "Maintenance window", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= text_field_tag "deployment_assurance[release_management][maintenance_window]", release_management["maintenance_window"], id: "deployment_assurance_release_management_maintenance_window", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white", placeholder: "Sun 02:00-04:00" %>
+              </div>
+              <div>
+                <%= label_tag "deployment_assurance_release_management_maintenance_timezone", "Window timezone", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= text_field_tag "deployment_assurance[release_management][maintenance_timezone]", release_management["maintenance_timezone"], id: "deployment_assurance_release_management_maintenance_timezone", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white", placeholder: "UTC" %>
+              </div>
+              <div>
+                <%= label_tag "deployment_assurance_release_management_version_support_policy", "Version support", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= select_tag "deployment_assurance[release_management][version_support_policy]", options_for_select([["Latest", "latest"], ["N-1", "n_minus_one"], ["LTS", "lts"]], release_management["version_support_policy"]), id: "deployment_assurance_release_management_version_support_policy", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+              <div>
+                <%= label_tag "deployment_assurance_release_management_support_window_days", "Support window days", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= number_field_tag "deployment_assurance[release_management][support_window_days]", release_management["support_window_days"], min: 1, class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+            </div>
+          </section>
+
+          <section class="rounded-2xl border border-gray-200 p-4 dark:border-gray-700">
+            <div>
+              <h3 class="text-lg font-semibold text-gray-900 dark:text-white">BYOC reference stack</h3>
+              <p class="text-sm text-gray-600 dark:text-gray-300">Use this when the tenant runs Paid in its own cloud account with validated automation.</p>
+            </div>
+
+            <div class="mt-4 grid gap-4 md:grid-cols-3">
+              <div>
+                <%= label_tag "deployment_assurance_byoc_cloud_provider", "Cloud provider", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= text_field_tag "deployment_assurance[byoc][cloud_provider]", byoc["cloud_provider"], id: "deployment_assurance_byoc_cloud_provider", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white", placeholder: "AWS" %>
+              </div>
+              <div>
+                <%= label_tag "deployment_assurance_byoc_automation_stack", "Automation stack", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= text_field_tag "deployment_assurance[byoc][automation_stack]", byoc["automation_stack"], id: "deployment_assurance_byoc_automation_stack", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white", placeholder: "Terraform + ECS" %>
+              </div>
+              <div>
+                <%= label_tag "deployment_assurance_byoc_reference_stack", "Reference stack", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= text_field_tag "deployment_assurance[byoc][reference_stack]", byoc["reference_stack"], id: "deployment_assurance_byoc_reference_stack", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white", placeholder: "aws-terraform-v1" %>
               </div>
             </div>
           </section>

--- a/app/views/accounts/compliance_dashboards/show.html.erb
+++ b/app/views/accounts/compliance_dashboards/show.html.erb
@@ -8,6 +8,35 @@
 <% disaster_recovery = deployment_assurance["disaster_recovery"] %>
 <% release_management = deployment_assurance["release_management"] %>
 <% byoc = deployment_assurance["byoc"] %>
+<%
+  deployment_model_options = [
+    ["Managed cloud", "managed_cloud"],
+    ["Private SaaS", "private_saas"],
+    ["Bring your own cloud", "byoc"]
+  ]
+  network_boundary_options = [
+    ["Paid-managed", "paid_managed"],
+    ["Private connect", "private_connect"],
+    ["Customer VPC", "customer_vpc"]
+  ]
+  reference_architecture_options = [
+    ["Managed control plane", "managed_control_plane"],
+    ["Dedicated hosted stack", "dedicated_hosted_stack"],
+    ["Customer cloud stack", "customer_cloud_stack"]
+  ]
+
+  if TenantSetting::LEGACY_DEPLOYMENT_ASSURANCE_MODELS.include?(deployment_assurance["deployment_model"])
+    deployment_model_options.prepend([deployment_assurance["deployment_model"].humanize + " (legacy)", deployment_assurance["deployment_model"]])
+  end
+
+  if TenantSetting::LEGACY_DEPLOYMENT_ASSURANCE_NETWORK_BOUNDARIES.include?(deployment_assurance["network_boundary"])
+    network_boundary_options.prepend([deployment_assurance["network_boundary"].humanize + " (legacy)", deployment_assurance["network_boundary"]])
+  end
+
+  if TenantSetting::LEGACY_DEPLOYMENT_ASSURANCE_REFERENCE_ARCHITECTURES.include?(deployment_assurance["reference_architecture"])
+    reference_architecture_options.prepend([deployment_assurance["reference_architecture"].humanize + " (legacy)", deployment_assurance["reference_architecture"]])
+  end
+%>
 
 <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
@@ -109,7 +138,7 @@
           <section class="grid gap-4 md:grid-cols-2">
             <div>
               <%= label_tag "deployment_assurance_deployment_model", "Deployment model", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
-              <%= select_tag "deployment_assurance[deployment_model]", options_for_select([["Managed cloud", "managed_cloud"], ["Private SaaS", "private_saas"], ["Bring your own cloud", "byoc"]], deployment_assurance["deployment_model"]), id: "deployment_assurance_deployment_model", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              <%= select_tag "deployment_assurance[deployment_model]", options_for_select(deployment_model_options, deployment_assurance["deployment_model"]), id: "deployment_assurance_deployment_model", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
             </div>
             <div>
               <%= label_tag "deployment_assurance_tenant_isolation", "Tenant isolation", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
@@ -117,11 +146,11 @@
             </div>
             <div>
               <%= label_tag "deployment_assurance_network_boundary", "Network boundary", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
-              <%= select_tag "deployment_assurance[network_boundary]", options_for_select([["Paid-managed", "paid_managed"], ["Private connect", "private_connect"], ["Customer VPC", "customer_vpc"]], deployment_assurance["network_boundary"]), id: "deployment_assurance_network_boundary", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              <%= select_tag "deployment_assurance[network_boundary]", options_for_select(network_boundary_options, deployment_assurance["network_boundary"]), id: "deployment_assurance_network_boundary", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
             </div>
             <div>
               <%= label_tag "deployment_assurance_reference_architecture", "Reference architecture", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
-              <%= select_tag "deployment_assurance[reference_architecture]", options_for_select([["Managed control plane", "managed_control_plane"], ["Dedicated hosted stack", "dedicated_hosted_stack"], ["Customer cloud stack", "customer_cloud_stack"]], deployment_assurance["reference_architecture"]), id: "deployment_assurance_reference_architecture", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              <%= select_tag "deployment_assurance[reference_architecture]", options_for_select(reference_architecture_options, deployment_assurance["reference_architecture"]), id: "deployment_assurance_reference_architecture", class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
             </div>
             <div>
               <%= label_tag "deployment_assurance_operations_owner", "Operations owner", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>

--- a/docs/compliance/operational-assurance-runbooks.md
+++ b/docs/compliance/operational-assurance-runbooks.md
@@ -9,10 +9,11 @@
 
 ## Upgrade Validation
 
-1. Stage the target Paid release in a non-production environment that matches the production topology.
-2. Run migrations, smoke tests, and critical account workflows before approving production rollout.
-3. Document rollback prerequisites and rollback timing before the production change window.
-4. Record the last validated upgrade date in the compliance dashboard after the rehearsal completes.
+1. Assign each tenant to an upgrade channel (`stable`, `extended_support`, or `preview`) and record the declared version-support policy.
+2. Stage the target Paid release in a non-production environment that matches the production topology.
+3. Run migrations, smoke tests, and critical account workflows before approving production rollout.
+4. Document rollback prerequisites plus the production maintenance window before the change is scheduled.
+5. Record the last validated upgrade date in the compliance dashboard after the rehearsal completes.
 
 ## Secret Rotation
 
@@ -20,3 +21,10 @@
 2. Update the compliance dashboard with the KMS provider, key reference, and most recent key rotation date.
 3. Record the operator owner and most recent secret rotation workflow completion date.
 4. Export a compliance evidence pack after each rotation cycle for audit review.
+
+## BYOC Reference Stack Validation
+
+1. Identify the approved customer-cloud reference stack and the owning cloud provider for the tenant.
+2. Re-run deployment automation in a clean validation environment whenever the stack definition or managed dependencies change.
+3. Verify monitoring, backups, restore paths, and upgrade rollout behavior against the validated stack.
+4. Record the reference stack identifier and most recent validation date in the compliance dashboard.

--- a/docs/compliance/reference-architectures.md
+++ b/docs/compliance/reference-architectures.md
@@ -1,19 +1,19 @@
 # Reference Architectures
 
-## Self-hosted reference architecture
+## Managed cloud reference architecture
 
-- Deploy Paid Rails, PostgreSQL, Redis, and object storage inside a single tenant boundary.
-- Terminate ingress at a managed reverse proxy or load balancer with TLS and IP allowlists.
-- Run agent containers on dedicated worker hosts with isolated Docker storage and outbound egress controls.
+- Run a Paid-operated control plane with tenant isolation enforced through account scoping, row-level security, and isolated execution workspaces.
+- Provide managed PostgreSQL, Redis, and object storage with routine backups, monitoring, and platform-led upgrades.
+- Expose customer access through standard SaaS endpoints while keeping operator access behind hardened administrative controls and audit logging.
 
-## Private VPC reference architecture
+## Private SaaS reference architecture
 
-- Place Paid web, worker, database, and cache tiers on private subnets with tightly scoped security groups.
-- Expose operator access through VPN, bastion, or identity-aware proxy rather than broad public ingress.
-- Prefer managed PostgreSQL, Redis, and object storage with customer-controlled network policies and backup retention.
+- Provision a dedicated single-tenant stack per customer with isolated Rails, worker, database, cache, and object-storage resources.
+- Restrict ingress through private connectivity, IP allowlists, or customer-approved identity-aware access paths.
+- Keep Paid responsible for patching, upgrades, backup verification, and production monitoring while preserving customer-specific network and residency controls.
 
-## Air-gapped reference architecture
+## Bring-your-own-cloud reference architecture
 
-- Build release artifacts in a connected staging environment, then promote signed packages into the disconnected network.
-- Mirror Ruby gems, Yarn packages, container images, and model/runtime dependencies into an approved offline registry.
-- Validate restore, upgrade, and rollback procedures against the promoted artifact set before production rollout.
+- Deploy Paid into the customer's cloud account using validated reference stacks such as `aws-terraform-v1`, `azure-aks-v1`, or `gcp-gke-v1`.
+- Keep network boundaries, persistence services, and runtime identities inside customer-owned cloud resources while preserving the same application behavior as managed offerings.
+- Re-validate automation, upgrades, rollback steps, and managed-service dependencies whenever the approved reference stack changes.

--- a/spec/models/tenant_setting_spec.rb
+++ b/spec/models/tenant_setting_spec.rb
@@ -275,6 +275,25 @@ RSpec.describe TenantSetting do
   end
 
   describe "deployment assurance" do
+    let(:legacy_deployment_assurance) do
+      {
+        "deployment_model" => "air_gapped",
+        "network_boundary" => "offline",
+        "reference_architecture" => "offline_promotion",
+        "disaster_recovery" => {
+          "backup_cadence" => "daily",
+          "rpo_hours" => 24,
+          "rto_hours" => 8
+        },
+        "customer_managed_keys" => {
+          "rotation_interval_days" => 90
+        },
+        "secret_rotation" => {
+          "interval_days" => 90
+        }
+      }
+    end
+
     it "merges the Phase 8.1 deployment defaults" do
       setting = build(:tenant_setting)
 
@@ -302,10 +321,21 @@ RSpec.describe TenantSetting do
       expect(setting.deployment_assurance_configuration.dig("customer_managed_keys", "rotation_interval_days")).to eq(45)
     end
 
+    it "accepts legacy deployment assurance payloads while stored records are upgraded" do
+      setting = build(
+        :tenant_setting,
+        features: {
+          "deployment_assurance" => legacy_deployment_assurance
+        }
+      )
+
+      expect(setting).to be_valid
+    end
+
     it "rejects unsupported deployment model policy values" do
       setting = build(:tenant_setting)
       setting.deployment_assurance_configuration = {
-        "deployment_model" => "air_gapped",
+        "deployment_model" => "public_cloud",
         "tenant_isolation" => "shared",
         "release_management" => { "upgrade_channel" => "rapid", "support_window_days" => 0 }
       }

--- a/spec/models/tenant_setting_spec.rb
+++ b/spec/models/tenant_setting_spec.rb
@@ -274,6 +274,50 @@ RSpec.describe TenantSetting do
     end
   end
 
+  describe "deployment assurance" do
+    it "merges the Phase 8.1 deployment defaults" do
+      setting = build(:tenant_setting)
+
+      expect(setting.deployment_assurance_configuration).to include(
+        "deployment_model" => "managed_cloud",
+        "tenant_isolation" => "multi_tenant_rls",
+        "network_boundary" => "paid_managed",
+        "reference_architecture" => "managed_control_plane"
+      )
+      expect(setting.deployment_assurance_configuration.dig("release_management", "upgrade_channel")).to eq("stable")
+      expect(setting.deployment_assurance_configuration.dig("release_management", "support_window_days")).to eq(30)
+    end
+
+    it "normalizes nested deployment assurance integers" do
+      setting = build(:tenant_setting)
+
+      setting.deployment_assurance_configuration = {
+        "release_management" => { "support_window_days" => "60" },
+        "disaster_recovery" => { "reference_stack_last_validated_at" => Date.current.iso8601 },
+        "customer_managed_keys" => { "enabled" => "1", "rotation_interval_days" => "45" }
+      }
+
+      expect(setting.deployment_assurance_configuration.dig("release_management", "support_window_days")).to eq(60)
+      expect(setting.deployment_assurance_configuration.dig("customer_managed_keys", "enabled")).to be(true)
+      expect(setting.deployment_assurance_configuration.dig("customer_managed_keys", "rotation_interval_days")).to eq(45)
+    end
+
+    it "rejects unsupported deployment model policy values" do
+      setting = build(:tenant_setting)
+      setting.deployment_assurance_configuration = {
+        "deployment_model" => "air_gapped",
+        "tenant_isolation" => "shared",
+        "release_management" => { "upgrade_channel" => "rapid", "support_window_days" => 0 }
+      }
+
+      expect(setting).not_to be_valid
+      expect(setting.errors[:features]).to include(match(/deployment_assurance\.deployment_model/))
+      expect(setting.errors[:features]).to include(match(/deployment_assurance\.tenant_isolation/))
+      expect(setting.errors[:features]).to include(match(/deployment_assurance\.release_management\.upgrade_channel/))
+      expect(setting.errors[:features]).to include(match(/deployment_assurance\.release_management\.support_window_days/))
+    end
+  end
+
   describe ".resolve_worker_setting" do
     it "returns ENV value when no DB setting exists" do
       result = described_class.resolve_worker_setting(

--- a/spec/requests/accounts/compliance_dashboards_spec.rb
+++ b/spec/requests/accounts/compliance_dashboards_spec.rb
@@ -98,6 +98,29 @@ RSpec.describe "Accounts::ComplianceDashboards" do
       expect(response.body).not_to include("Export evidence pack")
       expect(response.body).not_to include("Save compliance settings")
     end
+
+    it "renders currently stored legacy deployment assurance options" do
+      account.tenant_setting!.update!(
+        features: {
+          "deployment_assurance" => {
+            "deployment_model" => "air_gapped",
+            "tenant_isolation" => "single_tenant",
+            "network_boundary" => "offline",
+            "reference_architecture" => "offline_promotion"
+          }
+        }
+      )
+
+      get account_compliance_dashboard_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('value="air_gapped"')
+      expect(response.body).to include("Air gapped (legacy)")
+      expect(response.body).to include('value="offline"')
+      expect(response.body).to include("Offline (legacy)")
+      expect(response.body).to include('value="offline_promotion"')
+      expect(response.body).to include("Offline promotion (legacy)")
+    end
   end
 
   describe "PATCH /account_compliance_dashboard" do

--- a/spec/requests/accounts/compliance_dashboards_spec.rb
+++ b/spec/requests/accounts/compliance_dashboards_spec.rb
@@ -9,10 +9,16 @@ RSpec.describe "Accounts::ComplianceDashboards" do
   let(:deployment_assurance_params) do
     {
       deployment_assurance: {
-        deployment_model: "private_vpc",
-        network_boundary: "private_vpc",
-        reference_architecture: "private_services",
+        deployment_model: "byoc",
+        tenant_isolation: "customer_cloud",
+        network_boundary: "customer_vpc",
+        reference_architecture: "customer_cloud_stack",
         operations_owner: "platform@example.com",
+        monitoring: {
+          provider: "Datadog",
+          escalation_owner: "sre@example.com",
+          last_reviewed_at: Date.current.iso8601
+        },
         customer_managed_keys: {
           enabled: "1",
           provider: "AWS KMS",
@@ -31,12 +37,41 @@ RSpec.describe "Accounts::ComplianceDashboards" do
           backup_last_verified_at: Date.current.iso8601,
           restore_last_tested_at: Date.current.iso8601,
           upgrade_last_validated_at: Date.current.iso8601,
-          air_gap_package_validated_at: "",
+          reference_stack_last_validated_at: Date.current.iso8601,
           rpo_hours: "4",
           rto_hours: "8"
+        },
+        release_management: {
+          upgrade_channel: "extended_support",
+          maintenance_window: "Sun 02:00-04:00",
+          maintenance_timezone: "UTC",
+          version_support_policy: "lts",
+          support_window_days: "60"
+        },
+        byoc: {
+          cloud_provider: "AWS",
+          automation_stack: "Terraform + ECS",
+          reference_stack: "aws-terraform-v1"
         }
       }
     }
+  end
+  let(:unsupported_option_params) do
+    deployment_assurance_params.deep_merge(
+      deployment_assurance: {
+        deployment_model: "public_cloud",
+        tenant_isolation: "shared_everything",
+        network_boundary: "open_internet",
+        reference_architecture: "shared_tenant",
+        release_management: {
+          upgrade_channel: "fast_ring",
+          version_support_policy: "forever"
+        },
+        disaster_recovery: {
+          backup_cadence: "monthly"
+        }
+      }
+    )
   end
 
   before do
@@ -74,9 +109,13 @@ RSpec.describe "Accounts::ComplianceDashboards" do
       expect(response).to redirect_to(account_compliance_dashboard_path)
 
       assurance = account.tenant_setting!.reload.deployment_assurance_configuration
-      expect(assurance["deployment_model"]).to eq("private_vpc")
+      expect(assurance["deployment_model"]).to eq("byoc")
+      expect(assurance["tenant_isolation"]).to eq("customer_cloud")
+      expect(assurance.dig("monitoring", "provider")).to eq("Datadog")
       expect(assurance.dig("customer_managed_keys", "enabled")).to be(true)
       expect(assurance.dig("secret_rotation", "interval_days")).to eq(60)
+      expect(assurance.dig("release_management", "upgrade_channel")).to eq("extended_support")
+      expect(assurance.dig("byoc", "reference_stack")).to eq("aws-terraform-v1")
       expect(account.account_activity_events.recent.first.action).to eq("compliance.assurance_updated")
     end
 
@@ -84,34 +123,28 @@ RSpec.describe "Accounts::ComplianceDashboards" do
       expect do
         patch account_compliance_dashboard_path, params: deployment_assurance_params.deep_merge(
           deployment_assurance: {
-            customer_managed_keys: { rotation_interval_days: "oops" }
+            release_management: { support_window_days: "oops" }
           }
         )
       end.not_to change(AccountActivityEvent, :count)
 
       expect(response).to have_http_status(:unprocessable_content)
-      expect(account.tenant_setting!.reload.deployment_assurance_configuration.dig("customer_managed_keys", "rotation_interval_days")).to eq(90)
+      expect(account.tenant_setting!.reload.deployment_assurance_configuration.dig("release_management", "support_window_days")).to eq(30)
     end
 
     it "rejects unsupported deployment assurance option values" do
-      patch account_compliance_dashboard_path, params: deployment_assurance_params.deep_merge(
-        deployment_assurance: {
-          deployment_model: "public_cloud",
-          network_boundary: "open_internet",
-          reference_architecture: "shared_tenant",
-          disaster_recovery: {
-            backup_cadence: "monthly"
-          }
-        }
-      )
+      patch account_compliance_dashboard_path, params: unsupported_option_params
 
       expect(response).to have_http_status(:unprocessable_content)
 
       assurance = account.tenant_setting!.reload.deployment_assurance_configuration
-      expect(assurance["deployment_model"]).to eq("self_hosted")
-      expect(assurance["network_boundary"]).to eq("private_vpc")
-      expect(assurance["reference_architecture"]).to eq("single_tenant")
+      expect(assurance["deployment_model"]).to eq("managed_cloud")
+      expect(assurance["tenant_isolation"]).to eq("multi_tenant_rls")
+      expect(assurance["network_boundary"]).to eq("paid_managed")
+      expect(assurance["reference_architecture"]).to eq("managed_control_plane")
       expect(assurance.dig("disaster_recovery", "backup_cadence")).to eq("daily")
+      expect(assurance.dig("release_management", "upgrade_channel")).to eq("stable")
+      expect(assurance.dig("release_management", "version_support_policy")).to eq("n_minus_one")
     end
   end
 

--- a/spec/services/accounts/compliance/dashboard_spec.rb
+++ b/spec/services/accounts/compliance/dashboard_spec.rb
@@ -95,5 +95,25 @@ RSpec.describe Accounts::Compliance::Dashboard do
       expect(controls[:customer_managed_keys][:status]).to eq(:compliant)
       expect(controls[:byoc_reference_stack][:status]).to eq(:compliant)
     end
+
+    it "keeps legacy air-gapped tenants on an applicable validation control" do
+      tenant_setting.deployment_assurance_configuration = {
+        "deployment_model" => "air_gapped",
+        "tenant_isolation" => "single_tenant",
+        "network_boundary" => "offline",
+        "reference_architecture" => "offline_promotion",
+        "disaster_recovery" => {
+          "reference_stack_last_validated_at" => 10.days.ago.to_date.iso8601
+        }
+      }
+      tenant_setting.save!
+
+      result = described_class.call(account: account, tenant_setting: tenant_setting, billing_visible: false)
+      control = result[:controls].index_by { |item| item[:id] }.fetch(:byoc_reference_stack)
+
+      expect(control[:status]).to eq(:compliant)
+      expect(control[:evidence]).to include("Legacy air-gapped deployment retained until migration completes")
+      expect(result.dig(:counts, :not_applicable)).to eq(1)
+    end
   end
 end

--- a/spec/services/accounts/compliance/dashboard_spec.rb
+++ b/spec/services/accounts/compliance/dashboard_spec.rb
@@ -8,10 +8,16 @@ RSpec.describe Accounts::Compliance::Dashboard do
     let(:tenant_setting) { account.tenant_setting! }
     let(:recent_deployment_assurance) do
       {
-        "deployment_model" => "air_gapped",
-        "network_boundary" => "offline",
-        "reference_architecture" => "offline_promotion",
+        "deployment_model" => "byoc",
+        "tenant_isolation" => "customer_cloud",
+        "network_boundary" => "customer_vpc",
+        "reference_architecture" => "customer_cloud_stack",
         "operations_owner" => "platform@example.com",
+        "monitoring" => {
+          "provider" => "Datadog",
+          "escalation_owner" => "sre@example.com",
+          "last_reviewed_at" => 2.days.ago.to_date.iso8601
+        },
         "customer_managed_keys" => {
           "enabled" => true,
           "provider" => "AWS KMS",
@@ -30,9 +36,21 @@ RSpec.describe Accounts::Compliance::Dashboard do
           "backup_last_verified_at" => 5.days.ago.to_date.iso8601,
           "restore_last_tested_at" => 20.days.ago.to_date.iso8601,
           "upgrade_last_validated_at" => 30.days.ago.to_date.iso8601,
-          "air_gap_package_validated_at" => 15.days.ago.to_date.iso8601,
+          "reference_stack_last_validated_at" => 15.days.ago.to_date.iso8601,
           "rpo_hours" => 4,
           "rto_hours" => 8
+        },
+        "release_management" => {
+          "upgrade_channel" => "extended_support",
+          "maintenance_window" => "Sun 02:00-04:00",
+          "maintenance_timezone" => "UTC",
+          "version_support_policy" => "lts",
+          "support_window_days" => 60
+        },
+        "byoc" => {
+          "cloud_provider" => "AWS",
+          "automation_stack" => "Terraform + ECS",
+          "reference_stack" => "aws-terraform-v1"
         }
       }
     end
@@ -42,9 +60,10 @@ RSpec.describe Accounts::Compliance::Dashboard do
       controls = result[:controls].index_by { |control| control[:id] }
 
       expect(result[:readiness_score]).to be < 100
+      expect(controls[:monitoring_coverage][:status]).to eq(:gap)
       expect(controls[:customer_managed_keys][:status]).to eq(:not_applicable)
       expect(controls[:secret_rotation][:status]).to eq(:gap)
-      expect(controls[:air_gap_validation][:status]).to eq(:not_applicable)
+      expect(controls[:byoc_reference_stack][:status]).to eq(:not_applicable)
     end
 
     it "treats enabled customer-managed keys without supporting evidence as a gap" do
@@ -72,8 +91,9 @@ RSpec.describe Accounts::Compliance::Dashboard do
       expect(result[:readiness_score]).to eq(100)
       expect(controls[:deployment_topology][:status]).to eq(:compliant)
       expect(controls[:audit_export][:status]).to eq(:compliant)
+      expect(controls[:monitoring_coverage][:status]).to eq(:compliant)
       expect(controls[:customer_managed_keys][:status]).to eq(:compliant)
-      expect(controls[:air_gap_validation][:status]).to eq(:compliant)
+      expect(controls[:byoc_reference_stack][:status]).to eq(:compliant)
     end
   end
 end


### PR DESCRIPTION
## Summary

Implemented Phase 8.1 on the existing account compliance/deployment-assurance surface. The app now models `managed_cloud`, `private_saas`, and `byoc` deployment choices, captures tenant isolation, monitoring ownership, upgrade/support policy, and BYOC reference-stack metadata, and reflects that in the customer-facing dashboard, evidence export, and supporting docs.

Validation and coverage were updated in [app/models/tenant_setting.rb](/workspace/app/models/tenant_setting.rb), [app/services/accounts/compliance/dashboard.rb](/workspace/app/services/accounts/compliance/dashboard.rb), [app/views/accounts/compliance_dashboards/show.html.erb](/workspace/app/views/accounts/compliance_dashboards/show.html.erb), and the related specs/docs. I also bumped the evidence-pack schema version in [app/services/accounts/compliance/evidence_pack.rb](/workspace/app/services/accounts/compliance/evidence_pack.rb).

Verification passed:
- `DB_HOST=paid-svc-a3-s1-postgres DB_USERNAME=agent DB_PASSWORD=agent bundle exec bin/rails db:prepare`
- `DB_HOST=paid-svc-a3-s1-postgres DB_USERNAME=agent DB_PASSWORD=agent bundle exec rubocop`
- `DB_HOST=paid-svc-a3-s1-postgres DB_USERNAME=agent DB_PASSWORD=agent bundle exec rspec`

Committed as `feat(platform): add managed deployment operating models` at `6f655d9`.

---

Closes #2339