### PR TITLE
ci(mutation): track viamin/mutant feature parity via allowed-failure CI job

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -147,3 +147,80 @@ jobs:
         with:
           name: mutation-full-log
           path: ${{ env.MUTANT_OUTPUT_FILE }}
+
+  mutation-viamin-parity:
+    if: github.event_name == 'pull_request' || github.event_name == 'schedule'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    continue-on-error: true
+
+    services:
+      postgres:
+        image: postgres:16.14
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+
+      - name: Normalize test master key
+        if: env.RAILS_TEST_KEY == ''
+        env:
+          RAILS_MASTER_KEY_FALLBACK: ${{ secrets.RAILS_MASTER_KEY }}
+        run: |
+          if [ -n "$RAILS_MASTER_KEY_FALLBACK" ]; then
+            echo "RAILS_TEST_KEY=$RAILS_MASTER_KEY_FALLBACK" >> "$GITHUB_ENV"
+          fi
+
+      - name: Select viamin parity mode
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "MUTANT_PARITY_MODE=incremental" >> "$GITHUB_ENV"
+            echo "MUTANT_PARITY_TARGET_REF=origin/${{ github.base_ref }}" >> "$GITHUB_ENV"
+          else
+            echo "MUTANT_PARITY_MODE=full" >> "$GITHUB_ENV"
+          fi
+          echo "MUTANT_OUTPUT_FILE=tmp/mutant-viamin.log" >> "$GITHUB_ENV"
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f
+        env:
+          BUNDLE_GEMFILE: Gemfile.viamin
+          BUNDLE_FROZEN: "true"
+        with:
+          ruby-version: .tool-versions
+          bundler-cache: true
+
+      - name: Prepare database
+        env:
+          BUNDLE_GEMFILE: Gemfile.viamin
+        run: bundle exec bin/rails db:prepare
+
+      - name: Mutant viamin parity
+        env:
+          BUNDLE_GEMFILE: Gemfile.viamin
+        run: |
+          chmod +x script/ci/mutation_viamin_parity.sh
+          if [ "$MUTANT_PARITY_MODE" = "incremental" ]; then
+            script/ci/mutation_viamin_parity.sh incremental "$MUTANT_PARITY_TARGET_REF"
+          else
+            script/ci/mutation_viamin_parity.sh full
+          fi
+
+      - name: Upload parity log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: mutation-viamin-parity-log
+          path: ${{ env.MUTANT_OUTPUT_FILE }}

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -153,6 +153,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     continue-on-error: true
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/Gemfile.viamin
 
     services:
       postgres:
@@ -192,24 +194,19 @@ jobs:
             echo "MUTANT_PARITY_MODE=full" >> "$GITHUB_ENV"
           fi
           echo "MUTANT_OUTPUT_FILE=tmp/mutant-viamin.log" >> "$GITHUB_ENV"
+          mkdir -p tmp
+          : > tmp/mutant-viamin.log
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f
-        env:
-          BUNDLE_GEMFILE: Gemfile.viamin
-          BUNDLE_FROZEN: "true"
         with:
           ruby-version: .tool-versions
           bundler-cache: true
 
       - name: Prepare database
-        env:
-          BUNDLE_GEMFILE: Gemfile.viamin
         run: bundle exec bin/rails db:prepare
 
       - name: Mutant viamin parity
-        env:
-          BUNDLE_GEMFILE: Gemfile.viamin
         run: |
           chmod +x script/ci/mutation_viamin_parity.sh
           if [ "$MUTANT_PARITY_MODE" = "incremental" ]; then
@@ -224,3 +221,4 @@ jobs:
         with:
           name: mutation-viamin-parity-log
           path: ${{ env.MUTANT_OUTPUT_FILE }}
+          if-no-files-found: ignore

--- a/Gemfile.viamin
+++ b/Gemfile.viamin
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "rails", "~> 8.1.3"
+gem "propshaft"
+gem "pg", "~> 1.1"
+gem "puma", ">= 5.0"
+gem "jsbundling-rails"
+gem "turbo-rails"
+gem "stimulus-rails"
+gem "cssbundling-rails"
+gem "chartkick"
+gem "devise"
+gem "pundit"
+gem "avo", "4.0.0.beta.40"
+gem "discard"
+gem "csv"
+gem "octokit"
+gem "faraday-retry"
+gem "temporalio", require: false
+gem "docker-api", require: false
+gem "qdrant-ruby", require: false
+gem "aws-sdk-s3", require: false
+gem "agent-harness", "~> 0.18.2"
+gem "ruby_llm", "~> 1.15"
+gem "ruby-maat", require: false
+gem "strong_migrations"
+gem "flipper"
+gem "flipper-active_record"
+gem "tzinfo-data", platforms: %i[windows jruby]
+gem "solid_cache"
+gem "solid_cable"
+gem "bootsnap", require: false
+gem "kamal", require: false
+gem "thruster", require: false
+gem "good_job", "~> 4.19"
+gem "pagy", "~> 43.5"
+gem "pdf-reader"
+gem "ransack"
+gem "fx"
+gem "logidze"
+
+group :development, :test do
+  gem "debug", platforms: %i[mri windows], require: "debug/prelude"
+  gem "pg_query", require: false
+  gem "prosopite"
+  gem "rspec-rails"
+  gem "factory_bot_rails"
+  gem "faker"
+  gem "shoulda-matchers"
+end
+
+group :test do
+  gem "simplecov", require: false
+  gem "capybara"
+  gem "cuprite"
+  gem "fixture_kit"
+  gem "mutant", github: "viamin/mutant", branch: "main", require: false
+  gem "mutant-rspec", github: "viamin/mutant", branch: "main", require: false
+  gem "rspec-github", "~> 3.0", require: false
+  gem "test-prof"
+  gem "webmock"
+end

--- a/Gemfile.viamin.lock
+++ b/Gemfile.viamin.lock
@@ -1,0 +1,897 @@
+GIT
+  remote: https://github.com/viamin/mutant.git
+  revision: e893c4b68a8b4b743094c88fb3179b42a2955517
+  branch: main
+  specs:
+    mutant (0.8.25)
+      abstract_type (~> 0.0.7)
+      adamantium (~> 0.2.0)
+      anima (~> 0.3.2)
+      ast (~> 2.4)
+      concord (~> 0.1.6)
+      diff-lcs (~> 1.6)
+      equalizer (~> 0.0.11)
+      ice_nine (~> 0.11.2)
+      memoizable (~> 0.4.2)
+      morpher (~> 0.4.2)
+      parser (~> 3.3.0)
+      procto (~> 0.0.3)
+      racc (~> 1.8)
+      regexp_parser (~> 2.3.1, < 2.4)
+      unparser (~> 0.6.5)
+    mutant-rspec (0.8.25)
+      mutant (~> 0.8.25)
+      rspec-core (>= 3.13, < 4.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    Ascii85 (2.0.1)
+    abstract_type (0.0.7)
+    action_text-trix (2.1.19)
+      railties
+    actioncable (8.1.3)
+      actionpack (= 8.1.3)
+      activesupport (= 8.1.3)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+      zeitwerk (~> 2.6)
+    actionmailbox (8.1.3)
+      actionpack (= 8.1.3)
+      activejob (= 8.1.3)
+      activerecord (= 8.1.3)
+      activestorage (= 8.1.3)
+      activesupport (= 8.1.3)
+      mail (>= 2.8.0)
+    actionmailer (8.1.3)
+      actionpack (= 8.1.3)
+      actionview (= 8.1.3)
+      activejob (= 8.1.3)
+      activesupport (= 8.1.3)
+      mail (>= 2.8.0)
+      rails-dom-testing (~> 2.2)
+    actionpack (8.1.3)
+      actionview (= 8.1.3)
+      activesupport (= 8.1.3)
+      nokogiri (>= 1.8.5)
+      rack (>= 2.2.4)
+      rack-session (>= 1.0.1)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+      useragent (~> 0.16)
+    actiontext (8.1.3)
+      action_text-trix (~> 2.1.15)
+      actionpack (= 8.1.3)
+      activerecord (= 8.1.3)
+      activestorage (= 8.1.3)
+      activesupport (= 8.1.3)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (8.1.3)
+      activesupport (= 8.1.3)
+      builder (~> 3.1)
+      erubi (~> 1.11)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    active_link_to (1.0.5)
+      actionpack
+      addressable
+    activejob (8.1.3)
+      activesupport (= 8.1.3)
+      globalid (>= 0.3.6)
+    activemodel (8.1.3)
+      activesupport (= 8.1.3)
+    activerecord (8.1.3)
+      activemodel (= 8.1.3)
+      activesupport (= 8.1.3)
+      timeout (>= 0.4.0)
+    activestorage (8.1.3)
+      actionpack (= 8.1.3)
+      activejob (= 8.1.3)
+      activerecord (= 8.1.3)
+      activesupport (= 8.1.3)
+      marcel (~> 1.0)
+    activesupport (8.1.3)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      json
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    adamantium (0.2.0)
+      ice_nine (~> 0.11.0)
+      memoizable (~> 0.4.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    afm (1.0.0)
+    agent-harness (0.18.2)
+      logger (>= 1.6, < 2.0)
+    anima (0.3.2)
+      abstract_type (~> 0.0.7)
+      adamantium (~> 0.2)
+      equalizer (~> 0.0.11)
+    ast (2.4.3)
+    avo (4.0.0.beta.40)
+      actionview (>= 6.1)
+      active_link_to
+      activerecord (>= 6.1)
+      activesupport (>= 6.1)
+      addressable
+      avo-icons (>= 0.1.2)
+      docile
+      meta-tags
+      pagy (>= 43.0)
+      prop_initializer (>= 0.3.0)
+      turbo-rails (>= 2.0.0)
+      turbo_power (>= 0.6.0)
+      view_component (>= 3.7.0)
+      zeitwerk (>= 2.6.12)
+    avo-icons (0.1.4)
+      inline_svg
+    aws-eventstream (1.4.0)
+    aws-partitions (1.1255.0)
+    aws-sdk-core (3.250.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-kms (1.128.0)
+      aws-sdk-core (~> 3, >= 3.248.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.224.0)
+      aws-sdk-core (~> 3, >= 3.248.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.12.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+    base64 (0.3.0)
+    bcrypt (3.1.22)
+    bcrypt_pbkdf (1.1.2)
+    benchmark (0.5.0)
+    bigdecimal (4.1.2)
+    bootsnap (1.24.5)
+      msgpack (~> 1.2)
+    builder (3.3.0)
+    capybara (3.40.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
+    chartkick (5.2.1)
+    concord (0.1.6)
+      adamantium (~> 0.2.0)
+      equalizer (~> 0.0.9)
+    concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
+    crack (1.0.1)
+      bigdecimal
+      rexml
+    crass (1.0.6)
+    cssbundling-rails (1.4.3)
+      railties (>= 6.0.0)
+    csv (3.3.5)
+    cuprite (0.17)
+      capybara (~> 3.0)
+      ferrum (~> 0.17.0)
+    date (3.5.1)
+    debug (1.11.1)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
+    devise (5.0.4)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 7.0)
+      responders
+      warden (~> 1.2.3)
+    diff-lcs (1.6.2)
+    discard (2.0.0)
+      activerecord (>= 7.0, < 9.0)
+    docile (1.4.1)
+    docker-api (2.4.0)
+      excon (>= 0.64.0)
+      multi_json
+    dotenv (3.2.0)
+    drb (2.2.3)
+    ed25519 (1.4.0)
+    equalizer (0.0.11)
+    erb (6.0.4)
+    erubi (1.13.1)
+    et-orbi (1.4.0)
+      tzinfo
+    event_stream_parser (1.0.0)
+    excon (1.4.2)
+      logger
+    factory_bot (6.6.0)
+      activesupport (>= 6.1.0)
+    factory_bot_rails (6.5.1)
+      factory_bot (~> 6.5)
+      railties (>= 6.1.0)
+    faker (3.8.0)
+      i18n (>= 1.8.11, < 2)
+    faraday (2.14.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-multipart (1.2.0)
+      multipart-post (~> 2.0)
+    faraday-net_http (3.4.3)
+      net-http (~> 0.5)
+    faraday-retry (2.4.0)
+      faraday (~> 2.0)
+    ferrum (0.17.2)
+      addressable (~> 2.5)
+      base64 (~> 0.2)
+      concurrent-ruby (~> 1.1)
+      webrick (~> 1.7)
+      websocket-driver (~> 0.7)
+    fixture_kit (0.17.0)
+      activerecord (>= 8.0)
+      activesupport (>= 8.0)
+      benchmark
+    flipper (1.4.2)
+      concurrent-ruby (< 2)
+    flipper-active_record (1.4.2)
+      activerecord (>= 4.2, < 9)
+      flipper (~> 1.4.2)
+    fugit (1.12.2)
+      et-orbi (~> 1.4)
+      raabro (~> 1.4)
+    fx (0.11.0)
+      activerecord (>= 7.2)
+      railties (>= 7.2)
+    globalid (1.3.0)
+      activesupport (>= 6.1)
+    good_job (4.19.0)
+      activejob (>= 6.1.0)
+      activerecord (>= 6.1.0)
+      concurrent-ruby (>= 1.3.1)
+      fugit (>= 1.11.0)
+      railties (>= 6.1.0)
+      thor (>= 1.0.0)
+    google-protobuf (4.35.0)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-aarch64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-aarch64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-x86_64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.0-x86_64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    hashdiff (1.2.1)
+    hashery (2.1.2)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
+    inline_svg (1.10.0)
+      activesupport (>= 3.0)
+      nokogiri (>= 1.6)
+    io-console (0.8.2)
+    irb (1.18.0)
+      pp (>= 0.6.0)
+      prism (>= 1.3.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
+    jmespath (1.6.2)
+    jsbundling-rails (1.3.1)
+      railties (>= 6.0.0)
+    json (2.19.7)
+    kamal (2.11.0)
+      activesupport (>= 7.0)
+      base64 (~> 0.2)
+      bcrypt_pbkdf (~> 1.0)
+      concurrent-ruby (~> 1.2)
+      dotenv (~> 3.1)
+      ed25519 (~> 1.4)
+      net-ssh (~> 7.3)
+      sshkit (>= 1.23.0, < 2.0)
+      thor (~> 1.3)
+      zeitwerk (>= 2.6.18, < 3.0)
+    logger (1.7.0)
+    logidze (1.4.1)
+      activerecord (>= 6.0)
+      railties (>= 6.0)
+    loofah (2.25.1)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    mail (2.9.0)
+      logger
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    marcel (1.2.1)
+    matrix (0.4.3)
+    memoizable (0.4.2)
+      thread_safe (~> 0.3, >= 0.3.1)
+    meta-tags (2.23.0)
+      actionpack (>= 6.0.0)
+    mini_mime (1.1.5)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    morpher (0.4.2)
+      abstract_type (~> 0.0.7)
+      adamantium (~> 0.2.0)
+      anima (~> 0.3.0)
+      concord (~> 0.1.5)
+      equalizer (~> 0.0.9)
+      mprelude (~> 0.1.0)
+      procto (~> 0.0.2)
+    mprelude (0.1.0)
+      abstract_type (~> 0.0.7)
+      adamantium (~> 0.2.0)
+      concord (~> 0.1.5)
+      equalizer (~> 0.0.9)
+      ice_nine (~> 0.11.1)
+      procto (~> 0.0.2)
+    msgpack (1.8.1)
+    multi_json (1.21.1)
+    multipart-post (2.4.1)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
+    net-imap (0.6.4)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
+    net-scp (4.1.0)
+      net-ssh (>= 2.6.5, < 8.0.0)
+    net-sftp (4.0.0)
+      net-ssh (>= 5.0.0, < 8.0.0)
+    net-smtp (0.5.1)
+      net-protocol
+    net-ssh (7.3.2)
+    nio4r (2.7.5)
+    nokogiri (1.19.3-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.3-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.3-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.3-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.3-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.3-x86_64-linux-musl)
+      racc (~> 1.4)
+    numo-narray (0.9.2.1)
+    octokit (10.0.0)
+      faraday (>= 1, < 3)
+      sawyer (~> 0.9)
+    orm_adapter (0.5.0)
+    ostruct (0.6.3)
+    pagy (43.5.5)
+      json
+      uri
+      yaml
+    parser (3.3.11.1)
+      ast (~> 2.4.1)
+      racc
+    pdf-reader (2.15.1)
+      Ascii85 (>= 1.0, < 3.0, != 2.0.0)
+      afm (>= 0.2.1, < 2)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
+    pg (1.6.3)
+    pg (1.6.3-aarch64-linux)
+    pg (1.6.3-aarch64-linux-musl)
+    pg (1.6.3-x86_64-linux)
+    pg (1.6.3-x86_64-linux-musl)
+    pg_query (6.2.2)
+      google-protobuf (>= 3.25.3)
+    pp (0.6.3)
+      prettyprint
+    prettyprint (0.2.0)
+    prism (1.9.0)
+    procto (0.0.3)
+    prop_initializer (0.4.0)
+      zeitwerk (>= 2.6.18)
+    propshaft (1.3.2)
+      actionpack (>= 7.0.0)
+      activesupport (>= 7.0.0)
+      rack
+    prosopite (2.2.0)
+    psych (5.3.1)
+      date
+      stringio
+    public_suffix (7.0.5)
+    puma (8.0.2)
+      nio4r (~> 2.0)
+    pundit (2.5.2)
+      activesupport (>= 3.0.0)
+    qdrant-ruby (0.9.10)
+      faraday (>= 2.0.1, < 3)
+    raabro (1.4.0)
+    racc (1.8.1)
+    rack (3.2.6)
+    rack-session (2.1.2)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    rack-test (2.2.0)
+      rack (>= 1.3)
+    rackup (2.3.1)
+      rack (>= 3)
+    rails (8.1.3)
+      actioncable (= 8.1.3)
+      actionmailbox (= 8.1.3)
+      actionmailer (= 8.1.3)
+      actionpack (= 8.1.3)
+      actiontext (= 8.1.3)
+      actionview (= 8.1.3)
+      activejob (= 8.1.3)
+      activemodel (= 8.1.3)
+      activerecord (= 8.1.3)
+      activestorage (= 8.1.3)
+      activesupport (= 8.1.3)
+      bundler (>= 1.15.0)
+      railties (= 8.1.3)
+    rails-dom-testing (2.3.0)
+      activesupport (>= 5.0.0)
+      minitest
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.7.0)
+      loofah (~> 2.25)
+      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    railties (8.1.3)
+      actionpack (= 8.1.3)
+      activesupport (= 8.1.3)
+      irb (~> 1.13)
+      rackup (>= 1.0.0)
+      rake (>= 12.2)
+      thor (~> 1.0, >= 1.2.2)
+      tsort (>= 0.2)
+      zeitwerk (~> 2.6)
+    rake (13.4.2)
+    ransack (4.4.1)
+      activerecord (>= 7.2)
+      activesupport (>= 7.2)
+      i18n
+    rdoc (7.2.0)
+      erb
+      psych (>= 4.0.0)
+      tsort
+    regexp_parser (2.3.1)
+    reline (0.6.3)
+      io-console (~> 0.5)
+    responders (3.2.0)
+      actionpack (>= 7.0)
+      railties (>= 7.0)
+    rexml (3.4.4)
+    rover-df (0.5.0)
+      numo-narray (>= 0.9.1.9)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-github (3.0.0)
+      rspec-core (~> 3.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-rails (8.0.4)
+      actionpack (>= 7.2)
+      activesupport (>= 7.2)
+      railties (>= 7.2)
+      rspec-core (>= 3.13.0, < 5.0.0)
+      rspec-expectations (>= 3.13.0, < 5.0.0)
+      rspec-mocks (>= 3.13.0, < 5.0.0)
+      rspec-support (>= 3.13.0, < 5.0.0)
+    rspec-support (3.13.7)
+    ruby-maat (1.2.0)
+      csv (~> 3.2)
+      rexml (~> 3.2)
+      rover-df (~> 0.3)
+    ruby-rc4 (0.1.5)
+    ruby_llm (1.15.0)
+      base64
+      event_stream_parser (~> 1)
+      faraday (>= 1.10.0)
+      faraday-multipart (>= 1)
+      faraday-net_http (>= 1)
+      faraday-retry (>= 1)
+      marcel (~> 1)
+      ruby_llm-schema (~> 0)
+      zeitwerk (~> 2)
+    ruby_llm-schema (0.4.0)
+    sawyer (0.9.3)
+      addressable (>= 2.3.5)
+      faraday (>= 0.17.3, < 3)
+    securerandom (0.4.1)
+    shoulda-matchers (7.0.1)
+      activesupport (>= 7.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
+    solid_cable (4.0.0)
+      actioncable (>= 7.2)
+      activejob (>= 7.2)
+      activerecord (>= 7.2)
+      railties (>= 7.2)
+    solid_cache (1.0.10)
+      activejob (>= 7.2)
+      activerecord (>= 7.2)
+      railties (>= 7.2)
+    sshkit (1.25.0)
+      base64
+      logger
+      net-scp (>= 1.1.2)
+      net-sftp (>= 2.1.2)
+      net-ssh (>= 2.8.0)
+      ostruct
+    stimulus-rails (1.3.4)
+      railties (>= 6.0.0)
+    stringio (3.2.0)
+    strong_migrations (2.8.0)
+      activerecord (>= 7.2)
+    temporalio (1.4.1)
+      google-protobuf (>= 3.25.0)
+      logger
+    temporalio (1.4.1-aarch64-linux)
+      google-protobuf (>= 3.25.0)
+      logger
+    temporalio (1.4.1-aarch64-linux-musl)
+      google-protobuf (>= 3.25.0)
+      logger
+    temporalio (1.4.1-x86_64-linux)
+      google-protobuf (>= 3.25.0)
+      logger
+    temporalio (1.4.1-x86_64-linux-musl)
+      google-protobuf (>= 3.25.0)
+      logger
+    test-prof (1.6.1)
+    thor (1.5.0)
+    thread_safe (0.3.6)
+    thruster (0.1.21)
+    thruster (0.1.21-aarch64-linux)
+    thruster (0.1.21-x86_64-linux)
+    timeout (0.6.1)
+    tsort (0.2.0)
+    ttfunk (1.7.0)
+    turbo-rails (2.0.23)
+      actionpack (>= 7.1.0)
+      railties (>= 7.1.0)
+    turbo_power (0.7.0)
+      turbo-rails (>= 1.3.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unparser (0.6.15)
+      diff-lcs (~> 1.3)
+      parser (>= 3.3.0)
+    uri (1.1.1)
+    useragent (0.16.11)
+    view_component (4.11.0)
+      actionview (>= 7.1.0)
+      activesupport (>= 7.1.0)
+      concurrent-ruby (~> 1)
+    warden (1.2.9)
+      rack (>= 2.0.9)
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    webrick (1.9.2)
+    websocket-driver (0.8.0)
+      base64
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
+    yaml (0.4.0)
+    zeitwerk (2.8.2)
+
+PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  x86_64-linux
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  agent-harness (~> 0.18.2)
+  avo (= 4.0.0.beta.40)
+  aws-sdk-s3
+  bootsnap
+  capybara
+  chartkick
+  cssbundling-rails
+  csv
+  cuprite
+  debug
+  devise
+  discard
+  docker-api
+  factory_bot_rails
+  faker
+  faraday-retry
+  fixture_kit
+  flipper
+  flipper-active_record
+  fx
+  good_job (~> 4.19)
+  jsbundling-rails
+  kamal
+  logidze
+  mutant!
+  mutant-rspec!
+  octokit
+  pagy (~> 43.5)
+  pdf-reader
+  pg (~> 1.1)
+  pg_query
+  propshaft
+  prosopite
+  puma (>= 5.0)
+  pundit
+  qdrant-ruby
+  rails (~> 8.1.3)
+  ransack
+  rspec-github (~> 3.0)
+  rspec-rails
+  ruby-maat
+  ruby_llm (~> 1.15)
+  shoulda-matchers
+  simplecov
+  solid_cable
+  solid_cache
+  stimulus-rails
+  strong_migrations
+  temporalio
+  test-prof
+  thruster
+  turbo-rails
+  tzinfo-data
+  webmock
+
+CHECKSUMS
+  Ascii85 (2.0.1) sha256=15cb5d941808543cbb9e7e6aea3c8ec3877f154c3461e8b3673e97f7ecedbe5a
+  abstract_type (0.0.7) sha256=24b82b68ccd2f5126d517bb68747858d99ad057aff27d9a0ab5cb00c2b036324
+  action_text-trix (2.1.19) sha256=7012f59421009cf284aa651294896414d653a61a2417c9b8714c8476d2f74009
+  actioncable (8.1.3) sha256=e5bc7f75e44e6a22de29c4f43176927c3a9ce4824464b74ed18d8226e75a80f0
+  actionmailbox (8.1.3) sha256=df7da474eaa0e70df4ed5a6fef66eb3b3b0f2dbf7f14518deee8d77f1b4aae59
+  actionmailer (8.1.3) sha256=831f724891bb70d0aaa4d76581a6321124b6a752cb655c9346aae5479318448d
+  actionpack (8.1.3) sha256=af998cae4d47c5d581a2cc363b5c77eb718b7c4b45748d81b1887b25621c29a3
+  actiontext (8.1.3) sha256=d291019c00e1ea9e6463011fa214f6081a56d7b9a1d224e7d3f6384c1dafc7d2
+  actionview (8.1.3) sha256=1347c88c7f3edb38100c5ce0e9fb5e62d7755f3edc1b61cce2eb0b2c6ea2fd5d
+  active_link_to (1.0.5) sha256=4830847b3d14589df1e9fc62038ceec015257fce975ec1c2a77836c461b139ba
+  activejob (8.1.3) sha256=a149b1766aa8204c3c3da7309e4becd40fcd5529c348cffbf6c9b16b565fe8d3
+  activemodel (8.1.3) sha256=90c05cbe4cef3649b8f79f13016191ea94c4525ce4a5c0fb7ef909c4b91c8219
+  activerecord (8.1.3) sha256=8003be7b2466ba0a2a670e603eeb0a61dd66058fccecfc49901e775260ac70ab
+  activestorage (8.1.3) sha256=0564ce9309143951a67615e1bb4e090ee54b8befed417133cae614479b46384d
+  activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
+  adamantium (0.2.0) sha256=5379dc1090ec6ce115eaed4271a2056f3b72ee94d1ff866a169bbb37a3c8c504
+  addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  afm (1.0.0) sha256=5bd4d6f6241e7014ef090985ec6f4c3e9745f6de0828ddd58bc1efdd138f4545
+  agent-harness (0.18.2) sha256=ee7fba0996bd5f31367d83de087a336b9ce7472a50652d0e4239e13463cef9f0
+  anima (0.3.2) sha256=467f775e5c7721f1ac19c0efcef2ca56489b9673809371b12514a77e11cbfc00
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  avo (4.0.0.beta.40) sha256=58d97d49c0553f569c18837c618819fad4895213ea29f189ab6f9c19a9aff9cd
+  avo-icons (0.1.4) sha256=4f77070a5710ebb9db5cd6746aa5f043b8e71e61b27c7fba5210a40d87898e4d
+  aws-eventstream (1.4.0) sha256=116bf85c436200d1060811e6f5d2d40c88f65448f2125bc77ffce5121e6e183b
+  aws-partitions (1.1255.0) sha256=490ffc1f032d3eac771cf4a94ab7a3c7999c5edbe6fb7660904e702e291c93b5
+  aws-sdk-core (3.250.0) sha256=8df71164c7e5f2ff411782a3dc3a1ab5c0a73170284409ead111f385e9992963
+  aws-sdk-kms (1.128.0) sha256=20ce3957f80c7b40b3115a7e902af52b15a6eef42fe6b2e19db72f8e8c9e5658
+  aws-sdk-s3 (1.224.0) sha256=7d443c4ae9eda795b60e081d41f49b498e2483f1fc204f3239176ec922ed7879
+  aws-sigv4 (1.12.1) sha256=6973ff95cb0fd0dc58ba26e90e9510a2219525d07620c8babeb70ef831826c00
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  bcrypt (3.1.22) sha256=1f0072e88c2d705d94aff7f2c5cb02eb3f1ec4b8368671e19112527489f29032
+  bcrypt_pbkdf (1.1.2) sha256=c2414c23ce66869b3eb9f643d6a3374d8322dfb5078125c82792304c10b94cf6
+  benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
+  bootsnap (1.24.5) sha256=36b677448524d279b470469aabd5dff4a980e3fa4931a0df68da4a500eb1b6c4
+  builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
+  bundler (4.0.12) sha256=7f8b757d28dfb636e7b24fba2344ac6dd13b5b24f4b46d62573d483f211825ac
+  capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
+  chartkick (5.2.1) sha256=2848d7de87189f30f28d077eb0bbdebc8a1f0f6f81de1ded95008fe564369949
+  concord (0.1.6) sha256=184e9c146579ad5fc5d663c95dea3f6d1640b00d24e5e7248ffcfcd1d8f7f6ef
+  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
+  connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
+  crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
+  crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
+  cssbundling-rails (1.4.3) sha256=53aecd5a7d24ac9c8fcd92975acd0e830fead4ee4583d3d3d49bb64651946e41
+  csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
+  cuprite (0.17) sha256=b140d5dc70d08b97ad54bcf45cd95d0bd430e291e9dffe76fff851fddd57c12b
+  date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
+  debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
+  devise (5.0.4) sha256=d605f2b85854e74e56ee789e2d398702bc2d06e6bcd894717a670a3199c74cc1
+  diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
+  discard (2.0.0) sha256=0fc520786b4d7b9b1ea8b2b3dadbb13c3e41d2ce7d297d04869baf1c9e30d2c0
+  docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
+  docker-api (2.4.0) sha256=824be734f4cc8718189be9c8e795b6414acbbf7e8b082a06f959a27dd8dd63e6
+  dotenv (3.2.0) sha256=e375b83121ea7ca4ce20f214740076129ab8514cd81378161f11c03853fe619d
+  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
+  ed25519 (1.4.0) sha256=16e97f5198689a154247169f3453ef4cfd3f7a47481fde0ae33206cdfdcac506
+  equalizer (0.0.11) sha256=44e5bc46f49883e83d159ee9b1f7320b4ae8283bb6329e5d9716f5e7dde855ce
+  erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
+  erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
+  et-orbi (1.4.0) sha256=6c7e3c90779821f9e3b324c5e96fda9767f72995d6ae435b96678a4f3e2de8bc
+  event_stream_parser (1.0.0) sha256=a2683bab70126286f8184dc88f7968ffc4028f813161fb073ec90d171f7de3c8
+  excon (1.4.2) sha256=32d8d8eda619717d9b8043b4675e096fb5c2139b080e2ad3b267f88c545aaa35
+  factory_bot (6.6.0) sha256=1fc1b3b5620ec980a6a27aec1b6ec8c250ca82962e970e8a40f93e8d388d4b89
+  factory_bot_rails (6.5.1) sha256=d3cc4851eae4dea8a665ec4a4516895045e710554d2b5ac9e68b94d351bc6d68
+  faker (3.8.0) sha256=c147b308df73a90f27a4fc84f18d4c22ef0ad9c2a64b2b61c86fd0ca71753efc
+  faraday (2.14.2) sha256=73ccb9994a9e8648f010e32eca2ae82e41c57860aa10932cda29418b9e0223ad
+  faraday-multipart (1.2.0) sha256=7d89a949693714176f612323ca13746a2ded204031a6ba528adee788694ef757
+  faraday-net_http (3.4.3) sha256=9db13becec9312f345a769eeeecf9049c9287d54c0ae053d7235228993a4eec1
+  faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
+  ferrum (0.17.2) sha256=2c2540a850b211a46f4d81de21bfd62048f507e4c327d1807225c3823c17e6ee
+  fixture_kit (0.17.0) sha256=88504de297687d8cb189c72723711b08f1d4a9e002341fff1412d6273a79c233
+  flipper (1.4.2) sha256=dca7d65b5ec660b525b6c599e727219ac4994073c855b41b6656b2d91a9cb304
+  flipper-active_record (1.4.2) sha256=ab70aeb78a44d59c690b5538fc269b08d1c2918abb720fe82832ac77fb1dfcd1
+  fugit (1.12.2) sha256=643f2bf28db263bd400cbf8e0dd8b76b2c9b94bdb130e12d2394de04d9c20e5e
+  fx (0.11.0) sha256=537f2c0359b54da8b17574acaedcaecea806ead14dcd9239a16f70ee66c70f7d
+  globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
+  good_job (4.19.0) sha256=7fad3ce174d2c1b4bfde4e84056076b00ac81719b5d679900c53671a721284b9
+  google-protobuf (4.35.0) sha256=95346162c792ed78c9a28cbf2d937a53f706de6df36a27471582f63f03c30c0d
+  google-protobuf (4.35.0-aarch64-linux-gnu) sha256=2cabd61b420918aec1564f9f7414e455bf922d20c5f8139d62783df5558a7aea
+  google-protobuf (4.35.0-aarch64-linux-musl) sha256=f6b11f3420a4564f68e8233c95eac6924f6a727dfc2f81a56af2e09add551501
+  google-protobuf (4.35.0-x86_64-linux-gnu) sha256=999226f3b00cd9fddb1b26851d16060212fa1d90c406aaad47e574682b716059
+  google-protobuf (4.35.0-x86_64-linux-musl) sha256=be0218520d77b2aee898b363514b03819f6f63f9c041ae0d0d79b4ce5247bffd
+  hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
+  hashery (2.1.2) sha256=d239cc2310401903f6b79d458c2bbef5bf74c46f3f974ae9c1061fb74a404862
+  i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
+  ice_nine (0.11.2) sha256=5d506a7d2723d5592dc121b9928e4931742730131f22a1a37649df1c1e2e63db
+  inline_svg (1.10.0) sha256=5b652934236fd9f8adc61f3fd6e208b7ca3282698b19f28659971da84bf9a10f
+  io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
+  irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
+  jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
+  jsbundling-rails (1.3.1) sha256=0fa03f6d051c694cbf55a022d8be53399879f2c4cf38b2968f86379c62b1c2ca
+  json (2.19.7) sha256=fe432c8639f6efff69f9d73b518a3705d9581ab93156f981ea72806e1e5bcc3e
+  kamal (2.11.0) sha256=1408864425e0dec7e0a14d712a3b13f614e9f3a425b7661d3f9d287a51d7dd75
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  logidze (1.4.1) sha256=6303fbeff030e21cd2f143aa5f7dba300978236509327cbee41447cb2af5e368
+  loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
+  mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
+  marcel (1.2.1) sha256=1678e9360e32f9eafa917c80029e2f6d10b2715c66a4b87b6d0da9b9cd1f859f
+  matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
+  memoizable (0.4.2) sha256=acf4d2280fea019318e61cfc5e69077dcb3c2126817ee596ffd76d0ddf5e826c
+  meta-tags (2.23.0) sha256=ffe78b5bee398de4ff5ac3316f5a786049538a651643b8476def06c3acc762c1
+  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
+  minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
+  morpher (0.4.2) sha256=0a7afa16acfd8b619b0bc3dd9269c5fa42b502f496358e60e48027c58d1aa07b
+  mprelude (0.1.0) sha256=d851de873ed07eb4b40ffb70f1da3afd5c22f62148a0178a03fe095b49c55dd4
+  msgpack (1.8.1) sha256=3fef787cd3965fd119c08a22724a56a93ca25008c3421fc15039f603a8b7c86c
+  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
+  multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
+  mutant (0.8.25)
+  mutant-rspec (0.8.25)
+  net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
+  net-imap (0.6.4) sha256=9a5598c67a3022c284d98430ef1d4948e7dbdb62596f61081ea8ca933270a02b
+  net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
+  net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
+  net-scp (4.1.0) sha256=a99b0b92a1e5d360b0de4ffbf2dc0c91531502d3d4f56c28b0139a7c093d1a5d
+  net-sftp (4.0.0) sha256=65bb91c859c2f93b09826757af11b69af931a3a9155050f50d1b06d384526364
+  net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736
+  net-ssh (7.3.2) sha256=65029e213c380e20e5fd92ece663934ab0a0fe888e0cd7cc6a5b664074362dd4
+  nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
+  nokogiri (1.19.3-aarch64-linux-gnu) sha256=46b89e5d7b9e844c2ee360794240c6ea2a4e6fa0c5892a4ed487db621224b639
+  nokogiri (1.19.3-aarch64-linux-musl) sha256=8392dfdcd21be7a94dbbe9ccc138dea01b97b24cb2dc02a114ca98bfb1d9a0b7
+  nokogiri (1.19.3-arm-linux-gnu) sha256=3919d5ffc334ad778a4a9eb88fda7dcb8b1fb58c8a52ac640c6dcd2f038e774f
+  nokogiri (1.19.3-arm-linux-musl) sha256=9ce1cb6346bb9c67b1550eb537aa183ead91e4b6eadb2f36ade02d8dd2a79fb6
+  nokogiri (1.19.3-x86_64-linux-gnu) sha256=2f5078620fe12e83669b5b17311b32532a8153d02eee7ad06948b926d6080976
+  nokogiri (1.19.3-x86_64-linux-musl) sha256=248c906d2166eca5efb56d52fdee5f9a1f51d69a72e2b64fdac647b4ce39ea3f
+  numo-narray (0.9.2.1) sha256=eed76b47eebe1288ffd878b387f1882f4863d8e6ab5dd61453768139e14adceb
+  octokit (10.0.0) sha256=82e99a539b7637b7e905e6d277bb0c1a4bed56735935cc33db6da7eae49a24e8
+  orm_adapter (0.5.0) sha256=aa5d0be5d540cbb46d3a93e88061f4ece6a25f6e97d6a47122beb84fe595e9b9
+  ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
+  pagy (43.5.5) sha256=86790336da3a1966e3503c226989577f1f56e3353dad10353445e8c988412548
+  parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
+  pdf-reader (2.15.1) sha256=18c6a986a84a3117fa49f4279fc2de51f5d2399b71833df5d2bccd595c7068ce
+  pg (1.6.3) sha256=1388d0563e13d2758c1089e35e973a3249e955c659592d10e5b77c468f628a99
+  pg (1.6.3-aarch64-linux) sha256=0698ad563e02383c27510b76bf7d4cd2de19cd1d16a5013f375dd473e4be72ea
+  pg (1.6.3-aarch64-linux-musl) sha256=06a75f4ea04b05140146f2a10550b8e0d9f006a79cdaf8b5b130cde40e3ecc2c
+  pg (1.6.3-x86_64-linux) sha256=5d9e188c8f7a0295d162b7b88a768d8452a899977d44f3274d1946d67920ae8d
+  pg (1.6.3-x86_64-linux-musl) sha256=9c9c90d98c72f78eb04c0f55e9618fe55d1512128e411035fe229ff427864009
+  pg_query (6.2.2) sha256=316c194160ccfac8af9a7aff55cdc5b2d13bdd8bd8734976c6bddc477e779b6f
+  pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
+  prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  procto (0.0.3) sha256=0c15c8921530a4b59c4d34758c043e6e517136ef7039ef411e3f83d2c3db358e
+  prop_initializer (0.4.0) sha256=487d31d44a58ec7654a7db9eb23cad30030a5bbf16e6a53c71e3cbb88be9e1d8
+  propshaft (1.3.2) sha256=1d56a3e56a92c21bfc29caf07406b5386b00d4c47ddf357cf989a5a234b1389e
+  prosopite (2.2.0) sha256=14affaa3ff0ff15abe8f6ae2951de0984dc6da5df1c42333692d2c0789d08b91
+  psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
+  public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  puma (8.0.2) sha256=c8ed871dfbbe66448ea9ffd46692342d9804d4071522b52b5331b7b6e7b686fb
+  pundit (2.5.2) sha256=e374152baa24f90b630428293faf4b4c5468fc3cc010165f7d8fcb44ce108bbd
+  qdrant-ruby (0.9.10) sha256=18751c9dc9c6a540704bd777bdf7c526b0636ab09e4c64bf615d44f6de2d0c11
+  raabro (1.4.0) sha256=d4fa9ff5172391edb92b242eed8be802d1934b1464061ae5e70d80962c5da882
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
+  rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
+  rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
+  rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
+  rails (8.1.3) sha256=6d017ba5348c98fc909753a8169b21d44de14d2a0b92d140d1a966834c3c9cd3
+  rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
+  rails-html-sanitizer (1.7.0) sha256=28b145cceaf9cc214a9874feaa183c3acba036c9592b19886e0e45efc62b1e89
+  railties (8.1.3) sha256=913eb0e0cb520aac687ffd74916bd726d48fa21f47833c6292576ef6a286de22
+  rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  ransack (4.4.1) sha256=6aeaac36fc19088570e10da1044e6cfd88c740e20f871b84566fd30e32b7a63d
+  rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
+  regexp_parser (2.3.1) sha256=46cf42c6b7d95aabd12b8976edd767d0db0c54e3034c425a3695d6bd23476e1c
+  reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
+  responders (3.2.0) sha256=89c2d6ac0ae16f6458a11524cae4a8efdceba1a3baea164d28ee9046bd3df55a
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rover-df (0.5.0) sha256=4c886d3c7208f7b21fc3fe051cee0e3d5cd46ae414f1f63e8c2cef8818916035
+  rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
+  rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
+  rspec-github (3.0.0) sha256=46af3cd8cad3e4434c20598752b6e721c5325e73d7e36e256379f0d3a85968af
+  rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
+  rspec-rails (8.0.4) sha256=06235692fc0892683d3d34977e081db867434b3a24ae0dd0c6f3516bad4e22df
+  rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
+  ruby-maat (1.2.0) sha256=558797d7e1267126a56fbfc9db2d29002a5e5d2bc330b8a45ba106c0771ff844
+  ruby-rc4 (0.1.5) sha256=00cc40a39d20b53f5459e7ea006a92cf584e9bc275e2a6f7aa1515510e896c03
+  ruby_llm (1.15.0) sha256=ca207465bca1cca007010a79fce500d4012b1fbe188b025040cd37b884fb98af
+  ruby_llm-schema (0.4.0) sha256=e930f5a5316f9301bff3fb7fe572e44727d05bb8e50621001bbb49a47d63b8da
+  sawyer (0.9.3) sha256=0d0f19298408047037638639fe62f4794483fb04320269169bd41af2bdcf5e41
+  securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
+  shoulda-matchers (7.0.1) sha256=b4bfd8744c10e0a36c8ac1a687f921ee7e25ed529e50488d61b79a8688749c77
+  simplecov (0.22.0) sha256=fe2622c7834ff23b98066bb0a854284b2729a569ac659f82621fc22ef36213a5
+  simplecov-html (0.13.2) sha256=bd0b8e54e7c2d7685927e8d6286466359b6f16b18cb0df47b508e8d73c777246
+  simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
+  solid_cable (4.0.0) sha256=8379680ef6bf36e195eb876a6306ea290f87d5fa10bc4a757bc2a918f83229b5
+  solid_cache (1.0.10) sha256=bc05a2fb3ac78a6f43cbb5946679cf9db67dd30d22939ededc385cb93e120d41
+  sshkit (1.25.0) sha256=c8c6543cdb60f91f1d277306d585dd11b6a064cb44eab0972827e4311ff96744
+  stimulus-rails (1.3.4) sha256=765676ffa1f33af64ce026d26b48e8ffb2e0b94e0f50e9119e11d6107d67cb06
+  stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
+  strong_migrations (2.8.0) sha256=cb9c0f8160e60f3e9c0e76098d57a6f61825b9618e8eb41cebbd1c1079874439
+  temporalio (1.4.1) sha256=efaed53f8d2bfdbf7f036c2489ad8f2d5ea5f1884de73f087b0cba6f384f76c7
+  temporalio (1.4.1-aarch64-linux) sha256=d2eb9e44c5e7bc02ef61e4aea73461533a975a3ac53b36935d285d95ce0f8773
+  temporalio (1.4.1-aarch64-linux-musl) sha256=73f8cec8d334ec4bfed1824cd5ca062faf059a64be90983ed26f930dbcd7ad2c
+  temporalio (1.4.1-x86_64-linux) sha256=c534ff53eb75d545f8d0c2da8c6b67f3dd47138b662d29cefa250f1383c1c8d7
+  temporalio (1.4.1-x86_64-linux-musl) sha256=375aa26acc1162c501ddd6251cc215cee3f15bd8a4b6175e90aeef63ff37dd17
+  test-prof (1.6.1) sha256=0332d9c39a7c118ed942b2db582f055d9f24964d150004ec6b964d2fa262499e
+  thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
+  thread_safe (0.3.6) sha256=9ed7072821b51c57e8d6b7011a8e282e25aeea3a4065eab326e43f66f063b05a
+  thruster (0.1.21) sha256=dc67928f36e5894844579a95e45637a5091db7a7ea05468ee8c2c6eb0a3f77cf
+  thruster (0.1.21-aarch64-linux) sha256=f5aff78fb7a6431ed3d6ab4bde03a89c461e9a73981dbc97d6990d85c3db235c
+  thruster (0.1.21-x86_64-linux) sha256=6e2fbcf826540a72d3710ae4db072c2333287ac2ee57e7e52f35bc10900d74a7
+  timeout (0.6.1) sha256=78f57368a7e7bbadec56971f78a3f5ecbcfb59b7fcbb0a3ed6ddc08a5094accb
+  tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
+  ttfunk (1.7.0) sha256=2370ba484b1891c70bdcafd3448cfd82a32dd794802d81d720a64c15d3ef2a96
+  turbo-rails (2.0.23) sha256=ee0d90733aafff056cf51ff11e803d65e43cae258cc55f6492020ec1f9f9315f
+  turbo_power (0.7.0) sha256=ad95d147e0fa761d0023ad9ca00528c7b7ddf6bba8ca2e23755d5b21b290d967
+  tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
+  unparser (0.6.15) sha256=159e994ba6ad7f102f09d902e73ab429d8462774c3cb9f04e3ac0ecd687cade7
+  uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
+  useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
+  view_component (4.11.0) sha256=92df960575b8fa5e984522532df225ec333015a07a8105b3b1c200c655065517
+  warden (1.2.9) sha256=46684f885d35a69dbb883deabf85a222c8e427a957804719e143005df7a1efd0
+  webmock (3.26.2) sha256=774556f2ea6371846cca68c01769b2eac0d134492d21f6d0ab5dd643965a4c90
+  webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
+  websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962
+  websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
+  xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e
+  yaml (0.4.0) sha256=240e69d1e6ce3584d6085978719a0faa6218ae426e034d8f9b02fb54d3471942
+  zeitwerk (2.8.2) sha256=7212a61311083c604184b1ea2574b9aa05cd14f855a0841c06985cabe9181d12
+
+BUNDLED WITH
+  4.0.12

--- a/docs/MUTATION_TESTING.md
+++ b/docs/MUTATION_TESTING.md
@@ -1,0 +1,21 @@
+# Mutation Testing
+
+Paid runs a tier-1 mutation suite from [`/.mutant.yml`](/workspace/.mutant.yml) in CI. That suite stays intentionally small and targets high-blast-radius code such as trusted-comment filtering, tenant context handling, and authorization policy behavior.
+
+## CI jobs
+
+- `incremental` in [`.github/workflows/mutation.yml`](/workspace/.github/workflows/mutation.yml) runs the sanctioned `mutant-rspec` release on pull requests with `--usage opensource --since origin/<base-ref>`.
+- `full` in the same workflow runs the sanctioned release nightly across the full tier-1 suite.
+- `mutation-viamin-parity` runs against `viamin/mutant@main` as an allowed-failure check on every pull request and on the nightly schedule.
+
+## viamin parity signal
+
+`mutation-viamin-parity` is a measurement job, not a gate. It uses `BUNDLE_GEMFILE=Gemfile.viamin` so Bundler resolves `mutant` and `mutant-rspec` directly from `https://github.com/viamin/mutant` `main`.
+
+The green-light signal is simple: when `mutation-viamin-parity` starts passing without workflow-side workarounds, Paid can treat that as evidence that the structural blockers called out in issue `#2372` are effectively cleared and the sanctioned source can be flipped from the current release to `viamin/mutant`.
+
+Until then, the job’s step summary is the breadcrumb trail for upstream work. It records:
+
+- which parity probe command failed
+- whether a CLI flag or subcommand was unrecognized
+- which main `mutant run` invocation exited non-zero

--- a/docs/MUTATION_TESTING.md
+++ b/docs/MUTATION_TESTING.md
@@ -14,8 +14,8 @@ Paid runs a tier-1 mutation suite from [`.mutant.yml`](../.mutant.yml) in CI. Th
 
 The green-light signal is simple: when `mutation-viamin-parity` starts passing without workflow-side workarounds, Paid can treat that as evidence that the structural blockers called out in issue `#2372` are effectively cleared and the sanctioned source can be flipped from the current release to `viamin/mutant`.
 
-Until then, the job’s step summary is the breadcrumb trail for upstream work. It records:
+Until then, the job's step summary is the breadcrumb trail for upstream work. It records:
 
 - which parity probe command failed
-- whether a CLI flag or subcommand was unrecognized
-- which main `mutant run` invocation exited non-zero
+- whether a CLI flag or legacy subcommand was unrecognized
+- which main `mutant` invocation exited non-zero

--- a/docs/MUTATION_TESTING.md
+++ b/docs/MUTATION_TESTING.md
@@ -1,10 +1,10 @@
 # Mutation Testing
 
-Paid runs a tier-1 mutation suite from [`/.mutant.yml`](/workspace/.mutant.yml) in CI. That suite stays intentionally small and targets high-blast-radius code such as trusted-comment filtering, tenant context handling, and authorization policy behavior.
+Paid runs a tier-1 mutation suite from [`.mutant.yml`](../.mutant.yml) in CI. That suite stays intentionally small and targets high-blast-radius code such as trusted-comment filtering, tenant context handling, and authorization policy behavior.
 
 ## CI jobs
 
-- `incremental` in [`.github/workflows/mutation.yml`](/workspace/.github/workflows/mutation.yml) runs the sanctioned `mutant-rspec` release on pull requests with `--usage opensource --since origin/<base-ref>`.
+- `incremental` in [`.github/workflows/mutation.yml`](../.github/workflows/mutation.yml) runs the sanctioned `mutant-rspec` release on pull requests with `--usage opensource --since origin/<base-ref>`.
 - `full` in the same workflow runs the sanctioned release nightly across the full tier-1 suite.
 - `mutation-viamin-parity` runs against `viamin/mutant@main` as an allowed-failure check on every pull request and on the nightly schedule.
 

--- a/script/ci/mutation_viamin_parity.sh
+++ b/script/ci/mutation_viamin_parity.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+mode="${1:-incremental}"
+target_ref="${2:-}"
+output_file="${MUTANT_OUTPUT_FILE:-tmp/mutant-viamin.log}"
+
+mkdir -p "$(dirname "$output_file")"
+
+declare -a failures=()
+
+extract_note() {
+  local file="$1"
+
+  grep -Eim1 'wrong constant name run|unknown|unrecognized|invalid option|no such command|unknown switch' "$file" || true
+}
+
+run_probe() {
+  local label="$1"
+  shift
+
+  local probe_file
+  probe_file="$(mktemp)"
+
+  set +e
+  "$@" >"$probe_file" 2>&1
+  local status=$?
+  set -e
+
+  local note="ok"
+  if (( status != 0 )); then
+    note="$(extract_note "$probe_file")"
+    note="${note:-command exited non-zero}"
+    failures+=("- \`${label}\` exited ${status}: ${note}")
+  fi
+
+  {
+    echo "- \`${label}\`: exit ${status}"
+    if [[ -n "$note" && "$note" != "ok" ]]; then
+      echo "  ${note}"
+    fi
+  } >> "${output_file}.probes"
+
+  rm -f "$probe_file"
+}
+
+main_command=(bundle exec mutant run)
+if [[ "$mode" == "incremental" && -n "$target_ref" ]]; then
+  main_command+=(--since "$target_ref")
+fi
+
+: > "${output_file}.probes"
+run_probe "mutant run --help" bundle exec mutant run --help
+if [[ "$mode" == "incremental" && -n "$target_ref" ]]; then
+  run_probe "mutant run --since ${target_ref} --help" bundle exec mutant run --since "$target_ref" --help
+fi
+
+set +e
+"${main_command[@]}" 2>&1 | tee "$output_file"
+status=${PIPESTATUS[0]}
+set -e
+
+if (( status != 0 )); then
+  main_note="$(extract_note "$output_file")"
+  if [[ -n "$main_note" ]]; then
+    failures+=("- \`$(printf '%q ' "${main_command[@]}" | sed 's/ $//')\` exited ${status}: ${main_note}")
+  else
+    failures+=("- \`$(printf '%q ' "${main_command[@]}" | sed 's/ $//')\` exited ${status}")
+  fi
+fi
+
+{
+  echo "## viamin/mutant parity (${mode})"
+  echo
+  echo "- Bundle source: \`viamin/mutant@main\`"
+  if [[ -n "$target_ref" ]]; then
+    echo "- Target ref: \`${target_ref}\`"
+  fi
+  echo "- Command: \`$(printf '%q ' "${main_command[@]}" | sed 's/ $//')\`"
+  echo
+  echo "### CLI probe results"
+  cat "${output_file}.probes"
+  echo
+  echo "### Failing flags / commands"
+  if ((${#failures[@]} == 0)); then
+    echo "- None"
+  else
+    printf '%s\n' "${failures[@]}"
+  fi
+  echo
+  echo "### Command tail"
+  echo
+  echo '```text'
+  tail -n 200 "$output_file"
+  echo '```'
+} >> "$GITHUB_STEP_SUMMARY"
+
+exit "$status"

--- a/script/ci/mutation_viamin_parity.sh
+++ b/script/ci/mutation_viamin_parity.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-set -uo pipefail
+set -euo pipefail
 
 mode="${1:-incremental}"
 target_ref="${2:-}"
 output_file="${MUTANT_OUTPUT_FILE:-tmp/mutant-viamin.log}"
+summary_file="${GITHUB_STEP_SUMMARY:-/dev/null}"
 
 mkdir -p "$(dirname "$output_file")"
 
@@ -93,6 +94,6 @@ fi
   echo '```text'
   tail -n 200 "$output_file"
   echo '```'
-} >> "$GITHUB_STEP_SUMMARY"
+} >> "$summary_file"
 
 exit "$status"

--- a/script/ci/mutation_viamin_parity.sh
+++ b/script/ci/mutation_viamin_parity.sh
@@ -13,7 +13,7 @@ declare -a failures=()
 extract_note() {
   local file="$1"
 
-  grep -Eim1 'wrong constant name run|unknown|unrecognized|invalid option|no such command|unknown switch' "$file" || true
+  grep -Eim1 'wrong constant name|unknown|unrecognized|invalid option|no such command|unknown switch' "$file" || true
 }
 
 run_probe() {
@@ -45,15 +45,15 @@ run_probe() {
   rm -f "$probe_file"
 }
 
-main_command=(bundle exec mutant run)
+main_command=(bundle exec mutant)
 if [[ "$mode" == "incremental" && -n "$target_ref" ]]; then
   main_command+=(--since "$target_ref")
 fi
 
 : > "${output_file}.probes"
-run_probe "mutant run --help" bundle exec mutant run --help
+run_probe "mutant --help" bundle exec mutant --help
 if [[ "$mode" == "incremental" && -n "$target_ref" ]]; then
-  run_probe "mutant run --since ${target_ref} --help" bundle exec mutant run --since "$target_ref" --help
+  run_probe "mutant --since ${target_ref} --help" bundle exec mutant --since "$target_ref" --help
 fi
 
 set +e


### PR DESCRIPTION
## Summary

Add a non-blocking CI job that continuously probes `viamin/mutant` feature parity, so the team gets an automatic green-light signal the moment upstream structural blockers (viamin/mutant#9, #10, #11, #12) are resolved and Paid can flip to the sanctioned mutant source.

## Changes

**CI / Workflow (`.github/workflows/mutation.yml`)**
- New `mutation-viamin-parity` job that runs on every PR and on a nightly schedule
- Job uses `continue-on-error: true` so it never blocks PRs — purely informational
- Uploads parity log as a build artifact for post-mortem inspection

**Dependency isolation (`Gemfile.viamin`, `Gemfile.viamin.lock`)**
- Dedicated Gemfile that pulls `mutant` from `github: "viamin/mutant", branch: "main"` instead of rubygems
- Keeps the alternate dependency graph fully isolated from the production `Gemfile.lock`

**Parity probe script (`script/ci/mutation_viamin_parity.sh`)**
- Runs `bundle exec mutant run --since origin/$BASE_REF` without the `--usage` flag (which viamin/mutant#16 makes a no-op)
- Writes a GitHub Actions step summary capturing the exact command, probe results, and recognizable failure breadcrumbs (unsupported flags, non-zero exits)

**Documentation (`docs/MUTATION_TESTING.md`)**
- Documents what the parity job measures and what a passing run means: the upstream blockers are effectively resolved and the source switch can proceed

## Design Decisions

- **Separate Gemfile rather than a Bundler group**: Using `BUNDLE_GEMFILE=Gemfile.viamin` completely isolates the alternate mutant source from the main lockfile, avoiding version-resolution conflicts that a conditional group would introduce.
- **Shell script for summary generation**: Extracting the probe logic into `script/ci/mutation_viamin_parity.sh` keeps the workflow YAML declarative and makes local reproduction straightforward (`bash script/ci/mutation_viamin_parity.sh`).
- **No `--usage` flag**: viamin/mutant#16 turns `--usage` into a no-op or outright rejection, so the probe intentionally omits it to reflect realistic invocation.

---

Closes #2372