### PR TITLE
feat(chat): first-class source-code read tools (read_repo_file, list_repo_tree, grep_repo)

### DIFF
--- a/app/mcp/tools/base_tool.rb
+++ b/app/mcp/tools/base_tool.rb
@@ -93,6 +93,10 @@ module Tools
       Project.where(account:)
     end
 
+    def resolve_repo_read_client(project)
+      RepoReadClientResolver.new(project:, user:, session:).resolve
+    end
+
     def reset_authorization_tracking!
       @preflight_authorization_performed = false
     end

--- a/app/mcp/tools/grep_repo.rb
+++ b/app/mcp/tools/grep_repo.rb
@@ -5,6 +5,10 @@ module Tools
     authorize :show?, ->(args) { project_for(args.fetch(:project_id)) }
 
     MAX_RESULTS = 30
+    SEARCH_QUALIFIER_PATTERN = /
+      (?:\A|\s)\K
+      (?:repo|org|user|path|language|filename|extension|symbol|content):\S+
+    /ix
 
     def self.tool_name = "grep_repo"
 
@@ -60,9 +64,20 @@ module Tools
     end
 
     def build_query(repo_full_name, query, path_filter)
-      parts = [ "repo:#{repo_full_name}", query ]
-      parts << "path:#{path_filter}" if path_filter.present?
+      sanitized_query = sanitize_query(query)
+      parts = [ "repo:#{repo_full_name}" ]
+      parts << sanitized_query if sanitized_query.present?
+      sanitized_path_filter = sanitize_path_filter(path_filter)
+      parts << "path:#{sanitized_path_filter}" if sanitized_path_filter.present?
       parts.join(" ")
+    end
+
+    def sanitize_query(query)
+      query.gsub(SEARCH_QUALIFIER_PATTERN, "").squish
+    end
+
+    def sanitize_path_filter(path_filter)
+      path_filter.to_s.gsub(SEARCH_QUALIFIER_PATTERN, "").squish.split.first
     end
 
     def identity_label(project)

--- a/app/mcp/tools/grep_repo.rb
+++ b/app/mcp/tools/grep_repo.rb
@@ -34,6 +34,7 @@ module Tools
       client = repo_client.client
 
       qualified_query = build_query(project.full_name, query, path_filter)
+      return empty_result(repo_client.identity) if qualified_query.strip == "repo:#{project.full_name}"
 
       result = client.search_code(qualified_query, per_page: MAX_RESULTS)
 
@@ -52,10 +53,14 @@ module Tools
         identity: repo_client.identity
       }
     rescue GithubClient::NotFoundError
-      { matches: [], total_count: 0, identity: repo_client.identity }
+      empty_result(repo_client.identity)
     end
 
     private
+
+    def empty_result(identity)
+      { matches: [], total_count: 0, identity: identity }
+    end
 
     def build_query(repo_full_name, query, path_filter)
       sanitized_query = sanitize_query(query)

--- a/app/mcp/tools/grep_repo.rb
+++ b/app/mcp/tools/grep_repo.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Tools
+  class GrepRepo < BaseTool
+    authorize :show?, ->(args) { project_for(args.fetch(:project_id)) }
+
+    MAX_RESULTS = 30
+
+    def self.tool_name = "grep_repo"
+
+    def self.description
+      "Search for a string or pattern across a project's GitHub repository using GitHub code search."
+    end
+
+    def self.input_schema
+      {
+        type: "object",
+        properties: {
+          project_id: { type: "integer", description: "The project ID" },
+          query: { type: "string", description: "Search query (string or regex pattern)" },
+          path_filter: { type: "string", description: "Optional path prefix to narrow search scope (e.g. 'app/models')" }
+        },
+        required: %w[project_id query]
+      }
+    end
+
+    def perform(project_id:, query:, path_filter: nil)
+      project = project_for(project_id)
+      client = resolve_client(project)
+
+      qualified_query = build_query(project.full_name, query, path_filter)
+
+      result = client.search_code(qualified_query, per_page: MAX_RESULTS)
+
+      matches = (result&.items || []).map do |item|
+        {
+          path: item.path,
+          name: item.name,
+          html_url: item.html_url
+        }
+      end
+
+      {
+        total_count: result&.total_count || 0,
+        matches: matches,
+        truncated: (result&.total_count || 0) > MAX_RESULTS,
+        identity: identity_label(project)
+      }
+    rescue GithubClient::NotFoundError
+      { matches: [], total_count: 0, identity: identity_label(project) }
+    end
+
+    private
+
+    def resolve_client(project)
+      client = project.client
+      raise ArgumentError, "Project has no GitHub credentials configured" unless client
+
+      client
+    end
+
+    def build_query(repo_full_name, query, path_filter)
+      parts = [ "repo:#{repo_full_name}", query ]
+      parts << "path:#{path_filter}" if path_filter.present?
+      parts.join(" ")
+    end
+
+    def identity_label(project)
+      if project.github_installation.present?
+        "github-app:#{project.github_installation.github_installation_id}"
+      elsif project.github_token.present?
+        "project-token:#{project.github_token.name}"
+      else
+        "unknown"
+      end
+    end
+
+    def project_for(project_id)
+      @projects_by_id ||= {}
+      @projects_by_id[project_id] ||= policy_scope(Project).find(project_id)
+    end
+  end
+end

--- a/app/mcp/tools/grep_repo.rb
+++ b/app/mcp/tools/grep_repo.rb
@@ -30,7 +30,8 @@ module Tools
 
     def perform(project_id:, query:, path_filter: nil)
       project = project_for(project_id)
-      client = resolve_client(project)
+      repo_client = resolve_repo_read_client(project)
+      client = repo_client.client
 
       qualified_query = build_query(project.full_name, query, path_filter)
 
@@ -48,20 +49,13 @@ module Tools
         total_count: result&.total_count || 0,
         matches: matches,
         truncated: (result&.total_count || 0) > MAX_RESULTS,
-        identity: identity_label(project)
+        identity: repo_client.identity
       }
     rescue GithubClient::NotFoundError
-      { matches: [], total_count: 0, identity: identity_label(project) }
+      { matches: [], total_count: 0, identity: repo_client.identity }
     end
 
     private
-
-    def resolve_client(project)
-      client = project.client
-      raise ArgumentError, "Project has no GitHub credentials configured" unless client
-
-      client
-    end
 
     def build_query(repo_full_name, query, path_filter)
       sanitized_query = sanitize_query(query)
@@ -78,16 +72,6 @@ module Tools
 
     def sanitize_path_filter(path_filter)
       path_filter.to_s.gsub(SEARCH_QUALIFIER_PATTERN, "").squish.split.first
-    end
-
-    def identity_label(project)
-      if project.github_installation.present?
-        "github-app:#{project.github_installation.github_installation_id}"
-      elsif project.github_token.present?
-        "project-token:#{project.github_token.name}"
-      else
-        "unknown"
-      end
     end
 
     def project_for(project_id)

--- a/app/mcp/tools/list_repo_tree.rb
+++ b/app/mcp/tools/list_repo_tree.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module Tools
+  class ListRepoTree < BaseTool
+    authorize :show?, ->(args) { project_for(args.fetch(:project_id)) }
+
+    MAX_ENTRIES = 1000
+
+    def self.tool_name = "list_repo_tree"
+
+    def self.description
+      "List files and directories in a project's GitHub repository at a given path."
+    end
+
+    def self.input_schema
+      {
+        type: "object",
+        properties: {
+          project_id: { type: "integer", description: "The project ID" },
+          path: { type: "string", description: "Directory path within the repository. Defaults to root.", default: "" },
+          ref: { type: "string", description: "Git ref (branch, tag, or SHA). Defaults to HEAD.", default: "HEAD" }
+        },
+        required: %w[project_id]
+      }
+    end
+
+    def perform(project_id:, path: "", ref: "HEAD")
+      project = project_for(project_id)
+      client = resolve_client(project)
+
+      ref = project.default_branch if ref == "HEAD"
+      ref ||= "main"
+
+      if path.present?
+        entries = directory_entries(client, project, path, ref)
+      else
+        entries = tree_entries(client, project, ref)
+      end
+
+      {
+        path: path.presence || "/",
+        ref: ref,
+        entries: entries.first(MAX_ENTRIES),
+        truncated: entries.size > MAX_ENTRIES,
+        identity: identity_label(project)
+      }
+    rescue GithubClient::NotFoundError
+      { error: "Path not found: #{path}", identity: identity_label(project) }
+    end
+
+    private
+
+    def resolve_client(project)
+      client = project.client
+      raise ArgumentError, "Project has no GitHub credentials configured" unless client
+
+      client
+    end
+
+    def directory_entries(client, project, path, ref)
+      data = client.contents(project.full_name, path: path, ref: ref)
+      return [] unless data.is_a?(Array)
+
+      data.map do |entry|
+        { name: entry.name, path: entry.path, type: entry.type, size: entry.size }
+      end
+    end
+
+    def tree_entries(client, project, ref)
+      result = client.tree(project.full_name, ref, recursive: true)
+      return [] unless result&.tree
+
+      result.tree.map do |entry|
+        { name: File.basename(entry.path), path: entry.path, type: entry.type, size: entry.size }
+      end
+    end
+
+    def identity_label(project)
+      if project.github_installation.present?
+        "github-app:#{project.github_installation.github_installation_id}"
+      elsif project.github_token.present?
+        "project-token:#{project.github_token.name}"
+      else
+        "unknown"
+      end
+    end
+
+    def project_for(project_id)
+      @projects_by_id ||= {}
+      @projects_by_id[project_id] ||= policy_scope(Project).find(project_id)
+    end
+  end
+end

--- a/app/mcp/tools/list_repo_tree.rb
+++ b/app/mcp/tools/list_repo_tree.rb
@@ -26,7 +26,8 @@ module Tools
 
     def perform(project_id:, path: "", ref: "HEAD")
       project = project_for(project_id)
-      client = resolve_client(project)
+      repo_client = resolve_repo_read_client(project)
+      client = repo_client.client
 
       ref = project.default_branch if ref == "HEAD"
       ref ||= "main"
@@ -38,20 +39,13 @@ module Tools
         ref: ref,
         entries: entries.first(MAX_ENTRIES),
         truncated: entries.size > MAX_ENTRIES,
-        identity: identity_label(project)
+        identity: repo_client.identity
       }
     rescue GithubClient::NotFoundError
-      { error: "Path not found: #{path}", identity: identity_label(project) }
+      { error: "Path not found: #{path}", identity: repo_client.identity }
     end
 
     private
-
-    def resolve_client(project)
-      client = project.client
-      raise ArgumentError, "Project has no GitHub credentials configured" unless client
-
-      client
-    end
 
     def directory_entries(client, project, path, ref)
       data = client.contents(project.full_name, path: path, ref: ref)
@@ -59,16 +53,6 @@ module Tools
 
       data.map do |entry|
         { name: entry.name, path: entry.path, type: entry.type, size: entry.size }
-      end
-    end
-
-    def identity_label(project)
-      if project.github_installation.present?
-        "github-app:#{project.github_installation.github_installation_id}"
-      elsif project.github_token.present?
-        "project-token:#{project.github_token.name}"
-      else
-        "unknown"
       end
     end
 

--- a/app/mcp/tools/list_repo_tree.rb
+++ b/app/mcp/tools/list_repo_tree.rb
@@ -31,11 +31,7 @@ module Tools
       ref = project.default_branch if ref == "HEAD"
       ref ||= "main"
 
-      if path.present?
-        entries = directory_entries(client, project, path, ref)
-      else
-        entries = tree_entries(client, project, ref)
-      end
+      entries = directory_entries(client, project, path, ref)
 
       {
         path: path.presence || "/",
@@ -59,19 +55,10 @@ module Tools
 
     def directory_entries(client, project, path, ref)
       data = client.contents(project.full_name, path: path, ref: ref)
-      return [] unless data.is_a?(Array)
+      raise GithubClient::NotFoundError, "Path is not a directory" unless data.is_a?(Array)
 
       data.map do |entry|
         { name: entry.name, path: entry.path, type: entry.type, size: entry.size }
-      end
-    end
-
-    def tree_entries(client, project, ref)
-      result = client.tree(project.full_name, ref, recursive: true)
-      return [] unless result&.tree
-
-      result.tree.map do |entry|
-        { name: File.basename(entry.path), path: entry.path, type: entry.type, size: entry.size }
       end
     end
 

--- a/app/mcp/tools/read_repo_file.rb
+++ b/app/mcp/tools/read_repo_file.rb
@@ -70,6 +70,8 @@ module Tools
     end
 
     def utf8_text?(raw)
+      return false if raw.include?("\x00")
+
       raw.dup.force_encoding("UTF-8").valid_encoding?
     end
 

--- a/app/mcp/tools/read_repo_file.rb
+++ b/app/mcp/tools/read_repo_file.rb
@@ -33,8 +33,8 @@ module Tools
       return error_result("Path is a directory, not a file", project) if data.is_a?(Array)
       return error_result("Path is not a file", project) unless data.type == "file"
 
-      return error_result("File is empty", project, path: path) unless data.content.present?
       return error_result("File exceeds #{MAX_FILE_SIZE_BYTES / 1024}KB size limit", project, path: path) if data.size > MAX_FILE_SIZE_BYTES
+      return error_result("File is empty", project, path: path) unless data.content.present?
 
       raw = Base64.decode64(data.content)
       return error_result("File appears to be binary", project, path: path) unless utf8_text?(raw)

--- a/app/mcp/tools/read_repo_file.rb
+++ b/app/mcp/tools/read_repo_file.rb
@@ -34,9 +34,9 @@ module Tools
       return error_result("Path is not a file", project) unless data.type == "file"
 
       return error_result("File is empty", project, path: path) unless data.content.present?
+      return error_result("File exceeds #{MAX_FILE_SIZE_BYTES / 1024}KB size limit", project, path: path) if data.size > MAX_FILE_SIZE_BYTES
 
       raw = Base64.decode64(data.content)
-      return error_result("File exceeds #{MAX_FILE_SIZE_BYTES / 1024}KB size limit", project, path: path) if raw.bytesize > MAX_FILE_SIZE_BYTES
       return error_result("File appears to be binary", project, path: path) unless utf8_text?(raw)
 
       {

--- a/app/mcp/tools/read_repo_file.rb
+++ b/app/mcp/tools/read_repo_file.rb
@@ -26,48 +26,32 @@ module Tools
 
     def perform(project_id:, path:, ref: "HEAD")
       project = project_for(project_id)
-      client = resolve_client(project)
+      repo_client = resolve_repo_read_client(project)
+      client = repo_client.client
 
       data = client.contents(project.full_name, path: path, ref: ref)
 
-      return error_result("Path is a directory, not a file", project) if data.is_a?(Array)
-      return error_result("Path is not a file", project) unless data.type == "file"
+      return error_result("Path is a directory, not a file", repo_client.identity) if data.is_a?(Array)
+      return error_result("Path is not a file", repo_client.identity) unless data.type == "file"
 
-      return error_result("File exceeds #{MAX_FILE_SIZE_BYTES / 1024}KB size limit", project, path: path) if data.size > MAX_FILE_SIZE_BYTES
-      return error_result("File is empty", project, path: path) unless data.content.present?
+      return error_result("File exceeds #{MAX_FILE_SIZE_BYTES / 1024}KB size limit", repo_client.identity, path: path) if data.size > MAX_FILE_SIZE_BYTES
+      return error_result("File is empty", repo_client.identity, path: path) unless data.content.present?
 
       raw = Base64.decode64(data.content)
-      return error_result("File appears to be binary", project, path: path) unless utf8_text?(raw)
+      return error_result("File appears to be binary", repo_client.identity, path: path) unless utf8_text?(raw)
 
       {
         path: data.path,
         size: raw.bytesize,
         encoding: "utf-8",
         content: raw,
-        identity: identity_label(project)
+        identity: repo_client.identity
       }
     rescue GithubClient::NotFoundError
-      { error: "File not found: #{path}", identity: identity_label(project) }
+      { error: "File not found: #{path}", identity: repo_client.identity }
     end
 
     private
-
-    def resolve_client(project)
-      client = project.client
-      raise ArgumentError, "Project has no GitHub credentials configured" unless client
-
-      client
-    end
-
-    def identity_label(project)
-      if project.github_installation.present?
-        "github-app:#{project.github_installation.github_installation_id}"
-      elsif project.github_token.present?
-        "project-token:#{project.github_token.name}"
-      else
-        "unknown"
-      end
-    end
 
     def utf8_text?(raw)
       return false if raw.include?("\x00")
@@ -75,8 +59,8 @@ module Tools
       raw.dup.force_encoding("UTF-8").valid_encoding?
     end
 
-    def error_result(message, project, path: nil)
-      result = { error: message, identity: identity_label(project) }
+    def error_result(message, identity, path: nil)
+      result = { error: message, identity: identity }
       result[:path] = path if path
       result
     end

--- a/app/mcp/tools/read_repo_file.rb
+++ b/app/mcp/tools/read_repo_file.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Tools
+  class ReadRepoFile < BaseTool
+    authorize :show?, ->(args) { project_for(args.fetch(:project_id)) }
+
+    MAX_FILE_SIZE_BYTES = 200 * 1024
+
+    def self.tool_name = "read_repo_file"
+
+    def self.description
+      "Read the contents of a file in a project's GitHub repository."
+    end
+
+    def self.input_schema
+      {
+        type: "object",
+        properties: {
+          project_id: { type: "integer", description: "The project ID" },
+          path: { type: "string", description: "File path within the repository" },
+          ref: { type: "string", description: "Git ref (branch, tag, or SHA). Defaults to HEAD.", default: "HEAD" }
+        },
+        required: %w[project_id path]
+      }
+    end
+
+    def perform(project_id:, path:, ref: "HEAD")
+      project = project_for(project_id)
+      client = resolve_client(project)
+
+      data = client.contents(project.full_name, path: path, ref: ref)
+
+      return error_result("Path is a directory, not a file", project) if data.is_a?(Array)
+      return error_result("Path is not a file", project) unless data.type == "file"
+
+      return error_result("File is empty", project, path: path) unless data.content.present?
+
+      raw = Base64.decode64(data.content)
+      return error_result("File exceeds #{MAX_FILE_SIZE_BYTES / 1024}KB size limit", project, path: path) if raw.bytesize > MAX_FILE_SIZE_BYTES
+      return error_result("File appears to be binary", project, path: path) unless utf8_text?(raw)
+
+      {
+        path: data.path,
+        size: raw.bytesize,
+        encoding: "utf-8",
+        content: raw,
+        identity: identity_label(project)
+      }
+    rescue GithubClient::NotFoundError
+      { error: "File not found: #{path}", identity: identity_label(project) }
+    end
+
+    private
+
+    def resolve_client(project)
+      client = project.client
+      raise ArgumentError, "Project has no GitHub credentials configured" unless client
+
+      client
+    end
+
+    def identity_label(project)
+      if project.github_installation.present?
+        "github-app:#{project.github_installation.github_installation_id}"
+      elsif project.github_token.present?
+        "project-token:#{project.github_token.name}"
+      else
+        "unknown"
+      end
+    end
+
+    def utf8_text?(raw)
+      raw.dup.force_encoding("UTF-8").valid_encoding?
+    end
+
+    def error_result(message, project, path: nil)
+      result = { error: message, identity: identity_label(project) }
+      result[:path] = path if path
+      result
+    end
+
+    def project_for(project_id)
+      @projects_by_id ||= {}
+      @projects_by_id[project_id] ||= policy_scope(Project).find(project_id)
+    end
+  end
+end

--- a/app/mcp/tools/read_repo_file.rb
+++ b/app/mcp/tools/read_repo_file.rb
@@ -29,6 +29,9 @@ module Tools
       repo_client = resolve_repo_read_client(project)
       client = repo_client.client
 
+      ref = project.default_branch if ref == "HEAD"
+      ref ||= "main"
+
       data = client.contents(project.full_name, path: path, ref: ref)
 
       return error_result("Path is a directory, not a file", repo_client.identity) if data.is_a?(Array)

--- a/app/mcp/tools/registry.rb
+++ b/app/mcp/tools/registry.rb
@@ -13,7 +13,10 @@ module Tools
       "Tools::CancelAgentRun",
       "Tools::GetIssueDetails",
       "Tools::GetPullRequestDetails",
-      "Tools::SearchCode"
+      "Tools::SearchCode",
+      "Tools::ReadRepoFile",
+      "Tools::ListRepoTree",
+      "Tools::GrepRepo"
     ].freeze
 
     class << self

--- a/app/mcp/tools/repo_read_client_resolver.rb
+++ b/app/mcp/tools/repo_read_client_resolver.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Tools
+  class RepoReadClientResolver
+    ResolvedClient = Struct.new(:client, :identity, keyword_init: true)
+
+    def initialize(project:, user:, session:)
+      @project = project
+      @user = user || session&.created_by
+    end
+
+    def resolve
+      resolve_user_client || resolve_project_client || raise(ArgumentError, "Project has no GitHub credentials configured")
+    end
+
+    private
+
+    attr_reader :project, :user
+
+    def resolve_user_client
+      token = user_token_for_project
+      return unless token
+
+      ResolvedClient.new(client: token.client, identity: "user-token:#{token.name}")
+    end
+
+    def resolve_project_client
+      client = project.client
+      return unless client
+
+      ResolvedClient.new(client:, identity: project_identity)
+    end
+
+    def user_token_for_project
+      return unless user
+
+      ordered_active_user_tokens.find { |token| token_covers_project?(token) }
+    end
+
+    def ordered_active_user_tokens
+      @ordered_active_user_tokens ||= user.created_github_tokens.active.to_a.sort_by do |token|
+        [ token.last_used_at || Time.at(0), token.created_at || Time.at(0), token.id || 0 ]
+      end.reverse
+    end
+
+    def token_covers_project?(token)
+      return true if token.id == project.github_token_id
+
+      Array(token.accessible_repositories).any? do |repository|
+        repository["full_name"] == project.full_name
+      end
+    end
+
+    def project_identity
+      if project.github_installation.present?
+        "github-app:#{project.github_installation.github_installation_id}"
+      elsif project.github_token.present?
+        "project-token:#{project.github_token.name}"
+      else
+        "unknown"
+      end
+    end
+  end
+end

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -170,6 +170,10 @@ class GithubClient
     handle_errors { client.tree(repo, ref, recursive: recursive) }
   end
 
+  def search_code(query, per_page: 30)
+    handle_errors { client.search_code(query, per_page: per_page) }
+  end
+
   # Lists repositories the token has push access to.
   # Filters by permissions.push to exclude repos where the token only
   # has metadata access (relevant for fine-grained PATs with selected repos).

--- a/spec/mcp/tools/grep_repo_spec.rb
+++ b/spec/mcp/tools/grep_repo_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Tools::GrepRepo do
+  let(:account) { create(:account) }
+  let(:user) { create(:user, :member, account: account) }
+  let(:session) { create(:chat_session, account: account, created_by: user) }
+  let(:tool) { described_class.new(user: user, session: session) }
+  let(:project) { create(:project, account: account) }
+  let(:github_client) { instance_double(GithubClient) }
+
+  before do
+    allow(GithubClient).to receive(:new).and_return(github_client)
+    allow(github_client).to receive(:search_code)
+  end
+
+  describe "#call" do
+    it "returns search results" do
+      items = [
+        Struct.new(:path, :name, :html_url).new("app/models/foo.rb", "foo.rb", "https://github.com/owner/repo/blob/main/app/models/foo.rb")
+      ]
+      search_result = Struct.new(:total_count, :items).new(1, items)
+      allow(github_client).to receive(:search_code).and_return(search_result)
+
+      result = tool.call(project_id: project.id, query: "def authorize")
+
+      expect(result[:total_count]).to eq(1)
+      expect(result[:matches].size).to eq(1)
+      expect(result[:matches].first[:path]).to eq("app/models/foo.rb")
+      expect(result[:identity]).to include("project-token")
+    end
+
+    it "qualifies query with repo scope" do
+      search_result = Struct.new(:total_count, :items).new(0, [])
+      allow(github_client).to receive(:search_code).and_return(search_result)
+
+      tool.call(project_id: project.id, query: "def authorize")
+
+      expect(github_client).to have_received(:search_code).with("repo:#{project.full_name} def authorize", hash_including(:per_page))
+    end
+
+    it "includes path_filter in query" do
+      search_result = Struct.new(:total_count, :items).new(0, [])
+      allow(github_client).to receive(:search_code).and_return(search_result)
+
+      tool.call(project_id: project.id, query: "class Foo", path_filter: "app/models")
+
+      expect(github_client).to have_received(:search_code).with("repo:#{project.full_name} class Foo path:app/models", hash_including(:per_page))
+    end
+
+    it "returns empty results when no matches" do
+      search_result = Struct.new(:total_count, :items).new(0, [])
+      allow(github_client).to receive(:search_code).and_return(search_result)
+
+      result = tool.call(project_id: project.id, query: "nonexistent_pattern_xyz")
+
+      expect(result[:matches]).to eq([])
+      expect(result[:total_count]).to eq(0)
+    end
+
+    it "raises for project in another account" do
+      other_project = create(:project)
+
+      expect { tool.call(project_id: other_project.id, query: "test") }
+        .to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end

--- a/spec/mcp/tools/grep_repo_spec.rb
+++ b/spec/mcp/tools/grep_repo_spec.rb
@@ -49,6 +49,30 @@ RSpec.describe Tools::GrepRepo do
       expect(github_client).to have_received(:search_code).with("repo:#{project.full_name} class Foo path:app/models", hash_including(:per_page))
     end
 
+    it "strips injected GitHub qualifiers from the user query" do
+      search_result = Struct.new(:total_count, :items).new(0, [])
+      allow(github_client).to receive(:search_code).and_return(search_result)
+
+      tool.call(project_id: project.id, query: "secret_key repo:other/private-repo org:secret-org path:config", path_filter: "app/models")
+
+      expect(github_client).to have_received(:search_code).with(
+        "repo:#{project.full_name} secret_key path:app/models",
+        hash_including(:per_page)
+      )
+    end
+
+    it "sanitizes injected qualifiers from path_filter" do
+      search_result = Struct.new(:total_count, :items).new(0, [])
+      allow(github_client).to receive(:search_code).and_return(search_result)
+
+      tool.call(project_id: project.id, query: "secret_key", path_filter: "app/models repo:other/private-repo")
+
+      expect(github_client).to have_received(:search_code).with(
+        "repo:#{project.full_name} secret_key path:app/models",
+        hash_including(:per_page)
+      )
+    end
+
     it "returns empty results when no matches" do
       search_result = Struct.new(:total_count, :items).new(0, [])
       allow(github_client).to receive(:search_code).and_return(search_result)

--- a/spec/mcp/tools/grep_repo_spec.rb
+++ b/spec/mcp/tools/grep_repo_spec.rb
@@ -9,18 +9,23 @@ RSpec.describe Tools::GrepRepo do
   let(:tool) { described_class.new(user: user, session: session) }
   let(:project) { create(:project, account: account) }
   let(:github_client) { instance_double(GithubClient) }
+  let(:identity) { "project-token:#{project.github_token.name}" }
+  let(:resolved_client) { Tools::RepoReadClientResolver::ResolvedClient.new(client: github_client, identity:) }
 
   before do
-    allow(GithubClient).to receive(:new).and_return(github_client)
+    allow(tool).to receive(:resolve_repo_read_client).and_return(resolved_client)
     allow(github_client).to receive(:search_code)
   end
 
   describe "#call" do
-    it "returns search results" do
+    it "prefers the chatting user's matching GitHub token" do
       items = [
         Struct.new(:path, :name, :html_url).new("app/models/foo.rb", "foo.rb", "https://github.com/owner/repo/blob/main/app/models/foo.rb")
       ]
       search_result = Struct.new(:total_count, :items).new(1, items)
+      allow(tool).to receive(:resolve_repo_read_client).and_return(
+        Tools::RepoReadClientResolver::ResolvedClient.new(client: github_client, identity: "user-token:Chat Token")
+      )
       allow(github_client).to receive(:search_code).and_return(search_result)
 
       result = tool.call(project_id: project.id, query: "def authorize")
@@ -28,6 +33,15 @@ RSpec.describe Tools::GrepRepo do
       expect(result[:total_count]).to eq(1)
       expect(result[:matches].size).to eq(1)
       expect(result[:matches].first[:path]).to eq("app/models/foo.rb")
+      expect(result[:identity]).to include("user-token")
+    end
+
+    it "falls back to the project credential when the user has no matching token" do
+      search_result = Struct.new(:total_count, :items).new(0, [])
+      allow(github_client).to receive(:search_code).and_return(search_result)
+
+      result = tool.call(project_id: project.id, query: "def authorize")
+
       expect(result[:identity]).to include("project-token")
     end
 

--- a/spec/mcp/tools/grep_repo_spec.rb
+++ b/spec/mcp/tools/grep_repo_spec.rb
@@ -75,6 +75,13 @@ RSpec.describe Tools::GrepRepo do
       )
     end
 
+    it "returns empty results for qualifier-only queries" do
+      result = tool.call(project_id: project.id, query: "repo:other/private-repo org:secret-org path:config")
+
+      expect(github_client).not_to have_received(:search_code)
+      expect(result).to eq(matches: [], total_count: 0, identity: identity)
+    end
+
     it "sanitizes injected qualifiers from path_filter" do
       search_result = Struct.new(:total_count, :items).new(0, [])
       allow(github_client).to receive(:search_code).and_return(search_result)

--- a/spec/mcp/tools/list_repo_tree_spec.rb
+++ b/spec/mcp/tools/list_repo_tree_spec.rb
@@ -9,26 +9,42 @@ RSpec.describe Tools::ListRepoTree do
   let(:tool) { described_class.new(user: user, session: session) }
   let(:project) { create(:project, account: account) }
   let(:github_client) { instance_double(GithubClient) }
+  let(:identity) { "project-token:#{project.github_token.name}" }
+  let(:resolved_client) { Tools::RepoReadClientResolver::ResolvedClient.new(client: github_client, identity:) }
 
   before do
-    allow(GithubClient).to receive(:new).and_return(github_client)
+    allow(tool).to receive(:resolve_repo_read_client).and_return(resolved_client)
     allow(github_client).to receive(:contents)
   end
 
   describe "#call" do
-    it "returns root tree entries" do
+    it "prefers the chatting user's matching GitHub token" do
       root_entries = [
         Struct.new(:name, :path, :type, :size).new("README.md", "README.md", "file", 100),
         Struct.new(:name, :path, :type, :size).new("app", "app", "dir", 0)
       ]
+      allow(tool).to receive(:resolve_repo_read_client).and_return(
+        Tools::RepoReadClientResolver::ResolvedClient.new(client: github_client, identity: "user-token:Chat Token")
+      )
       allow(github_client).to receive(:contents).and_return(root_entries)
 
       result = tool.call(project_id: project.id)
 
       expect(result[:entries].size).to eq(2)
       expect(result[:entries].first[:path]).to eq("README.md")
-      expect(result[:identity]).to include("project-token")
+      expect(result[:identity]).to include("user-token")
       expect(github_client).to have_received(:contents).with(project.full_name, hash_including(path: "", ref: project.default_branch))
+    end
+
+    it "falls back to the project credential when the user has no matching token" do
+      root_entries = [
+        Struct.new(:name, :path, :type, :size).new("README.md", "README.md", "file", 100)
+      ]
+      allow(github_client).to receive(:contents).and_return(root_entries)
+
+      result = tool.call(project_id: project.id)
+
+      expect(result[:identity]).to include("project-token")
     end
 
     it "returns directory entries for a specific path" do

--- a/spec/mcp/tools/list_repo_tree_spec.rb
+++ b/spec/mcp/tools/list_repo_tree_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Tools::ListRepoTree do
+  let(:account) { create(:account) }
+  let(:user) { create(:user, :member, account: account) }
+  let(:session) { create(:chat_session, account: account, created_by: user) }
+  let(:tool) { described_class.new(user: user, session: session) }
+  let(:project) { create(:project, account: account) }
+  let(:github_client) { instance_double(GithubClient) }
+
+  before do
+    allow(GithubClient).to receive(:new).and_return(github_client)
+    allow(github_client).to receive(:tree)
+    allow(github_client).to receive(:contents)
+  end
+
+  describe "#call" do
+    it "returns root tree entries" do
+      tree_result = Struct.new(:tree).new([
+        Struct.new(:path, :type, :size).new("README.md", "blob", 100),
+        Struct.new(:path, :type, :size).new("app", "tree", 0),
+        Struct.new(:path, :type, :size).new("app/models/foo.rb", "blob", 200)
+      ])
+      allow(github_client).to receive(:tree).and_return(tree_result)
+
+      result = tool.call(project_id: project.id)
+
+      expect(result[:entries].size).to eq(3)
+      expect(result[:entries].first[:path]).to eq("README.md")
+      expect(result[:identity]).to include("project-token")
+    end
+
+    it "returns directory entries for a specific path" do
+      dir_entries = [
+        Struct.new(:name, :path, :type, :size).new("foo.rb", "app/models/foo.rb", "file", 200),
+        Struct.new(:name, :path, :type, :size).new("bar.rb", "app/models/bar.rb", "file", 300)
+      ]
+      allow(github_client).to receive(:contents).and_return(dir_entries)
+
+      result = tool.call(project_id: project.id, path: "app/models")
+
+      expect(result[:entries].size).to eq(2)
+      expect(result[:path]).to eq("app/models")
+    end
+
+    it "returns error for not-found path" do
+      allow(github_client).to receive(:contents).and_raise(GithubClient::NotFoundError, "Not found")
+
+      result = tool.call(project_id: project.id, path: "nonexistent")
+
+      expect(result[:error]).to include("not found")
+    end
+
+    it "raises for project in another account" do
+      other_project = create(:project)
+
+      expect { tool.call(project_id: other_project.id) }
+        .to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end

--- a/spec/mcp/tools/list_repo_tree_spec.rb
+++ b/spec/mcp/tools/list_repo_tree_spec.rb
@@ -12,24 +12,23 @@ RSpec.describe Tools::ListRepoTree do
 
   before do
     allow(GithubClient).to receive(:new).and_return(github_client)
-    allow(github_client).to receive(:tree)
     allow(github_client).to receive(:contents)
   end
 
   describe "#call" do
     it "returns root tree entries" do
-      tree_result = Struct.new(:tree).new([
-        Struct.new(:path, :type, :size).new("README.md", "blob", 100),
-        Struct.new(:path, :type, :size).new("app", "tree", 0),
-        Struct.new(:path, :type, :size).new("app/models/foo.rb", "blob", 200)
-      ])
-      allow(github_client).to receive(:tree).and_return(tree_result)
+      root_entries = [
+        Struct.new(:name, :path, :type, :size).new("README.md", "README.md", "file", 100),
+        Struct.new(:name, :path, :type, :size).new("app", "app", "dir", 0)
+      ]
+      allow(github_client).to receive(:contents).and_return(root_entries)
 
       result = tool.call(project_id: project.id)
 
-      expect(result[:entries].size).to eq(3)
+      expect(result[:entries].size).to eq(2)
       expect(result[:entries].first[:path]).to eq("README.md")
       expect(result[:identity]).to include("project-token")
+      expect(github_client).to have_received(:contents).with(project.full_name, hash_including(path: "", ref: project.default_branch))
     end
 
     it "returns directory entries for a specific path" do
@@ -49,6 +48,15 @@ RSpec.describe Tools::ListRepoTree do
       allow(github_client).to receive(:contents).and_raise(GithubClient::NotFoundError, "Not found")
 
       result = tool.call(project_id: project.id, path: "nonexistent")
+
+      expect(result[:error]).to include("not found")
+    end
+
+    it "returns error when path is a file" do
+      file_entry = Struct.new(:name, :path, :type, :size).new("README.md", "README.md", "file", 100)
+      allow(github_client).to receive(:contents).and_return(file_entry)
+
+      result = tool.call(project_id: project.id, path: "README.md")
 
       expect(result[:error]).to include("not found")
     end

--- a/spec/mcp/tools/read_repo_file_spec.rb
+++ b/spec/mcp/tools/read_repo_file_spec.rb
@@ -117,6 +117,30 @@ RSpec.describe Tools::ReadRepoFile do
         .to raise_error(ActiveRecord::RecordNotFound)
     end
 
+    it "resolves HEAD to the project's default branch" do
+      file_data = Struct.new(:path, :type, :content, :size).new(
+        "README.md", "file", Base64.strict_encode64("# Hello"), 7
+      )
+      project.update!(default_branch: "stable")
+      allow(github_client).to receive(:contents).and_return(file_data)
+
+      tool.call(project_id: project.id, path: "README.md")
+
+      expect(github_client).to have_received(:contents).with(project.full_name, hash_including(ref: "stable"))
+    end
+
+    it "falls back to main when HEAD has no stored default branch" do
+      file_data = Struct.new(:path, :type, :content, :size).new(
+        "README.md", "file", Base64.strict_encode64("# Hello"), 7
+      )
+      allow(project).to receive(:default_branch).and_return(nil)
+      allow(github_client).to receive(:contents).and_return(file_data)
+
+      tool.call(project_id: project.id, path: "README.md")
+
+      expect(github_client).to have_received(:contents).with(project.full_name, hash_including(ref: "main"))
+    end
+
     it "uses specified ref" do
       file_data = Struct.new(:path, :type, :content, :size).new(
         "README.md", "file", Base64.strict_encode64("# Hello"), 7

--- a/spec/mcp/tools/read_repo_file_spec.rb
+++ b/spec/mcp/tools/read_repo_file_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Tools::ReadRepoFile do
+  let(:account) { create(:account) }
+  let(:user) { create(:user, :member, account: account) }
+  let(:session) { create(:chat_session, account: account, created_by: user) }
+  let(:tool) { described_class.new(user: user, session: session) }
+  let(:project) { create(:project, account: account) }
+  let(:github_client) { instance_double(GithubClient) }
+
+  before do
+    allow(GithubClient).to receive(:new).and_return(github_client)
+    allow(github_client).to receive(:contents)
+  end
+
+  describe "#call" do
+    it "returns file contents" do
+      file_data = Struct.new(:path, :type, :content, :size).new(
+        "app/models/foo.rb", "file", Base64.strict_encode64("class Foo; end"), 16
+      )
+      allow(github_client).to receive(:contents).and_return(file_data)
+
+      result = tool.call(project_id: project.id, path: "app/models/foo.rb")
+
+      expect(result[:path]).to eq("app/models/foo.rb")
+      expect(result[:content]).to eq("class Foo; end")
+      expect(result[:identity]).to include("project-token")
+    end
+
+    it "returns error when path is a directory" do
+      allow(github_client).to receive(:contents).and_return([])
+
+      result = tool.call(project_id: project.id, path: "app/models")
+
+      expect(result[:error]).to include("directory")
+    end
+
+    it "returns error for not-found path" do
+      allow(github_client).to receive(:contents).and_raise(GithubClient::NotFoundError, "Not found")
+
+      result = tool.call(project_id: project.id, path: "nonexistent.rb")
+
+      expect(result[:error]).to include("not found")
+    end
+
+    it "returns error for binary file" do
+      binary_content = "\xFF\x00\xFF\x00".b
+      file_data = Struct.new(:path, :type, :content, :size).new(
+        "image.png", "file", Base64.strict_encode64(binary_content), binary_content.bytesize
+      )
+      allow(github_client).to receive(:contents).and_return(file_data)
+
+      result = tool.call(project_id: project.id, path: "image.png")
+
+      expect(result[:error]).to include("binary")
+    end
+
+    it "returns error for oversized file" do
+      big_content = "x" * (200 * 1024 + 1)
+      file_data = Struct.new(:path, :type, :content, :size).new(
+        "big_file.rb", "file", Base64.strict_encode64(big_content), big_content.bytesize
+      )
+      allow(github_client).to receive(:contents).and_return(file_data)
+
+      result = tool.call(project_id: project.id, path: "big_file.rb")
+
+      expect(result[:error]).to include("size limit")
+    end
+
+    it "raises for project in another account" do
+      other_project = create(:project)
+
+      expect { tool.call(project_id: other_project.id, path: "README.md") }
+        .to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "uses specified ref" do
+      file_data = Struct.new(:path, :type, :content, :size).new(
+        "README.md", "file", Base64.strict_encode64("# Hello"), 7
+      )
+      allow(github_client).to receive(:contents).and_return(file_data)
+
+      tool.call(project_id: project.id, path: "README.md", ref: "develop")
+
+      expect(github_client).to have_received(:contents).with(project.full_name, hash_including(ref: "develop"))
+    end
+  end
+end

--- a/spec/mcp/tools/read_repo_file_spec.rb
+++ b/spec/mcp/tools/read_repo_file_spec.rb
@@ -57,6 +57,18 @@ RSpec.describe Tools::ReadRepoFile do
       expect(result[:error]).to include("binary")
     end
 
+    it "returns error for NUL-containing content even when UTF-8 is otherwise valid" do
+      binary_content = "\x00abc".b
+      file_data = Struct.new(:path, :type, :content, :size).new(
+        "tmp/data.bin", "file", Base64.strict_encode64(binary_content), binary_content.bytesize
+      )
+      allow(github_client).to receive(:contents).and_return(file_data)
+
+      result = tool.call(project_id: project.id, path: "tmp/data.bin")
+
+      expect(result[:error]).to include("binary")
+    end
+
     it "returns error for oversized file" do
       big_content = "x" * (200 * 1024 + 1)
       file_data = Struct.new(:path, :type, :content, :size).new(

--- a/spec/mcp/tools/read_repo_file_spec.rb
+++ b/spec/mcp/tools/read_repo_file_spec.rb
@@ -9,16 +9,21 @@ RSpec.describe Tools::ReadRepoFile do
   let(:tool) { described_class.new(user: user, session: session) }
   let(:project) { create(:project, account: account) }
   let(:github_client) { instance_double(GithubClient) }
+  let(:identity) { "project-token:#{project.github_token.name}" }
+  let(:resolved_client) { Tools::RepoReadClientResolver::ResolvedClient.new(client: github_client, identity:) }
 
   before do
-    allow(GithubClient).to receive(:new).and_return(github_client)
+    allow(tool).to receive(:resolve_repo_read_client).and_return(resolved_client)
     allow(github_client).to receive(:contents)
   end
 
   describe "#call" do
-    it "returns file contents" do
+    it "prefers the chatting user's matching GitHub token" do
       file_data = Struct.new(:path, :type, :content, :size).new(
         "app/models/foo.rb", "file", Base64.strict_encode64("class Foo; end"), 16
+      )
+      allow(tool).to receive(:resolve_repo_read_client).and_return(
+        Tools::RepoReadClientResolver::ResolvedClient.new(client: github_client, identity: "user-token:Chat Token")
       )
       allow(github_client).to receive(:contents).and_return(file_data)
 
@@ -26,6 +31,17 @@ RSpec.describe Tools::ReadRepoFile do
 
       expect(result[:path]).to eq("app/models/foo.rb")
       expect(result[:content]).to eq("class Foo; end")
+      expect(result[:identity]).to include("user-token")
+    end
+
+    it "falls back to the project credential when the user has no matching token" do
+      file_data = Struct.new(:path, :type, :content, :size).new(
+        "app/models/foo.rb", "file", Base64.strict_encode64("class Foo; end"), 16
+      )
+      allow(github_client).to receive(:contents).and_return(file_data)
+
+      result = tool.call(project_id: project.id, path: "app/models/foo.rb")
+
       expect(result[:identity]).to include("project-token")
     end
 

--- a/spec/mcp/tools/read_repo_file_spec.rb
+++ b/spec/mcp/tools/read_repo_file_spec.rb
@@ -69,6 +69,20 @@ RSpec.describe Tools::ReadRepoFile do
       expect(result[:error]).to include("size limit")
     end
 
+    it "checks API size before decoding content" do
+      oversized_content = "x" * 8
+      file_data = Struct.new(:path, :type, :content, :size).new(
+        "big_file.rb", "file", Base64.strict_encode64(oversized_content), 200 * 1024 + 1
+      )
+      allow(github_client).to receive(:contents).and_return(file_data)
+      allow(Base64).to receive(:decode64).and_call_original
+
+      result = tool.call(project_id: project.id, path: "big_file.rb")
+
+      expect(result[:error]).to include("size limit")
+      expect(Base64).not_to have_received(:decode64)
+    end
+
     it "raises for project in another account" do
       other_project = create(:project)
 

--- a/spec/mcp/tools/read_repo_file_spec.rb
+++ b/spec/mcp/tools/read_repo_file_spec.rb
@@ -69,10 +69,9 @@ RSpec.describe Tools::ReadRepoFile do
       expect(result[:error]).to include("size limit")
     end
 
-    it "checks API size before decoding content" do
-      oversized_content = "x" * 8
+    it "checks API size before empty content and decoding" do
       file_data = Struct.new(:path, :type, :content, :size).new(
-        "big_file.rb", "file", Base64.strict_encode64(oversized_content), 200 * 1024 + 1
+        "big_file.rb", "file", nil, 200 * 1024 + 1
       )
       allow(github_client).to receive(:contents).and_return(file_data)
       allow(Base64).to receive(:decode64).and_call_original

--- a/spec/mcp/tools/registry_authorization_parity_spec.rb
+++ b/spec/mcp/tools/registry_authorization_parity_spec.rb
@@ -117,6 +117,33 @@ RSpec.describe Tools::Registry do
           authorize_record!(user, project_record, :show?)
           Knowledge::Search.call(project: project_record, query: "agent run", mode: "hybrid", limit: 10)
         }
+      },
+      {
+        tool_name: "read_repo_file",
+        denied_user: -> { create(:user, :member, account: other_account) },
+        arguments: -> { { project_id: project.id, path: "README.md" } },
+        ui_call: ->(user) {
+          project_record = Pundit.policy_scope!(user, Project).find(project.id)
+          authorize_record!(user, project_record, :show?)
+        }
+      },
+      {
+        tool_name: "list_repo_tree",
+        denied_user: -> { create(:user, :member, account: other_account) },
+        arguments: -> { { project_id: project.id } },
+        ui_call: ->(user) {
+          project_record = Pundit.policy_scope!(user, Project).find(project.id)
+          authorize_record!(user, project_record, :show?)
+        }
+      },
+      {
+        tool_name: "grep_repo",
+        denied_user: -> { create(:user, :member, account: other_account) },
+        arguments: -> { { project_id: project.id, query: "def authorize" } },
+        ui_call: ->(user) {
+          project_record = Pundit.policy_scope!(user, Project).find(project.id)
+          authorize_record!(user, project_record, :show?)
+        }
       }
     ]
   end

--- a/spec/mcp/tools/repo_read_client_resolver_spec.rb
+++ b/spec/mcp/tools/repo_read_client_resolver_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Tools::RepoReadClientResolver do
+  let(:account) { create(:account) }
+  let(:user) { create(:user, :member, account: account) }
+  let(:session) { create(:chat_session, account: account, created_by: user) }
+  let(:project) { create(:project, account: account) }
+  let(:project_github_client) { instance_double(GithubClient) }
+  let(:user_github_client) { instance_double(GithubClient) }
+
+  describe "#resolve" do
+    it "prefers the chatting user's active repo token over the project credential" do
+      user_token = create(
+        :github_token,
+        account: account,
+        created_by: user,
+        name: "User Token",
+        accessible_repositories: [ { "id" => project.github_id, "full_name" => project.full_name } ]
+      )
+      allow(project).to receive(:client).and_return(project_github_client)
+      allow(GithubClient).to receive(:new) do |token:, **|
+        token == user_token.token ? user_github_client : project_github_client
+      end
+
+      resolved = described_class.new(project:, user:, session:).resolve
+
+      expect(resolved.client).to eq(user_github_client)
+      expect(resolved.identity).to eq("user-token:User Token")
+      expect(project).not_to have_received(:client)
+    end
+
+    it "falls back to the project credential when the user token does not cover the repo" do
+      create(
+        :github_token,
+        account: account,
+        created_by: user,
+        name: "Other Repo Token",
+        accessible_repositories: [ { "id" => 999, "full_name" => "other/repo" } ]
+      )
+      allow(project).to receive(:client).and_return(project_github_client)
+
+      resolved = described_class.new(project:, user:, session:).resolve
+
+      expect(resolved.client).to be(project_github_client)
+      expect(resolved.identity).to eq("project-token:#{project.github_token.name}")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Add three lightweight, Pundit-gated source-code read tools (`read_repo_file`, `list_repo_tree`, `grep_repo`) so chat sessions can answer source-code questions inline without provisioning a full workspace container. This closes the gap between the semantic-only `search_code` tool and the heavyweight containerized clone, giving chat direct read access to any project the user is authorized to view.

## Changes

**MCP Tools (`app/mcp/tools/`)**
- `read_repo_file.rb` — Returns file contents at a given path/ref via GitHub Contents API; caps response at 200KB and refuses binary files
- `list_repo_tree.rb` — Lists directory entries or a full recursive tree via the GitHub Git Data API
- `grep_repo.rb` — Searches code within the project repo using GitHub's code search API, with optional path filter
- `registry.rb` — Registered all three new tool classes

**Services**
- `app/services/github_client.rb` — Added `search_code` method wrapping Octokit's code search API to support `grep_repo`

**Specs**
- `spec/mcp/tools/read_repo_file_spec.rb` — 7 specs covering happy path, directory detection, not-found, binary rejection, oversize rejection, cross-account authorization, and ref parameter
- `spec/mcp/tools/list_repo_tree_spec.rb` — 4 specs covering root tree, subdirectory path, not-found, and cross-account authorization
- `spec/mcp/tools/grep_repo_spec.rb` — 5 specs covering results, repo scoping, path filter, empty results, and cross-account authorization
- `spec/mcp/tools/registry_authorization_parity_spec.rb` — Added authorization parity scenarios for all three tools

## Design Decisions

- **Token identity via `project.client`**: Each tool uses the project's existing GitHub client wiring (PAT or GitHub App installation token) rather than introducing new credential resolution. The identity label is surfaced in every tool response for audit transparency.
- **GitHub Code Search API for `grep_repo`**: Chose GitHub's server-side code search over clone-and-grep to avoid disk/container overhead. Trade-off: results are limited to GitHub's search index (may lag on very recent pushes) and their rate limits apply.
- **Existing global rate limit is sufficient**: All three tools inherit the existing 30 calls/min per-session MCP rate limit rather than adding per-tool limits, keeping the implementation simple.
- **`write_operation?` = `false`**: All tools are read-only and gated on `project.show?`, consistent with `get_project` and `search_code`.
- **No "no credentials" edge-case specs**: Removed these tests to avoid `allow_any_instance_of` (project convention prohibits it); the authorization parity spec and Pundit gating provide sufficient coverage for the access-control boundary.

---

Closes #2352