### PR TITLE
feat(chat): add 'New Chat' button to start fresh chat session

### DIFF
--- a/app/javascript/controllers/chat_popup_controller.js
+++ b/app/javascript/controllers/chat_popup_controller.js
@@ -55,15 +55,32 @@ export default class extends Controller {
         this.writeState()
       }
 
-      const response = await window.fetch(this.panelUrl(sessionId), {
-        headers: { Accept: "text/html" },
-        credentials: "same-origin"
-      })
-
-      if (!response.ok) throw new Error(`Panel request failed with ${response.status}`)
-
-      this.contentTarget.innerHTML = await response.text()
+      await this.renderPanel(sessionId)
     } catch (error) {
+      this.contentTarget.innerHTML = this.errorMarkup()
+      window.console.error("chat popup failed", error)
+    } finally {
+      this.loading = false
+    }
+  }
+
+  async newChat(event) {
+    event?.preventDefault()
+    if (this.loading) return
+
+    const previousSessionId = this.state.sessionId
+
+    this.loading = true
+    this.contentTarget.innerHTML = this.loadingMarkup()
+
+    try {
+      const sessionId = await this.createSession()
+      this.state.sessionId = sessionId
+      this.writeState()
+      await this.renderPanel(sessionId)
+    } catch (error) {
+      this.state.sessionId = previousSessionId
+      this.writeState()
       this.contentTarget.innerHTML = this.errorMarkup()
       window.console.error("chat popup failed", error)
     } finally {
@@ -107,6 +124,17 @@ export default class extends Controller {
     })
 
     return response.ok
+  }
+
+  async renderPanel(sessionId) {
+    const response = await window.fetch(this.panelUrl(sessionId), {
+      headers: { Accept: "text/html" },
+      credentials: "same-origin"
+    })
+
+    if (!response.ok) throw new Error(`Panel request failed with ${response.status}`)
+
+    this.contentTarget.innerHTML = await response.text()
   }
 
   jsonHeaders() {

--- a/app/views/chat_sessions/_popup.html.erb
+++ b/app/views/chat_sessions/_popup.html.erb
@@ -1,4 +1,5 @@
 <% page_context = chat_session.page_context %>
+<% can_create_chat_session = policy(ChatSession.new(account: current_account)).create? %>
 
 <section class="flex h-full flex-col overflow-hidden rounded-[1.75rem] bg-white shadow-[0_32px_80px_-32px_rgba(15,23,42,0.45)] ring-1 ring-slate-200">
   <div class="border-b border-slate-200 bg-[radial-gradient(circle_at_top,_rgba(99,102,241,0.14),_transparent_55%),linear-gradient(180deg,_#ffffff_0%,_#f8fafc_100%)] px-5 py-4">
@@ -17,6 +18,13 @@
       </div>
 
       <div class="flex items-center gap-2">
+        <% if can_create_chat_session %>
+          <button type="button"
+                  class="inline-flex items-center rounded-full bg-slate-900 px-3 py-1.5 text-xs font-semibold text-white hover:bg-slate-700"
+                  data-action="chat-popup#newChat">
+            New Chat
+          </button>
+        <% end %>
         <%= link_to "Open page",
                     chat_session_path(chat_session),
                     class: "inline-flex items-center rounded-full bg-white px-3 py-1.5 text-xs font-semibold text-slate-600 ring-1 ring-slate-200 hover:bg-slate-50" %>

--- a/spec/lib/chat_popup_controller_node_harness_spec.rb
+++ b/spec/lib/chat_popup_controller_node_harness_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require "open3"
+require "rails_helper"
+
+class ChatPopupControllerNodeHarness
+  SCRIPT = <<~JAVASCRIPT
+    const fs = require("node:fs");
+
+    const source = fs.readFileSync("app/javascript/controllers/chat_popup_controller.js", "utf8");
+    const transformed = source
+      .replace('import { Controller } from "@hotwired/stimulus"', "class Controller {}")
+      .replace("export default class extends Controller {", "return class ChatPopupController extends Controller {");
+
+    const ChatPopupController = new Function(transformed)();
+
+    async function runNewChatSuccessCase() {
+      const writes = [];
+      const fetchCalls = [];
+      const contentTarget = { innerHTML: "" };
+      const controller = Object.create(ChatPopupController.prototype);
+
+      controller.contentTarget = contentTarget;
+      controller.state = { open: true, sessionId: 11 };
+      controller.loading = false;
+      controller.loadingMarkup = () => "loading";
+      controller.errorMarkup = () => "error";
+      controller.writeState = () => writes.push({ ...controller.state });
+      controller.createSession = async () => 42;
+      controller.renderPanel = async (sessionId) => {
+        fetchCalls.push(sessionId);
+        contentTarget.innerHTML = `panel-${sessionId}`;
+      };
+
+      await controller.newChat({ preventDefault() {} });
+
+      if (controller.state.sessionId !== 42) {
+        throw new Error(`Expected newChat() to replace the stored session id, saw ${controller.state.sessionId}`);
+      }
+
+      if (writes.length !== 1 || writes[0].sessionId !== 42) {
+        throw new Error(`Expected newChat() to persist the new session id once, saw ${JSON.stringify(writes)}`);
+      }
+
+      if (fetchCalls.length !== 1 || fetchCalls[0] !== 42) {
+        throw new Error(`Expected newChat() to render the new session once, saw ${JSON.stringify(fetchCalls)}`);
+      }
+
+      if (contentTarget.innerHTML !== "panel-42") {
+        throw new Error(`Expected rendered panel markup for the new session, saw ${contentTarget.innerHTML}`);
+      }
+
+      if (controller.loading !== false) {
+        throw new Error("Expected newChat() to clear the loading flag");
+      }
+    }
+
+    async function runNewChatFailureCase() {
+      const writes = [];
+      const contentTarget = { innerHTML: "" };
+      const controller = Object.create(ChatPopupController.prototype);
+
+      controller.contentTarget = contentTarget;
+      controller.state = { open: true, sessionId: 11 };
+      controller.loading = false;
+      controller.loadingMarkup = () => "loading";
+      controller.errorMarkup = () => "error";
+      controller.writeState = () => writes.push({ ...controller.state });
+      controller.createSession = async () => {
+        throw new Error("boom");
+      };
+      controller.renderPanel = async () => {
+        throw new Error("render should not run");
+      };
+
+      global.window = {
+        console: { error() {} }
+      };
+
+      await controller.newChat({ preventDefault() {} });
+
+      if (controller.state.sessionId !== 11) {
+        throw new Error(`Expected newChat() failure to preserve the previous session id, saw ${controller.state.sessionId}`);
+      }
+
+      if (writes.length !== 1 || writes[0].sessionId !== 11) {
+        throw new Error(`Expected failure path to persist the previous session id, saw ${JSON.stringify(writes)}`);
+      }
+
+      if (contentTarget.innerHTML !== "error") {
+        throw new Error(`Expected failure path to render the error state, saw ${contentTarget.innerHTML}`);
+      }
+
+      if (controller.loading !== false) {
+        throw new Error("Expected failure path to clear the loading flag");
+      }
+    }
+
+    async function run() {
+      global.window = {
+        console: { error() {} }
+      };
+
+      await runNewChatSuccessCase();
+      await runNewChatFailureCase();
+    }
+
+    run().catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+  JAVASCRIPT
+
+  def self.run
+    Open3.capture3("node", "-e", SCRIPT, chdir: Rails.root.to_s)
+  end
+end
+
+RSpec.describe ChatPopupControllerNodeHarness, :no_db do
+  it "replaces popup state only after a fresh session is created" do
+    stdout, stderr, status = described_class.run
+
+    expect(status.success?).to be(true), <<~MESSAGE
+      Node regression harness failed.
+      stdout:
+      #{stdout}
+      stderr:
+      #{stderr}
+    MESSAGE
+  end
+end

--- a/spec/requests/chat_sessions_spec.rb
+++ b/spec/requests/chat_sessions_spec.rb
@@ -262,6 +262,7 @@ RSpec.describe "ChatSessions" do
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("Support chat")
+        expect(response.body).to include("New Chat")
         expect(response.body).to include("Open page")
         expect(response.body).to include("Projects - Paid")
       end
@@ -330,6 +331,13 @@ RSpec.describe "ChatSessions" do
         expect(response.body).not_to include(%(name="chat_session[runner_id]"))
         expect(response.body).not_to include(%(name="chat_session[model]"))
         expect(response.body).not_to include(%(name="content"))
+        expect(response.body).not_to include("New Chat")
+      end
+
+      it "does not render popup new-chat controls" do
+        get chat_session_path(chat_session), params: { display: "popup" }, headers: { "Accept" => "text/html" }
+
+        expect(response).to have_http_status(:ok)
         expect(response.body).not_to include("New Chat")
       end
     end


### PR DESCRIPTION
## Summary

Added the popup `New Chat` flow in [app/views/chat_sessions/_popup.html.erb](/workspace/app/views/chat_sessions/_popup.html.erb) and [app/javascript/controllers/chat_popup_controller.js](/workspace/app/javascript/controllers/chat_popup_controller.js). The button is only shown for users who can create chat sessions, and the controller now creates a fresh session, switches popup state only after creation succeeds, and preserves the previous session in history.

I also added coverage in [spec/requests/chat_sessions_spec.rb](/workspace/spec/requests/chat_sessions_spec.rb) and [spec/lib/chat_popup_controller_node_harness_spec.rb](/workspace/spec/lib/chat_popup_controller_node_harness_spec.rb). `bundle install` succeeded after switching Bundler to `vendor/bundle`. `yarn install` initially failed with `ENOSPC`; it succeeded once I forced `YARN_CACHE_FOLDER` and `TMPDIR` into `/workspace/tmp`. `bin/rails db:prepare` succeeded with `DB_HOST=paid-svc-a3-s1-postgres DB_USERNAME=agent DB_PASSWORD=agent`. `bundle exec rubocop` passed, and the focused specs passed: `bundle exec rspec spec/requests/chat_sessions_spec.rb spec/lib/chat_popup_controller_node_harness_spec.rb`.

The remaining blocker is the required commit: the repo’s commit hook is running the full `bundle exec rspec` suite, and it did not complete within the available execution window, so the commit has not finished yet and the changes remain staged.

---

Closes #2399