### PR TITLE
feat: add unobtrusive chat popup to paid pages

### DIFF
--- a/app/controllers/chat_sessions_controller.rb
+++ b/app/controllers/chat_sessions_controller.rb
@@ -92,10 +92,17 @@ class ChatSessionsController < ApplicationController
 
     respond_to do |format|
       format.html do
-        load_sidebar_data(active_session: @chat_session)
-        scope = @chat_session.messages.chronological
-        @chat_messages = latest_messages(scope)
-        @has_older_messages = scope.where("chat_messages.id < ?", @chat_messages.first.id).exists? if @chat_messages.any?
+        load_chat_messages
+
+        if popup_request?
+          render partial: "chat_sessions/popup", locals: {
+            chat_session: @chat_session,
+            chat_messages: @chat_messages,
+            has_older_messages: @has_older_messages
+          }
+        else
+          load_sidebar_data(active_session: @chat_session)
+        end
       end
 
       format.json do
@@ -111,8 +118,9 @@ class ChatSessionsController < ApplicationController
   def update
     authorize @chat_session
     project_changed = update_params.key?(:project_id) && update_params[:project_id].to_s != @chat_session.project_id.to_s
+    metadata_changed = update_params.key?(:metadata) && update_params[:metadata] != @chat_session.metadata
     @chat_session.update!(update_params)
-    regenerate_system_message! if project_changed
+    regenerate_system_message! if project_changed || metadata_changed
 
     respond_to do |format|
       format.html { redirect_to chat_session_path(@chat_session), notice: "Chat session updated." }
@@ -151,14 +159,14 @@ class ChatSessionsController < ApplicationController
 
   def create_params
     source = params.key?(:chat_session) ? params.require(:chat_session) : params
-    permitted = source.permit(:mode, :model, :runner_id, :provider_id, :project_id, :system_prompt, :title)
+    permitted = source.permit(:mode, :model, :runner_id, :provider_id, :project_id, :system_prompt, :title, metadata: {})
       .to_h.symbolize_keys
     permitted[:runner_id] ||= permitted.delete(:provider_id)
     permitted
   end
 
   def update_params
-    permitted = params.fetch(:chat_session, params).permit(:title, :model, :project_id, :runner_id, :provider_id)
+    permitted = params.fetch(:chat_session, params).permit(:title, :model, :project_id, :runner_id, :provider_id, metadata: {})
       .to_h.symbolize_keys
     permitted[:runner_id] ||= permitted.delete(:provider_id)
     permitted
@@ -280,6 +288,16 @@ class ChatSessionsController < ApplicationController
     @available_runners = current_user.runners.kept_only.ordered
     @available_projects = current_account.projects.order(:name)
     @available_models = LlmModel.active.order(:provider, :display_name)
+  end
+
+  def load_chat_messages
+    scope = @chat_session.messages.chronological
+    @chat_messages = latest_messages(scope)
+    @has_older_messages = scope.where("chat_messages.id < ?", @chat_messages.first.id).exists? if @chat_messages.any?
+  end
+
+  def popup_request?
+    params[:display] == "popup"
   end
 
   def pinned_sidebar_batch(active_session)

--- a/app/helpers/chat_sessions_helper.rb
+++ b/app/helpers/chat_sessions_helper.rb
@@ -130,6 +130,35 @@ module ChatSessionsHelper
     JSON.pretty_generate(payload)
   end
 
+  def chat_popup_available?
+    user_signed_in? && controller_path != "chat_sessions"
+  end
+
+  def current_chat_popup_context
+    context = {
+      "url" => request.original_url,
+      "path" => request.fullpath,
+      "page_title" => content_for(:title).presence || "Paid",
+      "controller" => controller_path,
+      "action" => action_name
+    }
+
+    project = current_chat_popup_project
+    return context unless project
+
+    context.merge(
+      "project_id" => project.id,
+      "project_name" => project.name,
+      "project_full_name" => project.full_name
+    )
+  end
+
+  def current_chat_popup_project
+    return @project if defined?(@project) && @project.is_a?(Project)
+
+    nil
+  end
+
   private
 
   def preview_cache

--- a/app/javascript/controllers/chat_popup_controller.js
+++ b/app/javascript/controllers/chat_popup_controller.js
@@ -1,0 +1,174 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["button", "content", "panel"]
+  static values = {
+    accountId: Number,
+    context: Object,
+    createUrl: String,
+    panelUrlTemplate: String
+  }
+
+  connect() {
+    this.state = this.readState()
+    this.loading = false
+    this.renderState()
+
+    if (this.state.open) {
+      this.loadPanel()
+    }
+  }
+
+  toggle() {
+    this.state.open = !this.state.open
+    this.writeState()
+    this.renderState()
+
+    if (this.state.open) {
+      this.loadPanel()
+    }
+  }
+
+  close() {
+    this.state.open = false
+    this.writeState()
+    this.renderState()
+  }
+
+  async loadPanel() {
+    if (this.loading) return
+
+    this.loading = true
+    this.contentTarget.innerHTML = this.loadingMarkup()
+
+    try {
+      let sessionId = this.state.sessionId
+
+      if (sessionId) {
+        const updated = await this.updateSession(sessionId)
+        if (!updated) sessionId = null
+      }
+
+      if (!sessionId) {
+        sessionId = await this.createSession()
+        this.state.sessionId = sessionId
+        this.writeState()
+      }
+
+      const response = await window.fetch(this.panelUrl(sessionId), {
+        headers: { Accept: "text/html" },
+        credentials: "same-origin"
+      })
+
+      if (!response.ok) throw new Error(`Panel request failed with ${response.status}`)
+
+      this.contentTarget.innerHTML = await response.text()
+    } catch (error) {
+      this.contentTarget.innerHTML = this.errorMarkup()
+      window.console.error("chat popup failed", error)
+    } finally {
+      this.loading = false
+    }
+  }
+
+  async createSession() {
+    const response = await window.fetch(this.createUrlValue, {
+      method: "POST",
+      headers: this.jsonHeaders(),
+      credentials: "same-origin",
+      body: JSON.stringify({
+        mode: "api",
+        project_id: this.contextValue.project_id,
+        metadata: {
+          entry_point: "popup",
+          page_context: this.contextValue
+        }
+      })
+    })
+
+    if (!response.ok) throw new Error(`Create request failed with ${response.status}`)
+
+    const payload = await response.json()
+    return payload.id
+  }
+
+  async updateSession(sessionId) {
+    const response = await window.fetch(this.sessionUrl(sessionId), {
+      method: "PATCH",
+      headers: this.jsonHeaders(),
+      credentials: "same-origin",
+      body: JSON.stringify({
+        project_id: this.contextValue.project_id,
+        metadata: {
+          entry_point: "popup",
+          page_context: this.contextValue
+        }
+      })
+    })
+
+    return response.ok
+  }
+
+  jsonHeaders() {
+    const csrfToken = document.querySelector("meta[name='csrf-token']")?.content
+
+    return {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      "X-CSRF-Token": csrfToken
+    }
+  }
+
+  panelUrl(sessionId) {
+    return this.panelUrlTemplateValue.replace("__SESSION_ID__", String(sessionId))
+  }
+
+  sessionUrl(sessionId) {
+    return this.panelUrl(sessionId).replace("?display=popup", "")
+  }
+
+  storageKey() {
+    return `paid:chat-popup:${this.accountIdValue}`
+  }
+
+  readState() {
+    try {
+      const rawState = window.localStorage.getItem(this.storageKey())
+      if (!rawState) return { open: false, sessionId: null }
+
+      const parsed = JSON.parse(rawState)
+      return {
+        open: parsed.open === true,
+        sessionId: parsed.sessionId || null
+      }
+    } catch {
+      return { open: false, sessionId: null }
+    }
+  }
+
+  writeState() {
+    window.localStorage.setItem(this.storageKey(), JSON.stringify(this.state))
+  }
+
+  renderState() {
+    const open = this.state.open
+    this.panelTarget.classList.toggle("hidden", !open)
+    this.buttonTarget.setAttribute("aria-expanded", open ? "true" : "false")
+  }
+
+  loadingMarkup() {
+    return `
+      <div class="flex h-full items-center justify-center rounded-[1.75rem] bg-white p-6 text-sm text-slate-500 shadow-[0_32px_80px_-32px_rgba(15,23,42,0.45)] ring-1 ring-slate-200">
+        Loading chat…
+      </div>
+    `
+  }
+
+  errorMarkup() {
+    return `
+      <div class="flex h-full items-center justify-center rounded-[1.75rem] bg-white p-6 text-center text-sm text-slate-500 shadow-[0_32px_80px_-32px_rgba(15,23,42,0.45)] ring-1 ring-slate-200">
+        Unable to load chat right now.
+      </div>
+    `
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -22,6 +22,9 @@ application.register("chat-input", ChatInputController)
 import ChatMessageController from "./chat_message_controller"
 application.register("chat-message", ChatMessageController)
 
+import ChatPopupController from "./chat_popup_controller"
+application.register("chat-popup", ChatPopupController)
+
 import ChatSessionListController from "./chat_session_list_controller"
 application.register("chat-session-list", ChatSessionListController)
 

--- a/app/models/chat_session.rb
+++ b/app/models/chat_session.rb
@@ -101,6 +101,13 @@ class ChatSession < ApplicationRecord
     token_usages.sum(:cost_cents)
   end
 
+  def page_context
+    return {} unless metadata.is_a?(Hash)
+
+    context = metadata["page_context"]
+    context.is_a?(Hash) ? context : {}
+  end
+
   private
 
   def set_external_id

--- a/app/services/chat_sessions/build_system_prompt.rb
+++ b/app/services/chat_sessions/build_system_prompt.rb
@@ -45,6 +45,7 @@ module ChatSessions
     def build_sections
       sections = []
       sections << { priority: 0, content: base_identity }
+      sections << { priority: 1, content: page_context } if page_context.present?
       sections << { priority: 1, content: project_context } if primary_project
       sections << { priority: 2, content: tool_definitions } if mcp_tools.any?
       sections << { priority: 3, content: cross_project_context } if reference_projects.any?
@@ -105,6 +106,23 @@ module ChatSessions
       parts << recent_runs_section(project)
       parts << style_guide_section(project)
       parts.compact.join("\n\n")
+    end
+
+    def page_context
+      context = chat_session.page_context
+      return if context.blank?
+
+      lines = []
+      lines << "- URL: #{context["url"]}" if context["url"].present?
+      lines << "- Path: #{context["path"]}" if context["path"].present?
+      lines << "- Page title: #{context["page_title"]}" if context["page_title"].present?
+      lines << "- Controller: #{context["controller"]}" if context["controller"].present?
+      lines << "- Action: #{context["action"]}" if context["action"].present?
+      lines << "- Project: #{context["project_name"]}" if context["project_name"].present?
+
+      return if lines.empty?
+
+      "## Current Page Context\n#{lines.join("\n")}"
     end
 
     def cross_project_context

--- a/app/services/chat_sessions/create.rb
+++ b/app/services/chat_sessions/create.rb
@@ -15,10 +15,10 @@ module ChatSessions
   #   )
   class Create
     attr_reader :account, :user, :mode, :runner_id, :model,
-      :project_id, :system_prompt, :title
+      :project_id, :system_prompt, :title, :metadata
 
     def initialize(account:, user:, mode: nil, runner_id: nil, provider_id: nil, model: nil,
-      project_id: nil, system_prompt: nil, title: nil)
+      project_id: nil, system_prompt: nil, title: nil, metadata: nil)
       @account = account
       @user = user
       @mode = mode.presence || "api"
@@ -27,6 +27,7 @@ module ChatSessions
       @project_id = project_id
       @system_prompt = system_prompt
       @title = title
+      @metadata = metadata
     end
 
     def self.call(...)
@@ -66,7 +67,7 @@ module ChatSessions
         title: title,
         status: "active",
         idle_timeout_at: ChatSession::IDLE_TIMEOUT_DURATION.from_now,
-        metadata: {}
+        metadata: metadata.presence || {}
       )
     end
 

--- a/app/views/chat_sessions/_conversation.html.erb
+++ b/app/views/chat_sessions/_conversation.html.erb
@@ -1,0 +1,66 @@
+<% can_create_chat_message = policy(ChatMessage.new(chat_session: chat_session)).create? %>
+<% popup = local_assigns.fetch(:popup, false) %>
+
+<div class="flex h-full flex-col overflow-hidden rounded-lg border border-gray-200 bg-gray-50">
+  <div class="flex-1 overflow-y-auto px-4 py-5 sm:px-6 <%= popup ? 'min-h-[20rem]' : '' %>"
+       data-chat-target="container"
+       data-action="scroll->chat#handleScroll"
+       data-controller="chat-stream">
+    <div class="space-y-5"
+         data-chat-target="messages"
+         data-chat-stream-target="messageContainer">
+      <% if has_older_messages %>
+        <%= turbo_frame_tag "older_messages",
+              src: older_messages_chat_session_path(chat_session, before: chat_messages.first.id),
+              loading: :lazy do %>
+          <p class="py-2 text-center text-xs text-gray-400">Loading older messages...</p>
+        <% end %>
+      <% end %>
+      <% chat_messages.each do |message| %>
+        <%= render "chat_messages/message", message: message %>
+      <% end %>
+    </div>
+
+    <div class="hidden px-2 pt-3"
+         data-chat-target="typingIndicator"
+         data-chat-stream-target="typingIndicator">
+      <div class="inline-flex items-center gap-2 rounded-md bg-white px-4 py-2 text-sm text-gray-500 shadow-sm ring-1 ring-gray-200">
+        <span class="h-2 w-2 animate-pulse rounded-full bg-indigo-400"></span>
+        Assistant is typing...
+      </div>
+    </div>
+  </div>
+
+  <div class="border-t border-gray-200 bg-white px-4 py-4 sm:px-6">
+    <% if can_create_chat_message %>
+      <form data-controller="chat-input"
+            data-action="submit->chat-input#send chat-input:send->chat#sendMessage chat:busy->chat-input#disable chat:idle->chat-input#enable"
+            class="space-y-3">
+        <label class="block">
+          <span class="sr-only">Message</span>
+          <textarea name="content"
+                    rows="1"
+                    maxlength="12000"
+                    placeholder="Ask about this project, request code changes, or continue the thread..."
+                    class="max-h-72 min-h-[3.25rem] w-full resize-none rounded-md border-gray-300 px-4 py-3 text-sm leading-6 text-gray-900 placeholder:text-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-indigo-500"
+                    data-chat-input-target="textarea"
+                    data-chat-target="input"
+                    data-action="input->chat-input#resize keydown->chat-input#handleKeydown"></textarea>
+        </label>
+        <div class="flex items-center justify-between gap-3">
+          <p class="text-xs text-gray-500" data-chat-target="status">Ready</p>
+          <div class="flex items-center gap-3">
+            <span class="text-xs font-medium text-gray-400" data-chat-input-target="charCount">0 / 12000</span>
+            <button type="submit"
+                    class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 disabled:cursor-not-allowed disabled:bg-gray-300"
+                    data-chat-input-target="sendButton">
+              Send
+            </button>
+          </div>
+        </div>
+      </form>
+    <% else %>
+      <p class="text-sm text-gray-500">You have read-only access to this chat.</p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/chat_sessions/_popup.html.erb
+++ b/app/views/chat_sessions/_popup.html.erb
@@ -1,0 +1,56 @@
+<% page_context = chat_session.page_context %>
+
+<section class="flex h-full flex-col overflow-hidden rounded-[1.75rem] bg-white shadow-[0_32px_80px_-32px_rgba(15,23,42,0.45)] ring-1 ring-slate-200">
+  <div class="border-b border-slate-200 bg-[radial-gradient(circle_at_top,_rgba(99,102,241,0.14),_transparent_55%),linear-gradient(180deg,_#ffffff_0%,_#f8fafc_100%)] px-5 py-4">
+    <div class="flex items-start justify-between gap-4">
+      <div class="min-w-0">
+        <p class="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500">Support chat</p>
+        <h2 class="mt-1 truncate text-base font-semibold text-slate-900"><%= chat_session_title(chat_session) %></h2>
+        <div class="mt-2 flex flex-wrap items-center gap-2 text-xs text-slate-500">
+          <% if page_context["project_name"].present? %>
+            <span class="inline-flex items-center rounded-full bg-slate-900 px-2.5 py-1 font-medium text-white"><%= page_context["project_name"] %></span>
+          <% end %>
+          <% if page_context["page_title"].present? %>
+            <span class="inline-flex items-center rounded-full bg-white px-2.5 py-1 font-medium text-slate-600 ring-1 ring-slate-200"><%= page_context["page_title"] %></span>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="flex items-center gap-2">
+        <%= link_to "Open page",
+                    chat_session_path(chat_session),
+                    class: "inline-flex items-center rounded-full bg-white px-3 py-1.5 text-xs font-semibold text-slate-600 ring-1 ring-slate-200 hover:bg-slate-50" %>
+        <button type="button"
+                class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-slate-900 text-white hover:bg-slate-700"
+                data-action="chat-popup#close"
+                aria-label="Close chat">
+          <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+    </div>
+
+    <div class="mt-3 flex items-center justify-between text-xs text-slate-500">
+      <div class="flex flex-wrap items-center gap-2">
+        <%= chat_session_status_badge(chat_session) %>
+        <%= chat_mode_badge(chat_session.mode) %>
+        <%= chat_container_status_badge(chat_session) %>
+      </div>
+      <p class="font-medium text-slate-600">
+        <span data-chat-target="tokenUsage"><%= number_with_delimiter(chat_session.total_tokens) %></span>
+        tokens
+      </p>
+    </div>
+  </div>
+
+  <div class="flex-1 overflow-hidden"
+       data-controller="chat"
+       data-chat-session-id-value="<%= chat_session.id %>">
+    <%= render "conversation",
+               chat_session:,
+               chat_messages:,
+               has_older_messages:,
+               popup: true %>
+  </div>
+</section>

--- a/app/views/chat_sessions/show.html.erb
+++ b/app/views/chat_sessions/show.html.erb
@@ -1,7 +1,6 @@
 <% content_for(:title) { "#{chat_session_title(@chat_session)} - Chat - Paid" } %>
 <% can_update_chat_session = policy(@chat_session).update? %>
 <% can_destroy_chat_session = policy(@chat_session).destroy? %>
-<% can_create_chat_message = policy(ChatMessage.new(chat_session: @chat_session)).create? %>
 
 <%= turbo_stream_from current_account, :chat_sessions %>
 
@@ -122,70 +121,10 @@
         </header>
 
         <div class="flex-1 overflow-hidden px-4 pb-4 pt-5 sm:px-6">
-          <div class="flex h-full flex-col overflow-hidden rounded-lg border border-gray-200 bg-gray-50">
-            <div class="flex-1 overflow-y-auto px-4 py-5 sm:px-6"
-                 data-chat-target="container"
-                 data-action="scroll->chat#handleScroll"
-                 data-controller="chat-stream">
-              <div class="space-y-5"
-                   data-chat-target="messages"
-                   data-chat-stream-target="messageContainer">
-                <% if @has_older_messages %>
-                  <%= turbo_frame_tag "older_messages",
-                        src: older_messages_chat_session_path(@chat_session, before: @chat_messages.first.id),
-                        loading: :lazy do %>
-                    <p class="py-2 text-center text-xs text-gray-400">Loading older messages...</p>
-                  <% end %>
-                <% end %>
-                <% @chat_messages.each do |message| %>
-                  <%= render "chat_messages/message", message: message %>
-                <% end %>
-              </div>
-
-              <div class="hidden px-2 pt-3"
-                   data-chat-target="typingIndicator"
-                   data-chat-stream-target="typingIndicator">
-                <div class="inline-flex items-center gap-2 rounded-md bg-white px-4 py-2 text-sm text-gray-500 shadow-sm ring-1 ring-gray-200">
-                  <span class="h-2 w-2 animate-pulse rounded-full bg-indigo-400"></span>
-                  Assistant is typing...
-                </div>
-              </div>
-            </div>
-
-            <div class="border-t border-gray-200 bg-white px-4 py-4 sm:px-6">
-              <% if can_create_chat_message %>
-                <form data-controller="chat-input"
-                      data-action="submit->chat-input#send chat-input:send->chat#sendMessage chat:busy->chat-input#disable chat:idle->chat-input#enable"
-                      class="space-y-3">
-                  <label class="block">
-                    <span class="sr-only">Message</span>
-                    <textarea name="content"
-                              rows="1"
-                              maxlength="12000"
-                              placeholder="Ask about this project, request code changes, or continue the thread..."
-                              class="max-h-72 min-h-[3.25rem] w-full resize-none rounded-md border-gray-300 px-4 py-3 text-sm leading-6 text-gray-900 placeholder:text-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-indigo-500"
-                              data-chat-input-target="textarea"
-                              data-chat-target="input"
-                              data-action="input->chat-input#resize keydown->chat-input#handleKeydown"></textarea>
-                  </label>
-                  <div class="flex items-center justify-between gap-3">
-                    <p class="text-xs text-gray-500" data-chat-target="status">Ready</p>
-                    <div class="flex items-center gap-3">
-                      <span class="text-xs font-medium text-gray-400" data-chat-input-target="charCount">0 / 12000</span>
-                      <button type="submit"
-                              class="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 disabled:cursor-not-allowed disabled:bg-gray-300"
-                              data-chat-input-target="sendButton">
-                        Send
-                      </button>
-                    </div>
-                  </div>
-                </form>
-
-              <% else %>
-                <p class="text-sm text-gray-500">You have read-only access to this chat.</p>
-              <% end %>
-            </div>
-          </div>
+          <%= render "conversation",
+                     chat_session: @chat_session,
+                     chat_messages: @chat_messages,
+                     has_older_messages: @has_older_messages %>
         </div>
       </div>
     </section>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -190,5 +190,38 @@
     <main>
       <%= yield %>
     </main>
+
+    <% if chat_popup_available? %>
+      <div class="pointer-events-none fixed inset-x-4 bottom-4 z-40 sm:inset-x-auto sm:right-6 sm:w-[26rem]"
+           data-controller="chat-popup"
+           data-chat-popup-account-id-value="<%= current_account.id %>"
+           data-chat-popup-create-url-value="<%= chat_sessions_path %>"
+           data-chat-popup-panel-url-template-value="<%= chat_session_path("__SESSION_ID__") %>?display=popup"
+           data-chat-popup-context-value="<%= current_chat_popup_context.to_json %>">
+        <div class="pointer-events-auto">
+          <div data-chat-popup-target="panel" class="hidden h-[min(42rem,calc(100vh-7rem))]">
+            <div data-chat-popup-target="content" class="h-full"></div>
+          </div>
+
+          <div class="mt-3 flex justify-end">
+            <button type="button"
+                    class="group inline-flex items-center gap-3 rounded-full bg-slate-900 px-4 py-3 text-sm font-semibold text-white shadow-lg shadow-slate-900/20 transition hover:bg-slate-700"
+                    data-chat-popup-target="button"
+                    data-action="chat-popup#toggle"
+                    aria-expanded="false">
+              <span class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-white/10">
+                <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.8" stroke="currentColor" aria-hidden="true">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.76c0 1.6 1.123 2.95 2.629 3.297.38.087.618.468.618.858v2.165a.75.75 0 0 0 1.28.53l2.27-2.27a1.125 1.125 0 0 1 .796-.33h2.406c1.601 0 2.95-1.123 3.297-2.629m0 0a4.875 4.875 0 0 0 0-4.762m0 4.762a4.875 4.875 0 0 1-4.762 0m4.762-4.762a4.875 4.875 0 0 0-4.762 0m-7.68 6.45A4.875 4.875 0 1 1 15.75 7.5" />
+                </svg>
+              </span>
+              <span class="text-left">
+                <span class="block text-[0.7rem] font-medium uppercase tracking-[0.18em] text-slate-300">Need help?</span>
+                <span class="block">Open chat</span>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+    <% end %>
   </body>
 </html>

--- a/spec/models/chat_session_spec.rb
+++ b/spec/models/chat_session_spec.rb
@@ -132,4 +132,25 @@ RSpec.describe ChatSession do
       end
     end
   end
+
+  describe "#page_context" do
+    it "returns the stored page context hash" do
+      session = build(:chat_session,
+        metadata: {
+          "page_context" => {
+            "url" => "https://paid.example.test/projects/99",
+            "project_name" => "Acme API"
+          }
+        })
+
+      expect(session.page_context).to eq(
+        "url" => "https://paid.example.test/projects/99",
+        "project_name" => "Acme API"
+      )
+    end
+
+    it "returns an empty hash when no page context is present" do
+      expect(build(:chat_session, metadata: nil).page_context).to eq({})
+    end
+  end
 end

--- a/spec/requests/chat_sessions_spec.rb
+++ b/spec/requests/chat_sessions_spec.rb
@@ -130,6 +130,27 @@ RSpec.describe "ChatSessions" do
         expect(response.parsed_body["mode"]).to eq("api")
       end
 
+      it "creates a session with popup metadata context" do
+        post chat_sessions_path(format: :json), params: {
+          mode: "api",
+          project_id: create(:project, account: account).id,
+          metadata: {
+            entry_point: "popup",
+            page_context: {
+              url: "https://paid.example.test/projects/3",
+              page_title: "Acme API - Projects - Paid",
+              project_name: "Acme API"
+            }
+          }
+        }
+
+        expect(response).to have_http_status(:created)
+        expect(ChatSession.order(:id).last.metadata).to include(
+          "entry_point" => "popup",
+          "page_context" => include("project_name" => "Acme API")
+        )
+      end
+
       it "accepts provider_id as a legacy alias for runner_id" do
         runner = create(:runner, user: user)
 
@@ -225,6 +246,24 @@ RSpec.describe "ChatSessions" do
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("Assistant is typing")
         expect(response.body).to include("Rendered markdown")
+      end
+
+      it "renders the popup variant for embedded requests" do
+        chat_session.update!(
+          metadata: {
+            "page_context" => {
+              "page_title" => "Projects - Paid",
+              "project_name" => "Acme API"
+            }
+          }
+        )
+
+        get chat_session_path(chat_session), params: { display: "popup" }, headers: { "Accept" => "text/html" }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Support chat")
+        expect(response.body).to include("Open page")
+        expect(response.body).to include("Projects - Paid")
       end
 
       it "renders mobile archive controls without expanding the sidebar by default" do
@@ -365,6 +404,27 @@ RSpec.describe "ChatSessions" do
         expect(response).to redirect_to(chat_session_path(chat_session))
         expect(chat_session.reload.title).to eq("Updated From Form")
         expect(chat_session.model).to eq("gpt-4.1")
+      end
+
+      it "updates popup metadata context" do
+        patch chat_session_path(chat_session, format: :json), params: {
+          metadata: {
+            entry_point: "popup",
+            page_context: {
+              url: "https://paid.example.test/projects/9/quality",
+              page_title: "Quality Metrics - Acme API - Paid",
+              project_name: "Acme API"
+            }
+          }
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(chat_session.reload.metadata).to include(
+          "page_context" => include(
+            "url" => "https://paid.example.test/projects/9/quality",
+            "project_name" => "Acme API"
+          )
+        )
       end
     end
   end

--- a/spec/services/chat_sessions/build_system_prompt_spec.rb
+++ b/spec/services/chat_sessions/build_system_prompt_spec.rb
@@ -223,6 +223,32 @@ RSpec.describe ChatSessions::BuildSystemPrompt do
       end
     end
 
+    describe "page context" do
+      let(:chat_session) do
+        create(:chat_session,
+          account: account,
+          created_by: user,
+          metadata: {
+            "page_context" => {
+              "url" => "https://paid.example.test/projects/7/agent_runs",
+              "path" => "/projects/7/agent_runs",
+              "page_title" => "Agent Runs - Acme API - Paid",
+              "controller" => "projects/agent_runs",
+              "action" => "index",
+              "project_name" => "Acme API"
+            }
+          })
+      end
+
+      it "includes current page metadata from the session" do
+        expect(prompt).to include("Current Page Context")
+        expect(prompt).to include("URL: https://paid.example.test/projects/7/agent_runs")
+        expect(prompt).to include("Page title: Agent Runs - Acme API - Paid")
+        expect(prompt).to include("Controller: projects/agent_runs")
+        expect(prompt).to include("Project: Acme API")
+      end
+    end
+
     describe "cross-project context" do
       let(:ref_project) { create(:project, account: account, name: "shared-lib", owner: "acme", repo: "shared-lib") }
 

--- a/spec/services/chat_sessions/create_spec.rb
+++ b/spec/services/chat_sessions/create_spec.rb
@@ -130,5 +130,28 @@ RSpec.describe ChatSessions::Create do
 
       expect(session.title).to eq("Debug session")
     end
+
+    it "persists popup page context metadata when provided" do
+      session = described_class.call(
+        account: account,
+        user: user,
+        metadata: {
+          "entry_point" => "popup",
+          "page_context" => {
+            "url" => "https://paid.example.test/projects/42",
+            "page_title" => "Acme API - Projects - Paid",
+            "project_name" => "Acme API"
+          }
+        }
+      )
+
+      expect(session.metadata).to include(
+        "entry_point" => "popup",
+        "page_context" => include(
+          "url" => "https://paid.example.test/projects/42",
+          "project_name" => "Acme API"
+        )
+      )
+    end
   end
 end


### PR DESCRIPTION
## Summary

Implemented the contextual chat popup and committed it as `167c6c7` with message `feat(chat): add contextual popup chat widget`.

The change adds a lazy-loaded floating chat launcher to signed-in Paid pages outside the standalone chat screens, stores popup open/closed state in `localStorage`, reuses a shared chat conversation partial for popup and full-page modes, and passes page context through `chat_sessions.metadata` so the system prompt can include current URL, title, controller/action, and project details when available.

Validation passed:
- `bundle exec rubocop`
- `bundle exec rspec`
- commit hook lint + full test suite

I did need to run the checks and commit with explicit `DB_HOST`/`PAID_*_DATABASE` env overrides because the provided `DATABASE_URL` conflicts with this repo’s multi-database test setup. The worktree is clean and nothing was pushed.

---

Closes #2348