### PR TITLE
fix(agent-runs): handle Claude CLI streaming events in analyze_issue

### DIFF
--- a/app/temporal/activities/analyze_issue_activity.rb
+++ b/app/temporal/activities/analyze_issue_activity.rb
@@ -121,12 +121,14 @@ module Activities
       { content: "", sections: [], total_tokens: 0 }
     end
 
+    CLI_STREAMING_EVENT_PREFIX = '{"type":"session.'
+
     def call_llm(agent_run, prompt)
       chat_providers(agent_run.project).each do |provider|
         response = AgentHarness.send_message(prompt, **llm_options(provider))
-        return response if !response.respond_to?(:success?) || response.success?
+        next if response_failed_or_cli_leak?(response, agent_run, provider)
 
-        log_failed_response(agent_run, provider, response)
+        return response
       rescue AgentHarness::Error => e
         logger.warn(
           message: "agent_execution.analyze_issue_provider_failed",
@@ -142,6 +144,32 @@ module Activities
         type: "AnalyzeIssueLlmFailed",
         non_retryable: true
       )
+    end
+
+    def response_failed_or_cli_leak?(response, agent_run, provider)
+      if response.respond_to?(:success?) && !response.success?
+        log_failed_response(agent_run, provider, response)
+        return true
+      end
+
+      output = response.respond_to?(:output) ? response.output.to_s : ""
+      if cli_streaming_only?(output)
+        logger.warn(
+          message: "agent_execution.analyze_issue_cli_streaming_leak",
+          agent_run_id: agent_run.id,
+          provider: provider,
+          output_prefix: output.truncate(200)
+        )
+        agent_run.log!("stderr", "LLM returned CLI streaming event instead of analysis: #{output.truncate(500)}")
+        return true
+      end
+
+      false
+    end
+
+    def cli_streaming_only?(output)
+      return false unless output.start_with?(CLI_STREAMING_EVENT_PREFIX)
+      !output.include?('"result"')
     end
 
     def chat_providers(project)
@@ -247,7 +275,8 @@ module Activities
 
     def parse_response!(agent_run, response)
       output = response.respond_to?(:output) ? response.output.to_s : response.to_s
-      parsed = JSON.parse(strip_json_fence(output), symbolize_names: true)
+      parsed = extract_analysis_json(output)
+
       unless parsed.key?(:sufficient_context) && parsed.key?(:reasoning)
         raise JSON::ParserError, "missing sufficient_context or reasoning"
       end
@@ -256,11 +285,35 @@ module Activities
       parsed
     rescue JSON::ParserError => e
       agent_run.log!("stderr", "Failed to parse analysis response: #{e.message}")
+      agent_run.log!("stderr", "Raw output: #{output.truncate(2000)}")
       raise Temporalio::Error::ApplicationError.new(
         "LLM returned invalid analysis JSON",
         type: "AnalyzeIssueInvalidJson",
         non_retryable: true
       )
+    end
+
+    def extract_analysis_json(output)
+      stripped = strip_json_fence(output)
+      JSON.parse(stripped, symbolize_names: true)
+    rescue JSON::ParserError
+      result_payload = extract_result_from_jsonl(output)
+      raise JSON::ParserError, "no valid analysis JSON found" unless result_payload
+
+      JSON.parse(result_payload, symbolize_names: true)
+    end
+
+    def extract_result_from_jsonl(output)
+      output.each_line do |line|
+        next unless line.lstrip.start_with?("{")
+        parsed = JSON.parse(line, symbolize_names: true)
+        if parsed.is_a?(Hash) && parsed[:type] == "result" && parsed[:result].is_a?(String)
+          return parsed[:result]
+        end
+      rescue JSON::ParserError
+        next
+      end
+      nil
     end
 
     def strip_json_fence(output)

--- a/spec/temporal/activities/analyze_issue_activity_spec.rb
+++ b/spec/temporal/activities/analyze_issue_activity_spec.rb
@@ -114,6 +114,47 @@ RSpec.describe Activities::AnalyzeIssueActivity do
       }.to raise_error(Temporalio::Error::ApplicationError, "LLM returned invalid analysis JSON")
     end
 
+    it "rejects CLI streaming events and raises no-provider error" do
+      allow(llm_response).to receive(:output).and_return('{"type":"session.mcp_servers_loading"}')
+
+      expect {
+        activity.execute(agent_run_id: agent_run.id)
+      }.to raise_error(Temporalio::Error::ApplicationError, "No LLM provider produced an issue analysis")
+    end
+
+    it "rejects truncated CLI streaming events matching production failure pattern" do
+      allow(llm_response).to receive(:output).and_return('{"type":"session.mcp_servers_loa')
+
+      expect {
+        activity.execute(agent_run_id: agent_run.id)
+      }.to raise_error(Temporalio::Error::ApplicationError, "No LLM provider produced an issue analysis")
+    end
+
+    it "parses analysis from JSONL when the CLI outputs streaming events before the result" do
+      jsonl_output = [
+        '{"type":"session.mcp_servers_loading","data":{}}',
+        '{"type":"result","result":"{\"sufficient_context\":true,\"reasoning\":\"ok\",\"missing_context_areas\":[]}"}'
+      ].join("\n")
+      allow(llm_response).to receive(:output).and_return(jsonl_output)
+
+      result = activity.execute(agent_run_id: agent_run.id)
+
+      expect(result[:sufficient_context]).to be true
+      expect(result[:reasoning]).to eq("ok")
+    end
+
+    it "rejects JSONL output that has only streaming events and no result line" do
+      jsonl_output = [
+        '{"type":"session.mcp_servers_loading","data":{}}',
+        '{"type":"session.mcp_servers_loaded","data":{}}'
+      ].join("\n")
+      allow(llm_response).to receive(:output).and_return(jsonl_output)
+
+      expect {
+        activity.execute(agent_run_id: agent_run.id)
+      }.to raise_error(Temporalio::Error::ApplicationError, "No LLM provider produced an issue analysis")
+    end
+
     it "tracks token usage correctly" do
       activity.execute(agent_run_id: agent_run.id)
 


### PR DESCRIPTION
## Summary

Fixes ~15+ consecutive agent run failures where `analyze_issue` runs failed with `"LLM returned invalid analysis JSON"` because the Claude CLI was emitting truncated streaming session events to stdout instead of the expected JSON envelope.

## Root Cause

The Claude CLI auto-discovers `.mcp.json` from the working directory. When agent-harness invokes the CLI without `--mcp-config` (because no MCP servers are explicitly configured for analyze_issue), the CLI loads the workspace's `.mcp.json` (Playwright MCP server) and emits `{"type":"session.mcp_servers_loa...` to stdout. When the process is interrupted during MCP initialization, this truncated streaming event becomes `response.output`.

## Changes

### `AnalyzeIssueActivity` (app/temporal/activities/analyze_issue_activity.rb)

1. **`cli_streaming_only?`** — Detects output that is purely CLI streaming events (starts with `{"type":"session.` and contains no `"result"` key). These responses are skipped in `call_llm` before reaching the parser.

2. **`extract_result_from_jsonl`** — When the CLI outputs a mix of streaming events and the final result envelope as JSONL, scans each line for `{"type":"result","result":"..."}` and extracts the analysis JSON. Falls through from `extract_analysis_json` when direct JSON parse fails.

3. **Raw output logging** — Logs truncated raw output on parse failure for debugging.

### Tests (spec/temporal/activities/analyze_issue_activity_spec.rb)

- Rejects CLI streaming events → "No LLM provider produced an issue analysis"
- Rejects truncated streaming events (production failure pattern)
- Parses analysis from JSONL (streaming events + result envelope)
- Rejects JSONL with only streaming events and no result

## Follow-ups

- Upstream: viamin/agent-harness#225 — agent-harness should suppress `.mcp.json` auto-discovery
- #2364 — Adopt upstream fix when available
- #2365 — Paid-side MCP auto-discovery suppression patch

## Test Plan

```
bin/rspec spec/temporal/activities/analyze_issue_activity_spec.rb  # 18/18 passing
bin/lint --changed                                                  # Clean
```
