### PR TITLE
feat(github): pause agent runs while GitHub API is rate limited

### DIFF
--- a/app/jobs/process_run_queue_job.rb
+++ b/app/jobs/process_run_queue_job.rb
@@ -38,14 +38,8 @@ class ProcessRunQueueJob < ApplicationJob
     return unless acquired
 
     begin
-      github_state = GithubHealthState.find_by(endpoint: GithubHealthState::DEFAULT_ENDPOINT)
-      github_state&.check_circuit_recovery!
-      if github_state&.unavailable?
-        Rails.logger.info(
-          message: "process_run_queue.skipped_github_unavailable",
-          reason: github_state.rate_limited? ? "rate_limited" : "circuit_open",
-          available_at: github_state.rate_limited_until&.iso8601
-        )
+      if (github_state = unavailable_github_state)
+        log_github_unavailable(github_state)
         return
       end
 
@@ -53,6 +47,7 @@ class ProcessRunQueueJob < ApplicationJob
       starts_count = 0
       iterations = 0
       skipped_ids = Set.new
+      blocked_project_ids = Set.new
       blocked_user_ids = Set.new
       @user_capacity = {}  # { user_id => { active: count, max: limit } }
 
@@ -65,10 +60,17 @@ class ProcessRunQueueJob < ApplicationJob
         # can't start yet.
         next_run = AgentRun.peek_next_queued_run(
           exclude_ids: skipped_ids.to_a,
+          exclude_project_ids: blocked_project_ids.to_a,
           exclude_user_ids: blocked_user_ids.to_a
         )
 
         break unless next_run
+
+        if (github_state = unavailable_github_state(next_run.project.github_health_endpoint))
+          blocked_project_ids.add(next_run.project_id)
+          log_github_unavailable(github_state, project_id: next_run.project_id)
+          next
+        end
 
         # Resolve the project owner for capacity checks. If the owner
         # can't be resolved, fail the run immediately rather than
@@ -122,6 +124,24 @@ class ProcessRunQueueJob < ApplicationJob
   end
 
   private
+
+  def unavailable_github_state(endpoint = GithubHealthState::DEFAULT_ENDPOINT)
+    state = GithubHealthState.find_by(endpoint: endpoint)
+    return unless state
+
+    state.check_circuit_recovery!
+    state if state.unavailable?
+  end
+
+  def log_github_unavailable(state, project_id: nil)
+    payload = {
+      message: "process_run_queue.skipped_github_unavailable",
+      reason: state.rate_limited? ? "rate_limited" : "circuit_open",
+      available_at: state.rate_limited_until&.iso8601
+    }
+    payload[:project_id] = project_id if project_id
+    Rails.logger.info(payload)
+  end
 
   # Checks per-user capacity using an in-memory cache. The active count
   # is fetched from the DB on first access per user, then updated

--- a/app/jobs/process_run_queue_job.rb
+++ b/app/jobs/process_run_queue_job.rb
@@ -38,9 +38,13 @@ class ProcessRunQueueJob < ApplicationJob
     return unless acquired
 
     begin
-      if github_circuit_open?
+      github_state = GithubHealthState.find_by(endpoint: GithubHealthState::DEFAULT_ENDPOINT)
+      github_state&.check_circuit_recovery!
+      if github_state&.unavailable?
         Rails.logger.info(
-          message: "process_run_queue.skipped_github_circuit_open"
+          message: "process_run_queue.skipped_github_unavailable",
+          reason: github_state.rate_limited? ? "rate_limited" : "circuit_open",
+          available_at: github_state.rate_limited_until&.iso8601
         )
         return
       end
@@ -118,12 +122,6 @@ class ProcessRunQueueJob < ApplicationJob
   end
 
   private
-
-  # Checks GitHub circuit breaker state. Attempts recovery if the
-  # timeout has elapsed, allowing a half-open probe.
-  def github_circuit_open?
-    !GithubHealthState.github_available_with_recovery?
-  end
 
   # Checks per-user capacity using an in-memory cache. The active count
   # is fetched from the DB on first access per user, then updated

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -1181,13 +1181,14 @@ class AgentRun < ApplicationRecord
   # Runs whose project belongs to an account with a paused scheduler are
   # excluded so a "pause all" toggle can hold new starts while still
   # accepting new queue entries from the project trigger button.
-  def self.peek_next_queued_run(exclude_ids: [], exclude_user_ids: [])
+  def self.peek_next_queued_run(exclude_ids: [], exclude_project_ids: [], exclude_user_ids: [])
     scope = unclaimed_with_priority
       .joins(project: :account)
       .where(accounts: { scheduler_paused_at: nil })
       .where(projects: { scheduler_paused_at: nil })
       .where("agent_runs.trigger_type = 'manual' OR projects.quality_paused_at IS NULL")
     scope = scope.where.not(id: exclude_ids) if exclude_ids.any?
+    scope = scope.where.not(project_id: exclude_project_ids) if exclude_project_ids.any?
     scope = scope.where.not(project_owner: { user_id: exclude_user_ids }) if exclude_user_ids.any?
     next_queued_run_from(scope)
   end

--- a/app/models/github_health_state.rb
+++ b/app/models/github_health_state.rb
@@ -26,12 +26,14 @@ class GithubHealthState < ApplicationRecord
     find_by!(endpoint: endpoint)
   end
 
-  # Returns true if GitHub is currently unavailable (circuit open).
+  # Returns true if GitHub is currently available. Treats both an open
+  # circuit (infrastructure failures) and an active rate-limit window as
+  # unavailable so callers can pause dispatching uniformly.
   def self.github_available?(endpoint: DEFAULT_ENDPOINT)
     state = find_by(endpoint: endpoint)
     return true unless state
 
-    !state.circuit_open?
+    !state.unavailable?
   end
 
   # Checks recovery timeout, then returns true if GitHub is available.
@@ -83,7 +85,7 @@ class GithubHealthState < ApplicationRecord
   # recovery timeout.
   def record_success!
     with_lock do
-      return if circuit_state == "closed" && failure_count.zero?
+      return if circuit_state == "closed" && failure_count.zero? && rate_limited_until.blank?
       return if circuit_open?
 
       was_half_open = circuit_half_open?
@@ -92,7 +94,8 @@ class GithubHealthState < ApplicationRecord
         failure_count: 0,
         circuit_state: "closed",
         circuit_opened_at: nil,
-        last_error_message: nil
+        last_error_message: nil,
+        rate_limited_until: nil
       )
 
       if was_half_open
@@ -101,6 +104,25 @@ class GithubHealthState < ApplicationRecord
           endpoint: endpoint
         )
       end
+    end
+  end
+
+  # Records a GitHub rate-limit response and persists the reset time so
+  # the queue scheduler will pause dispatching until the limit resets.
+  # Best-effort: callers should not let persistence errors mask the
+  # original rate-limit exception.
+  #
+  # @param reset_at [Time, nil] When the rate limit resets. Defaults to 60 seconds from now.
+  def mark_rate_limited!(reset_at: nil)
+    reset_at ||= 60.seconds.from_now
+    with_lock do
+      update!(rate_limited_until: reset_at)
+
+      Rails.logger.warn(
+        message: "github_health.rate_limited",
+        endpoint: endpoint,
+        rate_limited_until: reset_at.iso8601
+      )
     end
   end
 
@@ -136,8 +158,15 @@ class GithubHealthState < ApplicationRecord
     circuit_state == "closed"
   end
 
-  # Returns true when dispatching should be paused.
+  # Returns true if a rate-limit window is currently active.
+  def rate_limited?
+    rate_limited_until.present? && rate_limited_until > Time.current
+  end
+
+  # Returns true when dispatching should be paused — either the circuit is
+  # open from infrastructure failures or a GitHub rate limit is still in
+  # effect.
   def unavailable?
-    circuit_open?
+    circuit_open? || rate_limited?
   end
 end

--- a/app/models/github_health_state.rb
+++ b/app/models/github_health_state.rb
@@ -9,6 +9,8 @@
 class GithubHealthState < ApplicationRecord
   CIRCUIT_STATES = %w[closed open half_open].freeze
   DEFAULT_ENDPOINT = "api"
+  GITHUB_TOKEN_ENDPOINT_PREFIX = "github_token".freeze
+  GITHUB_INSTALLATION_ENDPOINT_PREFIX = "github_installation".freeze
   DEFAULT_FAILURE_THRESHOLD = 5
   DEFAULT_RECOVERY_TIMEOUT = 300
 
@@ -17,6 +19,14 @@ class GithubHealthState < ApplicationRecord
   validates :failure_count, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
   scope :for_endpoint, ->(name) { where(endpoint: name) }
+
+  def self.endpoint_for_github_token(github_token_id)
+    "#{GITHUB_TOKEN_ENDPOINT_PREFIX}:#{github_token_id}"
+  end
+
+  def self.endpoint_for_github_installation(github_installation_id)
+    "#{GITHUB_INSTALLATION_ENDPOINT_PREFIX}:#{github_installation_id}"
+  end
 
   # Returns the singleton state for the default GitHub API endpoint,
   # creating it if it does not exist.

--- a/app/models/github_token.rb
+++ b/app/models/github_token.rb
@@ -112,7 +112,11 @@ class GithubToken < ApplicationRecord
   #
   # @return [GithubClient] GitHub API client
   def client
-    @client ||= GithubClient.new(token: token)
+    @client ||= GithubClient.new(token: token, health_endpoint: github_health_endpoint)
+  end
+
+  def github_health_endpoint
+    GithubHealthState.endpoint_for_github_token(id)
   end
 
   # Validates the token against GitHub API and updates scopes.

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -904,9 +904,19 @@ class Project < ApplicationRecord
   def client
     @client ||= if github_installation_id.present? || github_installation.present?
       credential = github_credential
-      credential.present? ? GithubClient.new(token: credential) : nil
+      credential.present? ? GithubClient.new(token: credential, health_endpoint: github_health_endpoint) : nil
     else
       github_token&.client
+    end
+  end
+
+  def github_health_endpoint
+    if github_installation_id.present? || github_installation.present?
+      GithubHealthState.endpoint_for_github_installation(github_installation.github_installation_id)
+    elsif github_token_id.present?
+      GithubHealthState.endpoint_for_github_token(github_token_id)
+    else
+      GithubHealthState::DEFAULT_ENDPOINT
     end
   end
 

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -62,16 +62,18 @@ class GithubClient
     end
   end
 
-  attr_reader :client
+  attr_reader :client, :health_endpoint
 
   # @param token [String] GitHub personal access token
+  # @param health_endpoint [String] Stable health-state key for the auth principal
   # @param options [Hash] Additional Octokit client options
-  def initialize(token:, **options)
+  def initialize(token:, health_endpoint: GithubHealthState::DEFAULT_ENDPOINT, **options)
     @client = Octokit::Client.new(
       access_token: token,
       auto_paginate: false,
       **options
     )
+    @health_endpoint = health_endpoint
 
     configure_middleware
   end
@@ -1488,7 +1490,7 @@ class GithubClient
   end
 
   def record_github_health_failure(error_message)
-    GithubHealthState.current.record_failure!(error_message: error_message)
+    GithubHealthState.current(endpoint: health_endpoint).record_failure!(error_message: error_message)
   rescue => e
     Rails.logger.warn(
       message: "github_client.health_state_record_failed",
@@ -1497,7 +1499,7 @@ class GithubClient
   end
 
   def record_github_rate_limit(reset_at)
-    GithubHealthState.current.mark_rate_limited!(reset_at: reset_at)
+    GithubHealthState.current(endpoint: health_endpoint).mark_rate_limited!(reset_at: reset_at)
   rescue => e
     Rails.logger.warn(
       message: "github_client.rate_limit_record_failed",
@@ -1506,7 +1508,7 @@ class GithubClient
   end
 
   def record_github_health_success
-    state = GithubHealthState.find_by(endpoint: GithubHealthState::DEFAULT_ENDPOINT)
+    state = GithubHealthState.find_by(endpoint: health_endpoint)
     return unless state && (state.failure_count > 0 || !state.circuit_closed? || state.rate_limited_until.present?)
 
     state.record_success!

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -1466,10 +1466,12 @@ class GithubClient
     raise NotFoundError, e.message
   rescue Octokit::TooManyRequests
     reset_at = client.rate_limit.resets_at rescue nil
+    record_github_rate_limit(reset_at)
     raise RateLimitError.new(reset_at)
   rescue Octokit::Forbidden => e
     if e.message.include?("rate limit")
       reset_at = client.rate_limit.resets_at rescue nil
+      record_github_rate_limit(reset_at)
       raise RateLimitError.new(reset_at)
     end
     raise ApiError.new(e.message, status: 403)
@@ -1494,9 +1496,18 @@ class GithubClient
     )
   end
 
+  def record_github_rate_limit(reset_at)
+    GithubHealthState.current.mark_rate_limited!(reset_at: reset_at)
+  rescue => e
+    Rails.logger.warn(
+      message: "github_client.rate_limit_record_failed",
+      error: e.message
+    )
+  end
+
   def record_github_health_success
     state = GithubHealthState.find_by(endpoint: GithubHealthState::DEFAULT_ENDPOINT)
-    return unless state && (state.failure_count > 0 || !state.circuit_closed?)
+    return unless state && (state.failure_count > 0 || !state.circuit_closed? || state.rate_limited_until.present?)
 
     state.record_success!
   rescue => e

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -15,19 +15,16 @@ module Activities
     def execute(input)
       project_id = input[:project_id]
 
-      github_state = GithubHealthState.find_by(endpoint: GithubHealthState::DEFAULT_ENDPOINT)
-      if github_state&.unavailable?
-        logger.info(
-          message: "fetch_issues.skipped_github_unavailable",
-          project_id: project_id,
-          reason: github_state.rate_limited? ? "rate_limited" : "circuit_open",
-          available_at: github_state.rate_limited_until&.iso8601
-        )
-        return { issues: [], project_id: project_id, github_circuit_open: true }
-      end
+      github_state = unavailable_github_state
 
       project = Project.find_by(id: project_id)
       return { issues: [], project_id: project_id, project_missing: true } unless project
+
+      github_state ||= unavailable_github_state(project.github_health_endpoint)
+      if github_state
+        log_github_unavailable(project_id, github_state)
+        return { issues: [], project_id: project_id, github_circuit_open: true }
+      end
 
       client = project.client
       incremental = project.last_issue_sync_at.present?
@@ -174,6 +171,23 @@ module Activities
       raise Temporalio::Error::ApplicationError.new(
         e.message,
         type: "RateLimit"
+      )
+    end
+
+    def unavailable_github_state(endpoint = GithubHealthState::DEFAULT_ENDPOINT)
+      state = GithubHealthState.find_by(endpoint: endpoint)
+      return unless state
+
+      state.check_circuit_recovery!
+      state if state.unavailable?
+    end
+
+    def log_github_unavailable(project_id, github_state)
+      logger.info(
+        message: "fetch_issues.skipped_github_unavailable",
+        project_id: project_id,
+        reason: github_state.rate_limited? ? "rate_limited" : "circuit_open",
+        available_at: github_state.rate_limited_until&.iso8601
       )
     end
 

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -15,10 +15,13 @@ module Activities
     def execute(input)
       project_id = input[:project_id]
 
-      unless GithubHealthState.github_available?
+      github_state = GithubHealthState.find_by(endpoint: GithubHealthState::DEFAULT_ENDPOINT)
+      if github_state&.unavailable?
         logger.info(
-          message: "fetch_issues.skipped_github_circuit_open",
-          project_id: project_id
+          message: "fetch_issues.skipped_github_unavailable",
+          project_id: project_id,
+          reason: github_state.rate_limited? ? "rate_limited" : "circuit_open",
+          available_at: github_state.rate_limited_until&.iso8601
         )
         return { issues: [], project_id: project_id, github_circuit_open: true }
       end

--- a/db/migrate/20260530075312_add_rate_limited_until_to_github_health_states.rb
+++ b/db/migrate/20260530075312_add_rate_limited_until_to_github_health_states.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddRateLimitedUntilToGithubHealthStates < ActiveRecord::Migration[8.1]
+  def change
+    add_column :github_health_states,
+               :rate_limited_until,
+               :datetime,
+               comment: "Timestamp at which the GitHub API rate limit is expected to reset. While this is in the future the endpoint is treated as unavailable so the queue scheduler pauses dispatching."
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_29_152437) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_30_075312) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -941,6 +941,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_29_152437) do
     t.string "endpoint", limit: 50, default: "api", null: false
     t.integer "failure_count", default: 0, null: false
     t.text "last_error_message"
+    t.datetime "rate_limited_until", comment: "Timestamp at which the GitHub API rate limit is expected to reset. While this is in the future the endpoint is treated as unavailable so the queue scheduler pauses dispatching."
     t.datetime "updated_at", null: false
     t.index ["endpoint"], name: "index_github_health_states_on_endpoint", unique: true
   end

--- a/spec/factories/github_health_states.rb
+++ b/spec/factories/github_health_states.rb
@@ -17,5 +17,9 @@ FactoryBot.define do
       failure_count { 5 }
       circuit_opened_at { 10.minutes.ago }
     end
+
+    trait :rate_limited do
+      rate_limited_until { 1.hour.from_now }
+    end
   end
 end

--- a/spec/jobs/process_run_queue_job_spec.rb
+++ b/spec/jobs/process_run_queue_job_spec.rb
@@ -332,10 +332,16 @@ RSpec.describe ProcessRunQueueJob do
       it "skips dispatching entirely" do
         create(:github_health_state, :circuit_open)
         create(:agent_run, :queued)
+        allow(Rails.logger).to receive(:info)
 
         expect(temporal_client).not_to receive(:start_workflow)
 
         described_class.new.perform
+
+        expect(Rails.logger).to have_received(:info).with(hash_including(
+          message: "process_run_queue.skipped_github_unavailable",
+          reason: "circuit_open"
+        ))
       end
 
       it "attempts circuit recovery when timeout has elapsed" do
@@ -348,6 +354,34 @@ RSpec.describe ProcessRunQueueJob do
         described_class.new.perform
 
         expect(state.reload.circuit_state).to eq("half_open")
+      end
+    end
+
+    context "when GitHub is rate limited" do
+      it "skips dispatching until the reset time has passed" do
+        reset_at = 30.minutes.from_now
+        create(:github_health_state, rate_limited_until: reset_at)
+        create(:agent_run, :queued)
+        allow(Rails.logger).to receive(:info)
+
+        expect(temporal_client).not_to receive(:start_workflow)
+
+        described_class.new.perform
+
+        expect(Rails.logger).to have_received(:info).with(hash_including(
+          message: "process_run_queue.skipped_github_unavailable",
+          reason: "rate_limited",
+          available_at: reset_at.iso8601
+        ))
+      end
+
+      it "resumes dispatching once the rate-limit window has elapsed" do
+        create(:github_health_state, rate_limited_until: 1.minute.ago)
+        create(:agent_run, :queued)
+
+        expect(temporal_client).to receive(:start_workflow).and_return(workflow_handle)
+
+        described_class.new.perform
       end
     end
 

--- a/spec/jobs/process_run_queue_job_spec.rb
+++ b/spec/jobs/process_run_queue_job_spec.rb
@@ -358,26 +358,40 @@ RSpec.describe ProcessRunQueueJob do
     end
 
     context "when GitHub is rate limited" do
-      it "skips dispatching until the reset time has passed" do
-        reset_at = 30.minutes.from_now
-        create(:github_health_state, rate_limited_until: reset_at)
-        create(:agent_run, :queued)
-        allow(Rails.logger).to receive(:info)
+      let(:reset_at) { 30.minutes.from_now }
+      let(:blocked_project) { create(:project) }
+      let(:runnable_project) { create(:project) }
+      let!(:blocked_run) { create(:agent_run, :queued, project: blocked_project, created_at: 2.minutes.ago) }
+      let!(:runnable_run) { create(:agent_run, :queued, project: runnable_project, created_at: 1.minute.ago) }
 
-        expect(temporal_client).not_to receive(:start_workflow)
+      before do
+        create(:github_health_state, endpoint: blocked_project.github_health_endpoint, rate_limited_until: reset_at)
+        allow(Rails.logger).to receive(:info)
+      end
+
+      it "skips only runs for projects using the rate-limited credential" do
+        expect(temporal_client).to receive(:start_workflow).with(
+          Workflows::AgentExecutionWorkflow,
+          hash_including(agent_run_id: runnable_run.id),
+          hash_including(task_queue: "paid-agent-tasks")
+        ).and_return(workflow_handle)
 
         described_class.new.perform
 
         expect(Rails.logger).to have_received(:info).with(hash_including(
           message: "process_run_queue.skipped_github_unavailable",
+          project_id: blocked_project.id,
           reason: "rate_limited",
           available_at: reset_at.iso8601
         ))
+        expect(blocked_run.reload.status).to eq("queued")
+        expect(runnable_run.reload.temporal_workflow_id).to be_present
       end
 
       it "resumes dispatching once the rate-limit window has elapsed" do
-        create(:github_health_state, rate_limited_until: 1.minute.ago)
-        create(:agent_run, :queued)
+        project = create(:project)
+        create(:github_health_state, endpoint: project.github_health_endpoint, rate_limited_until: 1.minute.ago)
+        create(:agent_run, :queued, project: project)
 
         expect(temporal_client).to receive(:start_workflow).and_return(workflow_handle)
 

--- a/spec/models/github_health_state_spec.rb
+++ b/spec/models/github_health_state_spec.rb
@@ -122,6 +122,16 @@ RSpec.describe GithubHealthState do
       create(:github_health_state, :circuit_half_open)
       expect(described_class.github_available?).to be true
     end
+
+    it "returns false while a rate-limit window is active" do
+      create(:github_health_state, :rate_limited)
+      expect(described_class.github_available?).to be false
+    end
+
+    it "returns true after the rate-limit window has elapsed" do
+      create(:github_health_state, rate_limited_until: 1.minute.ago)
+      expect(described_class.github_available?).to be true
+    end
   end
 
   describe ".github_available_with_recovery?" do
@@ -138,6 +148,11 @@ RSpec.describe GithubHealthState do
       state = create(:github_health_state, circuit_state: "open", circuit_opened_at: 10.minutes.ago)
       expect(described_class.github_available_with_recovery?).to be true
       expect(state.reload.circuit_state).to eq("half_open")
+    end
+
+    it "returns false while a rate-limit window is active even if the circuit is closed" do
+      create(:github_health_state, :rate_limited)
+      expect(described_class.github_available_with_recovery?).to be false
     end
   end
 
@@ -248,6 +263,13 @@ RSpec.describe GithubHealthState do
       expect(state.failure_count).to eq(0)
     end
 
+    it "clears rate_limited_until on a successful call" do
+      state = create(:github_health_state, rate_limited_until: 1.hour.from_now)
+      state.record_success!
+
+      expect(state.reload.rate_limited_until).to be_nil
+    end
+
     it "does not overwrite an open circuit when a failure races with success" do
       state = create(:github_health_state, :circuit_half_open)
       run_success_failure_race(state)
@@ -319,6 +341,71 @@ RSpec.describe GithubHealthState do
     it "returns false when circuit is half_open" do
       state = build(:github_health_state, :circuit_half_open)
       expect(state).not_to be_unavailable
+    end
+
+    it "returns true while a rate-limit window is active" do
+      state = build(:github_health_state, :rate_limited)
+      expect(state).to be_unavailable
+    end
+
+    it "returns false once the rate-limit window has elapsed" do
+      state = build(:github_health_state, rate_limited_until: 1.minute.ago)
+      expect(state).not_to be_unavailable
+    end
+  end
+
+  describe "#rate_limited?" do
+    it "returns true when rate_limited_until is in the future" do
+      state = build(:github_health_state, :rate_limited)
+      expect(state).to be_rate_limited
+    end
+
+    it "returns false when rate_limited_until is nil" do
+      state = build(:github_health_state)
+      expect(state).not_to be_rate_limited
+    end
+
+    it "returns false when rate_limited_until has already elapsed" do
+      state = build(:github_health_state, rate_limited_until: 1.minute.ago)
+      expect(state).not_to be_rate_limited
+    end
+  end
+
+  describe "#mark_rate_limited!" do
+    it "persists the supplied reset_at" do
+      state = create(:github_health_state)
+      reset_at = 30.minutes.from_now
+
+      state.mark_rate_limited!(reset_at: reset_at)
+
+      expect(state.reload.rate_limited_until).to be_within(1.second).of(reset_at)
+    end
+
+    it "defaults to 60 seconds from now when reset_at is nil" do
+      state = create(:github_health_state)
+      freeze_time do
+        state.mark_rate_limited!(reset_at: nil)
+        expect(state.reload.rate_limited_until).to eq(60.seconds.from_now)
+      end
+    end
+
+    it "logs a warning that includes the reset time" do
+      state = create(:github_health_state)
+      reset_at = 30.minutes.from_now
+
+      expect(Rails.logger).to receive(:warn).with(hash_including(
+        message: "github_health.rate_limited",
+        rate_limited_until: reset_at.iso8601
+      ))
+
+      state.mark_rate_limited!(reset_at: reset_at)
+    end
+
+    it "is treated as unavailable immediately after being marked" do
+      state = create(:github_health_state)
+      state.mark_rate_limited!(reset_at: 1.hour.from_now)
+
+      expect(described_class.github_available?).to be false
     end
   end
 end

--- a/spec/models/github_health_state_spec.rb
+++ b/spec/models/github_health_state_spec.rb
@@ -101,6 +101,22 @@ RSpec.describe GithubHealthState do
       existing = create(:github_health_state)
       expect(described_class.current).to eq(existing)
     end
+
+    it "looks up scoped records by endpoint" do
+      existing = create(:github_health_state, endpoint: described_class.endpoint_for_github_token(42))
+
+      expect(described_class.current(endpoint: described_class.endpoint_for_github_token(42))).to eq(existing)
+    end
+  end
+
+  describe "endpoint helpers" do
+    it "builds a scoped endpoint for GitHub tokens" do
+      expect(described_class.endpoint_for_github_token(42)).to eq("github_token:42")
+    end
+
+    it "builds a scoped endpoint for GitHub App installations" do
+      expect(described_class.endpoint_for_github_installation(1234)).to eq("github_installation:1234")
+    end
   end
 
   describe ".github_available?" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -988,7 +988,10 @@ RSpec.describe Project do
         github_client = instance_double(GithubClient)
 
         allow(project).to receive(:github_credential).and_return("ghs_app_token")
-        allow(GithubClient).to receive(:new).with(token: "ghs_app_token").and_return(github_client)
+        allow(GithubClient).to receive(:new).with(
+          token: "ghs_app_token",
+          health_endpoint: project.github_health_endpoint
+        ).and_return(github_client)
 
         expect(project.client).to be(github_client)
       end

--- a/spec/services/github_client_spec.rb
+++ b/spec/services/github_client_spec.rb
@@ -1926,6 +1926,26 @@ RSpec.describe GithubClient do
         expect(error.reset_at).not_to be_nil
       end
     end
+
+    it "marks the GitHub health state as rate limited so dispatching pauses" do
+      reset_at = 30.minutes.from_now
+      allow(client.client).to receive(:rate_limit)
+        .and_return(instance_double(Octokit::RateLimit, resets_at: reset_at))
+
+      expect { client.repository(repo) }.to raise_error(GithubClient::RateLimitError)
+
+      state = GithubHealthState.find_by(endpoint: GithubHealthState::DEFAULT_ENDPOINT)
+      expect(state).to be_present
+      expect(state.rate_limited_until).to be_within(1.second).of(reset_at)
+      expect(state).to be_rate_limited
+      expect(GithubHealthState.github_available?).to be false
+    end
+
+    it "still raises RateLimitError when persisting the rate-limit state fails" do
+      allow(GithubHealthState).to receive(:current).and_raise(ActiveRecord::StatementInvalid.new("boom"))
+
+      expect { client.repository(repo) }.to raise_error(GithubClient::RateLimitError)
+    end
   end
 
   describe "generic API error handling" do

--- a/spec/services/github_client_spec.rb
+++ b/spec/services/github_client_spec.rb
@@ -4,7 +4,8 @@ require "rails_helper"
 
 RSpec.describe GithubClient do
   let(:token) { "ghp_test_token_123456789012345678901234567890" }
-  let(:client) { described_class.new(token: token) }
+  let(:health_endpoint) { GithubHealthState::DEFAULT_ENDPOINT }
+  let(:client) { described_class.new(token: token, health_endpoint: health_endpoint) }
   let(:api_base) { "https://api.github.com" }
 
   before do
@@ -1899,6 +1900,7 @@ RSpec.describe GithubClient do
   describe "rate limit error handling" do
     let(:repo) { "owner/repo" }
     let(:reset_time) { Time.now.to_i + 3600 }
+    let(:health_endpoint) { GithubHealthState.endpoint_for_github_token(42) }
 
     before do
       stub_request(:get, "#{api_base}/repos/#{repo}")
@@ -1934,17 +1936,36 @@ RSpec.describe GithubClient do
 
       expect { client.repository(repo) }.to raise_error(GithubClient::RateLimitError)
 
-      state = GithubHealthState.find_by(endpoint: GithubHealthState::DEFAULT_ENDPOINT)
+      state = GithubHealthState.find_by(endpoint: health_endpoint)
       expect(state).to be_present
       expect(state.rate_limited_until).to be_within(1.second).of(reset_at)
       expect(state).to be_rate_limited
-      expect(GithubHealthState.github_available?).to be false
+      expect(GithubHealthState.github_available?(endpoint: health_endpoint)).to be false
     end
 
     it "still raises RateLimitError when persisting the rate-limit state fails" do
-      allow(GithubHealthState).to receive(:current).and_raise(ActiveRecord::StatementInvalid.new("boom"))
+      allow(GithubHealthState).to receive(:current).with(endpoint: health_endpoint)
+        .and_raise(ActiveRecord::StatementInvalid.new("boom"))
 
       expect { client.repository(repo) }.to raise_error(GithubClient::RateLimitError)
+    end
+
+    it "does not clear a different credential's rate-limit state on success" do
+      create(:github_health_state,
+        endpoint: GithubHealthState.endpoint_for_github_token(7),
+        rate_limited_until: 1.hour.from_now)
+
+      stub_request(:get, "#{api_base}/repos/other/repo")
+        .to_return(status: 200, body: { full_name: "other/repo" }.to_json, headers: { "Content-Type" => "application/json" })
+
+      expect {
+        described_class.new(
+          token: "ghp_other_token_123456789012345678901234567890",
+          health_endpoint: GithubHealthState.endpoint_for_github_token(8)
+        ).repository("other/repo")
+      }.not_to change {
+        GithubHealthState.find_by(endpoint: GithubHealthState.endpoint_for_github_token(7))&.rate_limited_until
+      }
     end
   end
 

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -186,6 +186,49 @@ RSpec.describe Activities::FetchIssuesActivity do
   end
 
   describe "#execute" do
+    context "when GitHub is unavailable" do
+      it "skips polling when the circuit is open and logs the reason" do
+        create(:github_health_state, :circuit_open)
+        stub_issues_by_label(nil => [])
+        allow(Rails.logger).to receive(:info)
+
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:github_circuit_open]).to be true
+        expect(github_client).not_to have_received(:issues)
+        expect(Rails.logger).to have_received(:info).with(hash_including(
+          message: "fetch_issues.skipped_github_unavailable",
+          reason: "circuit_open"
+        ))
+      end
+
+      it "skips polling while the rate-limit window is active" do
+        reset_at = 30.minutes.from_now
+        create(:github_health_state, rate_limited_until: reset_at)
+        stub_issues_by_label(nil => [])
+        allow(Rails.logger).to receive(:info)
+
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:github_circuit_open]).to be true
+        expect(github_client).not_to have_received(:issues)
+        expect(Rails.logger).to have_received(:info).with(hash_including(
+          message: "fetch_issues.skipped_github_unavailable",
+          reason: "rate_limited",
+          available_at: reset_at.iso8601
+        ))
+      end
+
+      it "does not skip once the rate-limit window has elapsed" do
+        create(:github_health_state, rate_limited_until: 1.minute.ago)
+        stub_issues_by_label(nil => [])
+
+        result = activity.execute(project_id: project.id)
+
+        expect(result[:github_circuit_open]).to be_nil
+      end
+    end
+
     context "when issues are found" do
       let(:build_issue) do
         OpenStruct.new(

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe Activities::FetchIssuesActivity do
 
       it "skips polling while the rate-limit window is active" do
         reset_at = 30.minutes.from_now
-        create(:github_health_state, rate_limited_until: reset_at)
+        create(:github_health_state, endpoint: project.github_health_endpoint, rate_limited_until: reset_at)
         stub_issues_by_label(nil => [])
         allow(Rails.logger).to receive(:info)
 
@@ -220,7 +220,7 @@ RSpec.describe Activities::FetchIssuesActivity do
       end
 
       it "does not skip once the rate-limit window has elapsed" do
-        create(:github_health_state, rate_limited_until: 1.minute.ago)
+        create(:github_health_state, endpoint: project.github_health_endpoint, rate_limited_until: 1.minute.ago)
         stub_issues_by_label(nil => [])
 
         result = activity.execute(project_id: project.id)


### PR DESCRIPTION
## Summary
- When `GithubClient` raises `RateLimitError` (Octokit 429 or 403 with "rate limit"), persist the reset timestamp on `GithubHealthState.current` so the queue scheduler (`ProcessRunQueueJob`) and issue-polling activity (`FetchIssuesActivity`) skip dispatching until the limit resets. Mirrors the `RunnerState.rate_limited_until` pattern used for provider rate limits.
- Add `rate_limited?`, `mark_rate_limited!(reset_at:)` to `GithubHealthState`; extend `unavailable?` and `.github_available?` to treat an active rate-limit window the same as an open circuit.
- Rename the GitHub-unavailability log key from `skipped_github_circuit_open` to `skipped_github_unavailable` with structured `reason` (`circuit_open` or `rate_limited`) and `available_at` fields, since the same skip path now fires for two distinct conditions.
- Best-effort persistence: if writing the rate-limit state fails, the original `RateLimitError` is still raised so callers see the real failure.

## Test plan
- [x] `bin/rspec spec/models/github_health_state_spec.rb spec/services/github_client_spec.rb spec/jobs/process_run_queue_job_spec.rb spec/temporal/activities/fetch_issues_activity_spec.rb` — 290 examples, 0 failures
- [x] `bin/rubocop` clean on all changed files
- [ ] After merge: confirm `agent_run` failures with "GitHub API rate limit exceeded. Resets at …" stop recurring; new runs queue and wait instead of failing immediately
- [ ] Verify `process_run_queue.skipped_github_unavailable` log lines appear with `reason: "rate_limited"` and `available_at` during the next throttling event
- [ ] Spot-check the dashboard / `GithubHealthState.current` after a real 429 to confirm `rate_limited_until` is populated and clears on the next successful call

🤖 Generated with [Claude Code](https://claude.com/claude-code)