### PR TITLE
feat: [P2] knowledge: ActiveRecord::RecordNotUnique

### DIFF
--- a/app/services/knowledge/artifact_store.rb
+++ b/app/services/knowledge/artifact_store.rb
@@ -2,6 +2,10 @@
 
 module Knowledge
   class ArtifactStore
+    ADVISORY_LOCK_SQL = "SELECT pg_advisory_lock($1, $2)".freeze
+    ADVISORY_UNLOCK_SQL = "SELECT pg_advisory_unlock($1, $2)".freeze
+    LOCK_NAMESPACE = 1_357_180_002
+
     attr_reader :project, :collector_run
 
     def initialize(project:, collector_run:)
@@ -29,34 +33,32 @@ module Knowledge
     private
 
     def store_artifact(data)
-      content_hash = compute_hash(data[:content])
+      with_artifact_lock(data) do
+        content_hash = compute_hash(data[:content])
+        existing = find_existing_artifact(data, content_hash)
 
-      existing = find_existing_artifact(data, content_hash)
+        if existing
+          reassign_to_current_run(existing)
+        else
+          # Atomic stale-then-insert to prevent interleaving with concurrent
+          # collectors that could violate the partial unique index on active artifacts.
+          begin
+            KnowledgeArtifact.transaction do
+              mark_prior_stale(data)
+              create_artifact(data, content_hash)
+            end
+          rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
+            raise unless unique_conflict?(e)
 
-      if existing
-        reassign_to_current_run(existing)
-      else
-        # Atomic stale-then-insert to prevent interleaving with concurrent
-        # collectors that could violate the partial unique index on active artifacts.
-        # Under high concurrency, two transactions can both mark prior rows stale
-        # and then race to insert an active row, causing a unique constraint
-        # violation. In that case, we refetch the now-existing artifact and
-        # reassign it to this collector_run.
-        begin
-          KnowledgeArtifact.transaction do
-            mark_prior_stale(data)
-            create_artifact(data, content_hash)
-          end
-        rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
-          raise unless content_hash_conflict?(e)
+            existing_after_conflict = find_existing_artifact(data, content_hash)
+            existing_after_conflict ||= find_active_artifact(data)
+            existing_after_conflict ||= find_by_run_and_hash(content_hash)
 
-          existing_after_conflict = find_existing_artifact(data, content_hash)
-          existing_after_conflict ||= find_by_run_and_hash(content_hash)
-
-          if existing_after_conflict
-            reassign_to_current_run(existing_after_conflict)
-          else
-            raise
+            if existing_after_conflict
+              reassign_to_current_run(existing_after_conflict)
+            else
+              raise
+            end
           end
         end
       end
@@ -84,6 +86,17 @@ module Knowledge
       KnowledgeArtifact.find_by(
         collector_run: collector_run,
         content_hash: content_hash,
+        status: "active"
+      )
+    end
+
+    def find_active_artifact(data)
+      KnowledgeArtifact.find_by(
+        project: project,
+        collector_type: collector_run.collector_type,
+        artifact_type: data[:artifact_type],
+        scope_path: data[:scope_path],
+        identifier: data[:identifier],
         status: "active"
       )
     end
@@ -179,7 +192,7 @@ module Knowledge
       end
     end
 
-    def content_hash_conflict?(exception)
+    def unique_conflict?(exception)
       case exception
       when ActiveRecord::RecordNotUnique
         true
@@ -192,6 +205,30 @@ module Knowledge
 
     def compute_hash(content)
       Digest::SHA256.hexdigest(content.to_s)
+    end
+
+    def with_artifact_lock(data)
+      execute_lock_sql(ADVISORY_LOCK_SQL, advisory_lock_key(data))
+      yield
+    ensure
+      execute_lock_sql(ADVISORY_UNLOCK_SQL, advisory_lock_key(data))
+    end
+
+    def advisory_lock_key(data)
+      Digest::SHA256
+        .digest([
+          project.id,
+          collector_run.collector_type,
+          data[:artifact_type],
+          data[:scope_path],
+          data[:identifier]
+        ].join(":"))
+        .unpack("l>")
+        .first
+    end
+
+    def execute_lock_sql(sql, lock_key)
+      ActiveRecord::Base.connection.raw_connection.exec_params(sql, [ LOCK_NAMESPACE, lock_key ])
     end
   end
 end

--- a/app/services/knowledge/artifact_store.rb
+++ b/app/services/knowledge/artifact_store.rb
@@ -40,27 +40,23 @@ module Knowledge
         if existing
           reassign_to_current_run(existing)
         else
-          # Atomic stale-then-insert to prevent interleaving with concurrent
-          # collectors that could violate the partial unique index on active artifacts.
           begin
-            KnowledgeArtifact.transaction do
-              mark_prior_stale(data)
-              create_artifact(data, content_hash)
-            end
+            replace_artifact(data, content_hash)
           rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
             raise unless unique_conflict?(e)
 
-            existing_after_conflict = find_existing_artifact(data, content_hash)
-            existing_after_conflict ||= find_active_artifact(data)
-            existing_after_conflict ||= find_by_run_and_hash(content_hash)
-
-            if existing_after_conflict
-              reassign_to_current_run(existing_after_conflict)
-            else
-              raise
-            end
+            recover_conflicted_artifact(data, content_hash)
           end
         end
+      end
+    end
+
+    def replace_artifact(data, content_hash)
+      # Atomic stale-then-insert to prevent interleaving with concurrent
+      # collectors that could violate the partial unique index on active artifacts.
+      KnowledgeArtifact.transaction do
+        mark_prior_stale(data)
+        create_artifact(data, content_hash)
       end
     end
 
@@ -99,6 +95,29 @@ module Knowledge
         identifier: data[:identifier],
         status: "active"
       )
+    end
+
+    def recover_conflicted_artifact(data, content_hash)
+      matching_artifact = find_existing_artifact(data, content_hash)
+      return reassign_to_current_run(matching_artifact) if matching_artifact
+
+      active_artifact = find_active_artifact(data)
+      return replace_artifact(data, content_hash) if active_artifact
+
+      run_hash_artifact = find_by_run_and_hash(content_hash)
+      return reassign_to_current_run(run_hash_artifact) if run_hash_artifact
+
+      raise ActiveRecord::RecordNotUnique, "Could not recover conflicting knowledge artifact insert"
+    rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
+      raise unless unique_conflict?(e)
+
+      matching_artifact = find_existing_artifact(data, content_hash)
+      return reassign_to_current_run(matching_artifact) if matching_artifact
+
+      run_hash_artifact = find_by_run_and_hash(content_hash)
+      return reassign_to_current_run(run_hash_artifact) if run_hash_artifact
+
+      raise
     end
 
     def reassign_to_current_run(artifact)

--- a/spec/services/knowledge/artifact_store_spec.rb
+++ b/spec/services/knowledge/artifact_store_spec.rb
@@ -97,18 +97,30 @@ RSpec.describe Knowledge::ArtifactStore do
       let(:new_version) { create(:project_version, project: project) }
       let(:new_run) { create(:collector_run, project_version: new_version, collector_type: "test") }
       let(:new_store) { described_class.new(project: project, collector_run: new_run) }
+      let(:updated_data) do
+        artifact_data.merge(content: '{"method":"GET","path":"/api/users","auth":true}')
+      end
 
-      it "recovers by reusing the active artifact instead of raising" do
+      it "preserves the incoming content instead of reassigning the mismatched active row" do
         store.store_all([ artifact_data ])
 
-        allow(new_store).to receive(:create_artifact)
-          .and_raise(ActiveRecord::RecordNotUnique.new('PG::UniqueViolation: ERROR: duplicate key value violates unique constraint "idx_knowledge_artifacts_active_unique"'))
+        conflict_raised = false
+        original_create_artifact = new_store.method(:create_artifact)
+        allow(new_store).to receive(:create_artifact).and_wrap_original do |_method, *args|
+          if conflict_raised
+            original_create_artifact.call(*args)
+          else
+            conflict_raised = true
+            raise ActiveRecord::RecordNotUnique.new('PG::UniqueViolation: ERROR: duplicate key value violates unique constraint "idx_knowledge_artifacts_active_unique"')
+          end
+        end
 
-        expect { new_store.store_all([ artifact_data.merge(content: '{"method":"GET","path":"/api/users","auth":true}') ]) }
-          .not_to raise_error
+        expect { new_store.store_all([ updated_data ]) }.not_to raise_error
 
         expect(KnowledgeArtifact.active.count).to eq(1)
+        expect(KnowledgeArtifact.stale.count).to eq(1)
         expect(KnowledgeArtifact.active.first.collector_run).to eq(new_run)
+        expect(KnowledgeArtifact.active.first.content).to eq(updated_data[:content])
       end
     end
   end

--- a/spec/services/knowledge/artifact_store_spec.rb
+++ b/spec/services/knowledge/artifact_store_spec.rb
@@ -92,5 +92,24 @@ RSpec.describe Knowledge::ArtifactStore do
         expect(KnowledgeArtifact.active.first.collector_run).to eq(new_run)
       end
     end
+
+    context "when an active-key race loses after another run inserts first" do
+      let(:new_version) { create(:project_version, project: project) }
+      let(:new_run) { create(:collector_run, project_version: new_version, collector_type: "test") }
+      let(:new_store) { described_class.new(project: project, collector_run: new_run) }
+
+      it "recovers by reusing the active artifact instead of raising" do
+        store.store_all([ artifact_data ])
+
+        allow(new_store).to receive(:create_artifact)
+          .and_raise(ActiveRecord::RecordNotUnique.new('PG::UniqueViolation: ERROR: duplicate key value violates unique constraint "idx_knowledge_artifacts_active_unique"'))
+
+        expect { new_store.store_all([ artifact_data.merge(content: '{"method":"GET","path":"/api/users","auth":true}') ]) }
+          .not_to raise_error
+
+        expect(KnowledgeArtifact.active.count).to eq(1)
+        expect(KnowledgeArtifact.active.first.collector_run).to eq(new_run)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Implemented the fix in [app/services/knowledge/artifact_store.rb](/workspace/app/services/knowledge/artifact_store.rb) and added a regression in [spec/services/knowledge/artifact_store_spec.rb](/workspace/spec/services/knowledge/artifact_store_spec.rb). The store now serializes writes per logical artifact key with a PostgreSQL advisory lock, and the conflict recovery path also falls back to the active logical-key row instead of only `content_hash` matches. That closes the race behind `idx_knowledge_artifacts_active_unique`.

Verification passed with `bundle exec rails db:prepare`, `bundle exec rubocop`, and full `bundle exec rspec` (`14234 examples, 0 failures, 7 pending`). Commit created on the current feature branch: `7d5906f` (`fix(knowledge): serialize artifact store writes`).

---

Closes #2417