### PR TITLE
feat(operations): Phase 8.2 — Enterprise Operations & Reliability

### DIFF
--- a/app/controllers/accounts/operations_dashboards_controller.rb
+++ b/app/controllers/accounts/operations_dashboards_controller.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module Accounts
+  class OperationsDashboardsController < ApplicationController
+    before_action :set_tenant_setting
+    before_action :load_operations_dashboard, only: :show
+
+    def show
+      authorize current_account, :show?
+    end
+
+    def update
+      authorize current_account, :update?
+
+      ActiveRecord::Base.transaction do
+        @tenant_setting.enterprise_operations_configuration = operations_params
+        @tenant_setting.save!
+
+        Accounts::RecordActivity.call(
+          account: current_account,
+          actor: current_user,
+          action: "operations.dashboard_updated",
+          subject: @tenant_setting,
+          metadata: { changed_fields: [ "enterprise_operations" ] }
+        )
+      end
+
+      redirect_to account_operations_dashboard_path, notice: "Operations settings saved."
+    rescue ActiveRecord::RecordInvalid
+      load_operations_dashboard
+      flash.now[:alert] = "Unable to save operations settings."
+      render :show, status: :unprocessable_content
+    end
+
+    def export
+      authorize current_account, :update?
+
+      report = Accounts::Operations::HealthReport.call(
+        account: current_account,
+        tenant_setting: @tenant_setting,
+        billing_visible: BillingPolicy.new(current_user, current_account).billing?
+      )
+
+      send_data JSON.pretty_generate(report),
+        filename: "operations-report-#{current_account.slug}-#{Date.current}.json",
+        type: "application/json"
+    end
+
+    private
+
+    def set_tenant_setting
+      @tenant_setting = current_account.tenant_setting!
+    end
+
+    def load_operations_dashboard
+      @operations_dashboard = Accounts::Operations::Dashboard.call(
+        account: current_account,
+        tenant_setting: @tenant_setting,
+        billing_visible: BillingPolicy.new(current_user, current_account).billing?
+      )
+    end
+
+    def operations_params
+      params.fetch(:enterprise_operations, ActionController::Parameters.new).permit(
+        service_levels: %i[
+          slo_window_days
+          uptime_target_percent
+          queue_health_target_percent
+          queue_start_slo_minutes
+          urgent_response_sla_hours
+          standard_response_sla_hours
+        ],
+        disaster_recovery: %i[
+          automated_backups_enabled
+          restore_drill_interval_days
+          restore_owner
+          last_restore_drill_at
+        ],
+        upgrades: %i[
+          release_channel
+          maintenance_window
+          compatibility_lookahead_days
+          last_compatibility_check_at
+          last_upgrade_at
+        ],
+        support: %i[
+          diagnostics_contact
+          safe_remediation_mode
+          health_report_recipients
+        ],
+        capacity_management: %i[
+          reserved_concurrency
+          queue_warning_threshold
+          queue_critical_threshold
+          monthly_budget_alert_percent
+        ]
+      ).to_h
+    end
+  end
+end

--- a/app/controllers/accounts/operations_dashboards_controller.rb
+++ b/app/controllers/accounts/operations_dashboards_controller.rb
@@ -16,13 +16,15 @@ module Accounts
         @tenant_setting.enterprise_operations_configuration = operations_params
         @tenant_setting.save!
 
-        Accounts::RecordActivity.call(
-          account: current_account,
-          actor: current_user,
-          action: "operations.dashboard_updated",
-          subject: @tenant_setting,
-          metadata: { changed_fields: [ "enterprise_operations" ] }
-        )
+        if @tenant_setting.saved_changes.except("updated_at").any?
+          Accounts::RecordActivity.call(
+            account: current_account,
+            actor: current_user,
+            action: "operations.dashboard_updated",
+            subject: @tenant_setting,
+            metadata: { changed_fields: [ "enterprise_operations" ] }
+          )
+        end
       end
 
       redirect_to account_operations_dashboard_path, notice: "Operations settings saved."

--- a/app/controllers/concerns/account_administration_page.rb
+++ b/app/controllers/concerns/account_administration_page.rb
@@ -19,6 +19,11 @@ module AccountAdministrationPage
       tenant_setting: @tenant_setting,
       billing_visible: @billing_visible
     )
+    @operations_dashboard = Accounts::Operations::Dashboard.call(
+      account: current_account,
+      tenant_setting: @tenant_setting,
+      billing_visible: @billing_visible
+    )
     @adoption_dashboard = Accounts::Adoption::Dashboard.call(
       account: current_account,
       tenant_setting: @tenant_setting

--- a/app/models/account_activity_event.rb
+++ b/app/models/account_activity_event.rb
@@ -13,6 +13,7 @@ class AccountActivityEvent < ApplicationRecord
     "lifecycle.deactivated" => "lifecycle",
     "tenant_configuration.updated" => "settings",
     "compliance.assurance_updated" => "settings",
+    "operations.dashboard_updated" => "settings",
     "project.created" => "project",
     "project.updated" => "project",
     "project.deleted" => "project",
@@ -98,6 +99,8 @@ class AccountActivityEvent < ApplicationRecord
       "Updated tenant configuration"
     when "compliance.assurance_updated"
       "Updated compliance and deployment assurance settings"
+    when "operations.dashboard_updated"
+      "Updated enterprise operations and reliability settings"
     when "project.created"
       "Created project #{metadata_value('name')}"
     when "project.updated"
@@ -141,7 +144,7 @@ class AccountActivityEvent < ApplicationRecord
 
   def detail_lines
     case action
-    when "account.updated", "tenant_configuration.updated", "compliance.assurance_updated"
+    when "account.updated", "tenant_configuration.updated", "compliance.assurance_updated", "operations.dashboard_updated"
       Array(metadata.to_h["changed_fields"]).map { |field| "#{field.humanize} changed" }
     when "ownership.transferred"
       [ "Previous owner: #{metadata_value('from_email')}" ]

--- a/app/models/tenant_setting.rb
+++ b/app/models/tenant_setting.rb
@@ -254,7 +254,9 @@ class TenantSetting < ApplicationRecord
 
   def enterprise_operations_configuration=(value)
     merged_features = normalize_hash(features)
-    merged_features["enterprise_operations"] = normalize_enterprise_operations(value)
+    merged_features["enterprise_operations"] = normalize_enterprise_operations(
+      enterprise_operations_configuration.deep_merge(normalize_hash(value))
+    )
     self.features = merged_features
   end
 

--- a/app/models/tenant_setting.rb
+++ b/app/models/tenant_setting.rb
@@ -59,10 +59,46 @@ class TenantSetting < ApplicationRecord
       "rto_hours" => 8
     }
   }.freeze
+  DEFAULT_ENTERPRISE_OPERATIONS = {
+    "service_levels" => {
+      "slo_window_days" => 30,
+      "uptime_target_percent" => 99.9,
+      "queue_health_target_percent" => 99.0,
+      "queue_start_slo_minutes" => 15,
+      "urgent_response_sla_hours" => 1,
+      "standard_response_sla_hours" => 4
+    },
+    "disaster_recovery" => {
+      "automated_backups_enabled" => true,
+      "restore_drill_interval_days" => 90,
+      "restore_owner" => "",
+      "last_restore_drill_at" => ""
+    },
+    "upgrades" => {
+      "release_channel" => "stable",
+      "maintenance_window" => "Sun 02:00 UTC",
+      "compatibility_lookahead_days" => 14,
+      "last_compatibility_check_at" => "",
+      "last_upgrade_at" => ""
+    },
+    "support" => {
+      "diagnostics_contact" => "",
+      "safe_remediation_mode" => "approval_required",
+      "health_report_recipients" => ""
+    },
+    "capacity_management" => {
+      "reserved_concurrency" => 0,
+      "queue_warning_threshold" => 20,
+      "queue_critical_threshold" => 50,
+      "monthly_budget_alert_percent" => 80
+    }
+  }.freeze
   DEPLOYMENT_ASSURANCE_MODELS = %w[self_hosted private_vpc air_gapped].freeze
   DEPLOYMENT_ASSURANCE_NETWORK_BOUNDARIES = %w[private_vpc public_ingress offline].freeze
   DEPLOYMENT_ASSURANCE_REFERENCE_ARCHITECTURES = %w[single_tenant private_services offline_promotion].freeze
   DEPLOYMENT_ASSURANCE_BACKUP_CADENCES = %w[hourly daily weekly].freeze
+  ENTERPRISE_OPERATIONS_RELEASE_CHANNELS = %w[stable canary lts].freeze
+  ENTERPRISE_OPERATIONS_REMEDIATION_MODES = %w[approval_required operator_applied observe_only].freeze
   DEFAULT_WORKER_SETTINGS = {
     "temporal_workflow_slots" => 20,
     "temporal_activity_slots" => 4,
@@ -106,6 +142,7 @@ class TenantSetting < ApplicationRecord
   validate :validate_worker_settings
   validate :validate_quality_thresholds
   validate :validate_deployment_assurance
+  validate :validate_enterprise_operations
   validates :self_repo_full_name,
     format: { with: REPO_NAME_FORMAT, message: "must be in owner/repo format" },
     allow_nil: true,
@@ -208,6 +245,16 @@ class TenantSetting < ApplicationRecord
   def deployment_assurance_configuration=(value)
     merged_features = normalize_hash(features)
     merged_features["deployment_assurance"] = normalize_deployment_assurance(value)
+    self.features = merged_features
+  end
+
+  def enterprise_operations_configuration
+    merge_defaults(DEFAULT_ENTERPRISE_OPERATIONS, features.fetch("enterprise_operations", {}))
+  end
+
+  def enterprise_operations_configuration=(value)
+    merged_features = normalize_hash(features)
+    merged_features["enterprise_operations"] = normalize_enterprise_operations(value)
     self.features = merged_features
   end
 
@@ -389,6 +436,74 @@ class TenantSetting < ApplicationRecord
     )
   end
 
+  def validate_enterprise_operations
+    return unless features.is_a?(Hash)
+
+    operations = features.fetch("enterprise_operations", nil)
+    return unless operations.is_a?(Hash)
+
+    validate_enterprise_operations_integer(
+      operations.dig("service_levels", "slo_window_days"),
+      path: "service_levels.slo_window_days"
+    )
+    validate_enterprise_operations_percent(
+      operations.dig("service_levels", "uptime_target_percent"),
+      path: "service_levels.uptime_target_percent"
+    )
+    validate_enterprise_operations_percent(
+      operations.dig("service_levels", "queue_health_target_percent"),
+      path: "service_levels.queue_health_target_percent"
+    )
+    validate_enterprise_operations_integer(
+      operations.dig("service_levels", "queue_start_slo_minutes"),
+      path: "service_levels.queue_start_slo_minutes"
+    )
+    validate_enterprise_operations_integer(
+      operations.dig("service_levels", "urgent_response_sla_hours"),
+      path: "service_levels.urgent_response_sla_hours"
+    )
+    validate_enterprise_operations_integer(
+      operations.dig("service_levels", "standard_response_sla_hours"),
+      path: "service_levels.standard_response_sla_hours"
+    )
+    validate_enterprise_operations_integer(
+      operations.dig("disaster_recovery", "restore_drill_interval_days"),
+      path: "disaster_recovery.restore_drill_interval_days"
+    )
+    validate_enterprise_operations_option(
+      operations.dig("upgrades", "release_channel"),
+      path: "upgrades.release_channel",
+      allowed_values: ENTERPRISE_OPERATIONS_RELEASE_CHANNELS
+    )
+    validate_enterprise_operations_integer(
+      operations.dig("upgrades", "compatibility_lookahead_days"),
+      path: "upgrades.compatibility_lookahead_days"
+    )
+    validate_enterprise_operations_option(
+      operations.dig("support", "safe_remediation_mode"),
+      path: "support.safe_remediation_mode",
+      allowed_values: ENTERPRISE_OPERATIONS_REMEDIATION_MODES
+    )
+    validate_enterprise_operations_integer(
+      operations.dig("capacity_management", "reserved_concurrency"),
+      path: "capacity_management.reserved_concurrency",
+      min: 0
+    )
+    validate_enterprise_operations_integer(
+      operations.dig("capacity_management", "queue_warning_threshold"),
+      path: "capacity_management.queue_warning_threshold"
+    )
+    validate_enterprise_operations_integer(
+      operations.dig("capacity_management", "queue_critical_threshold"),
+      path: "capacity_management.queue_critical_threshold"
+    )
+    validate_enterprise_operations_integer(
+      operations.dig("capacity_management", "monthly_budget_alert_percent"),
+      path: "capacity_management.monthly_budget_alert_percent",
+      max: 100
+    )
+  end
+
   def normalize_budget_hash(value)
     normalized_value = normalize_hash(value)
     return normalized_value unless normalized_value.is_a?(Hash)
@@ -479,6 +594,35 @@ class TenantSetting < ApplicationRecord
     end
   end
 
+  def normalize_enterprise_operations(value)
+    merge_defaults(DEFAULT_ENTERPRISE_OPERATIONS, normalize_hash(value)).tap do |normalized|
+      normalized["disaster_recovery"]["automated_backups_enabled"] =
+        ActiveModel::Type::Boolean.new.cast(normalized.dig("disaster_recovery", "automated_backups_enabled"))
+
+      %w[
+        slo_window_days queue_start_slo_minutes urgent_response_sla_hours standard_response_sla_hours
+      ].each do |key|
+        normalized["service_levels"][key] = normalize_integer_value(normalized.dig("service_levels", key))
+      end
+
+      %w[uptime_target_percent queue_health_target_percent].each do |key|
+        normalized["service_levels"][key] = normalize_decimal_value(normalized.dig("service_levels", key))
+      end
+
+      %w[restore_drill_interval_days].each do |key|
+        normalized["disaster_recovery"][key] = normalize_integer_value(normalized.dig("disaster_recovery", key))
+      end
+
+      %w[compatibility_lookahead_days].each do |key|
+        normalized["upgrades"][key] = normalize_integer_value(normalized.dig("upgrades", key))
+      end
+
+      %w[reserved_concurrency queue_warning_threshold queue_critical_threshold monthly_budget_alert_percent].each do |key|
+        normalized["capacity_management"][key] = normalize_integer_value(normalized.dig("capacity_management", key))
+      end
+    end
+  end
+
   def validate_deployment_assurance_integer(value, path:)
     return if value.is_a?(Integer) && value.between?(1, PG_INT_MAX)
 
@@ -491,6 +635,24 @@ class TenantSetting < ApplicationRecord
     errors.add(:features, "deployment_assurance.#{path} must be one of: #{allowed_values.join(', ')}")
   end
 
+  def validate_enterprise_operations_integer(value, path:, min: 1, max: PG_INT_MAX)
+    return if value.is_a?(Integer) && value.between?(min, max)
+
+    errors.add(:features, "enterprise_operations.#{path} must be an integer between #{min} and #{max}")
+  end
+
+  def validate_enterprise_operations_percent(value, path:)
+    return if value.is_a?(Numeric) && value.positive? && value <= 100
+
+    errors.add(:features, "enterprise_operations.#{path} must be greater than 0 and less than or equal to 100")
+  end
+
+  def validate_enterprise_operations_option(value, path:, allowed_values:)
+    return if allowed_values.include?(value)
+
+    errors.add(:features, "enterprise_operations.#{path} must be one of: #{allowed_values.join(', ')}")
+  end
+
   def validate_quality_threshold_integer(value, key:)
     return if value.is_a?(Integer) && value.between?(1, PG_INT_MAX)
 
@@ -501,6 +663,12 @@ class TenantSetting < ApplicationRecord
     return nil unless value.present?
 
     Integer(value, exception: false) || value
+  end
+
+  def normalize_decimal_value(value)
+    return nil unless value.present?
+
+    Float(value, exception: false) || value
   end
 
   def apply_guardrail_columns

--- a/app/services/accounts/operations/dashboard.rb
+++ b/app/services/accounts/operations/dashboard.rb
@@ -1,0 +1,234 @@
+# frozen_string_literal: true
+
+module Accounts
+  module Operations
+    class Dashboard
+      def self.call(...)
+        new(...).call
+      end
+
+      def initialize(account:, tenant_setting:, billing_visible: false)
+        @account = account
+        @tenant_setting = tenant_setting
+        @billing_visible = billing_visible
+      end
+
+      def call
+        {
+          configuration: configuration,
+          service_levels: service_levels_payload,
+          disaster_recovery: disaster_recovery_payload,
+          upgrades: upgrades_payload,
+          support: support_payload,
+          capacity: capacity_payload
+        }
+      end
+
+      private
+
+      attr_reader :account, :tenant_setting, :billing_visible
+
+      def configuration
+        @configuration ||= tenant_setting.enterprise_operations_configuration
+      end
+
+      def deployment_assurance
+        @deployment_assurance ||= tenant_setting.deployment_assurance_configuration
+      end
+
+      def time_window
+        @time_window ||= configuration.dig("service_levels", "slo_window_days").days.ago..Time.current
+      end
+
+      def recent_runs
+        @recent_runs ||= AgentRun.joins(:project)
+          .where(projects: { account_id: account.id }, agent_runs: { created_at: time_window })
+      end
+
+      def queue_monitor
+        @queue_monitor ||= Scaling::QueueMonitor.cached_for_account(account)
+      end
+
+      def runner_health
+        @runner_health ||= ::Dashboard::RunnerHealth.call(account: account)
+      end
+
+      def usage_period
+        @usage_period ||= account.billing_periods.order(starts_at: :desc).first
+      end
+
+      def aggregated_usage
+        return unless billing_visible
+        return unless usage_period
+
+        @aggregated_usage ||= Billing::AggregateTenantUsage.call(
+          account: account,
+          starts_at: usage_period.starts_at,
+          ends_at: usage_period.ends_at
+        )
+      end
+
+      def service_levels_payload
+        {
+          window_days: configuration.dig("service_levels", "slo_window_days"),
+          uptime_target_percent: configuration.dig("service_levels", "uptime_target_percent"),
+          uptime_actual_percent: uptime_actual_percent,
+          uptime_status: status_for_target(uptime_actual_percent, configuration.dig("service_levels", "uptime_target_percent")),
+          queue_health_target_percent: configuration.dig("service_levels", "queue_health_target_percent"),
+          queue_health_actual_percent: queue_health_actual_percent,
+          queue_health_status: status_for_target(
+            queue_health_actual_percent,
+            configuration.dig("service_levels", "queue_health_target_percent")
+          ),
+          queue_start_slo_minutes: configuration.dig("service_levels", "queue_start_slo_minutes"),
+          urgent_response_sla_hours: configuration.dig("service_levels", "urgent_response_sla_hours"),
+          standard_response_sla_hours: configuration.dig("service_levels", "standard_response_sla_hours"),
+          monitored_runs: monitored_run_count,
+          completed_runs: completed_run_count,
+          open_p1_incidents: account.exception_incidents.open_incidents.by_severity("p1").count,
+          open_queue_alerts: queue_monitor.alerts.count
+        }
+      end
+
+      def disaster_recovery_payload
+        recovery = deployment_assurance.fetch("disaster_recovery", {})
+        configured = configuration.fetch("disaster_recovery", {})
+        last_restore_drill_at = configured["last_restore_drill_at"].presence || recovery["restore_last_tested_at"]
+
+        {
+          automated_backups_enabled: configured["automated_backups_enabled"],
+          backup_cadence: recovery["backup_cadence"],
+          backup_last_verified_at: recovery["backup_last_verified_at"],
+          restore_drill_interval_days: configured["restore_drill_interval_days"],
+          restore_owner: configured["restore_owner"],
+          last_restore_drill_at: last_restore_drill_at,
+          restore_drill_status: freshness_status(last_restore_drill_at, configured["restore_drill_interval_days"]),
+          recovery_point_objective_hours: recovery["rpo_hours"],
+          recovery_time_objective_hours: recovery["rto_hours"]
+        }
+      end
+
+      def upgrades_payload
+        configured = configuration.fetch("upgrades", {})
+        last_compatibility_check_at = configured["last_compatibility_check_at"].presence ||
+          deployment_assurance.dig("disaster_recovery", "upgrade_last_validated_at")
+
+        {
+          release_channel: configured["release_channel"],
+          maintenance_window: configured["maintenance_window"],
+          compatibility_lookahead_days: configured["compatibility_lookahead_days"],
+          last_compatibility_check_at: last_compatibility_check_at,
+          compatibility_status: freshness_status(last_compatibility_check_at, configured["compatibility_lookahead_days"]),
+          last_upgrade_at: configured["last_upgrade_at"],
+          last_validated_upgrade_at: deployment_assurance.dig("disaster_recovery", "upgrade_last_validated_at")
+        }
+      end
+
+      def support_payload
+        configured = configuration.fetch("support", {})
+
+        {
+          diagnostics_contact: configured["diagnostics_contact"],
+          safe_remediation_mode: configured["safe_remediation_mode"],
+          health_report_recipients: configured["health_report_recipients"],
+          runner_total: runner_health[:total],
+          runner_available: runner_health[:available],
+          open_incidents: account.exception_incidents.open_incidents.count,
+          recent_account_events: account.account_activity_events.recent.limit(5).map(&:description),
+          actions: [
+            { label: "Open audit log", path: Rails.application.routes.url_helpers.account_audit_logs_path },
+            { label: "Edit tenant configuration", path: Rails.application.routes.url_helpers.edit_tenant_configuration_path }
+          ]
+        }
+      end
+
+      def capacity_payload
+        configured = configuration.fetch("capacity_management", {})
+        cost_ceiling_cents = tenant_setting.effective_guardrails["max_monthly_cost_cents"]
+        current_cost_cents = billing_visible ? usage_period&.total_cost_cents : nil
+
+        {
+          reserved_concurrency: configured["reserved_concurrency"],
+          configured_concurrency_limit: tenant_setting.effective_guardrails["max_concurrent_runs"],
+          queue_warning_threshold: configured["queue_warning_threshold"],
+          queue_critical_threshold: configured["queue_critical_threshold"],
+          current_queue_depth: queue_monitor.queue_depths.find { |depth| depth.type == :agent_run_queue }&.depth || 0,
+          current_queue_status: queue_monitor.healthy? ? :healthy : :constrained,
+          monthly_budget_alert_percent: configured["monthly_budget_alert_percent"],
+          monthly_cost_ceiling_cents: cost_ceiling_cents,
+          current_period_cost_cents: current_cost_cents,
+          cost_ceiling_utilization_percent: utilization_percent(current_cost_cents, cost_ceiling_cents),
+          project_budgets_count: account.projects.joins(:cost_budgets).distinct.count,
+          total_runs_in_period: usage_period&.total_runs,
+          total_compute_seconds_in_period: aggregated_usage&.dig(:compute_usage, :total_compute_seconds)
+        }
+      end
+
+      def monitored_run_count
+        @monitored_run_count ||= recent_runs.where.not(started_at: nil).count
+      end
+
+      def completed_run_count
+        @completed_run_count ||= recent_runs.where(status: "completed").count
+      end
+
+      def uptime_actual_percent
+        total_seconds = time_window.end - time_window.begin
+        return 100.0 if total_seconds <= 0
+
+        downtime_seconds = p1_incidents.sum { |incident| overlap_seconds(incident) }
+        percent = ((total_seconds - downtime_seconds) / total_seconds) * 100.0
+        percent.round(2).clamp(0.0, 100.0)
+      end
+
+      def queue_health_actual_percent
+        rows = recent_runs.where.not(started_at: nil).pluck(:created_at, :started_at)
+        return 100.0 if rows.empty?
+
+        target_minutes = configuration.dig("service_levels", "queue_start_slo_minutes")
+        met_count = rows.count { |created_at, started_at| ((started_at - created_at) / 60.0) <= target_minutes }
+        ((met_count / rows.size.to_f) * 100).round(2)
+      end
+
+      def p1_incidents
+        @p1_incidents ||= account.exception_incidents.by_severity("p1")
+          .where("last_occurred_at >= ? OR resolved_at >= ? OR status = ?", time_window.begin, time_window.begin, "open")
+      end
+
+      def overlap_seconds(incident)
+        start_time = [ incident.created_at, time_window.begin ].compact.max
+        end_time = [ incident.resolved_at || Time.current, time_window.end ].compact.min
+        return 0 if end_time <= start_time
+
+        end_time - start_time
+      end
+
+      def status_for_target(actual, target)
+        actual >= target ? :meeting : :at_risk
+      end
+
+      def freshness_status(date_value, interval_days)
+        date = parse_date(date_value)
+        return :missing unless date
+
+        date >= interval_days.days.ago.to_date ? :current : :stale
+      end
+
+      def utilization_percent(current, limit)
+        return nil if current.blank? || limit.blank? || limit.zero?
+
+        ((current.to_f / limit) * 100).round(1)
+      end
+
+      def parse_date(value)
+        return value if value.is_a?(Date)
+        return value.to_date if value.respond_to?(:to_date)
+        return if value.blank?
+
+        Date.iso8601(value.to_s)
+      rescue ArgumentError
+        nil
+      end
+    end
+  end
+end

--- a/app/services/accounts/operations/dashboard.rb
+++ b/app/services/accounts/operations/dashboard.rb
@@ -69,15 +69,18 @@ module Accounts
       end
 
       def service_levels_payload
+        uptime_percent = uptime_actual_percent
+        queue_health_percent = queue_health_actual_percent
+
         {
           window_days: configuration.dig("service_levels", "slo_window_days"),
           uptime_target_percent: configuration.dig("service_levels", "uptime_target_percent"),
-          uptime_actual_percent: uptime_actual_percent,
-          uptime_status: status_for_target(uptime_actual_percent, configuration.dig("service_levels", "uptime_target_percent")),
+          uptime_actual_percent: uptime_percent,
+          uptime_status: status_for_target(uptime_percent, configuration.dig("service_levels", "uptime_target_percent")),
           queue_health_target_percent: configuration.dig("service_levels", "queue_health_target_percent"),
-          queue_health_actual_percent: queue_health_actual_percent,
+          queue_health_actual_percent: queue_health_percent,
           queue_health_status: status_for_target(
-            queue_health_actual_percent,
+            queue_health_percent,
             configuration.dig("service_levels", "queue_health_target_percent")
           ),
           queue_start_slo_minutes: configuration.dig("service_levels", "queue_start_slo_minutes"),
@@ -173,21 +176,29 @@ module Accounts
       end
 
       def uptime_actual_percent
-        total_seconds = time_window.end - time_window.begin
-        return 100.0 if total_seconds <= 0
-
-        downtime_seconds = p1_incidents.sum { |incident| overlap_seconds(incident) }
-        percent = ((total_seconds - downtime_seconds) / total_seconds) * 100.0
-        percent.round(2).clamp(0.0, 100.0)
+        @uptime_actual_percent ||= begin
+          total_seconds = time_window.end - time_window.begin
+          if total_seconds <= 0
+            100.0
+          else
+            downtime_seconds = p1_incidents.sum { |incident| overlap_seconds(incident) }
+            percent = ((total_seconds - downtime_seconds) / total_seconds) * 100.0
+            percent.round(2).clamp(0.0, 100.0)
+          end
+        end
       end
 
       def queue_health_actual_percent
-        rows = recent_runs.where.not(started_at: nil).pluck(:created_at, :started_at)
-        return 100.0 if rows.empty?
-
-        target_minutes = configuration.dig("service_levels", "queue_start_slo_minutes")
-        met_count = rows.count { |created_at, started_at| ((started_at - created_at) / 60.0) <= target_minutes }
-        ((met_count / rows.size.to_f) * 100).round(2)
+        @queue_health_actual_percent ||= begin
+          rows = recent_runs.where.not(started_at: nil).pluck(:created_at, :started_at)
+          if rows.empty?
+            100.0
+          else
+            target_minutes = configuration.dig("service_levels", "queue_start_slo_minutes")
+            met_count = rows.count { |created_at, started_at| ((started_at - created_at) / 60.0) <= target_minutes }
+            ((met_count / rows.size.to_f) * 100).round(2)
+          end
+        end
       end
 
       def p1_incidents

--- a/app/services/accounts/operations/health_report.rb
+++ b/app/services/accounts/operations/health_report.rb
@@ -56,7 +56,7 @@ module Accounts
               last_occurred_at: incident.last_occurred_at.iso8601
             }
           },
-          recent_activity: account.account_activity_events.recent.limit(20).map { |event|
+          recent_activity: account.account_activity_events.includes(:actor).recent.limit(20).map { |event|
             {
               occurred_at: event.created_at.iso8601,
               actor: event.actor_label,

--- a/app/services/accounts/operations/health_report.rb
+++ b/app/services/accounts/operations/health_report.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Accounts
+  module Operations
+    class HealthReport
+      def self.call(...)
+        new(...).call
+      end
+
+      def initialize(account:, tenant_setting:, billing_visible: false)
+        @account = account
+        @tenant_setting = tenant_setting
+        @billing_visible = billing_visible
+      end
+
+      def call
+        {
+          schema_version: "2026-05-29",
+          generated_at: Time.current.iso8601,
+          account: {
+            id: account.id,
+            name: account.name,
+            slug: account.slug,
+            plan: account.plan,
+            status: account.status
+          },
+          operations_dashboard: dashboard,
+          queue_depths: Scaling::QueueMonitor.cached_for_account(account).queue_depths.map { |depth|
+            {
+              name: depth.name,
+              type: depth.type,
+              depth: depth.depth,
+              status: depth.status,
+              threshold_warning: depth.threshold_warning,
+              threshold_critical: depth.threshold_critical
+            }
+          },
+          runner_health: ::Dashboard::RunnerHealth.call(account: account).then { |stats|
+            stats.merge(runners: stats[:runners].map { |runner|
+              {
+                runner: runner.runner,
+                owner_email: runner.owner_email,
+                auth_type: runner.auth_type,
+                status: runner.status,
+                available: runner.available
+              }
+            })
+          },
+          open_incidents: account.exception_incidents.open_incidents.recent.limit(20).map { |incident|
+            {
+              fingerprint: incident.fingerprint,
+              subsystem: incident.subsystem,
+              severity: incident.severity,
+              status: incident.status,
+              action_taken: incident.action_taken,
+              last_occurred_at: incident.last_occurred_at.iso8601
+            }
+          },
+          recent_activity: account.account_activity_events.recent.limit(20).map { |event|
+            {
+              occurred_at: event.created_at.iso8601,
+              actor: event.actor_label,
+              action: event.action,
+              description: event.description
+            }
+          },
+          billing_visible: billing_visible
+        }
+      end
+
+      private
+
+      attr_reader :account, :tenant_setting, :billing_visible
+
+      def dashboard
+        @dashboard ||= Dashboard.call(
+          account: account,
+          tenant_setting: tenant_setting,
+          billing_visible: billing_visible
+        )
+      end
+    end
+  end
+end

--- a/app/services/screenshots/capture_targets.rb
+++ b/app/services/screenshots/capture_targets.rb
@@ -379,6 +379,7 @@ module Screenshots
       when /\Alinear_tokens\// then rest_resource_targets(relative_path, "linear_tokens", index: :linear_tokens, new: :linear_token_new, show: :linear_token_show, edit: :linear_token_show)
       when /\Auser_settings\// then [ :user_settings ]
       when /\Aaccounts\/compliance_dashboards\// then [ :account_compliance_dashboard ]
+      when /\Aaccounts\/operations_dashboards\// then [ :account_operations_dashboard ]
       when /\Aaccounts\/roi_dashboards\// then [ :account_roi_dashboard ]
       when /\Aaccounts\// then [ :account ]
       when /\Aaccount_audit_logs\// then [ :account_audit_logs ]

--- a/app/services/screenshots/capture_targets.rb
+++ b/app/services/screenshots/capture_targets.rb
@@ -32,6 +32,7 @@ module Screenshots
       user_settings
       account
       account_roi_dashboard
+      account_operations_dashboard
       account_audit_logs
       remediation_decision_show
       quality_dashboard
@@ -88,6 +89,7 @@ module Screenshots
       user_settings: Target.new(slug: "user_settings", path_builder: "/user_settings/edit", requires_auth: true),
       account: Target.new(slug: "account", path_builder: "/account", requires_auth: true),
       account_roi_dashboard: Target.new(slug: "account_roi_dashboard", path_builder: "/account_roi_dashboard", requires_auth: true),
+      account_operations_dashboard: Target.new(slug: "account_operations_dashboard", path_builder: "/account_operations_dashboard", requires_auth: true),
       account_compliance_dashboard: Target.new(slug: "account_compliance_dashboard", path_builder: "/account_compliance_dashboard", requires_auth: true),
       account_audit_logs: Target.new(slug: "account_audit_logs", path_builder: "/account_audit_logs", requires_auth: true),
       remediation_decision_show: Target.new(
@@ -261,6 +263,7 @@ module Screenshots
     NESTED_CONTROLLER_TARGETS = {
       "users/registrations_controller.rb" => [ :sign_up ],
       "accounts/compliance_dashboards_controller.rb" => [ :account_compliance_dashboard ],
+      "accounts/operations_dashboards_controller.rb" => [ :account_operations_dashboard ],
       "accounts/roi_dashboards_controller.rb" => [ :account_roi_dashboard ],
       "projects/agent_runs_controller.rb" => %i[project_agent_runs project_agent_run_new project_agent_run_show project_agent_run_provenance],
       "projects/bundle_performance_dashboards_controller.rb" => [ :project_bundle_performance_dashboard ],

--- a/app/views/accounts/operations_dashboards/show.html.erb
+++ b/app/views/accounts/operations_dashboards/show.html.erb
@@ -1,0 +1,285 @@
+<% content_for :title, "Operations Dashboard" %>
+
+<% can_manage_operations = policy(current_account).update? %>
+<% configuration = @operations_dashboard[:configuration] %>
+<% service_levels = @operations_dashboard[:service_levels] %>
+<% disaster_recovery = @operations_dashboard[:disaster_recovery] %>
+<% upgrades = @operations_dashboard[:upgrades] %>
+<% support = @operations_dashboard[:support] %>
+<% capacity = @operations_dashboard[:capacity] %>
+
+<div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+  <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+    <div>
+      <p class="text-sm font-medium uppercase tracking-[0.2em] text-amber-700 dark:text-amber-300">Operations</p>
+      <h1 class="mt-2 text-3xl font-semibold text-gray-900 dark:text-white">Enterprise Operations &amp; Reliability</h1>
+      <p class="mt-2 max-w-3xl text-sm text-gray-600 dark:text-gray-300">
+        Turn managed-service expectations into an explicit operating contract with customer-visible SLOs, restore commitments, upgrade readiness, and support-safe diagnostics.
+      </p>
+    </div>
+
+    <div class="flex flex-wrap gap-3">
+      <%= link_to "Back to account", account_path, class: "rounded-full border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-900" %>
+      <% if can_manage_operations %>
+        <%= link_to "Export operations report", export_account_operations_dashboard_path(format: :json), class: "rounded-full bg-amber-600 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-500" %>
+      <% end %>
+    </div>
+  </div>
+
+  <% if @tenant_setting.errors.any? %>
+    <div class="mt-6 rounded-2xl bg-red-50 px-4 py-3 text-sm text-red-800 dark:bg-red-950/40 dark:text-red-200">
+      <%= @tenant_setting.errors.full_messages.to_sentence %>
+    </div>
+  <% end %>
+
+  <div class="mt-8 grid gap-4 md:grid-cols-4">
+    <div class="rounded-3xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800 md:col-span-2">
+      <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Customer-visible reliability window</p>
+      <p class="mt-2 text-4xl font-semibold text-gray-900 dark:text-white"><%= service_levels[:window_days] %> days</p>
+      <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">SLO reporting period used for uptime and queue-start reporting.</p>
+    </div>
+    <div class="rounded-3xl border border-emerald-200 bg-emerald-50 p-5 shadow-sm dark:border-emerald-800 dark:bg-emerald-950/20">
+      <p class="text-xs uppercase tracking-wide text-emerald-700 dark:text-emerald-300">Uptime actual</p>
+      <p class="mt-2 text-4xl font-semibold text-gray-900 dark:text-white"><%= service_levels[:uptime_actual_percent] %>%</p>
+      <p class="text-sm text-gray-600 dark:text-gray-300">Target: <%= service_levels[:uptime_target_percent] %>%</p>
+    </div>
+    <div class="rounded-3xl border border-sky-200 bg-sky-50 p-5 shadow-sm dark:border-sky-800 dark:bg-sky-950/20">
+      <p class="text-xs uppercase tracking-wide text-sky-700 dark:text-sky-300">Queue health actual</p>
+      <p class="mt-2 text-4xl font-semibold text-gray-900 dark:text-white"><%= service_levels[:queue_health_actual_percent] %>%</p>
+      <p class="text-sm text-gray-600 dark:text-gray-300">Target: <%= service_levels[:queue_health_target_percent] %>%</p>
+    </div>
+  </div>
+
+  <div class="mt-8 grid gap-8 xl:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.9fr)]">
+    <div class="space-y-8">
+      <section class="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <div class="flex items-center justify-between gap-4">
+          <div>
+            <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Support-safe diagnostics</h2>
+            <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">Expose the minimum data support needs to diagnose tenant issues without turning the dashboard into an unsafe control plane.</p>
+          </div>
+        </div>
+
+        <div class="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <div class="rounded-2xl bg-gray-50 p-4 dark:bg-gray-900/60">
+            <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Open incidents</p>
+            <p class="mt-2 text-3xl font-semibold text-gray-900 dark:text-white"><%= support[:open_incidents] %></p>
+          </div>
+          <div class="rounded-2xl bg-gray-50 p-4 dark:bg-gray-900/60">
+            <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Available runners</p>
+            <p class="mt-2 text-3xl font-semibold text-gray-900 dark:text-white"><%= support[:runner_available] %> / <%= support[:runner_total] %></p>
+          </div>
+          <div class="rounded-2xl bg-gray-50 p-4 dark:bg-gray-900/60">
+            <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Safe remediation mode</p>
+            <p class="mt-2 text-lg font-semibold text-gray-900 dark:text-white"><%= support[:safe_remediation_mode].to_s.humanize %></p>
+          </div>
+          <div class="rounded-2xl bg-gray-50 p-4 dark:bg-gray-900/60">
+            <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Diagnostics contact</p>
+            <p class="mt-2 text-lg font-semibold text-gray-900 dark:text-white"><%= support[:diagnostics_contact].presence || "Unassigned" %></p>
+          </div>
+        </div>
+
+        <div class="mt-6 grid gap-6 lg:grid-cols-2">
+          <div>
+            <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Recent activity</h3>
+            <div class="mt-3 space-y-3">
+              <% support[:recent_account_events].each do |event| %>
+                <div class="rounded-2xl border border-gray-200 px-4 py-3 text-sm text-gray-700 dark:border-gray-700 dark:text-gray-200"><%= event %></div>
+              <% end %>
+            </div>
+          </div>
+
+          <div>
+            <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Support actions</h3>
+            <div class="mt-3 space-y-3">
+              <% support[:actions].each do |action| %>
+                <%= link_to action[:label], action[:path], class: "block rounded-2xl border border-gray-200 px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-900" %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <div>
+          <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Capacity &amp; cost controls</h2>
+          <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">Make queue pressure and managed-environment cost ceilings explicit before they become reliability incidents.</p>
+        </div>
+
+        <div class="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <div class="rounded-2xl bg-gray-50 p-4 dark:bg-gray-900/60">
+            <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Queue depth</p>
+            <p class="mt-2 text-3xl font-semibold text-gray-900 dark:text-white"><%= capacity[:current_queue_depth] %></p>
+            <p class="text-sm text-gray-500 dark:text-gray-400">Warn at <%= capacity[:queue_warning_threshold] %>, critical at <%= capacity[:queue_critical_threshold] %></p>
+          </div>
+          <div class="rounded-2xl bg-gray-50 p-4 dark:bg-gray-900/60">
+            <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Concurrency limit</p>
+            <p class="mt-2 text-3xl font-semibold text-gray-900 dark:text-white"><%= capacity[:configured_concurrency_limit] %></p>
+            <p class="text-sm text-gray-500 dark:text-gray-400">Reserved: <%= capacity[:reserved_concurrency] %></p>
+          </div>
+          <div class="rounded-2xl bg-gray-50 p-4 dark:bg-gray-900/60">
+            <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Monthly ceiling</p>
+            <p class="mt-2 text-3xl font-semibold text-gray-900 dark:text-white"><%= capacity[:monthly_cost_ceiling_cents] ? number_to_currency(capacity[:monthly_cost_ceiling_cents] / 100.0) : "None" %></p>
+            <p class="text-sm text-gray-500 dark:text-gray-400">Alert at <%= capacity[:monthly_budget_alert_percent] %>%</p>
+          </div>
+          <div class="rounded-2xl bg-gray-50 p-4 dark:bg-gray-900/60">
+            <p class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Period spend</p>
+            <p class="mt-2 text-3xl font-semibold text-gray-900 dark:text-white"><%= capacity[:current_period_cost_cents] ? number_to_currency(capacity[:current_period_cost_cents] / 100.0) : "Hidden" %></p>
+            <p class="text-sm text-gray-500 dark:text-gray-400"><%= capacity[:cost_ceiling_utilization_percent] ? "#{capacity[:cost_ceiling_utilization_percent]}% of ceiling" : "Billing visibility required" %></p>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <div class="space-y-8">
+      <section class="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <div>
+          <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Disaster recovery</h2>
+          <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">Track backup verification, restore drills, and customer-facing RPO/RTO commitments in one place.</p>
+        </div>
+
+        <dl class="mt-6 space-y-4 text-sm">
+          <div>
+            <dt class="font-medium text-gray-900 dark:text-white">Automated backups</dt>
+            <dd class="mt-1 text-gray-600 dark:text-gray-300"><%= disaster_recovery[:automated_backups_enabled] ? "Enabled" : "Disabled" %> • <%= disaster_recovery[:backup_cadence].to_s.humanize %></dd>
+          </div>
+          <div>
+            <dt class="font-medium text-gray-900 dark:text-white">Last backup verification</dt>
+            <dd class="mt-1 text-gray-600 dark:text-gray-300"><%= disaster_recovery[:backup_last_verified_at].presence || "Not recorded" %></dd>
+          </div>
+          <div>
+            <dt class="font-medium text-gray-900 dark:text-white">Last restore drill</dt>
+            <dd class="mt-1 text-gray-600 dark:text-gray-300"><%= disaster_recovery[:last_restore_drill_at].presence || "Not recorded" %> • <%= disaster_recovery[:restore_drill_status].to_s.humanize %></dd>
+          </div>
+          <div>
+            <dt class="font-medium text-gray-900 dark:text-white">Customer commitments</dt>
+            <dd class="mt-1 text-gray-600 dark:text-gray-300">RPO <%= disaster_recovery[:recovery_point_objective_hours] %>h • RTO <%= disaster_recovery[:recovery_time_objective_hours] %>h</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section class="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <div>
+          <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Upgrade orchestration</h2>
+          <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">Record maintenance windows, compatibility validation, and rollout channel choices before a fleet-wide upgrade.</p>
+        </div>
+
+        <dl class="mt-6 space-y-4 text-sm">
+          <div>
+            <dt class="font-medium text-gray-900 dark:text-white">Release channel</dt>
+            <dd class="mt-1 text-gray-600 dark:text-gray-300"><%= upgrades[:release_channel].to_s.humanize %></dd>
+          </div>
+          <div>
+            <dt class="font-medium text-gray-900 dark:text-white">Maintenance window</dt>
+            <dd class="mt-1 text-gray-600 dark:text-gray-300"><%= upgrades[:maintenance_window] %></dd>
+          </div>
+          <div>
+            <dt class="font-medium text-gray-900 dark:text-white">Compatibility check</dt>
+            <dd class="mt-1 text-gray-600 dark:text-gray-300"><%= upgrades[:last_compatibility_check_at].presence || "Not recorded" %> • <%= upgrades[:compatibility_status].to_s.humanize %></dd>
+          </div>
+          <div>
+            <dt class="font-medium text-gray-900 dark:text-white">Last upgrade</dt>
+            <dd class="mt-1 text-gray-600 dark:text-gray-300"><%= upgrades[:last_upgrade_at].presence || "Not recorded" %></dd>
+          </div>
+        </dl>
+      </section>
+
+      <section class="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <div>
+          <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Operations settings</h2>
+          <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">Manage the contract support and customer teams rely on when Paid is operated as a managed service.</p>
+        </div>
+
+        <%= form_with url: account_operations_dashboard_path, method: :patch, class: "mt-6 space-y-8" do %>
+          <section>
+            <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Service levels</h3>
+            <div class="mt-3 grid gap-4 sm:grid-cols-2">
+              <div>
+                <%= label_tag "enterprise_operations_service_levels_slo_window_days", "Reporting window (days)", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= number_field_tag "enterprise_operations[service_levels][slo_window_days]", configuration.dig("service_levels", "slo_window_days"), min: 1, class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+              <div>
+                <%= label_tag "enterprise_operations_service_levels_queue_start_slo_minutes", "Queue start SLO (minutes)", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= number_field_tag "enterprise_operations[service_levels][queue_start_slo_minutes]", configuration.dig("service_levels", "queue_start_slo_minutes"), min: 1, class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+              <div>
+                <%= label_tag "enterprise_operations_service_levels_uptime_target_percent", "Uptime target %", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= number_field_tag "enterprise_operations[service_levels][uptime_target_percent]", configuration.dig("service_levels", "uptime_target_percent"), min: 1, max: 100, step: 0.1, class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+              <div>
+                <%= label_tag "enterprise_operations_service_levels_queue_health_target_percent", "Queue health target %", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= number_field_tag "enterprise_operations[service_levels][queue_health_target_percent]", configuration.dig("service_levels", "queue_health_target_percent"), min: 1, max: 100, step: 0.1, class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+            </div>
+          </section>
+
+          <section>
+            <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Disaster recovery</h3>
+            <div class="mt-3 grid gap-4 sm:grid-cols-2">
+              <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-200">
+                <%= check_box_tag "enterprise_operations[disaster_recovery][automated_backups_enabled]", "1", configuration.dig("disaster_recovery", "automated_backups_enabled") %>
+                Automated backups enabled
+              </label>
+              <div>
+                <%= label_tag "enterprise_operations_disaster_recovery_restore_drill_interval_days", "Restore drill interval (days)", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= number_field_tag "enterprise_operations[disaster_recovery][restore_drill_interval_days]", configuration.dig("disaster_recovery", "restore_drill_interval_days"), min: 1, class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+              <div>
+                <%= label_tag "enterprise_operations_disaster_recovery_restore_owner", "Restore owner", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= text_field_tag "enterprise_operations[disaster_recovery][restore_owner]", configuration.dig("disaster_recovery", "restore_owner"), class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+              <div>
+                <%= label_tag "enterprise_operations_disaster_recovery_last_restore_drill_at", "Last restore drill", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= date_field_tag "enterprise_operations[disaster_recovery][last_restore_drill_at]", configuration.dig("disaster_recovery", "last_restore_drill_at"), class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+            </div>
+          </section>
+
+          <section>
+            <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Upgrades, support, and capacity</h3>
+            <div class="mt-3 grid gap-4 sm:grid-cols-2">
+              <div>
+                <%= label_tag "enterprise_operations_upgrades_release_channel", "Release channel", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= select_tag "enterprise_operations[upgrades][release_channel]", options_for_select(TenantSetting::ENTERPRISE_OPERATIONS_RELEASE_CHANNELS.map { |value| [value.humanize, value] }, configuration.dig("upgrades", "release_channel")), class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+              <div>
+                <%= label_tag "enterprise_operations_upgrades_maintenance_window", "Maintenance window", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= text_field_tag "enterprise_operations[upgrades][maintenance_window]", configuration.dig("upgrades", "maintenance_window"), class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+              <div>
+                <%= label_tag "enterprise_operations_upgrades_compatibility_lookahead_days", "Compatibility lookahead (days)", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= number_field_tag "enterprise_operations[upgrades][compatibility_lookahead_days]", configuration.dig("upgrades", "compatibility_lookahead_days"), min: 1, class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+              <div>
+                <%= label_tag "enterprise_operations_upgrades_last_compatibility_check_at", "Last compatibility check", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= date_field_tag "enterprise_operations[upgrades][last_compatibility_check_at]", configuration.dig("upgrades", "last_compatibility_check_at"), class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+              <div>
+                <%= label_tag "enterprise_operations_support_diagnostics_contact", "Diagnostics contact", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= text_field_tag "enterprise_operations[support][diagnostics_contact]", configuration.dig("support", "diagnostics_contact"), class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+              <div>
+                <%= label_tag "enterprise_operations_support_safe_remediation_mode", "Safe remediation mode", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= select_tag "enterprise_operations[support][safe_remediation_mode]", options_for_select(TenantSetting::ENTERPRISE_OPERATIONS_REMEDIATION_MODES.map { |value| [value.humanize, value] }, configuration.dig("support", "safe_remediation_mode")), class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+              <div>
+                <%= label_tag "enterprise_operations_capacity_management_reserved_concurrency", "Reserved concurrency", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= number_field_tag "enterprise_operations[capacity_management][reserved_concurrency]", configuration.dig("capacity_management", "reserved_concurrency"), min: 0, class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+              <div>
+                <%= label_tag "enterprise_operations_capacity_management_monthly_budget_alert_percent", "Budget alert %", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= number_field_tag "enterprise_operations[capacity_management][monthly_budget_alert_percent]", configuration.dig("capacity_management", "monthly_budget_alert_percent"), min: 1, max: 100, class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+            </div>
+          </section>
+
+          <% if can_manage_operations %>
+            <div class="flex justify-end">
+              <%= submit_tag "Save operations settings", class: "rounded-full bg-gray-900 px-5 py-2.5 text-sm font-semibold text-white hover:bg-gray-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200" %>
+            </div>
+          <% end %>
+        <% end %>
+      </section>
+    </div>
+  </div>
+</div>

--- a/app/views/accounts/operations_dashboards/show.html.erb
+++ b/app/views/accounts/operations_dashboards/show.html.erb
@@ -210,6 +210,14 @@
                 <%= label_tag "enterprise_operations_service_levels_queue_health_target_percent", "Queue health target %", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
                 <%= number_field_tag "enterprise_operations[service_levels][queue_health_target_percent]", configuration.dig("service_levels", "queue_health_target_percent"), min: 1, max: 100, step: 0.1, class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
               </div>
+              <div>
+                <%= label_tag "enterprise_operations_service_levels_urgent_response_sla_hours", "Urgent response SLA (hours)", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= number_field_tag "enterprise_operations[service_levels][urgent_response_sla_hours]", configuration.dig("service_levels", "urgent_response_sla_hours"), min: 1, class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+              <div>
+                <%= label_tag "enterprise_operations_service_levels_standard_response_sla_hours", "Standard response SLA (hours)", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= number_field_tag "enterprise_operations[service_levels][standard_response_sla_hours]", configuration.dig("service_levels", "standard_response_sla_hours"), min: 1, class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
             </div>
           </section>
 
@@ -256,6 +264,10 @@
                 <%= date_field_tag "enterprise_operations[upgrades][last_compatibility_check_at]", configuration.dig("upgrades", "last_compatibility_check_at"), class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
               </div>
               <div>
+                <%= label_tag "enterprise_operations_upgrades_last_upgrade_at", "Last upgrade", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= date_field_tag "enterprise_operations[upgrades][last_upgrade_at]", configuration.dig("upgrades", "last_upgrade_at"), class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+              <div>
                 <%= label_tag "enterprise_operations_support_diagnostics_contact", "Diagnostics contact", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
                 <%= text_field_tag "enterprise_operations[support][diagnostics_contact]", configuration.dig("support", "diagnostics_contact"), class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
               </div>
@@ -264,8 +276,20 @@
                 <%= select_tag "enterprise_operations[support][safe_remediation_mode]", options_for_select(TenantSetting::ENTERPRISE_OPERATIONS_REMEDIATION_MODES.map { |value| [value.humanize, value] }, configuration.dig("support", "safe_remediation_mode")), class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
               </div>
               <div>
+                <%= label_tag "enterprise_operations_support_health_report_recipients", "Health report recipients", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= text_field_tag "enterprise_operations[support][health_report_recipients]", configuration.dig("support", "health_report_recipients"), class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+              <div>
                 <%= label_tag "enterprise_operations_capacity_management_reserved_concurrency", "Reserved concurrency", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
                 <%= number_field_tag "enterprise_operations[capacity_management][reserved_concurrency]", configuration.dig("capacity_management", "reserved_concurrency"), min: 0, class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+              <div>
+                <%= label_tag "enterprise_operations_capacity_management_queue_warning_threshold", "Queue warning threshold", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= number_field_tag "enterprise_operations[capacity_management][queue_warning_threshold]", configuration.dig("capacity_management", "queue_warning_threshold"), min: 0, class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
+              </div>
+              <div>
+                <%= label_tag "enterprise_operations_capacity_management_queue_critical_threshold", "Queue critical threshold", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+                <%= number_field_tag "enterprise_operations[capacity_management][queue_critical_threshold]", configuration.dig("capacity_management", "queue_critical_threshold"), min: 0, class: "mt-1 block w-full rounded-xl border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-900 dark:text-white" %>
               </div>
               <div>
                 <%= label_tag "enterprise_operations_capacity_management_monthly_budget_alert_percent", "Budget alert %", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>

--- a/app/views/accounts/operations_dashboards/show.html.erb
+++ b/app/views/accounts/operations_dashboards/show.html.erb
@@ -217,6 +217,7 @@
             <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Disaster recovery</h3>
             <div class="mt-3 grid gap-4 sm:grid-cols-2">
               <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-200">
+                <%= hidden_field_tag "enterprise_operations[disaster_recovery][automated_backups_enabled]", "0" %>
                 <%= check_box_tag "enterprise_operations[disaster_recovery][automated_backups_enabled]", "1", configuration.dig("disaster_recovery", "automated_backups_enabled") %>
                 Automated backups enabled
               </label>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -309,6 +309,44 @@
         </div>
       </section>
 
+      <section class="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Operations & Reliability</h2>
+            <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">Publish customer-visible SLAs, backup posture, upgrade readiness, support diagnostics, and managed-service capacity signals.</p>
+          </div>
+          <div class="flex flex-wrap gap-3">
+            <%= link_to "Open dashboard", account_operations_dashboard_path, class: "rounded-full bg-amber-600 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-500" %>
+            <% if policy(current_account).update? %>
+              <%= link_to "Export report", export_account_operations_dashboard_path(format: :json), class: "rounded-full border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-900" %>
+            <% end %>
+          </div>
+        </div>
+
+        <div class="mt-6 grid gap-4 md:grid-cols-4">
+          <div class="rounded-2xl bg-emerald-50 p-4 dark:bg-emerald-950/20">
+            <p class="text-xs uppercase tracking-wide text-emerald-700 dark:text-emerald-300">Uptime</p>
+            <p class="mt-2 text-3xl font-semibold text-gray-900 dark:text-white"><%= @operations_dashboard.dig(:service_levels, :uptime_actual_percent) %>%</p>
+            <p class="text-sm text-gray-600 dark:text-gray-300">Target: <%= @operations_dashboard.dig(:service_levels, :uptime_target_percent) %>%</p>
+          </div>
+          <div class="rounded-2xl bg-sky-50 p-4 dark:bg-sky-950/20">
+            <p class="text-xs uppercase tracking-wide text-sky-700 dark:text-sky-300">Queue health</p>
+            <p class="mt-2 text-3xl font-semibold text-gray-900 dark:text-white"><%= @operations_dashboard.dig(:service_levels, :queue_health_actual_percent) %>%</p>
+            <p class="text-sm text-gray-600 dark:text-gray-300"><%= @operations_dashboard.dig(:service_levels, :queue_start_slo_minutes) %>-minute start SLO</p>
+          </div>
+          <div class="rounded-2xl bg-amber-50 p-4 dark:bg-amber-950/20">
+            <p class="text-xs uppercase tracking-wide text-amber-700 dark:text-amber-300">Restore drills</p>
+            <p class="mt-2 text-3xl font-semibold text-gray-900 dark:text-white"><%= @operations_dashboard.dig(:disaster_recovery, :last_restore_drill_at).presence || "Missing" %></p>
+            <p class="text-sm text-gray-600 dark:text-gray-300">Interval: every <%= @operations_dashboard.dig(:disaster_recovery, :restore_drill_interval_days) %> days</p>
+          </div>
+          <div class="rounded-2xl bg-violet-50 p-4 dark:bg-violet-950/20">
+            <p class="text-xs uppercase tracking-wide text-violet-700 dark:text-violet-300">Queue depth</p>
+            <p class="mt-2 text-3xl font-semibold text-gray-900 dark:text-white"><%= @operations_dashboard.dig(:capacity, :current_queue_depth) %></p>
+            <p class="text-sm text-gray-600 dark:text-gray-300">Reserved concurrency: <%= @operations_dashboard.dig(:capacity, :reserved_concurrency) %></p>
+          </div>
+        </div>
+      </section>
+
       <%= render "accounts/adoption_readiness", adoption_dashboard: @adoption_dashboard %>
 
       <% if @billing_visible %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,9 @@ Rails.application.routes.draw do
   resource :account_compliance_dashboard, only: [ :show, :update ], controller: "accounts/compliance_dashboards" do
     get :export
   end
+  resource :account_operations_dashboard, only: [ :show, :update ], controller: "accounts/operations_dashboards" do
+    get :export
+  end
   resources :account_memberships, only: [ :create, :update, :destroy ]
   resource :account_ownership_transfer, only: [ :create ]
   resource :account_lifecycle, only: [ :update ]

--- a/spec/requests/accounts/operations_dashboards_spec.rb
+++ b/spec/requests/accounts/operations_dashboards_spec.rb
@@ -108,6 +108,16 @@ RSpec.describe "Accounts::OperationsDashboards" do
       expect(account.account_activity_events.recent.first.action).to eq("operations.dashboard_updated")
     end
 
+    it "does not record activity for a no-op update" do
+      account.tenant_setting!.update!(enterprise_operations_configuration: operations_params.fetch(:enterprise_operations))
+
+      expect do
+        patch account_operations_dashboard_path, params: operations_params
+      end.not_to change(AccountActivityEvent, :count)
+
+      expect(response).to redirect_to(account_operations_dashboard_path)
+    end
+
     it "allows disabling automated backups" do
       account.tenant_setting!.update!(
         enterprise_operations_configuration: account.tenant_setting!.enterprise_operations_configuration.deep_merge(

--- a/spec/requests/accounts/operations_dashboards_spec.rb
+++ b/spec/requests/accounts/operations_dashboards_spec.rb
@@ -90,6 +90,25 @@ RSpec.describe "Accounts::OperationsDashboards" do
       expect(account.account_activity_events.recent.first.action).to eq("operations.dashboard_updated")
     end
 
+    it "allows disabling automated backups" do
+      account.tenant_setting!.update!(
+        enterprise_operations_configuration: account.tenant_setting!.enterprise_operations_configuration.deep_merge(
+          "disaster_recovery" => { "automated_backups_enabled" => true }
+        )
+      )
+
+      patch account_operations_dashboard_path, params: operations_params.deep_merge(
+        enterprise_operations: {
+          disaster_recovery: {
+            automated_backups_enabled: "0"
+          }
+        }
+      )
+
+      expect(response).to redirect_to(account_operations_dashboard_path)
+      expect(account.tenant_setting!.reload.enterprise_operations_configuration.dig("disaster_recovery", "automated_backups_enabled")).to be(false)
+    end
+
     it "rejects invalid enterprise operations values" do
       patch account_operations_dashboard_path, params: operations_params.deep_merge(
         enterprise_operations: {

--- a/spec/requests/accounts/operations_dashboards_spec.rb
+++ b/spec/requests/accounts/operations_dashboards_spec.rb
@@ -79,6 +79,32 @@ RSpec.describe "Accounts::OperationsDashboards" do
         "Disaster recovery",
         "Upgrade orchestration"
       )
+      expect(response.body).to include(
+        'name="enterprise_operations[service_levels][urgent_response_sla_hours]"',
+        'name="enterprise_operations[service_levels][standard_response_sla_hours]"',
+        'name="enterprise_operations[upgrades][last_upgrade_at]"',
+        'name="enterprise_operations[support][health_report_recipients]"',
+        'name="enterprise_operations[capacity_management][queue_warning_threshold]"',
+        'name="enterprise_operations[capacity_management][queue_critical_threshold]"'
+      )
+    end
+
+    it "renders persisted operations settings in the editable form" do
+      account.tenant_setting!.update!(
+        enterprise_operations_configuration: account.tenant_setting!.enterprise_operations_configuration.deep_merge(existing_operations_configuration)
+      )
+
+      get account_operations_dashboard_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(
+        'value="8"',
+        'value="16"',
+        'value="2026-05-01"',
+        'value="ops@example.com"',
+        'value="9"',
+        'value="18"'
+      )
     end
 
     it "hides the export link from members" do
@@ -181,6 +207,13 @@ RSpec.describe "Accounts::OperationsDashboards" do
 
   describe "GET /account_operations_dashboard/export" do
     it "exports the health report as JSON" do
+      AccountActivityEvent.create!(
+        account: account,
+        actor: owner,
+        action: "operations.dashboard_updated",
+        metadata: { "changed_fields" => [ "enterprise_operations" ] }
+      )
+
       get export_account_operations_dashboard_path(format: :json)
 
       expect(response).to have_http_status(:ok)
@@ -189,6 +222,7 @@ RSpec.describe "Accounts::OperationsDashboards" do
       body = JSON.parse(response.body)
       expect(body.fetch("account").fetch("name")).to eq("Acme")
       expect(body).to include("operations_dashboard", "queue_depths", "runner_health", "open_incidents")
+      expect(body.fetch("recent_activity").first.fetch("actor")).to eq(owner.email)
     end
 
     it "forbids members from exporting the health report" do

--- a/spec/requests/accounts/operations_dashboards_spec.rb
+++ b/spec/requests/accounts/operations_dashboards_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Accounts::OperationsDashboards" do
+  let(:account) { create(:account, name: "Acme") }
+  let(:owner) { create(:user, :owner, account: account) }
+  let(:member) { create(:user, :member, account: account) }
+  let(:operations_params) do
+    {
+      enterprise_operations: {
+        service_levels: {
+          slo_window_days: "45",
+          uptime_target_percent: "99.95",
+          queue_health_target_percent: "99.5",
+          queue_start_slo_minutes: "12",
+          urgent_response_sla_hours: "1",
+          standard_response_sla_hours: "4"
+        },
+        disaster_recovery: {
+          automated_backups_enabled: "1",
+          restore_drill_interval_days: "60",
+          restore_owner: "ops@example.com",
+          last_restore_drill_at: Date.current.iso8601
+        },
+        upgrades: {
+          release_channel: "lts",
+          maintenance_window: "Sat 03:00 UTC",
+          compatibility_lookahead_days: "21",
+          last_compatibility_check_at: Date.current.iso8601,
+          last_upgrade_at: Date.current.iso8601
+        },
+        support: {
+          diagnostics_contact: "support@example.com",
+          safe_remediation_mode: "approval_required",
+          health_report_recipients: "ops@example.com, buyer@example.com"
+        },
+        capacity_management: {
+          reserved_concurrency: "2",
+          queue_warning_threshold: "15",
+          queue_critical_threshold: "30",
+          monthly_budget_alert_percent: "75"
+        }
+      }
+    }
+  end
+
+  before do
+    sign_in owner
+  end
+
+  describe "GET /account_operations_dashboard" do
+    it "renders the operations dashboard" do
+      get account_operations_dashboard_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(
+        "Enterprise Operations &amp; Reliability",
+        "Support-safe diagnostics",
+        "Capacity &amp; cost controls",
+        "Disaster recovery",
+        "Upgrade orchestration"
+      )
+    end
+
+    it "hides the export link from members" do
+      sign_out owner
+      sign_in member
+
+      get account_operations_dashboard_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("Export operations report")
+      expect(response.body).not_to include("Save operations settings")
+    end
+  end
+
+  describe "PATCH /account_operations_dashboard" do
+    it "updates enterprise operations settings and records activity" do
+      expect do
+        patch account_operations_dashboard_path, params: operations_params
+      end.to change(AccountActivityEvent, :count).by(1)
+
+      expect(response).to redirect_to(account_operations_dashboard_path)
+
+      operations = account.tenant_setting!.reload.enterprise_operations_configuration
+      expect(operations.dig("service_levels", "slo_window_days")).to eq(45)
+      expect(operations.dig("service_levels", "uptime_target_percent")).to eq(99.95)
+      expect(operations.dig("upgrades", "release_channel")).to eq("lts")
+      expect(account.account_activity_events.recent.first.action).to eq("operations.dashboard_updated")
+    end
+
+    it "rejects invalid enterprise operations values" do
+      patch account_operations_dashboard_path, params: operations_params.deep_merge(
+        enterprise_operations: {
+          service_levels: { uptime_target_percent: "1000" },
+          support: { safe_remediation_mode: "freeform" }
+        }
+      )
+
+      expect(response).to have_http_status(:unprocessable_content)
+
+      operations = account.tenant_setting!.reload.enterprise_operations_configuration
+      expect(operations.dig("service_levels", "uptime_target_percent")).to eq(99.9)
+      expect(operations.dig("support", "safe_remediation_mode")).to eq("approval_required")
+    end
+  end
+
+  describe "GET /account_operations_dashboard/export" do
+    it "exports the health report as JSON" do
+      get export_account_operations_dashboard_path(format: :json)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("application/json")
+
+      body = JSON.parse(response.body)
+      expect(body.fetch("account").fetch("name")).to eq("Acme")
+      expect(body).to include("operations_dashboard", "queue_depths", "runner_health", "open_incidents")
+    end
+
+    it "forbids members from exporting the health report" do
+      sign_out owner
+      sign_in member
+
+      get export_account_operations_dashboard_path(format: :json)
+
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end

--- a/spec/requests/accounts/operations_dashboards_spec.rb
+++ b/spec/requests/accounts/operations_dashboards_spec.rb
@@ -44,6 +44,24 @@ RSpec.describe "Accounts::OperationsDashboards" do
       }
     }
   end
+  let(:existing_operations_configuration) do
+    {
+      "service_levels" => {
+        "urgent_response_sla_hours" => 8,
+        "standard_response_sla_hours" => 16
+      },
+      "support" => {
+        "health_report_recipients" => "ops@example.com"
+      },
+      "upgrades" => {
+        "last_upgrade_at" => "2026-05-01"
+      },
+      "capacity_management" => {
+        "queue_warning_threshold" => 9,
+        "queue_critical_threshold" => 18
+      }
+    }
+  end
 
   before do
     sign_in owner
@@ -107,6 +125,32 @@ RSpec.describe "Accounts::OperationsDashboards" do
 
       expect(response).to redirect_to(account_operations_dashboard_path)
       expect(account.tenant_setting!.reload.enterprise_operations_configuration.dig("disaster_recovery", "automated_backups_enabled")).to be(false)
+    end
+
+    it "preserves omitted enterprise operations values on partial updates" do
+      tenant_setting = account.tenant_setting!
+      tenant_setting.update!(
+        enterprise_operations_configuration: tenant_setting.enterprise_operations_configuration.deep_merge(existing_operations_configuration)
+      )
+
+      patch account_operations_dashboard_path, params: {
+        enterprise_operations: {
+          service_levels: {
+            slo_window_days: "45"
+          }
+        }
+      }
+
+      expect(response).to redirect_to(account_operations_dashboard_path)
+
+      operations = tenant_setting.reload.enterprise_operations_configuration
+      expect(operations.dig("service_levels", "slo_window_days")).to eq(45)
+      expect(operations.dig("service_levels", "urgent_response_sla_hours")).to eq(8)
+      expect(operations.dig("service_levels", "standard_response_sla_hours")).to eq(16)
+      expect(operations.dig("support", "health_report_recipients")).to eq("ops@example.com")
+      expect(operations.dig("upgrades", "last_upgrade_at")).to eq("2026-05-01")
+      expect(operations.dig("capacity_management", "queue_warning_threshold")).to eq(9)
+      expect(operations.dig("capacity_management", "queue_critical_threshold")).to eq(18)
     end
 
     it "rejects invalid enterprise operations values" do

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -23,20 +23,7 @@ RSpec.describe "Accounts" do
       get account_path
 
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include(
-        "Account Administration",
-        "Self-Heal Policy",
-        "Team",
-        "Tenant Limits and Usage",
-        "ROI, Evals & Benchmarking",
-        "Compliance & Deployment Assurance",
-        "Adoption &amp; Operational Readiness",
-        "Admin playbooks",
-        "Role-based training &amp; onboarding",
-        "Reference operating models",
-        "Billing",
-        "Activity Trail"
-      )
+      expect(response.body).to include(*account_page_sections)
     end
 
     it "allows a viewer to read the page" do
@@ -418,5 +405,23 @@ RSpec.describe "Accounts" do
 
       expect(response).to redirect_to(new_user_session_path)
     end
+  end
+
+  def account_page_sections
+    [
+      "Account Administration",
+      "Self-Heal Policy",
+      "Team",
+      "Tenant Limits and Usage",
+      "ROI, Evals & Benchmarking",
+      "Compliance & Deployment Assurance",
+      "Operations & Reliability",
+      "Adoption &amp; Operational Readiness",
+      "Admin playbooks",
+      "Role-based training &amp; onboarding",
+      "Reference operating models",
+      "Billing",
+      "Activity Trail"
+    ]
   end
 end

--- a/spec/services/accounts/operations/dashboard_spec.rb
+++ b/spec/services/accounts/operations/dashboard_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Accounts::Operations::Dashboard do
+  describe ".call" do
+    let(:account) { create(:account) }
+    let(:tenant_setting) { account.tenant_setting! }
+    let(:project) { create(:project, account: account) }
+
+    before do
+      create(:billing_plan, :per_run, account: account)
+      create(:billing_period, account: account, total_cost_cents: 15_000, total_runs: 12, starts_at: 20.days.ago, ends_at: 10.days.from_now)
+      create(:user, :owner, account: account)
+      allow(Scaling::QueueMonitor).to receive(:cached_for_account).and_return(
+        Scaling::QueueMonitor::Result.new(
+          queue_depths: [
+            Scaling::QueueMonitor::QueueDepth.new(
+              name: "agent_runs",
+              type: :agent_run_queue,
+              depth: 3,
+              threshold_warning: 20,
+              threshold_critical: 50,
+              status: :ok
+            )
+          ],
+          alerts: [],
+          healthy?: true
+        )
+      )
+    end
+
+    it "builds a customer-visible operations summary" do
+      create(:agent_run, project: project, created_at: 5.days.ago, started_at: 5.days.ago + 3.minutes, status: "completed")
+      create(:agent_run, project: project, created_at: 4.days.ago, started_at: 4.days.ago + 8.minutes, status: "completed")
+      create_resolved_p1_incident!
+      configure_operations!
+
+      result = described_class.call(account: account, tenant_setting: tenant_setting, billing_visible: true)
+
+      expect(result.dig(:service_levels, :queue_health_actual_percent)).to eq(100.0)
+      expect(result.dig(:service_levels, :uptime_actual_percent)).to be < 100.0
+      expect(result.dig(:disaster_recovery, :restore_drill_status)).to eq(:current)
+      expect(result.dig(:capacity, :current_queue_depth)).to eq(3)
+      expect(result.dig(:capacity, :current_period_cost_cents)).to eq(15_000)
+    end
+
+    it "hides billing-derived cost data when billing visibility is disabled" do
+      result = described_class.call(account: account, tenant_setting: tenant_setting, billing_visible: false)
+
+      expect(result.dig(:capacity, :current_period_cost_cents)).to be_nil
+      expect(result.dig(:capacity, :cost_ceiling_utilization_percent)).to be_nil
+    end
+
+    def configure_operations!
+      tenant_setting.enterprise_operations_configuration = {
+        "service_levels" => { "queue_start_slo_minutes" => 10 },
+        "disaster_recovery" => { "last_restore_drill_at" => 20.days.ago.to_date.iso8601 }
+      }
+      tenant_setting.save!
+    end
+
+    def create_resolved_p1_incident!
+      create(
+        :exception_incident,
+        account: account,
+        severity: "p1",
+        status: "resolved",
+        created_at: 2.days.ago,
+        resolved_at: 2.days.ago + 30.minutes,
+        last_occurred_at: 2.days.ago + 30.minutes
+      )
+    end
+  end
+end

--- a/spec/services/accounts/operations/dashboard_spec.rb
+++ b/spec/services/accounts/operations/dashboard_spec.rb
@@ -52,6 +52,16 @@ RSpec.describe Accounts::Operations::Dashboard do
       expect(result.dig(:capacity, :cost_ceiling_utilization_percent)).to be_nil
     end
 
+    it "reuses calculated service level metrics within a payload build" do
+      configure_operations!
+      dashboard = described_class.new(account: account, tenant_setting: tenant_setting, billing_visible: true)
+
+      expect(dashboard).to receive(:uptime_actual_percent).once.and_call_original
+      expect(dashboard).to receive(:queue_health_actual_percent).once.and_call_original
+
+      dashboard.send(:service_levels_payload)
+    end
+
     def configure_operations!
       tenant_setting.enterprise_operations_configuration = {
         "service_levels" => { "queue_start_slo_minutes" => 10 },

--- a/spec/services/screenshots/capture_targets_spec.rb
+++ b/spec/services/screenshots/capture_targets_spec.rb
@@ -72,6 +72,12 @@ RSpec.describe Screenshots::CaptureTargets, :no_db do
       expect(targets.map(&:slug)).to contain_exactly("account_roi_dashboard", "project_roi_dashboard")
     end
 
+    it "maps operations dashboard views to the dedicated account operations target" do
+      targets = described_class.call(changed_files: [ "app/views/accounts/operations_dashboards/show.html.erb" ])
+
+      expect(targets.map(&:slug)).to eq([ "account_operations_dashboard" ])
+    end
+
     it "maps component files to shared UI targets" do
       targets = described_class.call(changed_files: [ "app/components/sidebar_component.rb" ])
 


### PR DESCRIPTION
## Summary

Implemented Phase 8.2 as an account-facing operations surface. The main addition is a new Operations & Reliability dashboard at `account_operations_dashboard`, backed by structured `tenant_setting.features["enterprise_operations"]` config for SLOs, disaster recovery, upgrades, support-safe diagnostics, and capacity controls. I also linked it from the account page, added JSON export/reporting, recorded dashboard updates in `AccountActivityEvent`, and registered the new controller in screenshot capture targets.

Verification passed with `bundle exec rubocop` and full `bundle exec rspec` (`14103 examples, 0 failures, 7 pending`). I had to run Rails commands with `DB_HOST=paid-svc-a3-s1-postgres DB_USERNAME=agent DB_PASSWORD=agent` because this repo’s `database.yml` does not consume the provided `DATABASE_URL` host directly. The changes are committed as `feat(operations): add enterprise operations dashboard` at `0dd9794`.

---

Closes #2340