### PR TITLE
feat(chat): expand tool surface to mirror UI admin/tenant surfaces

### DIFF
--- a/app/mcp/tools/base_tool.rb
+++ b/app/mcp/tools/base_tool.rb
@@ -57,6 +57,19 @@ module Tools
       false
     end
 
+    def self.available_to?(user:)
+      user.present?
+    end
+
+    def self.policy_allows?(user:, record:, query:, policy_class: nil)
+      return false if user.blank?
+
+      policy = policy_class ? policy_class.new(user, record) : Pundit.policy(user, record)
+      policy&.public_send(query) == true
+    rescue Pundit::NotAuthorizedError
+      false
+    end
+
     def self.authorize(query, resolver = nil, policy_class: nil, &block)
       resolver ||= block
       raise ArgumentError, "#{name}.authorize requires a resolver" unless resolver

--- a/app/mcp/tools/base_tool.rb
+++ b/app/mcp/tools/base_tool.rb
@@ -61,6 +61,19 @@ module Tools
       user.present?
     end
 
+    def self.run_agent_available_to?(user:)
+      return false if user.blank?
+
+      record = Project.new(account: user.account)
+      return true if policy_allows?(user:, record:, query: :run_agent?, policy_class: ProjectPolicy)
+
+      Pundit.policy_scope!(user, Project).any? do |project|
+        policy_allows?(user:, record: project, query: :run_agent?, policy_class: ProjectPolicy)
+      end
+    rescue Pundit::NotAuthorizedError
+      false
+    end
+
     def self.policy_allows?(user:, record:, query:, policy_class: nil)
       return false if user.blank?
 

--- a/app/mcp/tools/cancel_agent_run.rb
+++ b/app/mcp/tools/cancel_agent_run.rb
@@ -11,6 +11,10 @@ module Tools
       "Cancel an in-flight agent run. Requires explicit confirmation."
     end
 
+    def self.available_to?(user:)
+      run_agent_available_to?(user:)
+    end
+
     def self.input_schema
       {
         type: "object",

--- a/app/mcp/tools/create_mcp_server_definition.rb
+++ b/app/mcp/tools/create_mcp_server_definition.rb
@@ -2,6 +2,8 @@
 
 module Tools
   class CreateMcpServerDefinition < BaseTool
+    include McpServerDefinitionAttributes
+
     authorize :create?, ->(_args) { account.mcp_server_definitions.build }, policy_class: McpServerDefinitionPolicy
 
     def self.tool_name = "create_mcp_server_definition"
@@ -31,9 +33,7 @@ module Tools
       raise ArgumentError, "Confirmation required: set confirmed=true to create an MCP server definition" unless confirmed
       raise ArgumentError, "attributes must be an object" unless attributes.is_a?(Hash)
 
-      definition = account.mcp_server_definitions.create!(attributes.symbolize_keys.slice(
-        :name, :transport, :install_type, :command, :args_json, :url, :image, :env_json, :enabled, :metadata_json
-      ))
+      definition = account.mcp_server_definitions.create!(normalize_mcp_server_definition_attributes(attributes))
       McpServerDefinitionSerialization.serialize_mcp_server_definition(definition)
     end
   end

--- a/app/mcp/tools/create_mcp_server_definition.rb
+++ b/app/mcp/tools/create_mcp_server_definition.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Tools
+  class CreateMcpServerDefinition < BaseTool
+    authorize :create?, ->(_args) { account.mcp_server_definitions.build }, policy_class: McpServerDefinitionPolicy
+
+    def self.tool_name = "create_mcp_server_definition"
+    def self.write_operation? = true
+
+    def self.description
+      "Create an MCP server definition for the current account."
+    end
+
+    def self.input_schema
+      {
+        type: "object",
+        properties: {
+          attributes: { type: "object" },
+          confirmed: { type: "boolean" }
+        },
+        required: %w[attributes confirmed]
+      }
+    end
+
+    def self.available_to?(user:)
+      record = user&.account&.mcp_server_definitions&.build
+      policy_allows?(user:, record:, query: :create?, policy_class: McpServerDefinitionPolicy)
+    end
+
+    def perform(attributes:, confirmed:)
+      raise ArgumentError, "Confirmation required: set confirmed=true to create an MCP server definition" unless confirmed
+      raise ArgumentError, "attributes must be an object" unless attributes.is_a?(Hash)
+
+      definition = account.mcp_server_definitions.create!(attributes.symbolize_keys.slice(
+        :name, :transport, :install_type, :command, :args_json, :url, :image, :env_json, :enabled, :metadata_json
+      ))
+      definition.attributes
+    end
+  end
+end

--- a/app/mcp/tools/create_mcp_server_definition.rb
+++ b/app/mcp/tools/create_mcp_server_definition.rb
@@ -34,7 +34,7 @@ module Tools
       definition = account.mcp_server_definitions.create!(attributes.symbolize_keys.slice(
         :name, :transport, :install_type, :command, :args_json, :url, :image, :env_json, :enabled, :metadata_json
       ))
-      definition.attributes
+      McpServerDefinitionSerialization.serialize_mcp_server_definition(definition)
     end
   end
 end

--- a/app/mcp/tools/create_provider_api_key.rb
+++ b/app/mcp/tools/create_provider_api_key.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Tools
+  class CreateProviderApiKey < BaseTool
+    authorize :create?, ->(_args) { current_user.provider_api_keys.build }, policy_class: ProviderApiKeyPolicy
+
+    def self.tool_name = "create_provider_api_key"
+    def self.write_operation? = true
+
+    def self.description
+      "Create a provider API key for the current user."
+    end
+
+    def self.input_schema
+      {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          api_key: { type: "string" },
+          api_service_type: { type: "string" },
+          confirmed: { type: "boolean" }
+        },
+        required: %w[name api_key api_service_type confirmed]
+      }
+    end
+
+    def perform(name:, api_key:, api_service_type:, confirmed:)
+      raise ArgumentError, "Confirmation required: set confirmed=true to create an API key" unless confirmed
+
+      provider_api_key = current_user.provider_api_keys.create!(
+        name:,
+        api_key:,
+        api_service_type:
+      )
+
+      {
+        id: provider_api_key.id,
+        name: provider_api_key.name,
+        api_service_type: provider_api_key.api_service_type,
+        masked_api_key: provider_api_key.masked_api_key
+      }
+    end
+  end
+end

--- a/app/mcp/tools/get_tenant_settings.rb
+++ b/app/mcp/tools/get_tenant_settings.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Tools
+  class GetTenantSettings < BaseTool
+    authorize :update?, ->(_args) { account }, policy_class: AccountPolicy
+
+    def self.tool_name = "get_tenant_settings"
+
+    def self.description
+      "Read tenant settings for the current account."
+    end
+
+    def self.available_to?(user:)
+      policy_allows?(user:, record: user&.account, query: :update?, policy_class: AccountPolicy)
+    end
+
+    def perform
+      account.tenant_setting!.attributes.except("id", "account_id", "created_at", "updated_at", "log_data")
+    end
+  end
+end

--- a/app/mcp/tools/get_user_settings.rb
+++ b/app/mcp/tools/get_user_settings.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Tools
+  class GetUserSettings < BaseTool
+    authorize :edit?, ->(_args) { current_user.settings }
+
+    def self.tool_name = "get_user_settings"
+
+    def self.description
+      "Read the current user's settings."
+    end
+
+    def perform
+      current_user.settings.attributes.except("id", "user_id", "created_at", "updated_at", "log_data")
+    end
+  end
+end

--- a/app/mcp/tools/invite_account_member.rb
+++ b/app/mcp/tools/invite_account_member.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Tools
+  class InviteAccountMember < BaseTool
+    authorize :update?, ->(_args) { account }, policy_class: AccountPolicy
+
+    def self.tool_name = "invite_account_member"
+    def self.write_operation? = true
+
+    def self.description
+      "Invite a user to the current account."
+    end
+
+    def self.input_schema
+      {
+        type: "object",
+        properties: {
+          email: { type: "string" },
+          name: { type: "string" },
+          role: { type: "string", enum: AccountMembership.roles.keys },
+          confirmed: { type: "boolean" }
+        },
+        required: %w[email role confirmed]
+      }
+    end
+
+    def self.available_to?(user:)
+      policy_allows?(user:, record: user&.account, query: :update?, policy_class: AccountPolicy)
+    end
+
+    def perform(email:, role:, confirmed:, name: nil)
+      raise ArgumentError, "Confirmation required: set confirmed=true to invite a member" unless confirmed
+
+      membership = Accounts::InviteMember.call(
+        account: account,
+        actor: current_user,
+        email:,
+        name:,
+        role:
+      )
+
+      {
+        id: membership.id,
+        user_id: membership.user_id,
+        email: membership.user.email,
+        name: membership.user.name,
+        role: membership.role
+      }
+    end
+  end
+end

--- a/app/mcp/tools/list_account_memberships.rb
+++ b/app/mcp/tools/list_account_memberships.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Tools
+  class ListAccountMemberships < BaseTool
+    authorize :show?, ->(_args) { account }, policy_class: AccountPolicy
+
+    def self.tool_name = "list_account_memberships"
+
+    def self.description
+      "List memberships for the current account."
+    end
+
+    def self.available_to?(user:)
+      policy_allows?(user:, record: user&.account, query: :show?, policy_class: AccountPolicy)
+    end
+
+    def perform
+      account.account_memberships.includes(:user).order(role: :desc, created_at: :asc).map do |membership|
+        {
+          id: membership.id,
+          user_id: membership.user_id,
+          email: membership.user.email,
+          name: membership.user.name,
+          role: membership.role,
+          created_at: membership.created_at
+        }
+      end
+    end
+  end
+end

--- a/app/mcp/tools/list_mcp_server_definitions.rb
+++ b/app/mcp/tools/list_mcp_server_definitions.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Tools
+  class ListMcpServerDefinitions < BaseTool
+    authorize :index?, ->(_args) { McpServerDefinition }, policy_class: McpServerDefinitionPolicy
+
+    def self.tool_name = "list_mcp_server_definitions"
+
+    def self.description
+      "List MCP server definitions for the current account."
+    end
+
+    def self.available_to?(user:)
+      policy_allows?(user:, record: McpServerDefinition, query: :index?, policy_class: McpServerDefinitionPolicy)
+    end
+
+    def perform
+      policy_scope(McpServerDefinition).includes(:account).order(created_at: :desc).map do |definition|
+        serialize_definition(definition)
+      end
+    end
+
+    private
+
+    def serialize_definition(definition)
+      definition.attributes.slice(
+        "id", "name", "transport", "install_type", "command", "url", "image", "enabled", "created_at", "updated_at"
+      ).merge(
+        "args" => definition.args,
+        "env" => definition.env,
+        "metadata" => definition.metadata
+      )
+    end
+  end
+end

--- a/app/mcp/tools/list_mcp_server_definitions.rb
+++ b/app/mcp/tools/list_mcp_server_definitions.rb
@@ -15,15 +15,21 @@ module Tools
     end
 
     def perform
-      policy_scope(McpServerDefinition).includes(:account).order(created_at: :desc).map do |definition|
-        serialize_definition(definition)
+      policy_scope(McpServerDefinition).order(created_at: :desc).map do |definition|
+        serialize_summary(definition)
       end
     end
 
     private
 
-    def serialize_definition(definition)
-      McpServerDefinitionSerialization.serialize_mcp_server_definition(definition)
+    def serialize_summary(definition)
+      definition.attributes.slice(
+        "id",
+        "name",
+        "install_type",
+        "transport",
+        "enabled"
+      )
     end
   end
 end

--- a/app/mcp/tools/list_mcp_server_definitions.rb
+++ b/app/mcp/tools/list_mcp_server_definitions.rb
@@ -23,13 +23,7 @@ module Tools
     private
 
     def serialize_definition(definition)
-      definition.attributes.slice(
-        "id", "name", "transport", "install_type", "command", "url", "image", "enabled", "created_at", "updated_at"
-      ).merge(
-        "args" => definition.args,
-        "env" => definition.env,
-        "metadata" => definition.metadata
-      )
+      McpServerDefinitionSerialization.serialize_mcp_server_definition(definition)
     end
   end
 end

--- a/app/mcp/tools/list_provider_api_keys.rb
+++ b/app/mcp/tools/list_provider_api_keys.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Tools
+  class ListProviderApiKeys < BaseTool
+    authorize :index?, ->(_args) { ProviderApiKey }, policy_class: ProviderApiKeyPolicy
+
+    def self.tool_name = "list_provider_api_keys"
+
+    def self.description
+      "List API keys owned by the current user."
+    end
+
+    def perform
+      policy_scope(ProviderApiKey).ordered.map do |provider_api_key|
+        {
+          id: provider_api_key.id,
+          name: provider_api_key.name,
+          api_service_type: provider_api_key.api_service_type,
+          masked_api_key: provider_api_key.masked_api_key,
+          created_at: provider_api_key.created_at
+        }
+      end
+    end
+  end
+end

--- a/app/mcp/tools/mcp_server_definition_attributes.rb
+++ b/app/mcp/tools/mcp_server_definition_attributes.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Tools
+  module McpServerDefinitionAttributes
+    PERMITTED_ATTRIBUTES = %i[
+      name
+      transport
+      install_type
+      command
+      args_json
+      url
+      image
+      env_json
+      enabled
+      metadata_json
+    ].freeze
+
+    private
+
+    def normalize_mcp_server_definition_attributes(attributes)
+      attributes.symbolize_keys.slice(*PERMITTED_ATTRIBUTES).tap do |attrs|
+        normalize_json_attribute!(attrs, :args_json, :args)
+        normalize_json_attribute!(attrs, :env_json, :env)
+        normalize_json_attribute!(attrs, :metadata_json, :metadata)
+      end
+    end
+
+    def normalize_json_attribute!(attrs, json_key, record_key)
+      return unless attrs.key?(json_key)
+      return if attrs[json_key].is_a?(String)
+
+      value = attrs.delete(json_key)
+      attrs[record_key] =
+        if value.nil?
+          default_value_for(record_key)
+        else
+          value
+        end
+    end
+
+    def default_value_for(record_key)
+      case record_key
+      when :args then []
+      when :env, :metadata then {}
+      end
+    end
+  end
+end

--- a/app/mcp/tools/mcp_server_definition_serialization.rb
+++ b/app/mcp/tools/mcp_server_definition_serialization.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Tools
+  module McpServerDefinitionSerialization
+    module_function
+
+    def serialize_mcp_server_definition(definition)
+      definition.attributes.slice(
+        "id", "name", "transport", "install_type", "command", "url", "image", "enabled", "created_at", "updated_at"
+      ).merge(
+        "args" => definition.args,
+        "env" => definition.env,
+        "metadata" => definition.metadata
+      )
+    end
+  end
+end

--- a/app/mcp/tools/mcp_server_definition_serialization.rb
+++ b/app/mcp/tools/mcp_server_definition_serialization.rb
@@ -9,7 +9,7 @@ module Tools
         "id", "name", "transport", "install_type", "command", "url", "image", "enabled", "created_at", "updated_at"
       ).merge(
         "args" => definition.args,
-        "env" => definition.env,
+        "env_keys" => definition.env.keys.sort,
         "metadata" => definition.metadata
       )
     end

--- a/app/mcp/tools/registry.rb
+++ b/app/mcp/tools/registry.rb
@@ -13,7 +13,23 @@ module Tools
       "Tools::CancelAgentRun",
       "Tools::GetIssueDetails",
       "Tools::GetPullRequestDetails",
-      "Tools::SearchCode"
+      "Tools::SearchCode",
+      "Tools::ListAccountMemberships",
+      "Tools::InviteAccountMember",
+      "Tools::UpdateAccountMembership",
+      "Tools::RemoveAccountMembership",
+      "Tools::GetUserSettings",
+      "Tools::UpdateUserSettings",
+      "Tools::GetTenantSettings",
+      "Tools::UpdateTenantSettings",
+      "Tools::ListProviderApiKeys",
+      "Tools::CreateProviderApiKey",
+      "Tools::UpdateProviderApiKey",
+      "Tools::RemoveProviderApiKey",
+      "Tools::ListMcpServerDefinitions",
+      "Tools::CreateMcpServerDefinition",
+      "Tools::UpdateMcpServerDefinition",
+      "Tools::RemoveMcpServerDefinition"
     ].freeze
 
     class << self
@@ -47,14 +63,7 @@ module Tools
       end
 
       def tool_available_to?(klass, user:)
-        return false if user.blank?
-        return true unless klass.write_operation?
-
-        return true if Pundit.policy(user, Project.new(account: user.account))&.run_agent?
-
-        scope = Pundit.policy_scope!(user, Project)
-
-        scope.any? { |project| Pundit.policy!(user, project).run_agent? }
+        klass.available_to?(user:)
       end
     end
   end

--- a/app/mcp/tools/remove_account_membership.rb
+++ b/app/mcp/tools/remove_account_membership.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Tools
+  class RemoveAccountMembership < BaseTool
+    authorize :update?, ->(_args) { account }, policy_class: AccountPolicy
+
+    def self.tool_name = "remove_account_membership"
+    def self.write_operation? = true
+
+    def self.description
+      "Remove a membership from the current account."
+    end
+
+    def self.input_schema
+      {
+        type: "object",
+        properties: {
+          membership_id: { type: "integer" },
+          confirmed: { type: "boolean" }
+        },
+        required: %w[membership_id confirmed]
+      }
+    end
+
+    def self.available_to?(user:)
+      policy_allows?(user:, record: user&.account, query: :update?, policy_class: AccountPolicy)
+    end
+
+    def perform(membership_id:, confirmed:)
+      raise ArgumentError, "Confirmation required: set confirmed=true to remove a membership" unless confirmed
+
+      membership = account.account_memberships.find(membership_id)
+      result = {
+        id: membership.id,
+        user_id: membership.user_id,
+        role: membership.role
+      }
+
+      Accounts::RemoveMembership.call(
+        account:,
+        membership:,
+        actor: current_user
+      )
+
+      result
+    end
+  end
+end

--- a/app/mcp/tools/remove_mcp_server_definition.rb
+++ b/app/mcp/tools/remove_mcp_server_definition.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Tools
+  class RemoveMcpServerDefinition < BaseTool
+    authorize :destroy?, ->(args) { mcp_server_definition_for(args.fetch(:mcp_server_definition_id)) }, policy_class: McpServerDefinitionPolicy
+
+    def self.tool_name = "remove_mcp_server_definition"
+    def self.write_operation? = true
+
+    def self.description
+      "Remove an MCP server definition from the current account."
+    end
+
+    def self.input_schema
+      {
+        type: "object",
+        properties: {
+          mcp_server_definition_id: { type: "integer" },
+          confirmed: { type: "boolean" }
+        },
+        required: %w[mcp_server_definition_id confirmed]
+      }
+    end
+
+    def self.available_to?(user:)
+      record = user&.account&.mcp_server_definitions&.build
+      policy_allows?(user:, record:, query: :destroy?, policy_class: McpServerDefinitionPolicy)
+    end
+
+    def perform(mcp_server_definition_id:, confirmed:)
+      raise ArgumentError, "Confirmation required: set confirmed=true to remove an MCP server definition" unless confirmed
+
+      definition = mcp_server_definition_for(mcp_server_definition_id)
+      result = { id: definition.id, name: definition.name }
+      definition.destroy!
+      result
+    end
+
+    private
+
+    def mcp_server_definition_for(definition_id)
+      policy_scope(McpServerDefinition).find(definition_id)
+    end
+  end
+end

--- a/app/mcp/tools/remove_provider_api_key.rb
+++ b/app/mcp/tools/remove_provider_api_key.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Tools
+  class RemoveProviderApiKey < BaseTool
+    authorize :destroy?, ->(args) { provider_api_key_for(args.fetch(:provider_api_key_id)) }, policy_class: ProviderApiKeyPolicy
+
+    def self.tool_name = "remove_provider_api_key"
+    def self.write_operation? = true
+
+    def self.description
+      "Remove a provider API key owned by the current user."
+    end
+
+    def self.input_schema
+      {
+        type: "object",
+        properties: {
+          provider_api_key_id: { type: "integer" },
+          confirmed: { type: "boolean" }
+        },
+        required: %w[provider_api_key_id confirmed]
+      }
+    end
+
+    def perform(provider_api_key_id:, confirmed:)
+      raise ArgumentError, "Confirmation required: set confirmed=true to remove an API key" unless confirmed
+
+      provider_api_key = provider_api_key_for(provider_api_key_id)
+      result = { id: provider_api_key.id, name: provider_api_key.name }
+      provider_api_key.destroy!
+      result
+    end
+
+    private
+
+    def provider_api_key_for(provider_api_key_id)
+      policy_scope(ProviderApiKey).find(provider_api_key_id)
+    end
+  end
+end

--- a/app/mcp/tools/trigger_agent_run.rb
+++ b/app/mcp/tools/trigger_agent_run.rb
@@ -11,6 +11,10 @@ module Tools
       "Start an agent run on an issue. Requires explicit confirmation."
     end
 
+    def self.available_to?(user:)
+      run_agent_available_to?(user:)
+    end
+
     def self.input_schema
       {
         type: "object",

--- a/app/mcp/tools/update_account_membership.rb
+++ b/app/mcp/tools/update_account_membership.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Tools
+  class UpdateAccountMembership < BaseTool
+    authorize :update?, ->(_args) { account }, policy_class: AccountPolicy
+
+    def self.tool_name = "update_account_membership"
+    def self.write_operation? = true
+
+    def self.description
+      "Update a membership role in the current account."
+    end
+
+    def self.input_schema
+      {
+        type: "object",
+        properties: {
+          membership_id: { type: "integer" },
+          role: { type: "string", enum: AccountMembership.roles.keys },
+          confirmed: { type: "boolean" }
+        },
+        required: %w[membership_id role confirmed]
+      }
+    end
+
+    def self.available_to?(user:)
+      policy_allows?(user:, record: user&.account, query: :update?, policy_class: AccountPolicy)
+    end
+
+    def perform(membership_id:, role:, confirmed:)
+      raise ArgumentError, "Confirmation required: set confirmed=true to update a membership" unless confirmed
+
+      membership = account.account_memberships.includes(:user).find(membership_id)
+
+      Accounts::UpdateMembership.call(
+        account:,
+        membership:,
+        actor: current_user,
+        role:
+      )
+
+      {
+        id: membership.id,
+        user_id: membership.user_id,
+        email: membership.user.email,
+        name: membership.user.name,
+        role: membership.reload.role
+      }
+    end
+  end
+end

--- a/app/mcp/tools/update_mcp_server_definition.rb
+++ b/app/mcp/tools/update_mcp_server_definition.rb
@@ -2,6 +2,8 @@
 
 module Tools
   class UpdateMcpServerDefinition < BaseTool
+    include McpServerDefinitionAttributes
+
     authorize :update?, ->(args) { mcp_server_definition_for(args.fetch(:mcp_server_definition_id)) }, policy_class: McpServerDefinitionPolicy
 
     def self.tool_name = "update_mcp_server_definition"
@@ -33,9 +35,7 @@ module Tools
       raise ArgumentError, "attributes must be an object" unless attributes.is_a?(Hash)
 
       definition = mcp_server_definition_for(mcp_server_definition_id)
-      definition.update!(attributes.symbolize_keys.slice(
-        :name, :transport, :install_type, :command, :args_json, :url, :image, :env_json, :enabled, :metadata_json
-      ))
+      definition.update!(normalize_mcp_server_definition_attributes(attributes))
       McpServerDefinitionSerialization.serialize_mcp_server_definition(definition)
     end
 

--- a/app/mcp/tools/update_mcp_server_definition.rb
+++ b/app/mcp/tools/update_mcp_server_definition.rb
@@ -36,7 +36,7 @@ module Tools
       definition.update!(attributes.symbolize_keys.slice(
         :name, :transport, :install_type, :command, :args_json, :url, :image, :env_json, :enabled, :metadata_json
       ))
-      definition.attributes
+      McpServerDefinitionSerialization.serialize_mcp_server_definition(definition)
     end
 
     private

--- a/app/mcp/tools/update_mcp_server_definition.rb
+++ b/app/mcp/tools/update_mcp_server_definition.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Tools
+  class UpdateMcpServerDefinition < BaseTool
+    authorize :update?, ->(args) { mcp_server_definition_for(args.fetch(:mcp_server_definition_id)) }, policy_class: McpServerDefinitionPolicy
+
+    def self.tool_name = "update_mcp_server_definition"
+    def self.write_operation? = true
+
+    def self.description
+      "Update an MCP server definition for the current account."
+    end
+
+    def self.input_schema
+      {
+        type: "object",
+        properties: {
+          mcp_server_definition_id: { type: "integer" },
+          attributes: { type: "object" },
+          confirmed: { type: "boolean" }
+        },
+        required: %w[mcp_server_definition_id attributes confirmed]
+      }
+    end
+
+    def perform(mcp_server_definition_id:, attributes:, confirmed:)
+      raise ArgumentError, "Confirmation required: set confirmed=true to update an MCP server definition" unless confirmed
+      raise ArgumentError, "attributes must be an object" unless attributes.is_a?(Hash)
+
+      definition = mcp_server_definition_for(mcp_server_definition_id)
+      definition.update!(attributes.symbolize_keys.slice(
+        :name, :transport, :install_type, :command, :args_json, :url, :image, :env_json, :enabled, :metadata_json
+      ))
+      definition.attributes
+    end
+
+    private
+
+    def mcp_server_definition_for(definition_id)
+      policy_scope(McpServerDefinition).find(definition_id)
+    end
+  end
+end

--- a/app/mcp/tools/update_mcp_server_definition.rb
+++ b/app/mcp/tools/update_mcp_server_definition.rb
@@ -23,6 +23,11 @@ module Tools
       }
     end
 
+    def self.available_to?(user:)
+      record = user&.account&.mcp_server_definitions&.build
+      policy_allows?(user:, record:, query: :update?, policy_class: McpServerDefinitionPolicy)
+    end
+
     def perform(mcp_server_definition_id:, attributes:, confirmed:)
       raise ArgumentError, "Confirmation required: set confirmed=true to update an MCP server definition" unless confirmed
       raise ArgumentError, "attributes must be an object" unless attributes.is_a?(Hash)

--- a/app/mcp/tools/update_provider_api_key.rb
+++ b/app/mcp/tools/update_provider_api_key.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Tools
+  class UpdateProviderApiKey < BaseTool
+    authorize :update?, ->(args) { provider_api_key_for(args.fetch(:provider_api_key_id)) }, policy_class: ProviderApiKeyPolicy
+
+    def self.tool_name = "update_provider_api_key"
+    def self.write_operation? = true
+
+    def self.description
+      "Update or rotate a provider API key owned by the current user."
+    end
+
+    def self.input_schema
+      {
+        type: "object",
+        properties: {
+          provider_api_key_id: { type: "integer" },
+          attributes: { type: "object" },
+          confirmed: { type: "boolean" }
+        },
+        required: %w[provider_api_key_id attributes confirmed]
+      }
+    end
+
+    def perform(provider_api_key_id:, attributes:, confirmed:)
+      raise ArgumentError, "Confirmation required: set confirmed=true to update an API key" unless confirmed
+      raise ArgumentError, "attributes must be an object" unless attributes.is_a?(Hash)
+
+      provider_api_key = provider_api_key_for(provider_api_key_id)
+      attrs = attributes.symbolize_keys.slice(:name, :api_key, :api_service_type)
+      attrs.delete(:api_key) if attrs[:api_key].blank?
+      provider_api_key.update!(attrs)
+
+      {
+        id: provider_api_key.id,
+        name: provider_api_key.name,
+        api_service_type: provider_api_key.api_service_type,
+        masked_api_key: provider_api_key.masked_api_key
+      }
+    end
+
+    private
+
+    def provider_api_key_for(provider_api_key_id)
+      policy_scope(ProviderApiKey).find(provider_api_key_id)
+    end
+  end
+end

--- a/app/mcp/tools/update_tenant_settings.rb
+++ b/app/mcp/tools/update_tenant_settings.rb
@@ -50,7 +50,20 @@ module Tools
 
       tenant_setting = account.tenant_setting!
       tenant_setting.update!(settings.symbolize_keys.slice(*PERMITTED_ATTRIBUTES))
+      record_activity!(tenant_setting) if tenant_setting.saved_changes.except("updated_at").any?
       tenant_setting.reload.attributes.except("id", "account_id", "created_at", "updated_at", "log_data")
+    end
+
+    private
+
+    def record_activity!(tenant_setting)
+      Accounts::RecordActivity.call(
+        account:,
+        actor: user,
+        action: "tenant_configuration.updated",
+        subject: tenant_setting,
+        metadata: { changed_fields: tenant_setting.saved_changes.except("updated_at").keys }
+      )
     end
   end
 end

--- a/app/mcp/tools/update_tenant_settings.rb
+++ b/app/mcp/tools/update_tenant_settings.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Tools
+  class UpdateTenantSettings < BaseTool
+    authorize :update?, ->(_args) { account }, policy_class: AccountPolicy
+
+    PERMITTED_ATTRIBUTES = %i[
+      max_concurrent_runs
+      max_projects
+      max_users
+      max_tokens_per_run
+      max_monthly_cost_cents
+      self_repo_full_name
+      allowed_runner_keys
+      auto_pick_skip_labels
+      runner_preferences
+      default_budgets
+      guardrails
+      quality_thresholds
+      agent_settings
+      worker_settings
+      features
+    ].freeze
+
+    def self.tool_name = "update_tenant_settings"
+    def self.write_operation? = true
+
+    def self.description
+      "Update tenant settings for the current account."
+    end
+
+    def self.input_schema
+      {
+        type: "object",
+        properties: {
+          settings: { type: "object" },
+          confirmed: { type: "boolean" }
+        },
+        required: %w[settings confirmed]
+      }
+    end
+
+    def self.available_to?(user:)
+      policy_allows?(user:, record: user&.account, query: :update?, policy_class: AccountPolicy)
+    end
+
+    def perform(settings:, confirmed:)
+      raise ArgumentError, "Confirmation required: set confirmed=true to update tenant settings" unless confirmed
+      raise ArgumentError, "settings must be an object" unless settings.is_a?(Hash)
+
+      tenant_setting = account.tenant_setting!
+      tenant_setting.update!(settings.symbolize_keys.slice(*PERMITTED_ATTRIBUTES))
+      tenant_setting.reload.attributes.except("id", "account_id", "created_at", "updated_at", "log_data")
+    end
+  end
+end

--- a/app/mcp/tools/update_user_settings.rb
+++ b/app/mcp/tools/update_user_settings.rb
@@ -41,7 +41,9 @@ module Tools
       fallback_enabled
       fallback_runners
       kb_embedding_runner
+      kb_embedding_fallback_runners
       kb_chat_runner
+      kb_chat_fallback_runners
       auto_pick_skip_labels
     ].freeze
 

--- a/app/mcp/tools/update_user_settings.rb
+++ b/app/mcp/tools/update_user_settings.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module Tools
+  class UpdateUserSettings < BaseTool
+    authorize :update?, ->(_args) { current_user.settings }
+
+    PERMITTED_ATTRIBUTES = %i[
+      theme_preference
+      default_poll_interval_seconds
+      github_token_cache_ttl_minutes
+      token_validation_stale_minutes
+      agent_timeout_seconds
+      marketplace_auto_attach_enabled
+      max_execution_seconds
+      default_agent_runner
+      container_memory_gb
+      max_concurrent_runs
+      container_timeout_seconds
+      default_branch
+      default_project_active
+      default_allowed_github_usernames_csv
+      allowed_service_images_csv
+      max_tokens_per_run
+      issue_goal_timeout_seconds
+      issue_goal_idle_timeout_seconds
+      review_goal_idle_timeout_seconds
+      git_clone_timeout_seconds
+      git_push_timeout_seconds
+      max_prompt_comments
+      max_comment_length
+      style_guide_max_raw_bytes
+      style_guide_max_total_bytes
+      style_guide_max_raw_prompt_bytes
+      circuit_breaker_failure_threshold
+      circuit_breaker_timeout_seconds
+      retry_max_attempts
+      retry_base_delay
+      retry_max_delay
+      max_issues_per_page
+      max_prs_per_page
+      fallback_enabled
+      fallback_runners
+      kb_embedding_runner
+      kb_chat_runner
+      auto_pick_skip_labels
+    ].freeze
+
+    def self.tool_name = "update_user_settings"
+    def self.write_operation? = true
+
+    def self.description
+      "Update the current user's settings."
+    end
+
+    def self.input_schema
+      {
+        type: "object",
+        properties: {
+          settings: { type: "object" },
+          confirmed: { type: "boolean" }
+        },
+        required: %w[settings confirmed]
+      }
+    end
+
+    def perform(settings:, confirmed:)
+      raise ArgumentError, "Confirmation required: set confirmed=true to update user settings" unless confirmed
+      raise ArgumentError, "settings must be an object" unless settings.is_a?(Hash)
+
+      attrs = settings.symbolize_keys.slice(*PERMITTED_ATTRIBUTES)
+      current_user.settings.update!(attrs)
+      current_user.settings.reload.attributes.except("id", "user_id", "created_at", "updated_at", "log_data")
+    end
+  end
+end

--- a/spec/mcp/paid_mcp_server_spec.rb
+++ b/spec/mcp/paid_mcp_server_spec.rb
@@ -82,7 +82,8 @@ RSpec.describe PaidMcpServer do
         "list_projects", "get_project", "get_project_issues",
         "get_project_pull_requests", "trigger_agent_run", "get_agent_run",
         "list_agent_runs", "cancel_agent_run", "get_issue_details",
-        "get_pull_request_details", "search_code"
+        "get_pull_request_details", "search_code", "list_account_memberships",
+        "get_user_settings", "list_provider_api_keys"
       )
     end
 

--- a/spec/mcp/tools/get_user_settings_spec.rb
+++ b/spec/mcp/tools/get_user_settings_spec.rb
@@ -29,6 +29,25 @@ RSpec.describe Tools::GetUserSettings do
       expect(result["theme_preference"]).to eq("dark")
       expect(user.settings.reload.theme_preference).to eq("dark")
     end
+
+    it "updates knowledge fallback runners" do
+      account = create(:account)
+      user = create(:user, :member, account:)
+      session = create(:chat_session, account:, created_by: user)
+
+      result = described_class.new(user:, session:).call(
+        settings: {
+          kb_embedding_fallback_runners: [ "openai", "deepseek" ],
+          kb_chat_fallback_runners: [ "claude", "cursor" ]
+        },
+        confirmed: true
+      )
+
+      expect(result["kb_embedding_fallback_runners"]).to eq(%w[openai deepseek])
+      expect(result["kb_chat_fallback_runners"]).to eq(%w[claude cursor])
+      expect(user.settings.reload.kb_embedding_fallback_runners).to eq(%w[openai deepseek])
+      expect(user.settings.kb_chat_fallback_runners).to eq(%w[claude cursor])
+    end
   end
 
   describe Tools::GetTenantSettings do

--- a/spec/mcp/tools/get_user_settings_spec.rb
+++ b/spec/mcp/tools/get_user_settings_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Tools::GetUserSettings do
+  describe Tools::GetUserSettings do
+    it "returns the current user's settings" do
+      account = create(:account)
+      user = create(:user, :member, account:)
+      session = create(:chat_session, account:, created_by: user)
+
+      result = described_class.new(user:, session:).call
+
+      expect(result["theme_preference"]).to eq(user.settings.theme_preference)
+    end
+  end
+
+  describe Tools::UpdateUserSettings do
+    it "updates the current user's settings" do
+      account = create(:account)
+      user = create(:user, :member, account:)
+      session = create(:chat_session, account:, created_by: user)
+
+      result = described_class.new(user:, session:).call(
+        settings: { theme_preference: "dark" },
+        confirmed: true
+      )
+
+      expect(result["theme_preference"]).to eq("dark")
+      expect(user.settings.reload.theme_preference).to eq("dark")
+    end
+  end
+
+  describe Tools::GetTenantSettings do
+    it "returns tenant settings for an owner" do
+      account = create(:account)
+      user = create(:user, :owner, account:)
+      session = create(:chat_session, account:, created_by: user)
+
+      result = described_class.new(user:, session:).call
+
+      expect(result["max_concurrent_runs"]).to eq(account.tenant_setting!.max_concurrent_runs)
+    end
+  end
+
+  describe Tools::UpdateTenantSettings do
+    it "updates tenant settings for an owner" do
+      account = create(:account)
+      user = create(:user, :owner, account:)
+      session = create(:chat_session, account:, created_by: user)
+
+      result = described_class.new(user:, session:).call(
+        settings: { max_concurrent_runs: 7 },
+        confirmed: true
+      )
+
+      expect(result["max_concurrent_runs"]).to eq(7)
+      expect(account.tenant_setting!.reload.max_concurrent_runs).to eq(7)
+    end
+  end
+end

--- a/spec/mcp/tools/get_user_settings_spec.rb
+++ b/spec/mcp/tools/get_user_settings_spec.rb
@@ -76,5 +76,22 @@ RSpec.describe Tools::GetUserSettings do
       expect(result["max_concurrent_runs"]).to eq(7)
       expect(account.tenant_setting!.reload.max_concurrent_runs).to eq(7)
     end
+
+    it "records tenant configuration activity when settings change" do
+      account = create(:account)
+      user = create(:user, :owner, account:)
+      session = create(:chat_session, account:, created_by: user)
+
+      described_class.new(user:, session:).call(
+        settings: { max_concurrent_runs: 7 },
+        confirmed: true
+      )
+
+      event = account.account_activity_events.recent.first
+      expect(event.action).to eq("tenant_configuration.updated")
+      expect(event.actor).to eq(user)
+      expect(event.subject).to eq(account.tenant_setting!)
+      expect(event.metadata["changed_fields"]).to include("max_concurrent_runs")
+    end
   end
 end

--- a/spec/mcp/tools/list_account_memberships_spec.rb
+++ b/spec/mcp/tools/list_account_memberships_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Tools::ListAccountMemberships do
+  let(:account) { create(:account) }
+  let(:owner) { create(:user, :owner, account:) }
+  let(:session) { create(:chat_session, account:, created_by: owner) }
+
+  describe "#call" do
+    it "lists memberships for the current account" do
+      member = create(:user, :member, account:)
+
+      result = described_class.new(user: owner, session:).call
+
+      expect(result.map { |row| row[:email] }).to include(owner.email, member.email)
+    end
+  end
+
+  describe Tools::InviteAccountMember do
+    it "invites a member through the account service" do
+      result = described_class.new(user: owner, session:).call(
+        email: "new-user@example.com",
+        name: "New User",
+        role: "member",
+        confirmed: true
+      )
+
+      expect(result[:email]).to eq("new-user@example.com")
+      expect(result[:role]).to eq("member")
+    end
+  end
+
+  describe Tools::UpdateAccountMembership do
+    it "updates a membership role through the account service" do
+      member = create(:user, :member, account:)
+      membership = account.account_memberships.find_by!(user: member)
+
+      result = described_class.new(user: owner, session:).call(
+        membership_id: membership.id,
+        role: "admin",
+        confirmed: true
+      )
+
+      expect(result[:role]).to eq("admin")
+      expect(membership.reload.role).to eq("admin")
+    end
+  end
+
+  describe Tools::RemoveAccountMembership do
+    it "removes a membership through the account service" do
+      member = create(:user, :member, account:)
+      membership = account.account_memberships.find_by!(user: member)
+
+      result = described_class.new(user: owner, session:).call(
+        membership_id: membership.id,
+        confirmed: true
+      )
+
+      expect(result[:id]).to eq(membership.id)
+      expect(account.account_memberships.where(id: membership.id)).to be_empty
+    end
+  end
+end

--- a/spec/mcp/tools/list_mcp_server_definitions_spec.rb
+++ b/spec/mcp/tools/list_mcp_server_definitions_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Tools::ListMcpServerDefinitions do
+  let(:account) { create(:account) }
+  let(:user) { create(:user, :owner, account:) }
+  let(:session) { create(:chat_session, account:, created_by: user) }
+
+  describe Tools::ListMcpServerDefinitions do
+    it "lists account MCP server definitions" do
+      definition = create(:mcp_server_definition, account:)
+
+      result = described_class.new(user:, session:).call
+
+      expect(result.map { |row| row["id"] || row[:id] }).to include(definition.id)
+    end
+  end
+
+  describe Tools::CreateMcpServerDefinition do
+    it "creates an MCP server definition" do
+      result = described_class.new(user:, session:).call(
+        attributes: {
+          name: "Docs Server",
+          transport: "stdio",
+          install_type: "npx",
+          command: "npx @paid/docs-mcp"
+        },
+        confirmed: true
+      )
+
+      expect(result["name"]).to eq("Docs Server")
+      expect(account.mcp_server_definitions.find(result["id"]).command).to eq("npx @paid/docs-mcp")
+    end
+  end
+
+  describe Tools::UpdateMcpServerDefinition do
+    it "updates an MCP server definition" do
+      definition = create(:mcp_server_definition, account:)
+
+      result = described_class.new(user:, session:).call(
+        mcp_server_definition_id: definition.id,
+        attributes: { name: "Updated Server" },
+        confirmed: true
+      )
+
+      expect(result["name"]).to eq("Updated Server")
+      expect(definition.reload.name).to eq("Updated Server")
+    end
+  end
+
+  describe Tools::RemoveMcpServerDefinition do
+    it "removes an MCP server definition" do
+      definition = create(:mcp_server_definition, account:)
+
+      result = described_class.new(user:, session:).call(
+        mcp_server_definition_id: definition.id,
+        confirmed: true
+      )
+
+      expect(result[:id]).to eq(definition.id)
+      expect(account.mcp_server_definitions.where(id: definition.id)).to be_empty
+    end
+  end
+end

--- a/spec/mcp/tools/list_mcp_server_definitions_spec.rb
+++ b/spec/mcp/tools/list_mcp_server_definitions_spec.rb
@@ -8,12 +8,27 @@ RSpec.describe Tools::ListMcpServerDefinitions do
   let(:session) { create(:chat_session, account:, created_by: user) }
 
   describe Tools::ListMcpServerDefinitions do
-    it "lists account MCP server definitions" do
-      definition = create(:mcp_server_definition, account:)
+    it "lists account MCP server definitions with summary fields only" do
+      definition = create(
+        :mcp_server_definition,
+        account:,
+        command: "npx @paid/docs-mcp",
+        env: { "API_KEY" => "secret" },
+        metadata: { "category" => "docs" }
+      )
 
       result = described_class.new(user:, session:).call
+      serialized_definition = result.find { |row| (row["id"] || row[:id]) == definition.id }
 
       expect(result.map { |row| row["id"] || row[:id] }).to include(definition.id)
+      expect(serialized_definition).to include(
+        "id" => definition.id,
+        "name" => definition.name,
+        "install_type" => definition.install_type,
+        "transport" => definition.transport,
+        "enabled" => definition.enabled
+      )
+      expect(serialized_definition).not_to include("command", "url", "image", "args", "env", "metadata")
     end
   end
 

--- a/spec/mcp/tools/list_mcp_server_definitions_spec.rb
+++ b/spec/mcp/tools/list_mcp_server_definitions_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe Tools::ListMcpServerDefinitions do
 
       expect(result["name"]).to eq("Docs Server")
       expect(account.mcp_server_definitions.find(result["id"]).command).to eq("npx @paid/docs-mcp")
+      expect(result["env_keys"]).to eq([])
       expect(result).not_to include("account_id", "log_data")
     end
 
@@ -67,6 +68,8 @@ RSpec.describe Tools::ListMcpServerDefinitions do
       expect(definition.args).to eq([ "--workspace", "/repo" ])
       expect(definition.env).to eq({ "API_KEY" => "test" })
       expect(definition.metadata).to eq({ "category" => "docs" })
+      expect(result["env_keys"]).to eq([ "API_KEY" ])
+      expect(result).not_to have_key("env")
     end
   end
 
@@ -82,6 +85,7 @@ RSpec.describe Tools::ListMcpServerDefinitions do
 
       expect(result["name"]).to eq("Updated Server")
       expect(definition.reload.name).to eq("Updated Server")
+      expect(result["env_keys"]).to eq([])
       expect(result).not_to include("account_id", "log_data")
     end
 
@@ -101,6 +105,20 @@ RSpec.describe Tools::ListMcpServerDefinitions do
       expect(definition.reload.args).to eq([ "--workspace", "/repo" ])
       expect(definition.env).to eq({ "API_KEY" => "updated" })
       expect(definition.metadata).to eq({ "category" => "docs" })
+      expect(definition.reload.env).to eq({ "API_KEY" => "updated" })
+    end
+
+    it "returns env key names without exposing env values" do
+      definition = create(:mcp_server_definition, account:, env: { "TOKEN" => "secret", "API_KEY" => "hidden" })
+
+      result = described_class.new(user:, session:).call(
+        mcp_server_definition_id: definition.id,
+        attributes: { name: "Renamed Server" },
+        confirmed: true
+      )
+
+      expect(result["env_keys"]).to eq(%w[API_KEY TOKEN])
+      expect(result).not_to have_key("env")
     end
   end
 

--- a/spec/mcp/tools/list_mcp_server_definitions_spec.rb
+++ b/spec/mcp/tools/list_mcp_server_definitions_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Tools::ListMcpServerDefinitions do
 
       expect(result["name"]).to eq("Docs Server")
       expect(account.mcp_server_definitions.find(result["id"]).command).to eq("npx @paid/docs-mcp")
+      expect(result).not_to include("account_id", "log_data")
     end
   end
 
@@ -46,6 +47,7 @@ RSpec.describe Tools::ListMcpServerDefinitions do
 
       expect(result["name"]).to eq("Updated Server")
       expect(definition.reload.name).to eq("Updated Server")
+      expect(result).not_to include("account_id", "log_data")
     end
   end
 

--- a/spec/mcp/tools/list_mcp_server_definitions_spec.rb
+++ b/spec/mcp/tools/list_mcp_server_definitions_spec.rb
@@ -33,6 +33,26 @@ RSpec.describe Tools::ListMcpServerDefinitions do
       expect(account.mcp_server_definitions.find(result["id"]).command).to eq("npx @paid/docs-mcp")
       expect(result).not_to include("account_id", "log_data")
     end
+
+    it "accepts structured MCP payloads for args, env, and metadata" do
+      result = described_class.new(user:, session:).call(
+        attributes: {
+          name: "Docs Server",
+          transport: "stdio",
+          install_type: "npx",
+          command: "npx @paid/docs-mcp",
+          args_json: [ "--workspace", "/repo" ],
+          env_json: { "API_KEY" => "test" },
+          metadata_json: { "category" => "docs" }
+        },
+        confirmed: true
+      )
+
+      definition = account.mcp_server_definitions.find(result["id"])
+      expect(definition.args).to eq([ "--workspace", "/repo" ])
+      expect(definition.env).to eq({ "API_KEY" => "test" })
+      expect(definition.metadata).to eq({ "category" => "docs" })
+    end
   end
 
   describe Tools::UpdateMcpServerDefinition do
@@ -48,6 +68,24 @@ RSpec.describe Tools::ListMcpServerDefinitions do
       expect(result["name"]).to eq("Updated Server")
       expect(definition.reload.name).to eq("Updated Server")
       expect(result).not_to include("account_id", "log_data")
+    end
+
+    it "accepts structured MCP payloads for args, env, and metadata" do
+      definition = create(:mcp_server_definition, account:)
+
+      described_class.new(user:, session:).call(
+        mcp_server_definition_id: definition.id,
+        attributes: {
+          args_json: [ "--workspace", "/repo" ],
+          env_json: { "API_KEY" => "updated" },
+          metadata_json: { "category" => "docs" }
+        },
+        confirmed: true
+      )
+
+      expect(definition.reload.args).to eq([ "--workspace", "/repo" ])
+      expect(definition.env).to eq({ "API_KEY" => "updated" })
+      expect(definition.metadata).to eq({ "category" => "docs" })
     end
   end
 

--- a/spec/mcp/tools/list_provider_api_keys_spec.rb
+++ b/spec/mcp/tools/list_provider_api_keys_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Tools::ListProviderApiKeys do
+  let(:account) { create(:account) }
+  let(:user) { create(:user, :member, account:) }
+  let(:session) { create(:chat_session, account:, created_by: user) }
+
+  describe Tools::ListProviderApiKeys do
+    it "lists the current user's API keys" do
+      key = create(:provider_api_key, user:)
+
+      result = described_class.new(user:, session:).call
+
+      expect(result.map { |row| row[:id] }).to include(key.id)
+    end
+  end
+
+  describe Tools::CreateProviderApiKey do
+    it "creates a provider API key" do
+      result = described_class.new(user:, session:).call(
+        name: "OpenAI",
+        api_key: "sk-test",
+        api_service_type: "openai",
+        confirmed: true
+      )
+
+      expect(result[:name]).to eq("OpenAI")
+      expect(user.provider_api_keys.find(result[:id]).api_service_type).to eq("openai")
+    end
+  end
+
+  describe Tools::UpdateProviderApiKey do
+    it "updates a provider API key" do
+      provider_api_key = create(:provider_api_key, user:, api_service_type: "openai")
+
+      result = described_class.new(user:, session:).call(
+        provider_api_key_id: provider_api_key.id,
+        attributes: { name: "Renamed" },
+        confirmed: true
+      )
+
+      expect(result[:name]).to eq("Renamed")
+      expect(provider_api_key.reload.name).to eq("Renamed")
+    end
+  end
+
+  describe Tools::RemoveProviderApiKey do
+    it "removes a provider API key" do
+      provider_api_key = create(:provider_api_key, user:)
+
+      result = described_class.new(user:, session:).call(
+        provider_api_key_id: provider_api_key.id,
+        confirmed: true
+      )
+
+      expect(result[:id]).to eq(provider_api_key.id)
+      expect(user.provider_api_keys.where(id: provider_api_key.id)).to be_empty
+    end
+  end
+end

--- a/spec/mcp/tools/registry_authorization_parity_spec.rb
+++ b/spec/mcp/tools/registry_authorization_parity_spec.rb
@@ -117,6 +117,184 @@ RSpec.describe Tools::Registry do
           authorize_record!(user, project_record, :show?)
           Knowledge::Search.call(project: project_record, query: "agent run", mode: "hybrid", limit: 10)
         }
+      },
+      {
+        tool_name: "list_account_memberships",
+        denied_user: -> { nil },
+        arguments: -> { {} },
+        ui_call: ->(user) {
+          authorize_record!(user, account, :show?, policy_class: AccountPolicy)
+          account.account_memberships.includes(:user).order(role: :desc, created_at: :asc).to_a
+        }
+      },
+      {
+        tool_name: "invite_account_member",
+        denied_user: -> { create(:user, :viewer, account: account) },
+        arguments: -> { { email: "blocked@example.com", role: "member", confirmed: true } },
+        ui_call: ->(user) {
+          authorize_record!(user, account, :update?, policy_class: AccountPolicy)
+          Accounts::InviteMember.call(account: account, actor: user, email: "blocked@example.com", role: "member")
+        }
+      },
+      {
+        tool_name: "update_account_membership",
+        denied_user: -> { create(:user, :viewer, account: account) },
+        arguments: -> {
+          membership = create(:account_membership, account: account, user: create(:user, account: account), role: :member)
+          { membership_id: membership.id, role: "admin", confirmed: true }
+        },
+        ui_call: ->(user) {
+          membership = account.account_memberships.order(:id).last
+          authorize_record!(user, account, :update?, policy_class: AccountPolicy)
+          Accounts::UpdateMembership.call(account: account, membership: membership, actor: user, role: "admin")
+        }
+      },
+      {
+        tool_name: "remove_account_membership",
+        denied_user: -> { create(:user, :viewer, account: account) },
+        arguments: -> {
+          membership = create(:account_membership, account: account, user: create(:user, account: account), role: :member)
+          { membership_id: membership.id, confirmed: true }
+        },
+        ui_call: ->(user) {
+          membership = account.account_memberships.order(:id).last
+          authorize_record!(user, account, :update?, policy_class: AccountPolicy)
+          Accounts::RemoveMembership.call(account: account, membership: membership, actor: user)
+        }
+      },
+      {
+        tool_name: "get_user_settings",
+        denied_user: -> { nil },
+        arguments: -> { {} },
+        ui_call: ->(user) {
+          settings_owner = create(:user, :member, account: account)
+          authorize_record!(user, settings_owner.settings, :edit?)
+          settings_owner.settings
+        }
+      },
+      {
+        tool_name: "update_user_settings",
+        denied_user: -> { nil },
+        arguments: -> { { settings: { theme_preference: "dark" }, confirmed: true } },
+        ui_call: ->(user) {
+          settings_owner = create(:user, :member, account: account)
+          authorize_record!(user, settings_owner.settings, :update?)
+          settings_owner.settings.update!(theme_preference: "dark")
+        }
+      },
+      {
+        tool_name: "get_tenant_settings",
+        denied_user: -> { create(:user, :member, account: account) },
+        arguments: -> { {} },
+        ui_call: ->(user) {
+          authorize_record!(user, account, :update?, policy_class: AccountPolicy)
+          account.tenant_setting!
+        }
+      },
+      {
+        tool_name: "update_tenant_settings",
+        denied_user: -> { create(:user, :member, account: account) },
+        arguments: -> { { settings: { max_concurrent_runs: 9 }, confirmed: true } },
+        ui_call: ->(user) {
+          authorize_record!(user, account, :update?, policy_class: AccountPolicy)
+          account.tenant_setting!.update!(max_concurrent_runs: 9)
+        }
+      },
+      {
+        tool_name: "list_provider_api_keys",
+        denied_user: -> { nil },
+        arguments: -> { {} },
+        ui_call: ->(user) { Pundit.policy_scope!(user, ProviderApiKey).ordered.to_a }
+      },
+      {
+        tool_name: "create_provider_api_key",
+        denied_user: -> { nil },
+        arguments: -> { { name: "Denied", api_key: "sk", api_service_type: "openai", confirmed: true } },
+        ui_call: ->(user) {
+          key_owner = create(:user, :member, account: account)
+          record = key_owner.provider_api_keys.build
+          authorize_record!(user, record, :create?, policy_class: ProviderApiKeyPolicy)
+          key_owner.provider_api_keys.create!(name: "Denied", api_key: "sk", api_service_type: "openai")
+        }
+      },
+      {
+        tool_name: "update_provider_api_key",
+        denied_user: -> { create(:user, :member, account: other_account) },
+        arguments: -> {
+          provider_api_key = create(:provider_api_key, user: create(:user, :member, account: account))
+          { provider_api_key_id: provider_api_key.id, attributes: { name: "Denied" }, confirmed: true }
+        },
+        ui_call: ->(user) {
+          provider_api_key = ProviderApiKey.order(:id).last
+          record = Pundit.policy_scope!(user, ProviderApiKey).find(provider_api_key.id)
+          authorize_record!(user, record, :update?, policy_class: ProviderApiKeyPolicy)
+          record.update!(name: "Denied")
+        }
+      },
+      {
+        tool_name: "remove_provider_api_key",
+        denied_user: -> { create(:user, :member, account: other_account) },
+        arguments: -> {
+          provider_api_key = create(:provider_api_key, user: create(:user, :member, account: account))
+          { provider_api_key_id: provider_api_key.id, confirmed: true }
+        },
+        ui_call: ->(user) {
+          provider_api_key = ProviderApiKey.order(:id).last
+          record = Pundit.policy_scope!(user, ProviderApiKey).find(provider_api_key.id)
+          authorize_record!(user, record, :destroy?, policy_class: ProviderApiKeyPolicy)
+          record.destroy!
+        }
+      },
+      {
+        tool_name: "list_mcp_server_definitions",
+        denied_user: -> { create(:user, :member, account: account) },
+        arguments: -> { {} },
+        ui_call: ->(user) {
+          authorize_record!(user, McpServerDefinition, :index?, policy_class: McpServerDefinitionPolicy)
+          Pundit.policy_scope!(user, McpServerDefinition).to_a
+        }
+      },
+      {
+        tool_name: "create_mcp_server_definition",
+        denied_user: -> { create(:user, :member, account: account) },
+        arguments: -> {
+          {
+            attributes: { name: "Denied", transport: "stdio", install_type: "npx", command: "npx denied" },
+            confirmed: true
+          }
+        },
+        ui_call: ->(user) {
+          record = account.mcp_server_definitions.build
+          authorize_record!(user, record, :create?, policy_class: McpServerDefinitionPolicy)
+          account.mcp_server_definitions.create!(name: "Denied", transport: "stdio", install_type: "npx", command: "npx denied")
+        }
+      },
+      {
+        tool_name: "update_mcp_server_definition",
+        denied_user: -> { create(:user, :member, account: other_account) },
+        arguments: -> {
+          definition = create(:mcp_server_definition, account: account)
+          { mcp_server_definition_id: definition.id, attributes: { name: "Denied" }, confirmed: true }
+        },
+        ui_call: ->(user) {
+          definition = McpServerDefinition.order(:id).last
+          definition = Pundit.policy_scope!(user, McpServerDefinition).find(definition.id)
+          authorize_record!(user, definition, :update?, policy_class: McpServerDefinitionPolicy)
+          definition.update!(name: "Denied")
+        }
+      },
+      {
+        tool_name: "remove_mcp_server_definition",
+        denied_user: -> { create(:user, :admin, account: account) },
+        arguments: -> {
+          definition = create(:mcp_server_definition, account: account)
+          { mcp_server_definition_id: definition.id, confirmed: true }
+        },
+        ui_call: ->(user) {
+          definition = Pundit.policy_scope!(user, McpServerDefinition).order(:id).last
+          authorize_record!(user, definition, :destroy?, policy_class: McpServerDefinitionPolicy)
+          definition.destroy!
+        }
       }
     ]
   end

--- a/spec/mcp/tools/registry_spec.rb
+++ b/spec/mcp/tools/registry_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe Tools::Registry do
       expect(definitions.map { |definition| definition[:name] }).to include(
         "invite_account_member",
         "update_tenant_settings",
-        "create_mcp_server_definition"
+        "create_mcp_server_definition",
+        "update_mcp_server_definition"
       )
     end
   end

--- a/spec/mcp/tools/registry_spec.rb
+++ b/spec/mcp/tools/registry_spec.rb
@@ -14,5 +14,18 @@ RSpec.describe Tools::Registry do
 
       expect(definitions.map { |definition| definition[:name] }).to include("trigger_agent_run", "cancel_agent_run")
     end
+
+    it "includes account admin write tools even when no project exists" do
+      account = create(:account)
+      user = create(:user, :owner, account: account)
+
+      definitions = described_class.definitions_for(user: user)
+
+      expect(definitions.map { |definition| definition[:name] }).to include(
+        "invite_account_member",
+        "update_tenant_settings",
+        "create_mcp_server_definition"
+      )
+    end
   end
 end

--- a/spec/mcp/tools/registry_spec.rb
+++ b/spec/mcp/tools/registry_spec.rb
@@ -15,6 +15,16 @@ RSpec.describe Tools::Registry do
       expect(definitions.map { |definition| definition[:name] }).to include("trigger_agent_run", "cancel_agent_run")
     end
 
+    it "hides run-management write tools when the user lacks run permissions" do
+      account = create(:account)
+      create(:project, account: account)
+      user = create(:user, :viewer, account: account)
+
+      definitions = described_class.definitions_for(user: user)
+
+      expect(definitions.map { |definition| definition[:name] }).not_to include("trigger_agent_run", "cancel_agent_run")
+    end
+
     it "includes account admin write tools even when no project exists" do
       account = create(:account)
       user = create(:user, :owner, account: account)

--- a/spec/models/style_guide_spec.rb
+++ b/spec/models/style_guide_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 RSpec.describe StyleGuide do
+  before do
+    TenantContext.with_system_access { described_class.delete_all }
+  end
+
   describe "associations" do
     it { is_expected.to belong_to(:account).optional }
     it { is_expected.to belong_to(:project).optional }

--- a/spec/services/metrics/prometheus_collector_spec.rb
+++ b/spec/services/metrics/prometheus_collector_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Metrics::PrometheusCollector do
+  before do
+    GoodJob::Job.delete_all
+  end
+
   describe ".call" do
     subject(:output) { described_class.call }
 

--- a/spec/services/prompts/build_for_pr_spec.rb
+++ b/spec/services/prompts/build_for_pr_spec.rb
@@ -66,11 +66,11 @@ RSpec.describe Prompts::BuildForPr do
   end
 
   before do
+    TenantContext.with_system_access { StyleGuide.delete_all }
+
     allow(github_client).to receive(:pull_request)
       .with(project.full_name, 42)
       .and_return(pr_data)
-
-
 
     allow(github_client).to receive_messages(
       check_runs_for_ref: [],

--- a/spec/services/style_guides/inject_into_prompt_spec.rb
+++ b/spec/services/style_guides/inject_into_prompt_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 RSpec.describe StyleGuides::InjectIntoPrompt do
+  before do
+    TenantContext.with_system_access { StyleGuide.delete_all }
+  end
+
   let(:account) { create(:account) }
   let(:project) { create(:project, account: account) }
   let(:base_prompt) { "# Task\n\nFix the bug in auth.rb" }


### PR DESCRIPTION
## Summary

Implemented and committed a first admin-surface MCP batch in `0458b6e` (`feat(chat): add admin MCP tools for memberships and settings`).

The change adds per-tool availability to the MCP registry and new tools for:
- account memberships: list, invite, update role, remove
- user settings: read, update
- tenant settings: read, update
- provider API keys: list, create, update/rotate, remove
- MCP server definitions: list, create, update, remove

I also added MCP specs for the new tools, expanded registry authorization-parity coverage, and updated MCP server tool-list expectations.

Verification:
- `bin/rails db:prepare` passed after exporting `DB_HOST`, `DB_USERNAME`, and `DB_PASSWORD` from the provided `DATABASE_URL`
- `bundle exec rubocop` passed
- `bundle exec rspec` passed: `14148 examples, 0 failures, 7 pending`

The worktree is clean and nothing was pushed.

---

Closes #2350