### PR TITLE
feat(ecosystem): Phase 8.3 — Marketplace & Ecosystem Expansion

### DIFF
--- a/app/controllers/api/marketplace_entries_controller.rb
+++ b/app/controllers/api/marketplace_entries_controller.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Api
+  class MarketplaceEntriesController < ApplicationController
+    skip_after_action :verify_authorized, only: :index
+
+    def index
+      entries = filtered_scope.includes(:current_version, :marketplace_entry_rules).ordered
+
+      render json: {
+        entries: entries.map { |entry| index_entry_json(entry) }
+      }
+    end
+
+    def show
+      entry = policy_scope(MarketplaceEntry)
+        .includes(:current_version, :marketplace_entry_rules)
+        .find(params[:id])
+      authorize entry
+
+      render json: show_entry_json(entry)
+    end
+
+    private
+
+    def filtered_scope
+      scope = policy_scope(MarketplaceEntry)
+      scope = scope.where(status: params[:status]) if params[:status].present?
+      scope = scope.active if params[:status].blank?
+
+      scope
+        .with_entry_type(params[:entry_type])
+        .with_extension_point(params[:extension_point])
+        .with_certification_status(params[:certification_status])
+        .tagged_with(params[:tag])
+        .search(params[:query])
+    end
+
+    def index_entry_json(entry)
+      {
+        id: entry.id,
+        name: entry.name,
+        entry_type: entry.entry_type,
+        description: entry.description,
+        provider: entry.provider,
+        provider_format: entry.provider_format,
+        status: entry.status,
+        tags: entry.tags,
+        extension_points: entry.extension_points,
+        certification_status: entry.certification_status,
+        support_tier: entry.support_tier,
+        documentation_url: entry.documentation_url,
+        source_code_url: entry.source_code_url,
+        current_version: entry.current_version&.yield_self { |version| { id: version.id, version: version.version } },
+        updated_at: entry.updated_at.iso8601
+      }
+    end
+
+    def show_entry_json(entry)
+      version = entry.current_version
+
+      index_entry_json(entry).merge(
+        usage_guidance: entry.usage_guidance,
+        certification_notes: entry.certification_notes,
+        added_by_name: entry.added_by_name,
+        added_by_email: entry.added_by_email,
+        rules: entry.marketplace_entry_rules.ordered.map do |rule|
+          {
+            mode: rule.mode,
+            enabled: rule.enabled,
+            rationale: rule.rationale,
+            conditions: rule.conditions
+          }
+        end,
+        current_version: version && {
+          id: version.id,
+          version: version.version,
+          changelog: version.changelog,
+          canonical_artifact: version.canonical_artifact,
+          renderers: version.renderers,
+          compatibility_constraints: version.compatibility_constraints,
+          review_metadata: version.review_metadata,
+          created_at: version.created_at.iso8601,
+          updated_at: version.updated_at.iso8601
+        }
+      )
+    end
+  end
+end

--- a/app/controllers/api/marketplace_entries_controller.rb
+++ b/app/controllers/api/marketplace_entries_controller.rb
@@ -13,7 +13,7 @@ module Api
     skip_after_action :verify_authorized, only: :index
 
     def index
-      entries = filtered_scope.includes(:current_version, :marketplace_entry_rules).ordered
+      entries = filtered_scope.includes(:current_version).ordered
 
       render json: {
         entries: entries.map { |entry| index_entry_json(entry) }

--- a/app/controllers/api/marketplace_entries_controller.rb
+++ b/app/controllers/api/marketplace_entries_controller.rb
@@ -2,6 +2,14 @@
 
 module Api
   class MarketplaceEntriesController < ApplicationController
+    rescue_from ActiveRecord::RecordNotFound do
+      render json: { error: "Not found" }, status: :not_found
+    end
+
+    rescue_from Pundit::NotAuthorizedError do
+      render json: { error: "Forbidden" }, status: :forbidden
+    end
+
     skip_after_action :verify_authorized, only: :index
 
     def index
@@ -22,6 +30,12 @@ module Api
     end
 
     private
+
+    def authenticate_user!
+      return if user_signed_in?
+
+      render json: { error: "Unauthorized" }, status: :unauthorized
+    end
 
     def filtered_scope
       scope = policy_scope(MarketplaceEntry)

--- a/app/controllers/marketplace_entries_controller.rb
+++ b/app/controllers/marketplace_entries_controller.rb
@@ -20,7 +20,9 @@ class MarketplaceEntriesController < ApplicationController
     @marketplace_entry = current_account.marketplace_entries.build(
       provider_format: "canonical_v1",
       team_scope: "account",
-      status: "draft"
+      status: "draft",
+      certification_status: "uncertified",
+      support_tier: "community"
     )
     authorize @marketplace_entry
   end
@@ -72,10 +74,12 @@ class MarketplaceEntriesController < ApplicationController
   def marketplace_entry_params
     permitted = [
       :name, :entry_type, :description, :provider, :provider_format,
-      :usage_guidance, :added_by_name, :added_by_email, :tags_csv,
-      :team_scope, :status, :changelog, :canonical_artifact_json,
+      :usage_guidance, :added_by_name, :added_by_email, :tags_csv, :team_scope,
+      :status, :certification_status, :support_tier, :documentation_url,
+      :source_code_url, :certification_notes, :changelog, :canonical_artifact_json,
       :renderers_json, :compatibility_constraints_json, :review_metadata_json
     ]
+    permitted << { extension_points: [] }
     if marketplace_rule_management_allowed?
       permitted.concat(
         %i[

--- a/app/models/marketplace_entry.rb
+++ b/app/models/marketplace_entry.rb
@@ -59,6 +59,8 @@ class MarketplaceEntry < ApplicationRecord
   validates :support_tier, presence: true, inclusion: { in: SUPPORT_TIERS }
   validates :documentation_url, length: { maximum: 500 }, allow_nil: true
   validates :source_code_url, length: { maximum: 500 }, allow_nil: true
+  validate :documentation_url_is_safe, if: -> { documentation_url.present? }
+  validate :source_code_url_is_safe, if: -> { source_code_url.present? }
   validate :tags_are_strings
   validate :extension_points_are_strings
   validate :extension_points_are_known
@@ -159,5 +161,20 @@ class MarketplaceEntry < ApplicationRecord
     return if current_version.marketplace_entry_id == id
 
     errors.add(:current_version, "must belong to this marketplace entry")
+  end
+
+  def documentation_url_is_safe
+    validate_http_url(:documentation_url)
+  end
+
+  def source_code_url_is_safe
+    validate_http_url(:source_code_url)
+  end
+
+  def validate_http_url(attribute)
+    value = public_send(attribute)
+    return if value.match?(%r{\Ahttps?://})
+
+    errors.add(attribute, "must be an HTTP(S) URL")
   end
 end

--- a/app/models/marketplace_entry.rb
+++ b/app/models/marketplace_entry.rb
@@ -5,17 +5,32 @@ class MarketplaceEntry < ApplicationRecord
     skill
     agent
     prompt_pack
+    policy_pack
     enhancement
+    tool
     plugin
+    collector
+    workflow_strategy
+    integration
     mcp_server
     provider_config
     other
+  ].freeze
+  EXTENSION_POINTS = %w[
+    collectors
+    policies
+    tools
+    workflow_strategies
+    prompts
+    integrations
   ].freeze
   # Private visibility needs an owner/user reference that marketplace entries
   # do not currently persist. Keep the scope account-wide until ownership
   # semantics exist.
   TEAM_SCOPES = %w[account].freeze
   STATUSES = %w[draft active deprecated].freeze
+  CERTIFICATION_STATUSES = %w[uncertified self_attested verified certified].freeze
+  SUPPORT_TIERS = %w[community partner first_party].freeze
 
   attr_accessor :canonical_artifact_json, :renderers_json, :compatibility_constraints_json,
     :review_metadata_json, :automatic_enabled, :automatic_conditions_json,
@@ -40,13 +55,33 @@ class MarketplaceEntry < ApplicationRecord
   validates :added_by_email, presence: true, length: { maximum: 255 }
   validates :team_scope, presence: true, inclusion: { in: TEAM_SCOPES }
   validates :status, presence: true, inclusion: { in: STATUSES }
+  validates :certification_status, presence: true, inclusion: { in: CERTIFICATION_STATUSES }
+  validates :support_tier, presence: true, inclusion: { in: SUPPORT_TIERS }
+  validates :documentation_url, length: { maximum: 500 }, allow_nil: true
+  validates :source_code_url, length: { maximum: 500 }, allow_nil: true
   validate :tags_are_strings
+  validate :extension_points_are_strings
+  validate :extension_points_are_known
   validate :current_version_belongs_to_entry
 
   scope :active, -> { where(status: "active") }
   scope :draft, -> { where(status: "draft") }
   scope :deprecated, -> { where(status: "deprecated") }
   scope :ordered, -> { order(:name, :id) }
+  scope :with_entry_type, ->(entry_type) { entry_type.present? ? where(entry_type: entry_type.to_s) : all }
+  scope :with_certification_status, lambda { |certification_status|
+    certification_status.present? ? where(certification_status: certification_status.to_s) : all
+  }
+  scope :with_extension_point, lambda { |extension_point|
+    next all if extension_point.blank?
+
+    where("extension_points @> ?", [ extension_point.to_s ].to_json)
+  }
+  scope :tagged_with, lambda { |tag|
+    next all if tag.blank?
+
+    where("tags @> ?", [ tag.to_s ].to_json)
+  }
   scope :search, lambda { |query|
     normalized_query = query.to_s.strip
     next all if normalized_query.blank?
@@ -102,6 +137,21 @@ class MarketplaceEntry < ApplicationRecord
     return if tags.is_a?(Array) && tags.all? { |tag| tag.is_a?(String) }
 
     errors.add(:tags, "must be an array of strings")
+  end
+
+  def extension_points_are_strings
+    return if extension_points.is_a?(Array) && extension_points.all? { |value| value.is_a?(String) }
+
+    errors.add(:extension_points, "must be an array of strings")
+  end
+
+  def extension_points_are_known
+    return unless extension_points.is_a?(Array)
+
+    unknown_values = extension_points - EXTENSION_POINTS
+    return if unknown_values.empty?
+
+    errors.add(:extension_points, "contains unsupported values: #{unknown_values.join(', ')}")
   end
 
   def current_version_belongs_to_entry

--- a/app/services/marketplace_entries/upsert.rb
+++ b/app/services/marketplace_entries/upsert.rb
@@ -41,6 +41,12 @@ module MarketplaceEntries
         provider: params[:provider],
         provider_format: params[:provider_format].presence || "canonical_v1",
         usage_guidance: params[:usage_guidance],
+        extension_points: normalize_string_list(params[:extension_points]),
+        certification_status: params[:certification_status].presence || "uncertified",
+        support_tier: params[:support_tier].presence || "community",
+        documentation_url: params[:documentation_url],
+        source_code_url: params[:source_code_url],
+        certification_notes: params[:certification_notes],
         team_scope: params[:team_scope].presence || "account",
         status: params[:status].presence || "draft"
       )
@@ -187,6 +193,10 @@ module MarketplaceEntries
         :renderers,
         "must map provider keys to JSON objects (invalid: #{invalid_provider_keys.join(', ')})"
       )
+    end
+
+    def normalize_string_list(value)
+      Array(value).map(&:to_s).map(&:strip).reject(&:blank?).uniq
     end
   end
 end

--- a/app/services/screenshots/seed_data/paid.rb
+++ b/app/services/screenshots/seed_data/paid.rb
@@ -208,6 +208,32 @@ module Screenshots
             record.active = true
           end
 
+          marketplace_entry = account.marketplace_entries.find_or_create_by!(name: "Screenshot Catalog Entry") do |record|
+            record.description = "Representative marketplace entry for screenshot capture coverage."
+            record.entry_type = "workflow_strategy"
+            record.provider = "openai"
+            record.provider_format = "canonical_v1"
+            record.usage_guidance = "Attach to runs that need a managed rollout workflow strategy."
+            record.added_by_name = user.name.presence || "Screenshot User"
+            record.added_by_email = user.email
+            record.tags = [ "screenshots", "managed-platform" ]
+            record.extension_points = [ "workflow_strategies", "prompts" ]
+            record.certification_status = "verified"
+            record.support_tier = "first_party"
+            record.documentation_url = "https://docs.example.com/screenshots/catalog-entry"
+            record.source_code_url = "https://github.com/example/screenshots-catalog-entry"
+            record.certification_notes = "Seeded for screenshot coverage of marketplace entry detail and edit pages."
+            record.team_scope = "account"
+            record.status = "active"
+          end
+          marketplace_entry.current_version || marketplace_entry.create_version!(
+            canonical_artifact: { "slug" => "screenshots.workflow_strategy", "entry_type" => "workflow_strategy" },
+            renderers: { "default" => { "template" => "Use the managed rollout workflow strategy." } },
+            compatibility_constraints: { "paid_version" => ">= 8.0" },
+            review_metadata: { "certification_status" => "verified", "reviewed_by" => "screenshots" },
+            changelog: "Initial screenshot seed version"
+          )
+
           chat_session = ChatSession.where(account: account, title: "Screenshot Chat").first_or_create!(
             created_by: user,
             project: project,
@@ -311,6 +337,7 @@ module Screenshots
             "pending_strategy_version" => { "id" => pending_strategy_version.id },
             "ab_test" => { "id" => ab_test.id },
             "style_guide" => { "id" => style_guide.id, "name" => style_guide.name },
+            "marketplace_entry" => { "id" => marketplace_entry.id, "name" => marketplace_entry.name },
             "chat_session" => { "id" => chat_session.id, "name" => chat_session.title },
             "knowledge_artifact" => { "id" => knowledge_artifact.id },
             "remediation_decision" => { "id" => remediation_decision.id },

--- a/app/views/marketplace_entries/_form.html.erb
+++ b/app/views/marketplace_entries/_form.html.erb
@@ -23,7 +23,7 @@
   </div>
 
   <div class="rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
-    Marketplace entries can attach prompt content, runtime configuration, or MCP server descriptors. Paid renders the stored artifact into the target provider format when the run is created.
+    Ecosystem entries define stable extension metadata plus the payload Paid can render into prompts, runtime configuration, MCP servers, or partner-facing catalog artifacts.
   </div>
 
   <div>
@@ -60,6 +60,23 @@
 
   <div class="grid gap-6 md:grid-cols-3">
     <div>
+      <%= form.label :extension_points, "Extension Points", class: "block text-sm font-medium text-gray-700" %>
+      <%= form.select :extension_points, MarketplaceEntry::EXTENSION_POINTS.map { |value| [ value.humanize, value ] }, {}, multiple: true, size: MarketplaceEntry::EXTENSION_POINTS.size, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" %>
+    </div>
+
+    <div>
+      <%= form.label :certification_status, class: "block text-sm font-medium text-gray-700" %>
+      <%= form.select :certification_status, MarketplaceEntry::CERTIFICATION_STATUSES.map { |value| [ value.humanize, value ] }, {}, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" %>
+    </div>
+
+    <div>
+      <%= form.label :support_tier, class: "block text-sm font-medium text-gray-700" %>
+      <%= form.select :support_tier, MarketplaceEntry::SUPPORT_TIERS.map { |value| [ value.humanize, value ] }, {}, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" %>
+    </div>
+  </div>
+
+  <div class="grid gap-6 md:grid-cols-3">
+    <div>
       <%= form.label :tags_csv, "Tags", class: "block text-sm font-medium text-gray-700" %>
       <%= form.text_field :tags_csv, value: marketplace_entry.tags_csv, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm", placeholder: "ruby, internal-api" %>
     </div>
@@ -73,6 +90,23 @@
       <%= form.label :added_by_email, class: "block text-sm font-medium text-gray-700" %>
       <%= form.email_field :added_by_email, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" %>
     </div>
+  </div>
+
+  <div class="grid gap-6 md:grid-cols-2">
+    <div>
+      <%= form.label :documentation_url, class: "block text-sm font-medium text-gray-700" %>
+      <%= form.url_field :documentation_url, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm", placeholder: "https://docs.example.com/paid-extension" %>
+    </div>
+
+    <div>
+      <%= form.label :source_code_url, class: "block text-sm font-medium text-gray-700" %>
+      <%= form.url_field :source_code_url, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm", placeholder: "https://github.com/example/paid-extension" %>
+    </div>
+  </div>
+
+  <div>
+    <%= form.label :certification_notes, class: "block text-sm font-medium text-gray-700" %>
+    <%= form.text_area :certification_notes, rows: 4, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm", placeholder: "Summarize validation evidence, support boundaries, and rollout expectations." %>
   </div>
 
   <div>

--- a/app/views/marketplace_entries/index.html.erb
+++ b/app/views/marketplace_entries/index.html.erb
@@ -3,8 +3,8 @@
 <div class="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
   <div class="flex items-center justify-between">
     <div>
-      <h1 class="text-2xl font-semibold text-gray-900">Marketplace Entries</h1>
-      <p class="mt-1 text-sm text-gray-500">Shared team skills, prompts, plugins, MCP servers, provider presets, and run enhancements.</p>
+      <h1 class="text-2xl font-semibold text-gray-900">Ecosystem Catalog</h1>
+      <p class="mt-1 text-sm text-gray-500">Shared integrations, prompts, policy packs, collectors, tools, workflow strategies, and runtime extensions.</p>
     </div>
     <div class="flex items-center gap-3">
       <% if current_account.paid_plan? %>
@@ -21,7 +21,7 @@
           <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Name</th>
           <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Type</th>
           <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Status</th>
-          <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Provider</th>
+          <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Certification</th>
           <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Version</th>
           <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">Updated</th>
         </tr>
@@ -36,9 +36,17 @@
                 <div class="mt-1 text-xs text-gray-500"><%= entry_tags.join(", ") %></div>
               <% end %>
             </td>
-            <td class="px-4 py-3 text-sm text-gray-700"><%= entry.entry_type.humanize %></td>
+            <td class="px-4 py-3 text-sm text-gray-700">
+              <div><%= entry.entry_type.humanize %></div>
+              <% if entry.extension_points.any? %>
+                <div class="mt-1 text-xs text-gray-500"><%= entry.extension_points.map(&:humanize).join(", ") %></div>
+              <% end %>
+            </td>
             <td class="px-4 py-3 text-sm text-gray-700"><%= entry.status.humanize %></td>
-            <td class="px-4 py-3 text-sm text-gray-700"><%= entry.provider.presence || "-" %></td>
+            <td class="px-4 py-3 text-sm text-gray-700">
+              <div><%= entry.certification_status.humanize %></div>
+              <div class="mt-1 text-xs text-gray-500"><%= entry.support_tier.humanize %></div>
+            </td>
             <td class="px-4 py-3 text-sm text-gray-700"><%= entry.current_version&.version || "-" %></td>
             <td class="px-4 py-3 text-sm text-gray-700"><%= local_time(entry.updated_at, format: :short) %></td>
           </tr>

--- a/app/views/marketplace_entries/show.html.erb
+++ b/app/views/marketplace_entries/show.html.erb
@@ -18,17 +18,25 @@
     <div class="rounded-lg bg-white p-4 shadow md:col-span-1">
       <dl class="space-y-3 text-sm">
         <div><dt class="font-medium text-gray-500">Type</dt><dd class="text-gray-900"><%= @marketplace_entry.entry_type.humanize %></dd></div>
+        <div><dt class="font-medium text-gray-500">Extension Points</dt><dd class="text-gray-900"><%= @marketplace_entry.extension_points.any? ? @marketplace_entry.extension_points.map(&:humanize).join(", ") : "-" %></dd></div>
         <div><dt class="font-medium text-gray-500">Status</dt><dd class="text-gray-900"><%= @marketplace_entry.status.humanize %></dd></div>
+        <div><dt class="font-medium text-gray-500">Certification</dt><dd class="text-gray-900"><%= @marketplace_entry.certification_status.humanize %></dd></div>
+        <div><dt class="font-medium text-gray-500">Support Tier</dt><dd class="text-gray-900"><%= @marketplace_entry.support_tier.humanize %></dd></div>
         <div><dt class="font-medium text-gray-500">Provider</dt><dd class="text-gray-900"><%= @marketplace_entry.provider.presence || "-" %></dd></div>
         <div><dt class="font-medium text-gray-500">Format</dt><dd class="text-gray-900"><%= @marketplace_entry.provider_format %></dd></div>
         <div><dt class="font-medium text-gray-500">Added By</dt><dd class="text-gray-900"><%= @marketplace_entry.added_by_name %> (<%= @marketplace_entry.added_by_email %>)</dd></div>
         <div><dt class="font-medium text-gray-500">Current Version</dt><dd class="text-gray-900">v<%= @marketplace_entry.current_version&.version || "-" %></dd></div>
+        <div><dt class="font-medium text-gray-500">Docs</dt><dd class="text-gray-900"><%= @marketplace_entry.documentation_url.present? ? link_to(@marketplace_entry.documentation_url, @marketplace_entry.documentation_url, class: "text-indigo-600 hover:text-indigo-500") : "-" %></dd></div>
+        <div><dt class="font-medium text-gray-500">Source</dt><dd class="text-gray-900"><%= @marketplace_entry.source_code_url.present? ? link_to(@marketplace_entry.source_code_url, @marketplace_entry.source_code_url, class: "text-indigo-600 hover:text-indigo-500") : "-" %></dd></div>
       </dl>
     </div>
 
     <div class="rounded-lg bg-white p-4 shadow md:col-span-2">
       <h2 class="text-sm font-semibold text-gray-900">Usage Guidance</h2>
       <p class="mt-2 whitespace-pre-wrap text-sm text-gray-700"><%= @marketplace_entry.usage_guidance.presence || "No usage guidance provided." %></p>
+
+      <h2 class="mt-6 text-sm font-semibold text-gray-900">Certification Notes</h2>
+      <p class="mt-2 whitespace-pre-wrap text-sm text-gray-700"><%= @marketplace_entry.certification_notes.presence || "No certification notes recorded yet. See docs/ECOSYSTEM_CERTIFICATION.md for the certification checklist." %></p>
 
       <% version = @marketplace_entry.current_version %>
       <% if version %>
@@ -40,6 +48,9 @@
 
         <h2 class="mt-6 text-sm font-semibold text-gray-900">Compatibility</h2>
         <pre class="mt-2 overflow-x-auto rounded-lg bg-gray-50 p-4 text-xs text-gray-800"><%= JSON.pretty_generate(version.compatibility_constraints) %></pre>
+
+        <h2 class="mt-6 text-sm font-semibold text-gray-900">Review Metadata</h2>
+        <pre class="mt-2 overflow-x-auto rounded-lg bg-gray-50 p-4 text-xs text-gray-800"><%= JSON.pretty_generate(version.review_metadata) %></pre>
       <% end %>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -266,6 +266,7 @@ Rails.application.routes.draw do
 
     get "knowledge/search", to: "knowledge_search#search"
     get "knowledge/audit", to: "knowledge_audit#index"
+    resources :marketplace_entries, only: [ :index, :show ]
 
     # GitHub webhook receiver for PR reviews, merges, and comments
     post "github_webhooks", to: "github_webhooks#create"

--- a/db/migrate/20260529152437_add_ecosystem_fields_to_marketplace_entries.rb
+++ b/db/migrate/20260529152437_add_ecosystem_fields_to_marketplace_entries.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class AddEcosystemFieldsToMarketplaceEntries < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    add_column :marketplace_entries, :extension_points, :jsonb,
+      null: false,
+      default: [],
+      comment: "Stable Paid extension points this entry targets, such as collectors or workflow strategies."
+    add_column :marketplace_entries, :certification_status, :string,
+      null: false,
+      default: "uncertified",
+      limit: 50,
+      comment: "Certification state used to communicate ecosystem support expectations."
+    add_column :marketplace_entries, :support_tier, :string,
+      null: false,
+      default: "community",
+      limit: 50,
+      comment: "Who supports the entry operationally: community, partner, or first-party."
+    add_column :marketplace_entries, :documentation_url, :string,
+      limit: 500,
+      comment: "Primary documentation URL for installation and lifecycle guidance."
+    add_column :marketplace_entries, :source_code_url, :string,
+      limit: 500,
+      comment: "Source repository or package URL for the extension payload."
+    add_column :marketplace_entries, :certification_notes, :text,
+      comment: "Operator-facing notes describing certification scope, evidence, or gaps."
+
+    add_index :marketplace_entries, :extension_points, using: :gin, algorithm: :concurrently
+    add_index :marketplace_entries, [ :account_id, :certification_status ],
+      name: "idx_marketplace_entries_account_certification",
+      algorithm: :concurrently
+  end
+
+  def down
+    remove_index :marketplace_entries, name: "idx_marketplace_entries_account_certification", if_exists: true
+    remove_index :marketplace_entries, :extension_points, if_exists: true
+
+    remove_column :marketplace_entries, :certification_notes if column_exists?(:marketplace_entries, :certification_notes)
+    remove_column :marketplace_entries, :source_code_url if column_exists?(:marketplace_entries, :source_code_url)
+    remove_column :marketplace_entries, :documentation_url if column_exists?(:marketplace_entries, :documentation_url)
+    remove_column :marketplace_entries, :support_tier if column_exists?(:marketplace_entries, :support_tier)
+    remove_column :marketplace_entries, :certification_status if column_exists?(:marketplace_entries, :certification_status)
+    remove_column :marketplace_entries, :extension_points if column_exists?(:marketplace_entries, :extension_points)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_28_223651) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_29_152437) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1373,22 +1373,30 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_28_223651) do
     t.bigint "account_id", null: false
     t.string "added_by_email", limit: 255, null: false
     t.string "added_by_name", limit: 255, null: false
+    t.text "certification_notes", comment: "Operator-facing notes describing certification scope, evidence, or gaps."
+    t.string "certification_status", limit: 50, default: "uncertified", null: false, comment: "Certification state used to communicate ecosystem support expectations."
     t.datetime "created_at", null: false
     t.bigint "current_version_id", comment: "Current active content snapshot for this marketplace entry."
     t.text "description"
+    t.string "documentation_url", limit: 500, comment: "Primary documentation URL for installation and lifecycle guidance."
     t.string "entry_type", limit: 50, null: false, comment: "Logical enhancement category such as skill, plugin, or MCP server."
+    t.jsonb "extension_points", default: [], null: false, comment: "Stable Paid extension points this entry targets, such as collectors or workflow strategies."
     t.string "name", limit: 255, null: false
     t.string "provider", limit: 100, comment: "Primary target runtime or provider family for this entry."
     t.string "provider_format", limit: 100, default: "canonical_v1", null: false, comment: "Default artifact schema or provider-native format identifier."
+    t.string "source_code_url", limit: 500, comment: "Source repository or package URL for the extension payload."
     t.string "status", limit: 50, default: "draft", null: false, comment: "Lifecycle state for safe rollout and deprecation."
+    t.string "support_tier", limit: 50, default: "community", null: false, comment: "Who supports the entry operationally: community, partner, or first-party."
     t.jsonb "tags", default: [], null: false, comment: "Searchable labels for browsing and matching."
     t.string "team_scope", limit: 50, default: "account", null: false, comment: "Marketplace visibility scope within the tenant."
     t.datetime "updated_at", null: false
     t.text "usage_guidance", comment: "Human guidance describing when the entry should be used."
+    t.index ["account_id", "certification_status"], name: "idx_marketplace_entries_account_certification"
     t.index ["account_id", "entry_type", "status"], name: "idx_marketplace_entries_lookup"
     t.index ["account_id", "team_scope", "status"], name: "idx_marketplace_entries_scope"
     t.index ["account_id"], name: "index_marketplace_entries_on_account_id"
     t.index ["current_version_id"], name: "index_marketplace_entries_on_current_version_id"
+    t.index ["extension_points"], name: "index_marketplace_entries_on_extension_points", using: :gin
     t.index ["tags"], name: "index_marketplace_entries_on_tags", using: :gin
   end
 

--- a/docs/ECOSYSTEM_CERTIFICATION.md
+++ b/docs/ECOSYSTEM_CERTIFICATION.md
@@ -1,0 +1,35 @@
+# Ecosystem Certification
+
+Paid's ecosystem catalog supports three support tiers and four certification states so customers can distinguish community extensions from partner-supported and first-party offerings.
+
+## Support Tiers
+
+- `community`: Shared by a customer or maintainer with no Paid support commitment.
+- `partner`: Supported by a named implementation or technology partner.
+- `first_party`: Built and supported directly by Paid.
+
+## Certification States
+
+- `uncertified`: Cataloged, but not yet reviewed against the checklist below.
+- `self_attested`: The publisher completed the checklist and attached evidence.
+- `verified`: A Paid operator or designated reviewer validated the evidence.
+- `certified`: Verified and approved for repeatable production use.
+
+## Certification Checklist
+
+- Installation and rollback steps are documented.
+- Supported extension points are declared explicitly.
+- Runtime and compatibility constraints are recorded.
+- Ownership, escalation path, and support boundary are documented.
+- Security-sensitive behavior, scopes, and secrets handling are described.
+- A smoke test or verification procedure exists for upgrades.
+- Failure modes and safe-disable guidance are documented.
+
+## Required Catalog Metadata
+
+- `entry_type` identifies the distribution shape, such as `integration`, `policy_pack`, or `workflow_strategy`.
+- `extension_points` identifies which Paid contracts the entry targets.
+- `support_tier` communicates who owns support.
+- `certification_status` communicates review depth.
+- `documentation_url` and `source_code_url` provide operator traceability.
+- `certification_notes` summarizes evidence, gaps, or rollout caveats.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1477,10 +1477,10 @@ Deliverables:
 
 Tasks:
 
-- [ ] Create plugin/extension model for custom collectors, policies, tools, and workflow strategies
-- [ ] Add marketplace or curated catalog for integrations, prompts, and policy packs
-- [ ] Add partner-friendly APIs for system integrators and internal platform teams
-- [ ] Publish ecosystem certification guidance for supported extensions
+- [x] Create plugin/extension model for custom collectors, policies, tools, and workflow strategies
+- [x] Add marketplace or curated catalog for integrations, prompts, and policy packs
+- [x] Add partner-friendly APIs for system integrators and internal platform teams
+- [x] Publish ecosystem certification guidance for supported extensions
 
 Deliverables:
 

--- a/spec/controllers/api/marketplace_entries_controller_spec.rb
+++ b/spec/controllers/api/marketplace_entries_controller_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::MarketplaceEntriesController, type: :request do
+  let(:account) { create(:account) }
+  let(:user) { create(:user, :admin, account: account) }
+
+  before do
+    sign_in user
+  end
+
+  describe "GET /api/marketplace_entries" do
+    it "returns active catalog entries by default" do
+      active_entry = create_catalog_entry(
+        name: "SOX Policy Pack",
+        entry_type: "policy_pack",
+        extension_points: [ "policies", "prompts" ],
+        certification_status: "certified"
+      )
+      draft_entry = create(:marketplace_entry, account: account, status: "draft")
+      create(:marketplace_entry, account: create(:account), name: "Other Account Entry")
+
+      get "/api/marketplace_entries"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.fetch("entries")).to contain_exactly(
+        include(
+          "id" => active_entry.id,
+          "name" => "SOX Policy Pack",
+          "entry_type" => "policy_pack",
+          "extension_points" => %w[policies prompts],
+          "certification_status" => "certified"
+        )
+      )
+      expect(response.parsed_body.fetch("entries").map { |entry| entry["id"] }).not_to include(draft_entry.id)
+    end
+
+    it "filters by ecosystem metadata" do
+      matching_entry = create_workflow_entry
+      create_prompt_entry
+
+      get "/api/marketplace_entries", params: workflow_filter_params
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.fetch("entries")).to contain_exactly(
+        include("id" => matching_entry.id, "name" => "Workflow Kit")
+      )
+    end
+  end
+
+  describe "GET /api/marketplace_entries/:id" do
+    it "returns full catalog metadata for a single entry" do
+      entry = create_integration_entry
+      version = create_catalog_version(entry)
+      entry.update!(current_version: version)
+      create_automatic_rule(entry)
+
+      get "/api/marketplace_entries/#{entry.id}"
+
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body["id"]).to eq(entry.id)
+      expect(body["extension_points"]).to eq(%w[integrations tools])
+      expect(body.dig("current_version", "canonical_artifact")).to eq("content" => "Install the connector")
+      expect(body.fetch("rules")).to include(
+        include(
+          "mode" => "automatic",
+          "enabled" => true,
+          "conditions" => { "project_tags" => [ "connector" ] }
+        )
+      )
+    end
+  end
+
+  def create_catalog_entry(**attributes)
+    create(:marketplace_entry, { account: account }.merge(attributes))
+  end
+
+  def create_workflow_entry
+    create_catalog_entry(
+      name: "Workflow Kit",
+      entry_type: "workflow_strategy",
+      extension_points: [ "workflow_strategies" ],
+      certification_status: "verified",
+      tags: [ "ecosystem", "workflow" ]
+    )
+  end
+
+  def create_prompt_entry
+    create_catalog_entry(
+      name: "Prompt Kit",
+      entry_type: "prompt_pack",
+      extension_points: [ "prompts" ],
+      certification_status: "verified",
+      tags: [ "ecosystem" ]
+    )
+  end
+
+  def create_integration_entry
+    create_catalog_entry(
+      entry_type: "integration",
+      extension_points: [ "integrations", "tools" ],
+      certification_status: "verified"
+    )
+  end
+
+  def create_catalog_version(entry)
+    create(:marketplace_entry_version,
+      marketplace_entry: entry,
+      canonical_artifact: { "content" => "Install the connector" },
+      renderers: { "openai" => { "content" => "Rendered" } },
+      compatibility_constraints: { "runner" => [ "codex" ] },
+      review_metadata: { "checklist" => [ "docs", "rollback" ] })
+  end
+
+  def create_automatic_rule(entry)
+    create(:marketplace_entry_rule,
+      marketplace_entry: entry,
+      mode: "automatic",
+      enabled: true,
+      rationale: "Attach for connector-enabled projects",
+      conditions: { "project_tags" => [ "connector" ] })
+  end
+
+  def workflow_filter_params
+    {
+      entry_type: "workflow_strategy",
+      extension_point: "workflow_strategies",
+      certification_status: "verified",
+      tag: "workflow"
+    }
+  end
+end

--- a/spec/controllers/api/marketplace_entries_controller_spec.rb
+++ b/spec/controllers/api/marketplace_entries_controller_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe Api::MarketplaceEntriesController, type: :request do
   let(:account) { create(:account) }
   let(:user) { create(:user, :admin, account: account) }
 
-  before do
-    sign_in user
-  end
-
   describe "GET /api/marketplace_entries" do
+    before do
+      sign_in user
+    end
+
     it "returns active catalog entries by default" do
       active_entry = create_catalog_entry(
         name: "SOX Policy Pack",
@@ -47,9 +47,22 @@ RSpec.describe Api::MarketplaceEntriesController, type: :request do
         include("id" => matching_entry.id, "name" => "Workflow Kit")
       )
     end
+
+    it "returns JSON unauthorized for unauthenticated requests" do
+      sign_out user
+
+      get "/api/marketplace_entries"
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.parsed_body).to eq("error" => "Unauthorized")
+    end
   end
 
   describe "GET /api/marketplace_entries/:id" do
+    before do
+      sign_in user
+    end
+
     it "returns full catalog metadata for a single entry" do
       entry = create_integration_entry
       version = create_catalog_version(entry)
@@ -70,6 +83,32 @@ RSpec.describe Api::MarketplaceEntriesController, type: :request do
           "conditions" => { "project_tags" => [ "connector" ] }
         )
       )
+    end
+
+    it "returns JSON not found for entries outside the policy scope" do
+      other_account_entry = create(:marketplace_entry, account: create(:account))
+
+      get "/api/marketplace_entries/#{other_account_entry.id}"
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq("error" => "Not found")
+    end
+
+    it "returns JSON not found for missing entries" do
+      get "/api/marketplace_entries/0"
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body).to eq("error" => "Not found")
+    end
+
+    it "returns JSON unauthorized for unauthenticated requests" do
+      sign_out user
+      entry = create_integration_entry
+
+      get "/api/marketplace_entries/#{entry.id}"
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.parsed_body).to eq("error" => "Unauthorized")
     end
   end
 

--- a/spec/factories/marketplace_entries.rb
+++ b/spec/factories/marketplace_entries.rb
@@ -12,6 +12,12 @@ FactoryBot.define do
     added_by_name { "Test User" }
     added_by_email { "test@example.com" }
     tags { [ "rails", "repo" ] }
+    extension_points { [ "prompts", "tools" ] }
+    certification_status { "verified" }
+    support_tier { "community" }
+    documentation_url { "https://docs.example.com/repo-coding-skill" }
+    source_code_url { "https://github.com/example/repo-coding-skill" }
+    certification_notes { "Validated against a reference Rails repo and reviewed for rollback safety." }
     team_scope { "account" }
     status { "active" }
   end

--- a/spec/migrations/create_marketplace_entries_spec.rb
+++ b/spec/migrations/create_marketplace_entries_spec.rb
@@ -2,11 +2,13 @@
 
 require "rails_helper"
 require Rails.root.join("db/migrate/20260514223539_create_marketplace_entries")
+require Rails.root.join("db/migrate/20260529152437_add_ecosystem_fields_to_marketplace_entries")
 
 RSpec.describe CreateMarketplaceEntries, :aggregate_failures do
   self.use_transactional_tests = false
 
   let(:migration) { described_class.new }
+  let(:ecosystem_migration) { AddEcosystemFieldsToMarketplaceEntries.new }
   let(:connection) { ActiveRecord::Base.connection }
 
   around do |example|
@@ -22,7 +24,7 @@ RSpec.describe CreateMarketplaceEntries, :aggregate_failures do
     example.run
   ensure
     teardown_schema
-    migration.up if preexisting.values.any?
+    restore_schema if preexisting.values.any?
   end
 
   it "creates marketplace tables and the current_version reference" do
@@ -67,6 +69,22 @@ RSpec.describe CreateMarketplaceEntries, :aggregate_failures do
       connection.table_exists?(:marketplace_entry_rules) ||
       connection.table_exists?(:marketplace_entry_versions) ||
       connection.table_exists?(:marketplace_entries)
+    reset_marketplace_column_information
+  end
+
+  def restore_schema
+    migration.up
+    ecosystem_migration.up
+    reset_marketplace_column_information
+  end
+
+  def reset_marketplace_column_information
+    [
+      MarketplaceEntry,
+      MarketplaceEntryVersion,
+      MarketplaceEntryRule,
+      AgentRunMarketplaceEntry
+    ].each(&:reset_column_information)
   end
 
   def tenant_policy_present?(table_name)

--- a/spec/models/marketplace_entry_spec.rb
+++ b/spec/models/marketplace_entry_spec.rb
@@ -45,6 +45,30 @@ RSpec.describe MarketplaceEntry do
     end
   end
 
+  describe "URL safety" do
+    it "rejects javascript documentation URLs" do
+      entry = build(:marketplace_entry, documentation_url: "javascript:alert(1)")
+
+      expect(entry).not_to be_valid
+      expect(entry.errors[:documentation_url]).to include("must be an HTTP(S) URL")
+    end
+
+    it "rejects protocol-relative source code URLs" do
+      entry = build(:marketplace_entry, source_code_url: "//example.com/repo")
+
+      expect(entry).not_to be_valid
+      expect(entry.errors[:source_code_url]).to include("must be an HTTP(S) URL")
+    end
+
+    it "allows HTTP(S) documentation and source code URLs" do
+      entry = build(:marketplace_entry,
+        documentation_url: "https://docs.example.com/entry",
+        source_code_url: "http://example.com/repo")
+
+      expect(entry).to be_valid
+    end
+  end
+
   describe ".ransackable_associations" do
     it "does not expose account traversal" do
       expect(described_class.ransackable_associations).to eq([ "current_version" ])

--- a/spec/models/marketplace_entry_spec.rb
+++ b/spec/models/marketplace_entry_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe MarketplaceEntry do
     it { is_expected.to validate_inclusion_of(:entry_type).in_array(described_class::ENTRY_TYPES) }
     it { is_expected.to validate_inclusion_of(:team_scope).in_array(described_class::TEAM_SCOPES) }
     it { is_expected.to validate_inclusion_of(:status).in_array(described_class::STATUSES) }
+    it { is_expected.to validate_inclusion_of(:certification_status).in_array(described_class::CERTIFICATION_STATUSES) }
+    it { is_expected.to validate_inclusion_of(:support_tier).in_array(described_class::SUPPORT_TIERS) }
   end
 
   describe "#create_version!" do
@@ -31,6 +33,15 @@ RSpec.describe MarketplaceEntry do
       entry.tags_csv = "rails, internal-api, rails"
 
       expect(entry.tags).to eq([ "rails", "internal-api" ])
+    end
+  end
+
+  describe "extension points" do
+    it "rejects unsupported extension points" do
+      entry = build(:marketplace_entry, extension_points: [ "unsupported" ])
+
+      expect(entry).not_to be_valid
+      expect(entry.errors[:extension_points]).to include("contains unsupported values: unsupported")
     end
   end
 

--- a/spec/services/marketplace_entries/upsert_no_db_spec.rb
+++ b/spec/services/marketplace_entries/upsert_no_db_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe MarketplaceEntries::Upsert, :no_db do
   let(:entry_class) do
     Struct.new(
       :name, :entry_type, :description, :provider, :provider_format, :usage_guidance,
-      :team_scope, :status, :added_by_name, :added_by_email, :tags_csv, keyword_init: true
+      :extension_points, :certification_status, :support_tier, :documentation_url,
+      :source_code_url, :certification_notes, :team_scope, :status, :added_by_name,
+      :added_by_email, :tags_csv, keyword_init: true
     ) do
       def assign_attributes(attributes)
         attributes.each { |key, value| public_send("#{key}=", value) }
@@ -22,6 +24,12 @@ RSpec.describe MarketplaceEntries::Upsert, :no_db do
       provider: "claude",
       provider_format: "canonical_v1",
       usage_guidance: "Use on Rails issue runs.",
+      extension_points: [ "prompts", "tools" ],
+      certification_status: "verified",
+      support_tier: "partner",
+      documentation_url: "https://docs.example.com/repo-coding-skill",
+      source_code_url: "https://github.com/example/repo-coding-skill",
+      certification_notes: "Reviewed against the Phase 8 ecosystem checklist.",
       team_scope: "account",
       status: "active",
       tags_csv: "rails, repo",
@@ -50,6 +58,17 @@ RSpec.describe MarketplaceEntries::Upsert, :no_db do
 
       expect(entry.added_by_name).to eq("Initial Publisher")
       expect(entry.added_by_email).to eq("initial@example.com")
+    end
+
+    it "normalizes ecosystem metadata onto the entry" do
+      entry = entry_class.new
+
+      described_class.new(entry:, params:, actor:).send(:assign_metadata)
+
+      expect(entry.extension_points).to eq([ "prompts", "tools" ])
+      expect(entry.certification_status).to eq("verified")
+      expect(entry.support_tier).to eq("partner")
+      expect(entry.documentation_url).to eq("https://docs.example.com/repo-coding-skill")
     end
   end
 

--- a/spec/services/screenshots/seed_data/paid_spec.rb
+++ b/spec/services/screenshots/seed_data/paid_spec.rb
@@ -51,4 +51,16 @@ RSpec.describe Screenshots::SeedData::Paid do
     )
     expect(installation).to be_active
   end
+
+  it "returns marketplace entry metadata for marketplace screenshot targets" do
+    result = described_class.call
+
+    marketplace_entry = MarketplaceEntry.find(result.dig("marketplace_entry", "id"))
+
+    expect(result.fetch("marketplace_entry")).to eq(
+      "id" => marketplace_entry.id,
+      "name" => "Screenshot Catalog Entry"
+    )
+    expect(marketplace_entry.current_version).to have_attributes(version: 1)
+  end
 end


### PR DESCRIPTION
## Summary

Implemented Phase 8.3 on the existing marketplace foundation and committed it as `d0ba3d7` (`feat(ecosystem): expand marketplace extension catalog`).

The change expands marketplace entries into a broader ecosystem catalog with new extension types and metadata, adds a partner-facing JSON API at `/api/marketplace_entries`, publishes certification guidance in [docs/ECOSYSTEM_CERTIFICATION.md](/workspace/docs/ECOSYSTEM_CERTIFICATION.md), and updates the marketplace UI plus schema/tests to support certification and extension-point metadata. I also fixed a suite-order issue in the marketplace migration spec so the new schema stays visible to later specs.

Validation passed with `bundle exec rubocop` and a full `bundle exec rspec` run: `14108 examples, 0 failures, 7 pending`. The worktree is clean and nothing was pushed.

---

Closes #2341