### PR TITLE
chore(dev): add dial profiler for per-request profiling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -141,6 +141,9 @@ group :development do
   # Request-level performance metrics dashboard [https://github.com/igorkasyanchuk/rails_performance]
   gem "rails_performance"
 
+  # Per-request profiler overlay backed by vernier + prosopite [https://github.com/codergeek121/dial]
+  gem "dial", "~> 0.6"
+
   # Developer tools for HTML+ERB templates [https://herb-tools.dev]
   gem "herb", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,13 @@ GEM
       railties (>= 7.0)
       responders
       warden (~> 1.2.3)
+    dial (0.6.0)
+      actionpack (>= 7.1)
+      activerecord (>= 7.1)
+      pg_query
+      prosopite
+      railties (>= 7.1)
+      vernier
     diff-lcs (1.6.2)
     discard (2.0.0)
       activerecord (>= 7.0, < 9.0)
@@ -620,6 +627,7 @@ GEM
       prism (>= 1.5.1)
     uri (1.1.1)
     useragent (0.16.11)
+    vernier (1.10.1)
     view_component (4.11.0)
       actionview (>= 7.1.0)
       activesupport (>= 7.1.0)
@@ -670,6 +678,7 @@ DEPENDENCIES
   cuprite
   debug
   devise
+  dial (~> 0.6)
   discard
   docker-api
   factory_bot_rails
@@ -771,6 +780,7 @@ CHECKSUMS
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
   devise (5.0.4) sha256=d605f2b85854e74e56ee789e2d398702bc2d06e6bcd894717a670a3199c74cc1
+  dial (0.6.0) sha256=ff48a651577046ed736be6421079aaa404d80435248c753f2b9995fe06849ff5
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   discard (2.0.0) sha256=0fc520786b4d7b9b1ea8b2b3dadbb13c3e41d2ce7d297d04869baf1c9e30d2c0
   docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
@@ -957,6 +967,7 @@ CHECKSUMS
   unparser (0.9.0) sha256=4331f174a73a23b69250b13d47da3794ed1449711ee0f9ed8947dc020ba76067
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
+  vernier (1.10.1) sha256=f2ab2e163b75ac3ef4e3173262d27d27da6219cf04b1b4a7171e4798114275ce
   view_component (4.11.0) sha256=92df960575b8fa5e984522532df225ec333015a07a8105b3b1c200c655065517
   warden (1.2.9) sha256=46684f885d35a69dbb883deabf85a222c8e427a957804719e143005df7a1efd0
   web-console (4.3.0) sha256=e13b71301cdfc2093f155b5aa3a622db80b4672d1f2f713119cc7ec7ac6a6da4

--- a/config/initializers/dial.rb
+++ b/config/initializers/dial.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+return unless defined?(Dial)
+
+Dial.configure do |config|
+  # Opt-in profiling. Dial's middleware appends a panel of HTML/CSS/JS to every
+  # response with Accept: text/html, which mangles Turbo Frame and Stimulus
+  # `innerHTML = await response.text()` flows (e.g. the chat popup, dashboard
+  # widget partials). Setting enabled=false routes profiling exclusively through
+  # `?profile=1`, so partial XHRs stay clean unless you explicitly target them.
+  config.enabled = false
+  config.force_param = "profile"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@
 
 Rails.application.routes.draw do
   mount RailsPerformance::Engine, at: "rails/performance" if defined?(RailsPerformance)
+  mount Dial::Engine, at: "/dial" if defined?(Dial::Engine)
 
   devise_for :users, controllers: { registrations: "users/registrations" }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@
 
 Rails.application.routes.draw do
   mount RailsPerformance::Engine, at: "rails/performance" if defined?(RailsPerformance)
-  mount Dial::Engine, at: "/dial" if defined?(Dial::Engine)
+  mount Dial::Engine, at: "dial" if defined?(Dial::Engine)
 
   devise_for :users, controllers: { registrations: "users/registrations" }
 


### PR DESCRIPTION
## Summary

- Adds the [dial](https://github.com/joshuay03/dial) gem (vernier + prosopite under the hood) to the `:development` group so we can profile dashboard slowness in-browser.
- Mounts `Dial::Engine` at `/dial` (guarded by `defined?(Dial::Engine)`, mirroring the existing `RailsPerformance::Engine` mount).
- Disables auto-profiling by default and opts in via `?profile=1` to avoid a real functional regression: dial's middleware appends a panel of HTML/CSS/JS to every response with `Accept: text/html`, which would land inside containers that do `innerHTML = await response.text()` — notably the chat popup from #2397 and the dashboard widget partials (`metrics`, `performance`, `decision_metrics`, `knowledge_stats`, `runner_health`, `queue_health`).

## How to use

Add `?profile=1` to any URL you want to profile (e.g. `/dashboard?profile=1`). The dial panel appears bottom-right with N+1s, server timing, GC/RubyVM stats, and a link to the vernier viewer.

## Notes

- The existing `Prosopite::Middleware::Rack` ([config/initializers/prosopite.rb](config/initializers/prosopite.rb)) is left alone. Nested `Prosopite.scan` is safe — the inner scan no-ops via prosopite's own guard — and the existing middleware still feeds N+1s to `rails_logger` on non-profiled requests.
- `rails_performance` remains mounted at `/rails/performance`. Three dev-only instrumentation layers (rails_performance, prosopite middleware, dial) is more than ideal, but all idle until exercised.
- Visual nit when profiling: dial's panel and the chat popup button are both `position: fixed; bottom-right` and will overlap. Dismiss one while you work.

## Test plan

- [ ] `bin/dev`, navigate to `/dashboard`, open chat popup — popup renders cleanly with no dial panel injected into its container.
- [ ] Navigate to `/dashboard?profile=1` — dial panel appears bottom-right with N+1s and timing for the dashboard render.
- [ ] Click "View profile" link in panel — vernier viewer loads the flame graph from `/dial/profile?key=...`.
- [ ] `RAILS_ENV=production bin/rails routes` does not list `dial_*` routes (gem is dev-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)