### PR TITLE
feat(chat): enforce "chat ≤ user" authorization invariant in tool framework

### DIFF
--- a/app/mcp/paid_mcp_server.rb
+++ b/app/mcp/paid_mcp_server.rb
@@ -51,12 +51,7 @@ class PaidMcpServer
   end
 
   def call_tool(name:, arguments:)
-    tool_class = Tools::Registry.find(name)
-    raise ArgumentError, "Unknown tool: #{name}" unless tool_class
-    raise ArgumentError, "Tool arguments must be a JSON object" unless arguments.is_a?(Hash)
-
-    tool = tool_class.new(user:, session:)
-    tool.call(**arguments.symbolize_keys)
+    Tools::Registry.dispatch(name:, arguments:, user:, session:)
   end
 
   class RateLimitExceeded < StandardError; end

--- a/app/mcp/tools/base_tool.rb
+++ b/app/mcp/tools/base_tool.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module Tools
+  class UnauthorizedError < Pundit::NotAuthorizedError; end
+
   class BaseTool
     include Pundit::Authorization
 
@@ -11,8 +13,25 @@ module Tools
       @session = session
     end
 
-    def call(**_args)
-      raise NotImplementedError, "#{self.class}#call must be implemented"
+    def call(**args)
+      dispatch(**args)
+    end
+
+    def dispatch(**args)
+      raise UnauthorizedError, "Tool calls require an authenticated user" if user.blank?
+
+      TenantContext.with(account) do
+        reset_authorization_tracking!
+        run_declared_authorizations!(args)
+
+        perform(**args).tap do
+          raise UnauthorizedError, "#{self.class.tool_name} must authorize before execution" unless authorized?
+        end
+      end
+    end
+
+    def perform(**_args)
+      raise NotImplementedError, "#{self.class}#perform must be implemented"
     end
 
     def self.tool_name
@@ -39,7 +58,29 @@ module Tools
       false
     end
 
+    def self.authorize(query, resolver = nil, policy_class: nil, &block)
+      resolver ||= block
+      raise ArgumentError, "#{name}.authorize requires a resolver" unless resolver
+
+      own_authorization_rules << {
+        query: query,
+        resolver: resolver,
+        policy_class: policy_class
+      }
+    end
+
+    def self.authorization_rules
+      inherited_rules = superclass.respond_to?(:authorization_rules) ? superclass.authorization_rules : []
+      inherited_rules + own_authorization_rules
+    end
+
     private
+
+    def authorize(record, query = nil, policy_class: nil)
+      @authorization_performed = true
+      super
+    end
+    alias_method :authorize!, :authorize
 
     # Pundit expects current_user
     def current_user
@@ -52,6 +93,25 @@ module Tools
 
     def scoped_projects
       Project.where(account:)
+    end
+
+    def run_declared_authorizations!(args)
+      self.class.authorization_rules.each do |rule|
+        record = instance_exec(args, &rule[:resolver])
+        authorize(record, rule[:query], policy_class: rule[:policy_class])
+      end
+    end
+
+    def reset_authorization_tracking!
+      @authorization_performed = false
+    end
+
+    def authorized?
+      @authorization_performed
+    end
+
+    def self.own_authorization_rules
+      @own_authorization_rules ||= []
     end
   end
 end

--- a/app/mcp/tools/base_tool.rb
+++ b/app/mcp/tools/base_tool.rb
@@ -23,10 +23,9 @@ module Tools
       TenantContext.with(account) do
         reset_authorization_tracking!
         run_declared_authorizations!(args)
+        raise UnauthorizedError, "#{self.class.tool_name} must authorize before execution" unless preflight_authorized?
 
-        perform(**args).tap do
-          raise UnauthorizedError, "#{self.class.tool_name} must authorize before execution" unless authorized?
-        end
+        perform(**args)
       end
     end
 
@@ -77,7 +76,6 @@ module Tools
     private
 
     def authorize(record, query = nil, policy_class: nil)
-      @authorization_performed = true
       super
     end
     alias_method :authorize!, :authorize
@@ -95,23 +93,24 @@ module Tools
       Project.where(account:)
     end
 
-    def run_declared_authorizations!(args)
-      self.class.authorization_rules.each do |rule|
-        record = instance_exec(args, &rule[:resolver])
-        authorize(record, rule[:query], policy_class: rule[:policy_class])
-      end
-    end
-
     def reset_authorization_tracking!
-      @authorization_performed = false
+      @preflight_authorization_performed = false
     end
 
-    def authorized?
-      @authorization_performed
+    def preflight_authorized?
+      @preflight_authorization_performed
     end
 
     def self.own_authorization_rules
       @own_authorization_rules ||= []
+    end
+
+    def run_declared_authorizations!(args)
+      self.class.authorization_rules.each do |rule|
+        record = instance_exec(args, &rule[:resolver])
+        @preflight_authorization_performed = true
+        authorize(record, rule[:query], policy_class: rule[:policy_class])
+      end
     end
   end
 end

--- a/app/mcp/tools/cancel_agent_run.rb
+++ b/app/mcp/tools/cancel_agent_run.rb
@@ -47,7 +47,8 @@ module Tools
     private
 
     def run_for(agent_run_id)
-      @run = policy_scope(AgentRun).find(agent_run_id)
+      @runs_by_id ||= {}
+      @runs_by_id[agent_run_id] ||= policy_scope(AgentRun).find(agent_run_id)
     end
   end
 end

--- a/app/mcp/tools/cancel_agent_run.rb
+++ b/app/mcp/tools/cancel_agent_run.rb
@@ -2,6 +2,8 @@
 
 module Tools
   class CancelAgentRun < BaseTool
+    authorize :cancel?, ->(args) { run_for(args.fetch(:agent_run_id)) }
+
     def self.tool_name = "cancel_agent_run"
     def self.write_operation? = true
 
@@ -20,11 +22,10 @@ module Tools
       }
     end
 
-    def call(agent_run_id:, confirmed: false)
+    def perform(agent_run_id:, confirmed: false)
       raise ArgumentError, "Confirmation required: set confirmed=true to cancel an agent run" unless confirmed
 
-      run = policy_scope(AgentRun).find(agent_run_id)
-      authorize run, :cancel?
+      run = run_for(agent_run_id)
 
       unless run.cancellable?
         raise ArgumentError, "Agent run is not cancellable (current status: #{run.status})"
@@ -41,6 +42,12 @@ module Tools
         status: run.status,
         cancelled_at: run.updated_at
       }
+    end
+
+    private
+
+    def run_for(agent_run_id)
+      @run = policy_scope(AgentRun).find(agent_run_id)
     end
   end
 end

--- a/app/mcp/tools/get_agent_run.rb
+++ b/app/mcp/tools/get_agent_run.rb
@@ -49,7 +49,8 @@ module Tools
     private
 
     def run_for(agent_run_id)
-      @run = policy_scope(AgentRun).find(agent_run_id)
+      @runs_by_id ||= {}
+      @runs_by_id[agent_run_id] ||= policy_scope(AgentRun).find(agent_run_id)
     end
   end
 end

--- a/app/mcp/tools/get_agent_run.rb
+++ b/app/mcp/tools/get_agent_run.rb
@@ -2,6 +2,8 @@
 
 module Tools
   class GetAgentRun < BaseTool
+    authorize :show?, ->(args) { run_for(args.fetch(:agent_run_id)) }
+
     def self.tool_name = "get_agent_run"
 
     def self.description
@@ -18,9 +20,8 @@ module Tools
       }
     end
 
-    def call(agent_run_id:)
-      run = policy_scope(AgentRun).find(agent_run_id)
-      authorize run, :show?
+    def perform(agent_run_id:)
+      run = run_for(agent_run_id)
 
       {
         id: run.id,
@@ -43,6 +44,12 @@ module Tools
         completed_at: run.completed_at,
         created_at: run.created_at
       }
+    end
+
+    private
+
+    def run_for(agent_run_id)
+      @run = policy_scope(AgentRun).find(agent_run_id)
     end
   end
 end

--- a/app/mcp/tools/get_issue_details.rb
+++ b/app/mcp/tools/get_issue_details.rb
@@ -47,7 +47,8 @@ module Tools
     private
 
     def project_for(project_id)
-      @project = policy_scope(Project).find(project_id)
+      @projects_by_id ||= {}
+      @projects_by_id[project_id] ||= policy_scope(Project).find(project_id)
     end
 
     def fetch_comments(project, issue)

--- a/app/mcp/tools/get_issue_details.rb
+++ b/app/mcp/tools/get_issue_details.rb
@@ -2,6 +2,8 @@
 
 module Tools
   class GetIssueDetails < BaseTool
+    authorize :show?, ->(args) { project_for(args.fetch(:project_id)) }
+
     def self.tool_name = "get_issue_details"
 
     def self.description
@@ -19,9 +21,8 @@ module Tools
       }
     end
 
-    def call(project_id:, issue_id:)
-      project = policy_scope(Project).find(project_id)
-      authorize project, :show?
+    def perform(project_id:, issue_id:)
+      project = project_for(project_id)
 
       issue = project.issues.find(issue_id)
 
@@ -44,6 +45,10 @@ module Tools
     end
 
     private
+
+    def project_for(project_id)
+      @project = policy_scope(Project).find(project_id)
+    end
 
     def fetch_comments(project, issue)
       client = project.github_token&.client

--- a/app/mcp/tools/get_project.rb
+++ b/app/mcp/tools/get_project.rb
@@ -2,6 +2,8 @@
 
 module Tools
   class GetProject < BaseTool
+    authorize :show?, ->(args) { project_for(args.fetch(:project_id)) }
+
     def self.tool_name = "get_project"
 
     def self.description
@@ -18,9 +20,8 @@ module Tools
       }
     end
 
-    def call(project_id:)
-      project = policy_scope(Project).find(project_id)
-      authorize project, :show?
+    def perform(project_id:)
+      project = project_for(project_id)
 
       recent_runs = project.agent_runs.recent.limit(5)
 
@@ -37,6 +38,10 @@ module Tools
     end
 
     private
+
+    def project_for(project_id)
+      @project = policy_scope(Project).find(project_id)
+    end
 
     def run_summary(run)
       {

--- a/app/mcp/tools/get_project.rb
+++ b/app/mcp/tools/get_project.rb
@@ -40,7 +40,8 @@ module Tools
     private
 
     def project_for(project_id)
-      @project = policy_scope(Project).find(project_id)
+      @projects_by_id ||= {}
+      @projects_by_id[project_id] ||= policy_scope(Project).find(project_id)
     end
 
     def run_summary(run)

--- a/app/mcp/tools/get_project_issues.rb
+++ b/app/mcp/tools/get_project_issues.rb
@@ -2,6 +2,8 @@
 
 module Tools
   class GetProjectIssues < BaseTool
+    authorize :show?, ->(args) { project_for(args.fetch(:project_id)) }
+
     def self.tool_name = "get_project_issues"
 
     def self.description
@@ -21,9 +23,8 @@ module Tools
       }
     end
 
-    def call(project_id:, state: nil, is_pull_request: false, limit: 20)
-      project = policy_scope(Project).find(project_id)
-      authorize project, :show?
+    def perform(project_id:, state: nil, is_pull_request: false, limit: 20)
+      project = project_for(project_id)
 
       issues = is_pull_request ? project.issues.pull_requests_only : project.issues.issues_only
       issues = issues.by_paid_state(state) if state.present?
@@ -39,6 +40,12 @@ module Tools
           updated_at: issue.updated_at
         }
       end
+    end
+
+    private
+
+    def project_for(project_id)
+      @project = policy_scope(Project).find(project_id)
     end
   end
 end

--- a/app/mcp/tools/get_project_issues.rb
+++ b/app/mcp/tools/get_project_issues.rb
@@ -45,7 +45,8 @@ module Tools
     private
 
     def project_for(project_id)
-      @project = policy_scope(Project).find(project_id)
+      @projects_by_id ||= {}
+      @projects_by_id[project_id] ||= policy_scope(Project).find(project_id)
     end
   end
 end

--- a/app/mcp/tools/get_project_pull_requests.rb
+++ b/app/mcp/tools/get_project_pull_requests.rb
@@ -2,6 +2,8 @@
 
 module Tools
   class GetProjectPullRequests < BaseTool
+    authorize :show?, ->(args) { project_for(args.fetch(:project_id)) }
+
     def self.tool_name = "get_project_pull_requests"
 
     def self.description
@@ -20,9 +22,8 @@ module Tools
       }
     end
 
-    def call(project_id:, github_state: nil, limit: 20)
-      project = policy_scope(Project).find(project_id)
-      authorize project, :show?
+    def perform(project_id:, github_state: nil, limit: 20)
+      project = project_for(project_id)
 
       prs = project.issues.pull_requests_only
       prs = prs.where(github_state:) if github_state.present?
@@ -39,6 +40,12 @@ module Tools
           updated_at: pr.updated_at
         }
       end
+    end
+
+    private
+
+    def project_for(project_id)
+      @project = policy_scope(Project).find(project_id)
     end
   end
 end

--- a/app/mcp/tools/get_project_pull_requests.rb
+++ b/app/mcp/tools/get_project_pull_requests.rb
@@ -45,7 +45,8 @@ module Tools
     private
 
     def project_for(project_id)
-      @project = policy_scope(Project).find(project_id)
+      @projects_by_id ||= {}
+      @projects_by_id[project_id] ||= policy_scope(Project).find(project_id)
     end
   end
 end

--- a/app/mcp/tools/get_pull_request_details.rb
+++ b/app/mcp/tools/get_pull_request_details.rb
@@ -48,7 +48,8 @@ module Tools
     private
 
     def project_for(project_id)
-      @project = policy_scope(Project).find(project_id)
+      @projects_by_id ||= {}
+      @projects_by_id[project_id] ||= policy_scope(Project).find(project_id)
     end
 
     def fetch_comments(project, pr)

--- a/app/mcp/tools/get_pull_request_details.rb
+++ b/app/mcp/tools/get_pull_request_details.rb
@@ -2,6 +2,8 @@
 
 module Tools
   class GetPullRequestDetails < BaseTool
+    authorize :show?, ->(args) { project_for(args.fetch(:project_id)) }
+
     def self.tool_name = "get_pull_request_details"
 
     def self.description
@@ -19,9 +21,8 @@ module Tools
       }
     end
 
-    def call(project_id:, issue_id:)
-      project = policy_scope(Project).find(project_id)
-      authorize project, :show?
+    def perform(project_id:, issue_id:)
+      project = project_for(project_id)
 
       pr = project.issues.pull_requests_only.find(issue_id)
 
@@ -45,6 +46,10 @@ module Tools
     end
 
     private
+
+    def project_for(project_id)
+      @project = policy_scope(Project).find(project_id)
+    end
 
     def fetch_comments(project, pr)
       client = project.github_token&.client

--- a/app/mcp/tools/list_agent_runs.rb
+++ b/app/mcp/tools/list_agent_runs.rb
@@ -2,6 +2,8 @@
 
 module Tools
   class ListAgentRuns < BaseTool
+    authorize :index?, ->(_args) { AgentRun.new(project: Project.new(account: account)) }, policy_class: AgentRunPolicy
+
     def self.tool_name = "list_agent_runs"
 
     def self.description
@@ -19,7 +21,7 @@ module Tools
       }
     end
 
-    def call(project_id: nil, status: nil, limit: 20)
+    def perform(project_id: nil, status: nil, limit: 20)
       runs = policy_scope(AgentRun)
       runs = runs.where(project_id:) if project_id.present?
       runs = runs.by_status(status) if status.present?

--- a/app/mcp/tools/list_projects.rb
+++ b/app/mcp/tools/list_projects.rb
@@ -2,6 +2,8 @@
 
 module Tools
   class ListProjects < BaseTool
+    authorize :index?, ->(_args) { Project.new(account: account) }, policy_class: ProjectPolicy
+
     def self.tool_name = "list_projects"
 
     def self.description
@@ -20,7 +22,7 @@ module Tools
 
     VALID_STATUSES = %w[active inactive].freeze
 
-    def call(status: nil, limit: 20)
+    def perform(status: nil, limit: 20)
       if status.present? && !VALID_STATUSES.include?(status)
         raise ArgumentError, "Invalid status filter '#{status}': must be 'active' or 'inactive'"
       end

--- a/app/mcp/tools/registry.rb
+++ b/app/mcp/tools/registry.rb
@@ -17,6 +17,14 @@ module Tools
     ].freeze
 
     class << self
+      def dispatch(name:, arguments:, user:, session:)
+        tool_class = find(name)
+        raise ArgumentError, "Unknown tool: #{name}" unless tool_class
+        raise ArgumentError, "Tool arguments must be a JSON object" unless arguments.is_a?(Hash)
+
+        tool_class.new(user:, session:).dispatch(**arguments.symbolize_keys)
+      end
+
       def find(name)
         tool_hash[name]
       end
@@ -39,6 +47,7 @@ module Tools
       end
 
       def tool_available_to?(klass, user:)
+        return false if user.blank?
         return true unless klass.write_operation?
 
         return true if Pundit.policy(user, Project.new(account: user.account))&.run_agent?

--- a/app/mcp/tools/search_code.rb
+++ b/app/mcp/tools/search_code.rb
@@ -2,6 +2,8 @@
 
 module Tools
   class SearchCode < BaseTool
+    authorize :show?, ->(args) { project_for(args.fetch(:project_id)) }
+
     def self.tool_name = "search_code"
 
     def self.description
@@ -20,9 +22,8 @@ module Tools
       }
     end
 
-    def call(project_id:, query:, limit: 10)
-      project = policy_scope(Project).find(project_id)
-      authorize project, :show?
+    def perform(project_id:, query:, limit: 10)
+      project = project_for(project_id)
 
       search_limit = limit.to_i.clamp(1, 50)
 
@@ -43,6 +44,12 @@ module Tools
           content_preview: r[:content].to_s.truncate(500)
         }
       end
+    end
+
+    private
+
+    def project_for(project_id)
+      @project = policy_scope(Project).find(project_id)
     end
   end
 end

--- a/app/mcp/tools/search_code.rb
+++ b/app/mcp/tools/search_code.rb
@@ -49,7 +49,8 @@ module Tools
     private
 
     def project_for(project_id)
-      @project = policy_scope(Project).find(project_id)
+      @projects_by_id ||= {}
+      @projects_by_id[project_id] ||= policy_scope(Project).find(project_id)
     end
   end
 end

--- a/app/mcp/tools/trigger_agent_run.rb
+++ b/app/mcp/tools/trigger_agent_run.rb
@@ -66,7 +66,8 @@ module Tools
     private
 
     def project_for(project_id)
-      @project = policy_scope(Project).find(project_id)
+      @projects_by_id ||= {}
+      @projects_by_id[project_id] ||= policy_scope(Project).find(project_id)
     end
 
     def duplicate_active_issue_run?(error)

--- a/app/mcp/tools/trigger_agent_run.rb
+++ b/app/mcp/tools/trigger_agent_run.rb
@@ -2,6 +2,8 @@
 
 module Tools
   class TriggerAgentRun < BaseTool
+    authorize :run_agent?, ->(args) { project_for(args.fetch(:project_id)) }, policy_class: ProjectPolicy
+
     def self.tool_name = "trigger_agent_run"
     def self.write_operation? = true
 
@@ -22,11 +24,10 @@ module Tools
       }
     end
 
-    def call(project_id:, issue_id:, confirmed: false, goal: "create_pr")
+    def perform(project_id:, issue_id:, confirmed: false, goal: "create_pr")
       raise ArgumentError, "Confirmation required: set confirmed=true to trigger an agent run" unless confirmed
 
-      project = policy_scope(Project).find(project_id)
-      authorize project, :run_agent?, policy_class: ProjectPolicy
+      project = project_for(project_id)
 
       issue = project.issues.find(issue_id)
 
@@ -63,6 +64,10 @@ module Tools
     end
 
     private
+
+    def project_for(project_id)
+      @project = policy_scope(Project).find(project_id)
+    end
 
     def duplicate_active_issue_run?(error)
       (error.cause&.message || error.message).include?("idx_agent_runs_unique_active_issue")

--- a/spec/mcp/paid_mcp_server_spec.rb
+++ b/spec/mcp/paid_mcp_server_spec.rb
@@ -96,6 +96,21 @@ RSpec.describe PaidMcpServer do
     end
   end
 
+  describe "#call_tool" do
+    it "routes tool calls through the registry" do
+      allow(Tools::Registry).to receive(:dispatch).and_return([])
+
+      server.call_tool(name: "list_projects", arguments: {})
+
+      expect(Tools::Registry).to have_received(:dispatch).with(
+        name: "list_projects",
+        arguments: {},
+        user: user,
+        session: chat_session
+      )
+    end
+  end
+
   describe "rate limiting" do
     it "raises RateLimitExceeded when limit is hit" do
       allow(Rails.cache).to receive(:increment).and_return(PaidMcpServer::RATE_LIMIT_MAX + 1)

--- a/spec/mcp/tools/base_tool_no_system_access_spec.rb
+++ b/spec/mcp/tools/base_tool_no_system_access_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Tools::BaseTool do
+  describe "system access guard" do
+    it "does not allow TenantContext.with_system_access in tool bodies" do
+      offending_files = Dir.glob(Rails.root.join("app/mcp/tools/**/*.rb")).filter_map do |path|
+        path if File.read(path).include?("TenantContext.with_system_access")
+      end
+
+      expect(offending_files).to eq([])
+    end
+  end
+end

--- a/spec/mcp/tools/base_tool_spec.rb
+++ b/spec/mcp/tools/base_tool_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Tools::BaseTool do
+  let(:account) { create(:account) }
+  let(:user) { create(:user, :member, account: account) }
+  let(:session) { create(:chat_session, account: account, created_by: user) }
+  let(:project) { create(:project, account: account) }
+
+  before do
+    stub_const("Tools::BaseToolAuthorizedSpecTool", Class.new(described_class) do
+      authorize :show?, ->(args) { Project.find(args.fetch(:project_id)) }
+
+      def self.tool_name = "base_tool_authorized_spec"
+      def self.description = "Authorized base tool spec"
+
+      def perform(project_id:)
+        {
+          current_account_id: Current.account&.id,
+          bypass_enabled: TenantContext.bypass_enabled?,
+          authorization_performed: instance_variable_get(:@authorization_performed),
+          project_id: Project.find(project_id).id
+        }
+      end
+    end)
+
+    stub_const("Tools::BaseToolUnauthorizedSpecTool", Class.new(described_class) do
+      def self.tool_name = "base_tool_unauthorized_spec"
+      def self.description = "Unauthorized base tool spec"
+
+      def perform
+        { ok: true }
+      end
+    end)
+  end
+
+  describe "#dispatch" do
+    it "requires an authenticated user" do
+      tool = Tools::BaseToolAuthorizedSpecTool.new(user: nil, session: nil)
+
+      expect { tool.dispatch(project_id: project.id) }
+        .to raise_error(Tools::UnauthorizedError, "Tool calls require an authenticated user")
+    end
+
+    it "runs the tool inside the user's tenant context and authorizes before the body" do
+      tool = Tools::BaseToolAuthorizedSpecTool.new(user: user, session: session)
+      other_account = create(:account)
+
+      result = nil
+      restored_account = TenantContext.with(other_account) do
+        result = tool.dispatch(project_id: project.id)
+        Current.account
+      end
+
+      expect(result).to include(
+        current_account_id: account.id,
+        bypass_enabled: false,
+        authorization_performed: true,
+        project_id: project.id
+      )
+      expect(restored_account).to eq(other_account)
+    end
+
+    it "raises when the tool body never performs authorization" do
+      tool = Tools::BaseToolUnauthorizedSpecTool.new(user: user, session: session)
+
+      expect { tool.dispatch }
+        .to raise_error(Tools::UnauthorizedError, "base_tool_unauthorized_spec must authorize before execution")
+    end
+  end
+end

--- a/spec/mcp/tools/base_tool_spec.rb
+++ b/spec/mcp/tools/base_tool_spec.rb
@@ -19,17 +19,33 @@ RSpec.describe Tools::BaseTool do
         {
           current_account_id: Current.account&.id,
           bypass_enabled: TenantContext.bypass_enabled?,
-          authorization_performed: instance_variable_get(:@authorization_performed),
+          authorization_performed: instance_variable_get(:@preflight_authorization_performed),
           project_id: Project.find(project_id).id
         }
       end
     end)
 
     stub_const("Tools::BaseToolUnauthorizedSpecTool", Class.new(described_class) do
+      attr_reader :perform_called
+
       def self.tool_name = "base_tool_unauthorized_spec"
       def self.description = "Unauthorized base tool spec"
 
       def perform
+        @perform_called = true
+        { ok: true }
+      end
+    end)
+
+    stub_const("Tools::BaseToolPostHocAuthorizedSpecTool", Class.new(described_class) do
+      attr_reader :perform_called
+
+      def self.tool_name = "base_tool_post_hoc_authorized_spec"
+      def self.description = "Post hoc authorization base tool spec"
+
+      def perform(project_id:)
+        @perform_called = true
+        authorize(Project.find(project_id), :show?)
         { ok: true }
       end
     end)
@@ -67,6 +83,15 @@ RSpec.describe Tools::BaseTool do
 
       expect { tool.dispatch }
         .to raise_error(Tools::UnauthorizedError, "base_tool_unauthorized_spec must authorize before execution")
+      expect(tool.perform_called).to be_nil
+    end
+
+    it "raises before entering perform when authorization only happens post hoc" do
+      tool = Tools::BaseToolPostHocAuthorizedSpecTool.new(user: user, session: session)
+
+      expect { tool.dispatch(project_id: project.id) }
+        .to raise_error(Tools::UnauthorizedError, "base_tool_post_hoc_authorized_spec must authorize before execution")
+      expect(tool.perform_called).to be_nil
     end
   end
 end

--- a/spec/mcp/tools/cancel_agent_run_spec.rb
+++ b/spec/mcp/tools/cancel_agent_run_spec.rb
@@ -56,5 +56,15 @@ RSpec.describe Tools::CancelAgentRun do
         tool.call(agent_run_id: run.id, confirmed: true)
       }.to raise_error(ArgumentError, /not cancellable/)
     end
+
+    it "reuses the authorized run lookup during perform" do
+      run = create(:agent_run, :running, project: project)
+      scope = instance_double(ActiveRecord::Relation)
+
+      allow(tool).to receive(:policy_scope).with(AgentRun).and_return(scope)
+      expect(scope).to receive(:find).once.with(run.id).and_return(run)
+
+      tool.call(agent_run_id: run.id, confirmed: true)
+    end
   end
 end

--- a/spec/mcp/tools/get_agent_run_spec.rb
+++ b/spec/mcp/tools/get_agent_run_spec.rb
@@ -35,5 +35,15 @@ RSpec.describe Tools::GetAgentRun do
       expect { tool.call(agent_run_id: other_run.id) }
         .to raise_error(ActiveRecord::RecordNotFound)
     end
+
+    it "reuses the authorized run lookup during perform" do
+      run = create(:agent_run, project: create(:project, account: account))
+      scope = instance_double(ActiveRecord::Relation)
+
+      allow(tool).to receive(:policy_scope).with(AgentRun).and_return(scope)
+      expect(scope).to receive(:find).once.with(run.id).and_return(run)
+
+      tool.call(agent_run_id: run.id)
+    end
   end
 end

--- a/spec/mcp/tools/get_project_spec.rb
+++ b/spec/mcp/tools/get_project_spec.rb
@@ -36,5 +36,15 @@ RSpec.describe Tools::GetProject do
       expect { tool.call(project_id: other_project.id) }
         .to raise_error(ActiveRecord::RecordNotFound)
     end
+
+    it "reuses the authorized project lookup during perform" do
+      project = create(:project, account: account)
+      scope = instance_double(ActiveRecord::Relation)
+
+      allow(tool).to receive(:policy_scope).with(Project).and_return(scope)
+      expect(scope).to receive(:find).once.with(project.id).and_return(project)
+
+      tool.call(project_id: project.id)
+    end
   end
 end

--- a/spec/mcp/tools/registry_authorization_parity_spec.rb
+++ b/spec/mcp/tools/registry_authorization_parity_spec.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Tools::Registry do
+  let(:account) { create(:account) }
+  let(:project) { create(:project, account: account) }
+  let(:issue) { create(:issue, project: project) }
+  let(:pull_request) { create(:issue, :pull_request, project: project) }
+  let(:agent_run) { create(:agent_run, :running, project: project, issue: issue) }
+  let(:other_account) { create(:account) }
+
+  let(:scenarios) do
+    [
+      {
+        tool_name: "list_projects",
+        denied_user: -> { nil },
+        arguments: -> { {} },
+        ui_call: ->(user) { Pundit.policy_scope!(user, Project).order(updated_at: :desc).limit(20).to_a }
+      },
+      {
+        tool_name: "list_agent_runs",
+        denied_user: -> { nil },
+        arguments: -> { {} },
+        ui_call: ->(user) { Pundit.policy_scope!(user, AgentRun).recent.limit(20).to_a }
+      },
+      {
+        tool_name: "get_project",
+        denied_user: -> { create(:user, :member, account: other_account) },
+        arguments: -> { { project_id: project.id } },
+        ui_call: ->(user) {
+          project_record = Pundit.policy_scope!(user, Project).find(project.id)
+          authorize_record!(user, project_record, :show?)
+        }
+      },
+      {
+        tool_name: "get_project_issues",
+        denied_user: -> { create(:user, :member, account: other_account) },
+        arguments: -> { { project_id: project.id } },
+        ui_call: ->(user) {
+          project_record = Pundit.policy_scope!(user, Project).find(project.id)
+          authorize_record!(user, project_record, :show?)
+          project_record.issues.issues_only.order(updated_at: :desc).limit(20).to_a
+        }
+      },
+      {
+        tool_name: "get_project_pull_requests",
+        denied_user: -> { create(:user, :member, account: other_account) },
+        arguments: -> { { project_id: project.id } },
+        ui_call: ->(user) {
+          project_record = Pundit.policy_scope!(user, Project).find(project.id)
+          authorize_record!(user, project_record, :show?)
+          project_record.issues.pull_requests_only.order(updated_at: :desc).limit(20).to_a
+        }
+      },
+      {
+        tool_name: "trigger_agent_run",
+        denied_user: -> {
+          project
+          create(:user, :viewer, account: account)
+        },
+        arguments: -> { { project_id: project.id, issue_id: issue.id, confirmed: true } },
+        ui_call: ->(user) {
+          project_record = Pundit.policy_scope!(user, Project).find(project.id)
+          authorize_record!(user, project_record, :run_agent?, policy_class: ProjectPolicy)
+          project_record.issues.find(issue.id)
+        }
+      },
+      {
+        tool_name: "get_agent_run",
+        denied_user: -> { create(:user, :member, account: other_account) },
+        arguments: -> { { agent_run_id: agent_run.id } },
+        ui_call: ->(user) {
+          run_record = Pundit.policy_scope!(user, AgentRun).find(agent_run.id)
+          authorize_record!(user, run_record, :show?)
+        }
+      },
+      {
+        tool_name: "cancel_agent_run",
+        denied_user: -> {
+          project
+          create(:user, :viewer, account: account)
+        },
+        arguments: -> { { agent_run_id: agent_run.id, confirmed: true } },
+        ui_call: ->(user) {
+          project_record = Pundit.policy_scope!(user, Project).find(project.id)
+          run_record = project_record.agent_runs.find(agent_run.id)
+          authorize_record!(user, run_record, :cancel?)
+        }
+      },
+      {
+        tool_name: "get_issue_details",
+        denied_user: -> { create(:user, :member, account: other_account) },
+        arguments: -> { { project_id: project.id, issue_id: issue.id } },
+        ui_call: ->(user) {
+          project_record = Pundit.policy_scope!(user, Project).find(project.id)
+          authorize_record!(user, project_record, :show?)
+          project_record.issues.find(issue.id)
+        }
+      },
+      {
+        tool_name: "get_pull_request_details",
+        denied_user: -> { create(:user, :member, account: other_account) },
+        arguments: -> { { project_id: project.id, issue_id: pull_request.id } },
+        ui_call: ->(user) {
+          project_record = Pundit.policy_scope!(user, Project).find(project.id)
+          authorize_record!(user, project_record, :show?)
+          project_record.issues.pull_requests_only.find(pull_request.id)
+        }
+      },
+      {
+        tool_name: "search_code",
+        denied_user: -> { create(:user, :member, account: other_account) },
+        arguments: -> { { project_id: project.id, query: "agent run" } },
+        ui_call: ->(user) {
+          project_record = Pundit.policy_scope!(user, Project).find(project.id)
+          authorize_record!(user, project_record, :show?)
+          Knowledge::Search.call(project: project_record, query: "agent run", mode: "hybrid", limit: 10)
+        }
+      }
+    ]
+  end
+
+  describe "authorization parity" do
+    it "covers every registered tool" do
+      expect(scenarios.map { |scenario| scenario[:tool_name] })
+        .to match_array(described_class.all.map(&:tool_name))
+    end
+
+    it "denies every registered tool through chat whenever the direct path is denied" do
+      scenarios.each do |scenario|
+        user = instance_exec(&scenario[:denied_user])
+        arguments = instance_exec(&scenario[:arguments])
+
+        chat_error = capture_error do
+          described_class.dispatch(
+            name: scenario[:tool_name],
+            arguments: arguments,
+            user: user,
+            session: build(:chat_session, account: user&.account || account, created_by: user)
+          )
+        end
+
+        ui_error = capture_error do
+          instance_exec(user, &scenario[:ui_call])
+        end
+
+        expect(chat_error).to be_present, "expected chat path denial for #{scenario[:tool_name]}"
+        expect(ui_error).to be_present, "expected direct path denial for #{scenario[:tool_name]}"
+        expect(normalize_denial(chat_error)).to eq(normalize_denial(ui_error)),
+          "expected matching denials for #{scenario[:tool_name]}"
+      end
+    end
+  end
+
+  private
+
+  def capture_error
+    yield
+    nil
+  rescue StandardError => error
+    error
+  end
+
+  def normalize_denial(error)
+    case error
+    when ActiveRecord::RecordNotFound
+      :record_not_found
+    when Pundit::NotAuthorizedError
+      :not_authorized
+    else
+      error&.class
+    end
+  end
+
+  def authorize_record!(user, record, query, policy_class: nil)
+    policy = policy_class ? policy_class.new(user, record) : Pundit.policy!(user, record)
+    return record if policy.public_send(query)
+
+    raise Pundit::NotAuthorizedError.new(query: query, record: record, policy: policy)
+  end
+end


### PR DESCRIPTION
## Summary

Enforce a "chat ≤ user" authorization invariant at the framework level so that every MCP tool call is guaranteed to resolve a user, run inside the correct tenant context, and perform at least one Pundit authorization check — eliminating reliance on per-tool discipline that could silently grant chat callers privileges their UI session doesn't have.

## Changes

### MCP Tool Framework (`app/mcp/tools/`)

- **`BaseTool#dispatch`** — new chokepoint wrapper that asserts `user.present?`, opens `TenantContext.with(user.account)` for the entire tool execution, runs class-level declared authorizations before the tool body, and raises `Tools::UnauthorizedError` if no authorization occurred before mutation
- **Class-level `authorize` DSL** — tools now declare their authorization contract declaratively rather than scattering inline `Pundit.policy` calls
- **`#perform` convention** — tool bodies moved from `#call` to `#perform`, with `#dispatch` owning the lifecycle

### MCP Server & Registry

- **`Tools::Registry.dispatch`** — becomes the single execution entrypoint for all tool calls
- **`PaidMcpServer#call_tool`** — routes through `Registry.dispatch` instead of invoking tools directly

### Existing Tool Refactors

- All current tools refactored to declare their authorization contract via the new DSL and implement `#perform` — no behavior change, only structural alignment with the new framework

### Tests

- **Base wrapper spec** — validates user requirement, tenant scoping, and authorization-was-called enforcement
- **System access prohibition spec** — asserts `TenantContext.with_system_access` does not appear anywhere under `app/mcp/tools/**`
- **Parity spec** — walks every registered tool, constructs an unauthorized user, and verifies that chat-path denial matches direct Servo/controller-path denial
- **Server spec** — updated to assert registry dispatch routing

## Design Decisions

- **Framework-enforced, not convention-enforced**: The prior model relied on each tool author remembering to call `authorize!`. A single forgotten check would silently escalate privileges. The `dispatch` wrapper makes this structurally impossible — tools that skip authorization raise at runtime.
- **`with_system_access` banned in tool bodies**: System-access bypass is only legitimate in the controller/job bootstrap that resolves the session (which already exists). A grep-based spec enforces this boundary, preventing future tools from accidentally escaping tenant isolation.
- **Parity spec as the critical safety net**: Rather than testing tools in isolation, the parity spec ensures chat authorization and UI authorization always agree. A failure means chat can do something the UI cannot — the exact class of bug this change prevents.

---

Closes #2349