### PR TITLE
feat: Add exception_notification gem to Gemfile (RDR-039 T1)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "stimulus-rails"
 # Bundle and process CSS [https://github.com/rails/cssbundling-rails]
 gem "cssbundling-rails"
 gem "chartkick"
+gem "exception_notification", "~> 5.0"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "stimulus-rails"
 # Bundle and process CSS [https://github.com/rails/cssbundling-rails]
 gem "cssbundling-rails"
 gem "chartkick"
+# Exception reporting (RDR-039)
 gem "exception_notification", "~> 5.0"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,6 +191,9 @@ GEM
     et-orbi (1.4.0)
       tzinfo
     event_stream_parser (1.0.0)
+    exception_notification (5.0.1)
+      actionmailer (>= 7.1, < 9)
+      activesupport (>= 7.1, < 9)
     excon (1.4.2)
       logger
     factory_bot (6.5.6)
@@ -681,6 +684,7 @@ DEPENDENCIES
   dial (~> 0.6)
   discard
   docker-api
+  exception_notification (~> 5.0)
   factory_bot_rails
   faker
   faraday-retry
@@ -792,6 +796,7 @@ CHECKSUMS
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   et-orbi (1.4.0) sha256=6c7e3c90779821f9e3b324c5e96fda9767f72995d6ae435b96678a4f3e2de8bc
   event_stream_parser (1.0.0) sha256=a2683bab70126286f8184dc88f7968ffc4028f813161fb073ec90d171f7de3c8
+  exception_notification (5.0.1) sha256=a9698c8d4670ec50f1714fd14a61a9f83da082d3b5535fd830baf3dc75ba28f9
   excon (1.4.2) sha256=32d8d8eda619717d9b8043b4675e096fb5c2139b080e2ad3b267f88c545aaa35
   factory_bot (6.5.6) sha256=12beb373214dccc086a7a63763d6718c49769d5606f0501e0a4442676917e077
   factory_bot_rails (6.5.1) sha256=d3cc4851eae4dea8a665ec4a4516895045e710554d2b5ac9e68b94d351bc6d68


### PR DESCRIPTION
## Summary
This change prepares the app for exception reporting work in RDR-039 by adding the `exception_notification` dependency now so later wiring can land against a pinned, validated gem setup. The expected outcome is a clean dependency update with no behavioral changes yet and no unrelated gem churn.

## Changes
- Dependencies
  - Added `exception_notification ~> 5.0` to `Gemfile`.
  - Updated `Gemfile.lock` with only the corresponding new gem entries required for `exception_notification`.
  - Kept the scope intentionally narrow: no `exception_notification-rails` UI dependency was added.

- Application behavior
  - No runtime wiring, initializer changes, or notification configuration were introduced in this PR.
  - No user-facing behavior changes are expected from this commit; integration work is deferred to T3.

- Verification
  - Confirmed the dependency resolves successfully with `bundle install`.
  - Re-ran the existing setup and quality checks after the lockfile update to ensure the new gem does not destabilize the app.

## Design Decisions
- This PR separates dependency introduction from feature wiring so reviewers can validate gem selection and lockfile impact independently of notifier configuration.
- The change explicitly avoids `exception_notification-rails` because this task is limited to the core gem dependency; UI-related dependencies are out of scope for RDR-039 T1.
- The lockfile was kept minimal to satisfy the acceptance requirement that no unrelated gem changes be introduced.

## Operational Notes
- No deployment steps are required beyond installing bundled gems as part of the normal deploy/build process.
- No migrations or infrastructure changes are included in this PR.
- Local verification required explicit `DB_HOST`, `DB_USERNAME`, and `DB_PASSWORD` sourced from `DATABASE_URL` because `config/database.yml` does not currently read `DATABASE_URL` directly for development/test host settings.

---

Closes #2388