### PR TITLE
feat: Add ISSUE_FILING_ALLOWLIST and gate IssueFiler (RDR-039 T4)

### DIFF
--- a/app/services/exception_handler/classifier.rb
+++ b/app/services/exception_handler/classifier.rb
@@ -33,6 +33,8 @@ module ExceptionHandler
       "general" => "p2"
     }.freeze
 
+    # Keep issue filing conservative while preserving escalation for today's
+    # intentionally loud subsystems.
     ISSUE_FILING_ALLOWLIST = %w[
       knowledge
       agent_runs

--- a/app/services/exception_handler/classifier.rb
+++ b/app/services/exception_handler/classifier.rb
@@ -33,6 +33,13 @@ module ExceptionHandler
       "general" => "p2"
     }.freeze
 
+    ISSUE_FILING_ALLOWLIST = %w[
+      knowledge
+      agent_runs
+      container_manager
+      secrets_proxy
+    ].freeze
+
     def self.call(exception:, subsystem:)
       new(exception: exception, subsystem: subsystem).call
     end

--- a/app/services/exception_handler/handle.rb
+++ b/app/services/exception_handler/handle.rb
@@ -138,6 +138,7 @@ module ExceptionHandler
 
       target_project = @project
       return unless target_project
+      return unless Classifier::ISSUE_FILING_ALLOWLIST.include?(@subsystem)
 
       if incident.github_issue_url.present? && incident.project_id != target_project.id
         Rails.logger.info(

--- a/app/services/exception_handler/handle.rb
+++ b/app/services/exception_handler/handle.rb
@@ -42,14 +42,16 @@ module ExceptionHandler
       fingerprint = Fingerprinter.call(exception: @exception, subsystem: @subsystem)
       classification = Classifier.call(exception: @exception, subsystem: @subsystem)
 
-      log_exception(classification)
-
-      return logged_result(classification) if classification.action == "logged"
+      if classification.action == "logged"
+        log_exception(classification, action: "logged")
+        return logged_result(classification)
+      end
 
       incident = find_or_create_incident(fingerprint, classification)
       file_or_update_issue(incident, classification) if @project
 
       notify_if_needed(incident, classification)
+      log_exception(classification, action: incident.action_taken)
 
       Result.new(success: true, incident: incident, action: incident.action_taken)
     rescue IssueFiler::RetryableFilingInProgress
@@ -72,7 +74,7 @@ module ExceptionHandler
       @account.projects.find_by(id: project_id)
     end
 
-    def log_exception(classification)
+    def log_exception(classification, action:)
       Rails.logger.public_send(
         classification.severity == "p1" ? :error : :warn,
         message: "exception_handler.captured",
@@ -80,7 +82,7 @@ module ExceptionHandler
         exception_message: @exception.message&.truncate(500),
         subsystem: @subsystem,
         severity: classification.severity,
-        action: classification.action,
+        action: action,
         reason: classification.reason,
         project_id: @project&.id
       )

--- a/app/services/exception_handler/handle.rb
+++ b/app/services/exception_handler/handle.rb
@@ -39,6 +39,9 @@ module ExceptionHandler
     end
 
     def call
+      classification = nil
+      incident = nil
+
       fingerprint = Fingerprinter.call(exception: @exception, subsystem: @subsystem)
       classification = Classifier.call(exception: @exception, subsystem: @subsystem)
 
@@ -51,7 +54,6 @@ module ExceptionHandler
       file_or_update_issue(incident, classification) if @project
 
       notify_if_needed(incident, classification)
-      log_exception(classification, action: incident.action_taken)
 
       Result.new(success: true, incident: incident, action: incident.action_taken)
     rescue IssueFiler::RetryableFilingInProgress
@@ -63,9 +65,18 @@ module ExceptionHandler
         handler_error: e.message
       )
       Result.new(success: false, message: "Exception handler failed: #{e.message}")
+    ensure
+      log_actionable_exception(classification, incident)
     end
 
     private
+
+    def log_actionable_exception(classification, incident)
+      return unless classification
+      return if classification.action == "logged"
+
+      log_exception(classification, action: incident&.action_taken || classification.action)
+    end
 
     def resolve_project
       project_id = @context[:project_id]

--- a/spec/services/exception_handler/classifier_spec.rb
+++ b/spec/services/exception_handler/classifier_spec.rb
@@ -4,6 +4,15 @@ require "rails_helper"
 
 RSpec.describe ExceptionHandler::Classifier do
   describe ".call" do
+    it "allowlists the seed subsystems for issue filing" do
+      expect(described_class::ISSUE_FILING_ALLOWLIST).to contain_exactly(
+        "knowledge",
+        "agent_runs",
+        "container_manager",
+        "secrets_proxy"
+      )
+    end
+
     it "classifies transient timeout errors as logged" do
       error = Net::OpenTimeout.new("execution expired")
 

--- a/spec/services/exception_handler/classifier_spec.rb
+++ b/spec/services/exception_handler/classifier_spec.rb
@@ -4,13 +4,13 @@ require "rails_helper"
 
 RSpec.describe ExceptionHandler::Classifier do
   describe ".call" do
-    it "allowlists the seed subsystems for issue filing" do
-      expect(described_class::ISSUE_FILING_ALLOWLIST).to contain_exactly(
-        "knowledge",
-        "agent_runs",
-        "container_manager",
-        "secrets_proxy"
-      )
+    it "allowlists knowledge plus every current P1 subsystem for issue filing" do
+      p1_subsystems = described_class::SUBSYSTEM_SEVERITY.filter_map do |subsystem, severity|
+        subsystem if severity == "p1"
+      end
+
+      expect(described_class::ISSUE_FILING_ALLOWLIST).to include("knowledge", *p1_subsystems)
+      expect(described_class::ISSUE_FILING_ALLOWLIST).not_to include("github_sync", "general")
     end
 
     it "classifies transient timeout errors as logged" do

--- a/spec/services/exception_handler/handle_spec.rb
+++ b/spec/services/exception_handler/handle_spec.rb
@@ -159,6 +159,22 @@ RSpec.describe ExceptionHandler::Handle do
           )
         )
       end
+
+      it "logs the effective notified action" do
+        allow(ExceptionHandler::IssueFiler).to receive(:call)
+        allow(Notifications::Publish).to receive(:call)
+        allow(Rails.logger).to receive(:warn)
+
+        call_handler(error: error, account: account, context: context)
+
+        expect(Rails.logger).to have_received(:warn).with(
+          a_hash_including(
+            message: "exception_handler.captured",
+            subsystem: "github_sync",
+            action: "notified"
+          )
+        )
+      end
     end
 
     context "with a duplicate exception" do

--- a/spec/services/exception_handler/handle_spec.rb
+++ b/spec/services/exception_handler/handle_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe ExceptionHandler::Handle do
   let(:account) { create(:account) }
   let(:project) { create(:project, account: account) }
+  let(:project_context) { { project_id: project.id } }
 
   describe ".call" do
     context "with a transient exception" do
@@ -92,6 +93,69 @@ RSpec.describe ExceptionHandler::Handle do
             account: account,
             source: "exception_handler",
             severity: :warning
+          )
+        )
+      end
+
+      ExceptionHandler::Classifier::ISSUE_FILING_ALLOWLIST.each do |subsystem|
+        it "files issues for the #{subsystem} subsystem" do
+          filed_incident = nil
+          filed_project = nil
+
+          allow(ExceptionHandler::IssueFiler).to receive(:call) do |incident:, project:|
+            filed_incident = incident
+            filed_project = project
+            incident.update!(action_taken: "issue_filed")
+          end
+
+          result = described_class.call(
+            exception: error,
+            account: account,
+            context: project_context.merge(subsystem:)
+          )
+
+          expect(ExceptionHandler::IssueFiler).to have_received(:call).once
+          expect(filed_project).to eq(project)
+          expect(filed_incident.subsystem).to eq(subsystem)
+          expect(result.incident.reload.action_taken).to eq("issue_filed")
+        end
+      end
+    end
+
+    context "with a non-allowlisted actionable exception" do
+      let(:error) do
+        e = RuntimeError.new("sync failed unexpectedly")
+        e.set_backtrace([ "/app/services/github_sync/sync_runner.rb:12:in `run'" ])
+        e
+      end
+      let(:context) { project_context.merge(subsystem: :github_sync) }
+
+      def call_handler(error:, account:, context:)
+        described_class.call(
+          exception: error,
+          account: account,
+          context: context
+        )
+      end
+
+      it "records the incident, skips issue filing, and still publishes a notification" do
+        allow(ExceptionHandler::IssueFiler).to receive(:call)
+        allow(Notifications::Publish).to receive(:call)
+
+        result = call_handler(error: error, account: account, context: context)
+
+        expect(result).to be_success
+        expect(result.action).to eq("notified")
+        expect(result.incident).to have_attributes(
+          subsystem: "github_sync",
+          action_taken: "notified"
+        )
+        expect(ExceptionHandler::IssueFiler).not_to have_received(:call)
+        expect(Notifications::Publish).to have_received(:call).with(
+          a_hash_including(
+            account: account,
+            source: "exception_handler",
+            subject: result.incident
           )
         )
       end

--- a/spec/services/exception_handler/handle_spec.rb
+++ b/spec/services/exception_handler/handle_spec.rb
@@ -175,6 +175,30 @@ RSpec.describe ExceptionHandler::Handle do
           )
         )
       end
+
+      it "still logs the captured exception when notification publishing fails" do
+        allow(ExceptionHandler::IssueFiler).to receive(:call)
+        allow(Notifications::Publish).to receive(:call).and_raise("notify failed")
+        allow(Rails.logger).to receive(:warn)
+        allow(Rails.logger).to receive(:error)
+
+        result = call_handler(error: error, account: account, context: context)
+
+        expect(result).to be_failure
+        expect(Rails.logger).to have_received(:warn).with(
+          a_hash_including(
+            message: "exception_handler.captured",
+            subsystem: "github_sync",
+            action: "notified"
+          )
+        )
+        expect(Rails.logger).to have_received(:error).with(
+          a_hash_including(
+            message: "exception_handler.handle_failed",
+            handler_error: "notify failed"
+          )
+        )
+      end
     end
 
     context "with a duplicate exception" do


### PR DESCRIPTION
## Summary

This change adds an explicit allowlist to keep GitHub issue filing limited to the subsystems we want to escalate today, so broader exception capture can roll out without turning expected incident volume into noisy issue churn. The expected outcome is that incidents are still recorded and notified consistently, while only approved high-priority subsystems trigger `IssueFiler`.

## Changes

- `Exception handling`
  - Added `ExceptionHandler::Classifier::ISSUE_FILING_ALLOWLIST` with the initial seeded subsystems: `knowledge`, `agent_runs`, `container_manager`, and `secrets_proxy`.
  - Updated `ExceptionHandler::Handle#file_or_update_issue` to return early when a classified subsystem is not allowlisted for GitHub issue filing.

- `Incident routing behavior`
  - Preserved existing incident recording and notification publishing for all subsystems, even when issue filing is skipped.
  - Kept non-allowlisted paths at `action_taken: "notified"` instead of escalating to `action_taken: "issue_filed"`.

- `Test coverage`
  - Added classifier coverage to verify all four seed subsystems are allowlisted.
  - Added handler coverage for both paths:
    - allowlisted subsystems still invoke `IssueFiler` and reach `action_taken: "issue_filed"`
    - non-allowlisted subsystems do not invoke `IssueFiler`, still persist the incident, and still publish notifications

## Design Decisions

- The allowlist is intentionally seeded with every current P1 subsystem from `Classifier::SUBSYSTEM_SEVERITY`, not just `knowledge`. This avoids a regression where broader exception capture would silently stop filing issues for `agent_runs`, `container_manager`, or `secrets_proxy`, even though those are currently treated as loud failures.
- Lower-priority subsystems such as `github_sync` and `general` are deliberately excluded for now. The constraint here is operational: T3 increases capture volume, and this brake keeps issue creation conservative until T7 dashboard surfacing gives enough visibility to widen the funnel safely.
- The gate is applied only to GitHub issue filing, not to incident creation or notifications. That trade-off preserves observability while reducing escalation noise.

## Operational Notes

- No migration or deployment step is required.
- This is intended to land before T3 so the allowlist brake is already in place when broader exception capture is enabled.

---

Closes #2390