### PR TITLE
feat: Remove redundant screenshot config section from project settings

### DIFF
--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -855,38 +855,6 @@
       <% end %>
     </div>
   </div>
-  <% suggested_screenshot_cache_key = flash[:screenshot_config_suggestion_cache_key] %>
-  <% suggested_screenshot_config_yaml = suggested_screenshot_cache_key.present? ? Rails.cache.read(suggested_screenshot_cache_key) : nil %>
-  <% suggested_screenshot_framework = flash[:screenshot_config_framework] %>
-  <% suggested_screenshot_confidence = flash[:screenshot_config_confidence] %>
-  <div class="mt-6 bg-white shadow sm:rounded-lg">
-    <div class="px-4 py-5 sm:p-6">
-      <div class="flex items-center justify-between gap-4">
-        <div>
-          <h2 class="text-lg font-semibold text-gray-900">Screenshot Config</h2>
-          <p class="mt-1 text-sm text-gray-500">
-            Detect the app framework and generate a starter <code class="rounded bg-gray-100 px-1 py-0.5 text-xs">.paid/screenshots.yml</code>.
-          </p>
-        </div>
-        <%= button_to "Detect & Suggest", detect_project_screenshot_config_path(@project), method: :post, class: "rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 cursor-pointer" %>
-      </div>
-
-      <% if suggested_screenshot_config_yaml.present? %>
-        <div class="mt-4 rounded-md border border-gray-200 bg-gray-50 p-4">
-          <p class="text-sm font-medium text-gray-900">
-            Suggested config for <%= suggested_screenshot_framework.to_s.humanize %>
-            <% if suggested_screenshot_confidence.present? %>
-              <span class="font-normal text-gray-500">(<%= number_to_percentage(suggested_screenshot_confidence.to_f * 100, precision: 0) %> confidence)</span>
-            <% end %>
-          </p>
-          <p class="mt-1 text-sm text-gray-500">
-            Review this YAML, then copy it into <code class="rounded bg-white px-1 py-0.5 text-xs">.paid/screenshots.yml</code> or adapt it for project settings.
-          </p>
-          <textarea readonly rows="18" class="mt-3 block w-full rounded-md border-0 px-3 py-2 font-mono text-sm text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600"><%= suggested_screenshot_config_yaml %></textarea>
-        </div>
-      <% end %>
-    </div>
-  </div>
   <%# Service Containers section %>
   <div class="mt-6 bg-white shadow sm:rounded-lg">
     <div class="px-4 py-5 sm:p-6">

--- a/spec/system/projects/screenshot_settings_spec.rb
+++ b/spec/system/projects/screenshot_settings_spec.rb
@@ -48,6 +48,21 @@ RSpec.describe "Project screenshot settings", system_driver: :rack_test, type: :
     end
   end
 
+  def stub_detect_framework
+    allow(Projects::Screenshots::DetectFramework).to receive(:call).and_return(
+      Projects::Screenshots::DetectFramework::Result.new(
+        framework: "Rails",
+        confidence: "high",
+        driver: "cuprite",
+        service_dependencies: [ "postgres" ],
+        setup_commands: [ "bin/setup --skip-server" ],
+        suggested_config: { "driver" => "cuprite" },
+        suggested_yaml: "driver: cuprite\n",
+        detected_at: Time.current.iso8601
+      )
+    )
+  end
+
   def persisted_project
     TenantContext.with_system_access { Project.find(project.id) }
   end
@@ -85,20 +100,10 @@ RSpec.describe "Project screenshot settings", system_driver: :rack_test, type: :
   end
 
   it "runs framework detection from the settings page" do
-    allow(Projects::Screenshots::DetectFramework).to receive(:call).and_return(
-      Projects::Screenshots::DetectFramework::Result.new(
-        framework: "Rails",
-        confidence: "high",
-        driver: "cuprite",
-        service_dependencies: [ "postgres" ],
-        setup_commands: [ "bin/setup --skip-server" ],
-        suggested_config: { "driver" => "cuprite" },
-        suggested_yaml: "driver: cuprite\n",
-        detected_at: Time.current.iso8601
-      )
-    )
-
+    stub_detect_framework
     visit edit_project_path(project)
+    expect(page).to have_button("Auto-detect")
+    expect(page).to have_no_button("Detect & Suggest")
     click_button "Auto-detect"
 
     expect(page).to have_content("Detected Rails with high confidence.")


### PR DESCRIPTION
## Summary

Remove the redundant second screenshot configuration section from the project settings page, which duplicated the auto-detect functionality already available in the main settings section.

## Changes

- **UI**: Removed the lower screenshot config panel with the "Detect & Suggest" button from `app/views/projects/edit.html.erb`, leaving the main section's "Auto-detect" button as the single entry point
- **Tests**: Updated `spec/system/projects/screenshot_settings_spec.rb` to assert "Auto-detect" is present and "Detect & Suggest" no longer appears

---

Closes #2411