### PR TITLE
fix(chat): audit dangerous_mode: true fallback in BuildLlmClient when no runner is configured

### DIFF
--- a/app/controllers/chat_messages_controller.rb
+++ b/app/controllers/chat_messages_controller.rb
@@ -83,6 +83,8 @@ class ChatMessagesController < ApplicationController
     # Client disconnected — nothing to send
   rescue NotImplementedError => e
     write_sse_event("error", { message: e.message }) rescue IOError
+  rescue ChatSessions::LlmClientConfigurationError => e
+    write_sse_event("error", { message: e.message }) rescue IOError
   rescue ArgumentError => e
     write_sse_event("error", { message: e.message }) rescue IOError
   rescue StandardError => e
@@ -105,6 +107,8 @@ class ChatMessagesController < ApplicationController
 
     render json: message_json(assistant_message), status: :created
   rescue NotImplementedError => e
+    render json: { error: e.message }, status: :service_unavailable
+  rescue ChatSessions::LlmClientConfigurationError => e
     render json: { error: e.message }, status: :service_unavailable
   rescue ArgumentError => e
     render json: { error: e.message }, status: :unprocessable_content

--- a/app/jobs/chat_sessions/process_message_job.rb
+++ b/app/jobs/chat_sessions/process_message_job.rb
@@ -44,6 +44,8 @@ class ChatSessions::ProcessMessageJob < ApplicationJob
     broadcast_error(chat_session_id, stream_message_id, e.message)
   rescue NotImplementedError => e
     broadcast_error(chat_session_id, stream_message_id, e.message)
+  rescue ChatSessions::LlmClientConfigurationError => e
+    broadcast_error(chat_session_id, stream_message_id, e.message)
   rescue ChatSessions::TokenLimitExceededError => e
     broadcast_error(chat_session_id, stream_message_id, e.message)
   rescue ActiveRecord::RecordNotFound

--- a/app/services/chat_sessions/build_llm_client.rb
+++ b/app/services/chat_sessions/build_llm_client.rb
@@ -16,16 +16,16 @@ module ChatSessions
       provider = chat_session.runner
       raise LlmClientConfigurationError, missing_runner_message unless provider
 
-      api_key_record = provider.provider_api_key
-      unless api_key_record&.api_key.present?
+      api_key = provider.effective_api_secret
+      unless api_key.present?
         raise LlmClientConfigurationError, missing_api_key_message(provider)
       end
 
-      case api_key_record.api_service_type
+      case provider_service_type(provider)
       when ANTHROPIC_SERVICE_TYPE
-        anthropic_client(api_key_record)
+        anthropic_client(api_key)
       else
-        openai_compatible_client(api_key_record)
+        openai_compatible_client(provider, api_key)
       end
     end
 
@@ -33,21 +33,21 @@ module ChatSessions
 
     attr_reader :chat_session
 
-    def anthropic_client(api_key_record)
-      transport = AgentHarness::TextTransport.new(api_key: api_key_record.api_key)
+    def anthropic_client(api_key)
+      transport = AgentHarness::TextTransport.new(api_key: api_key)
       model = chat_session.model || AgentHarness::TextTransport::DEFAULT_MODEL
       HttpClient.new(transport: transport, model: model, provider_type: :anthropic)
     end
 
-    def openai_compatible_client(api_key_record)
-      service_type = api_key_record.api_service_type
+    def openai_compatible_client(provider, api_key)
+      service_type = provider_service_type(provider)
       config = Runner::DIRECT_OUTBOUND_API_PROVIDERS.values.find { |c| c[:service_type] == service_type }
       base_url = config&.dig(:base_url) || "https://api.openai.com/v1"
       model = chat_session.model || "gpt-4o"
 
       transport = AgentHarness::OpenAICompatibleTransport.new(
         base_url: base_url,
-        api_key: api_key_record.api_key,
+        api_key: api_key,
         model: model
       )
 
@@ -61,6 +61,10 @@ module ChatSessions
     def missing_api_key_message(provider)
       label = provider.name.presence || provider.display_name
       "Chat runner #{label} is missing an API key. Choose a chat-enabled runner with a configured API key."
+    end
+
+    def provider_service_type(provider)
+      provider.provider_api_key&.api_service_type || provider.required_api_service_type
     end
 
     class HttpClient

--- a/app/services/chat_sessions/build_llm_client.rb
+++ b/app/services/chat_sessions/build_llm_client.rb
@@ -14,10 +14,12 @@ module ChatSessions
 
     def call
       provider = chat_session.runner
-      return fallback_client unless provider
+      raise LlmClientConfigurationError, missing_runner_message unless provider
 
       api_key_record = provider.provider_api_key
-      return fallback_client unless api_key_record && api_key_record.api_key.present?
+      unless api_key_record&.api_key.present?
+        raise LlmClientConfigurationError, missing_api_key_message(provider)
+      end
 
       case api_key_record.api_service_type
       when ANTHROPIC_SERVICE_TYPE
@@ -52,8 +54,13 @@ module ChatSessions
       HttpClient.new(transport: transport, model: model, provider_type: :openai_compatible)
     end
 
-    def fallback_client
-      FallbackClient.new(model: chat_session.model)
+    def missing_runner_message
+      "Chat requires a configured API-key runner. Add a chat-enabled runner with an API key and select it for this session."
+    end
+
+    def missing_api_key_message(provider)
+      label = provider.name.presence || provider.display_name
+      "Chat runner #{label} is missing an API key. Choose a chat-enabled runner with a configured API key."
     end
 
     class HttpClient
@@ -101,42 +108,6 @@ module ChatSessions
           entry[:tool_name] = msg[:tool_name].to_s if msg[:tool_name].present?
           entry
         end
-      end
-    end
-
-    class FallbackClient
-      attr_reader :model
-
-      def initialize(model: nil)
-        @model = model
-      end
-
-      def call(conversation, on_chunk: nil)
-        prompt = serialize_conversation(conversation)
-        response = AgentHarness.send_message(prompt, dangerous_mode: true)
-
-        if on_chunk && response.output.present?
-          response.output.scan(/\S+\s*|\s+/).each { |chunk| on_chunk.call(chunk) }
-        end
-
-        {
-          content: response.output,
-          model: response.model,
-          tokens_input: response.input_tokens,
-          tokens_output: response.output_tokens,
-          tool_calls: nil
-        }
-      end
-
-      private
-
-      def serialize_conversation(conversation)
-        conversation.filter_map do |msg|
-          next nil if msg[:content].nil?
-
-          role = msg[:role].to_s.capitalize
-          "#{role}: #{msg[:content]}"
-        end.join("\n\n")
       end
     end
   end

--- a/app/services/chat_sessions/llm_client_configuration_error.rb
+++ b/app/services/chat_sessions/llm_client_configuration_error.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module ChatSessions
+  class LlmClientConfigurationError < StandardError; end
+end

--- a/spec/requests/chat_messages_spec.rb
+++ b/spec/requests/chat_messages_spec.rb
@@ -64,6 +64,8 @@ RSpec.describe "ChatMessages" do
       end
 
       it "creates a message and returns assistant response" do
+        llm_client = instance_double(Proc)
+        allow(ChatSessions::BuildLlmClient).to receive(:call).with(chat_session: chat_session).and_return(llm_client)
         allow(ChatSessions::SendMessage).to receive(:call).and_return(
           create(:chat_message, :assistant, chat_session: chat_session,
             content: "Hello back!", tokens_input: 10, tokens_output: 5)
@@ -97,6 +99,22 @@ RSpec.describe "ChatMessages" do
           request_type: "chat_message"
         )
       end
+
+      it "returns a clear setup error when no chat runner is configured" do
+        allow(ChatSessions::BuildLlmClient).to receive(:call)
+          .with(chat_session: chat_session)
+          .and_raise(
+            ChatSessions::LlmClientConfigurationError,
+            "Chat requires a configured API-key runner. Add a chat-enabled runner with an API key and select it for this session."
+          )
+
+        post chat_session_chat_messages_path(chat_session), params: { content: "Hello" }
+
+        expect(response).to have_http_status(:service_unavailable)
+        expect(response.parsed_body).to eq(
+          "error" => "Chat requires a configured API-key runner. Add a chat-enabled runner with an API key and select it for this session."
+        )
+      end
     end
 
     context "when authenticated with SSE response" do
@@ -105,6 +123,8 @@ RSpec.describe "ChatMessages" do
       it "returns SSE stream" do
         assistant_msg = create(:chat_message, :assistant, chat_session: chat_session,
           tokens_input: 10, tokens_output: 5)
+        llm_client = instance_double(Proc)
+        allow(ChatSessions::BuildLlmClient).to receive(:call).with(chat_session: chat_session).and_return(llm_client)
         allow(ChatSessions::SendMessage).to receive(:call) do |**args|
           args[:on_chunk].call("Hello ")
           args[:on_chunk].call("back!")

--- a/spec/services/chat_sessions/build_llm_client_spec.rb
+++ b/spec/services/chat_sessions/build_llm_client_spec.rb
@@ -44,23 +44,29 @@ RSpec.describe ChatSessions::BuildLlmClient, type: :service do
     end
 
     context "with a subscription runner (no API key)" do
-      it "returns a FallbackClient" do
+      it "raises a setup error" do
         runner = user.runners.find_or_create_by!(runner_key: "cursor", auth_type: "subscription")
         chat_session = create(:chat_session, account: account, created_by: user, runner: runner)
 
-        client = described_class.call(chat_session: chat_session)
-
-        expect(client).to be_a(described_class::FallbackClient)
+        expect {
+          described_class.call(chat_session: chat_session)
+        }.to raise_error(
+          ChatSessions::LlmClientConfigurationError,
+          "Chat runner #{runner.display_name} is missing an API key. Choose a chat-enabled runner with a configured API key."
+        )
       end
     end
 
     context "without a runner" do
-      it "returns a FallbackClient" do
+      it "raises a setup error" do
         chat_session = create(:chat_session, account: account, created_by: user)
 
-        client = described_class.call(chat_session: chat_session)
-
-        expect(client).to be_a(described_class::FallbackClient)
+        expect {
+          described_class.call(chat_session: chat_session)
+        }.to raise_error(
+          ChatSessions::LlmClientConfigurationError,
+          "Chat requires a configured API-key runner. Add a chat-enabled runner with an API key and select it for this session."
+        )
       end
     end
   end
@@ -168,54 +174,6 @@ RSpec.describe ChatSessions::BuildLlmClient, type: :service do
       result = client.call(conversation)
 
       expect(result[:tool_calls]).to eq([ { id: "tc_1", name: "search", arguments: '{"q":"test"}' } ])
-    end
-  end
-
-  describe described_class::FallbackClient do
-    let(:client) { described_class.new(model: "test-model") }
-    let(:conversation) do
-      [
-        { role: "system", content: "You are helpful." },
-        { role: "user", content: "Hello" }
-      ]
-    end
-
-    it "serializes conversation and calls AgentHarness.send_message" do
-      response = instance_double(AgentHarness::Response,
-        output: "Hi!",
-        model: "test-model",
-        input_tokens: 5,
-        output_tokens: 2,
-        metadata: {}
-      )
-      allow(AgentHarness).to receive(:send_message).and_return(response)
-
-      result = client.call(conversation)
-
-      expect(AgentHarness).to have_received(:send_message).with(
-        "System: You are helpful.\n\nUser: Hello",
-        dangerous_mode: true
-      )
-      expect(result[:content]).to eq("Hi!")
-      expect(result[:tokens_input]).to eq(5)
-      expect(result[:tokens_output]).to eq(2)
-      expect(result[:tool_calls]).to be_nil
-    end
-
-    it "replays response as chunks when on_chunk is provided" do
-      chunks_received = []
-      response = instance_double(AgentHarness::Response,
-        output: "Hello world",
-        model: "test-model",
-        input_tokens: 5,
-        output_tokens: 2,
-        metadata: {}
-      )
-      allow(AgentHarness).to receive(:send_message).and_return(response)
-
-      client.call(conversation, on_chunk: ->(chunk) { chunks_received << chunk })
-
-      expect(chunks_received.join).to eq("Hello world")
     end
   end
 end

--- a/spec/services/chat_sessions/build_llm_client_spec.rb
+++ b/spec/services/chat_sessions/build_llm_client_spec.rb
@@ -43,6 +43,30 @@ RSpec.describe ChatSessions::BuildLlmClient, type: :service do
       end
     end
 
+    context "with an integration credential-backed API key runner" do
+      it "returns an HttpClient using the runner's effective secret" do
+        integration_credential = create(:integration_credential,
+          account: account,
+          created_by: user,
+          service_key: "claude",
+          secret: "sk-integration-test-key"
+        )
+        runner = create(:runner,
+          user: user,
+          runner_key: "claude",
+          auth_type: "api_key",
+          provider_api_key: nil,
+          integration_credential: integration_credential
+        )
+        chat_session = create(:chat_session, account: account, created_by: user, runner: runner, model: "claude-3-7-sonnet")
+
+        client = described_class.call(chat_session: chat_session)
+
+        expect(client).to be_a(described_class::HttpClient)
+        expect(client.model).to eq("claude-3-7-sonnet")
+      end
+    end
+
     context "with a subscription runner (no API key)" do
       it "raises a setup error" do
         runner = user.runners.find_or_create_by!(runner_key: "cursor", auth_type: "subscription")


### PR DESCRIPTION
## Summary

This change closes an unsafe fallback so chat sessions only run when they have an explicitly configured runner and real credentials, preventing unconfigured chats from silently executing through `agent_harness` in elevated-permission mode. The expected outcome is a fail-closed setup path with clear user-facing errors instead of an implicit, weaker security posture.

## Changes

- `Chat setup and service behavior`
  - Removed the no-runner fallback in `ChatSessions::BuildLlmClient` that called `AgentHarness.send_message(..., dangerous_mode: true)`.
  - Added `ChatSessions::LlmClientConfigurationError` to represent chat sessions that are not safely runnable.
  - Updated chat execution to require an explicit runner with a real API key before building an LLM client.

- `Error handling and user experience`
  - The controller and async chat job now surface a clear service-unavailable/setup error when a session has no runner configured.
  - Subscription or no-key runners are treated as invalid for chat in this path rather than silently falling through to a default harness provider.

- `Security audit and guardrails`
  - Audited `dangerous_mode` behavior in `agent-harness` 0.18.2 and confirmed it enables elevated CLI execution modes:
    - Claude: `--dangerously-skip-permissions`
    - Codex: `--full-auto`
    - GitHub Copilot: `--yolo` with `COPILOT_ALLOW_ALL=true`
  - Removed the fallback entirely because the previous path could route an unconfigured chat session through Paid’s default harness providers in elevated-permission mode.

- `Tests`
  - Added/updated coverage in `spec/services/chat_sessions/build_llm_client_spec.rb` for fail-closed client construction.
  - Added/updated request coverage in `spec/requests/chat_messages_spec.rb` for the surfaced setup error behavior.

## Design Decisions

- The fallback was removed instead of scoped because `dangerous_mode` is not a harmless default; it materially changes provider execution permissions.
- A narrower gate for dev/test was rejected because Paid currently has no dedicated logging or metrics for this fallback path, so there was no reliable way to prove safe operational usage or detect drift.
- The chosen posture is explicit configuration over implicit defaults: if chat is not properly configured, it should fail clearly rather than guess a provider or runner.

## Operational Concerns

- No database migration or deploy-time data backfill is required.
- Environments that previously relied on the implicit fallback must now configure a valid chat runner and API key or they will receive the new setup error.
- Verification passed with `bin/rails db:prepare`, `bundle exec rubocop`, and `bundle exec rspec` (`14151 examples, 0 failures, 7 pending`).

---

Closes #2353