### PR TITLE
feat: Add archive functionality for chats from chat page and popup

### DIFF
--- a/app/controllers/chat_sessions_controller.rb
+++ b/app/controllers/chat_sessions_controller.rb
@@ -8,9 +8,9 @@ class ChatSessionsController < ApplicationController
   SIDEBAR_PAGE_SIZE = 50
 
   skip_after_action :verify_authorized, only: %i[index sidebar_page]
-  before_action :set_chat_session, only: %i[show update destroy older_messages]
+  before_action :set_chat_session, only: %i[show update destroy archive older_messages]
   before_action :enforce_create_rate_limit, only: :create
-  before_action :default_request_format_to_json, only: %i[index create show update destroy]
+  before_action :default_request_format_to_json, only: %i[index create show update destroy archive]
 
   def index
     respond_to do |format|
@@ -145,6 +145,16 @@ class ChatSessionsController < ApplicationController
     end
   end
 
+  def archive
+    authorize @chat_session, :archive?
+    ChatSessions::Archive.call(chat_session: @chat_session)
+
+    respond_to do |format|
+      format.html { redirect_after_archive }
+      format.json { render json: session_json(@chat_session) }
+    end
+  end
+
   private
 
   def set_chat_session
@@ -215,6 +225,7 @@ class ChatSessionsController < ApplicationController
 
   def session_scope
     policy_scope(ChatSession)
+      .visible
       .with_preview_content
       .includes(:project, :runner, :chat_session_projects, :projects)
       .order(updated_at: :desc, id: :desc)
@@ -222,6 +233,7 @@ class ChatSessionsController < ApplicationController
 
   def session_scope_with_token_totals
     policy_scope(ChatSession)
+      .visible
       .with_preview_content
       .select(
         "chat_sessions.*",
@@ -235,6 +247,13 @@ class ChatSessionsController < ApplicationController
 
   def pagination_meta(pagy)
     { page: pagy.page, pages: pagy.pages, count: pagy.count }
+  end
+
+  def redirect_after_archive
+    next_session = session_scope.where.not(id: @chat_session.id).first
+    target = next_session ? chat_session_path(next_session) : chat_sessions_path
+
+    redirect_to target, notice: "Chat session archived."
   end
 
   def session_projects(session)

--- a/app/javascript/controllers/chat_popup_controller.js
+++ b/app/javascript/controllers/chat_popup_controller.js
@@ -88,6 +88,34 @@ export default class extends Controller {
     }
   }
 
+  async archiveAndNewChat(event) {
+    event?.preventDefault()
+    if (this.loading) return
+
+    const previousSessionId = this.state.sessionId
+    let archiveCompleted = false
+
+    this.loading = true
+    this.contentTarget.innerHTML = this.loadingMarkup()
+
+    try {
+      await this.archiveSession(previousSessionId)
+      archiveCompleted = true
+
+      const sessionId = await this.createSession()
+      this.state.sessionId = sessionId
+      this.writeState()
+      await this.renderPanel(sessionId)
+    } catch (error) {
+      this.state.sessionId = archiveCompleted ? null : previousSessionId
+      this.writeState()
+      this.contentTarget.innerHTML = this.errorMarkup()
+      window.console.error("chat popup failed", error)
+    } finally {
+      this.loading = false
+    }
+  }
+
   async createSession() {
     const response = await window.fetch(this.createUrlValue, {
       method: "POST",
@@ -124,6 +152,16 @@ export default class extends Controller {
     })
 
     return response.ok
+  }
+
+  async archiveSession(sessionId) {
+    const response = await window.fetch(`${this.sessionUrl(sessionId)}/archive`, {
+      method: "PATCH",
+      headers: this.jsonHeaders(),
+      credentials: "same-origin"
+    })
+
+    if (!response.ok) throw new Error(`Archive request failed with ${response.status}`)
   }
 
   async renderPanel(sessionId) {

--- a/app/models/chat_session.rb
+++ b/app/models/chat_session.rb
@@ -43,6 +43,7 @@ class ChatSession < ApplicationRecord
   end
 
   scope :active, -> { where(status: "active") }
+  scope :visible, -> { where.not(status: "archived") }
   scope :idle_expired, -> { where(status: "active").where("idle_timeout_at < ?", Time.current) }
   scope :with_preview_content, lambda {
     preview_subquery = ChatMessage.where("chat_messages.chat_session_id = chat_sessions.id")
@@ -58,6 +59,10 @@ class ChatSession < ApplicationRecord
 
   def active?
     status == "active"
+  end
+
+  def archived?
+    status == "archived"
   end
 
   def generate_title_from_content!
@@ -149,7 +154,7 @@ class ChatSession < ApplicationRecord
       [ account, :chat_sessions ],
       target: ActionView::RecordIdentifier.dom_id(self)
     )
-    broadcast_sidebar_prepend
+    broadcast_sidebar_prepend unless archived?
   end
 
   def broadcast_sidebar_remove

--- a/app/policies/chat_session_policy.rb
+++ b/app/policies/chat_session_policy.rb
@@ -20,4 +20,8 @@ class ChatSessionPolicy < ApplicationPolicy
   def destroy?
     has_any_account_role?(:owner, :admin, :member)
   end
+
+  def archive?
+    has_any_account_role?(:owner, :admin, :member)
+  end
 end

--- a/app/services/chat_sessions/archive.rb
+++ b/app/services/chat_sessions/archive.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+module ChatSessions
+  class Archive
+    attr_reader :chat_session
+
+    def initialize(chat_session:)
+      @chat_session = chat_session
+    end
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def call
+      validate!
+
+      ActiveRecord::Base.transaction do
+        compute_totals if active_or_idle?
+        cleanup_workspace_resources if active_or_idle? && workspace_session?
+        chat_session.update!(archive_attributes)
+      end
+
+      chat_session
+    end
+
+    private
+
+    def validate!
+      return if %w[active idle closed].include?(chat_session.status)
+
+      raise ArgumentError, "chat session must be active, idle, or closed to archive (current: #{chat_session.status})"
+    end
+
+    def active_or_idle?
+      %w[active idle].include?(chat_session.status)
+    end
+
+    def workspace_session?
+      chat_session.mode == "workspace"
+    end
+
+    def compute_totals
+      totals = TenantContext.with_system_access do
+        [
+          TokenUsage.where(chat_session_id: chat_session.id).sum(:input_tokens),
+          TokenUsage.where(chat_session_id: chat_session.id).sum(:output_tokens),
+          TokenUsage.where(chat_session_id: chat_session.id).sum(:cost_cents),
+          ChatMessage.where(chat_session_id: chat_session.id).count
+        ]
+      end
+
+      chat_session.metadata = (chat_session.metadata || {}).merge(
+        "total_tokens_input" => totals[0],
+        "total_tokens_output" => totals[1],
+        "total_cost_cents" => totals[2],
+        "total_messages" => totals[3]
+      )
+    end
+
+    def archive_attributes
+      {
+        status: "archived",
+        idle_timeout_at: nil,
+        metadata: (chat_session.metadata || {}).merge("archived_at" => Time.current.iso8601)
+      }.merge(workspace_cleanup_attributes)
+    end
+
+    def workspace_cleanup_attributes
+      return {} unless workspace_session?
+
+      {
+        container_id: nil,
+        workspace_volume: nil
+      }
+    end
+
+    def cleanup_workspace_resources
+      cleanup_container_resource if chat_session.container_id.present?
+      cleanup_volume_resource if chat_session.workspace_volume.present?
+    end
+
+    def cleanup_container_resource
+      Rails.logger.info(
+        message: "chat_session.cleanup_container",
+        chat_session_id: chat_session.id,
+        container_id: chat_session.container_id
+      )
+    end
+
+    def cleanup_volume_resource
+      Rails.logger.info(
+        message: "chat_session.cleanup_volume",
+        chat_session_id: chat_session.id,
+        workspace_volume: chat_session.workspace_volume
+      )
+    end
+  end
+end

--- a/app/views/chat_sessions/_popup.html.erb
+++ b/app/views/chat_sessions/_popup.html.erb
@@ -1,4 +1,5 @@
 <% page_context = chat_session.page_context %>
+<% can_archive_chat_session = policy(chat_session).archive? && !chat_session.archived? %>
 <% can_create_chat_session = policy(ChatSession.new(account: current_account)).create? %>
 
 <section class="flex h-full flex-col overflow-hidden rounded-[1.75rem] bg-white shadow-[0_32px_80px_-32px_rgba(15,23,42,0.45)] ring-1 ring-slate-200">
@@ -18,6 +19,13 @@
       </div>
 
       <div class="flex items-center gap-2">
+        <% if can_create_chat_session && can_archive_chat_session %>
+          <button type="button"
+                  class="inline-flex items-center rounded-full bg-amber-100 px-3 py-1.5 text-xs font-semibold text-amber-900 hover:bg-amber-200"
+                  data-action="chat-popup#archiveAndNewChat">
+            Archive &amp; New Chat
+          </button>
+        <% end %>
         <% if can_create_chat_session %>
           <button type="button"
                   class="inline-flex items-center rounded-full bg-slate-900 px-3 py-1.5 text-xs font-semibold text-white hover:bg-slate-700"

--- a/app/views/chat_sessions/show.html.erb
+++ b/app/views/chat_sessions/show.html.erb
@@ -1,5 +1,6 @@
 <% content_for(:title) { "#{chat_session_title(@chat_session)} - Chat - Paid" } %>
 <% can_update_chat_session = policy(@chat_session).update? %>
+<% can_archive_chat_session = policy(@chat_session).archive? && !@chat_session.archived? %>
 <% can_destroy_chat_session = policy(@chat_session).destroy? %>
 
 <%= turbo_stream_from current_account, :chat_sessions %>
@@ -109,12 +110,20 @@
                     tokens
                   </p>
                 </div>
-                <% if can_destroy_chat_session %>
-                  <%= button_to "Close",
-                                chat_session_path(@chat_session),
-                                method: :delete,
-                                class: "inline-flex items-center rounded-md bg-white/10 px-3 py-2 text-xs font-semibold text-white hover:bg-white/20" %>
-                <% end %>
+                <div class="flex items-center gap-2">
+                  <% if can_archive_chat_session %>
+                    <%= button_to "Archive",
+                                  archive_chat_session_path(@chat_session),
+                                  method: :patch,
+                                  class: "inline-flex items-center rounded-md bg-amber-400/15 px-3 py-2 text-xs font-semibold text-amber-100 hover:bg-amber-400/25" %>
+                  <% end %>
+                  <% if can_destroy_chat_session %>
+                    <%= button_to "Close",
+                                  chat_session_path(@chat_session),
+                                  method: :delete,
+                                  class: "inline-flex items-center rounded-md bg-white/10 px-3 py-2 text-xs font-semibold text-white hover:bg-white/20" %>
+                  <% end %>
+                </div>
               </div>
             </div>
           </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -292,6 +292,7 @@ Rails.application.routes.draw do
 
   # Chat sessions and messages
   resources :chat_sessions, path: "chat", only: %i[index create show update destroy] do
+    patch :archive, on: :member
     collection do
       get :sidebar_page
     end

--- a/spec/lib/chat_popup_controller_node_harness_spec.rb
+++ b/spec/lib/chat_popup_controller_node_harness_spec.rb
@@ -96,6 +96,92 @@ class ChatPopupControllerNodeHarness
       }
     }
 
+    async function runArchiveAndNewChatSuccessCase() {
+      const writes = [];
+      const fetchCalls = [];
+      const contentTarget = { innerHTML: "" };
+      const controller = Object.create(ChatPopupController.prototype);
+
+      controller.contentTarget = contentTarget;
+      controller.state = { open: true, sessionId: 11 };
+      controller.loading = false;
+      controller.loadingMarkup = () => "loading";
+      controller.errorMarkup = () => "error";
+      controller.writeState = () => writes.push({ ...controller.state });
+      controller.archiveSession = async (sessionId) => {
+        if (sessionId !== 11) throw new Error(`Expected archiveSession() to receive 11, saw ${sessionId}`);
+      };
+      controller.createSession = async () => 42;
+      controller.renderPanel = async (sessionId) => {
+        fetchCalls.push(sessionId);
+        contentTarget.innerHTML = `panel-${sessionId}`;
+      };
+
+      await controller.archiveAndNewChat({ preventDefault() {} });
+
+      if (controller.state.sessionId !== 42) {
+        throw new Error(`Expected archiveAndNewChat() to replace the stored session id, saw ${controller.state.sessionId}`);
+      }
+
+      if (writes.length !== 1 || writes[0].sessionId !== 42) {
+        throw new Error(`Expected archiveAndNewChat() to persist the new session id once, saw ${JSON.stringify(writes)}`);
+      }
+
+      if (fetchCalls.length !== 1 || fetchCalls[0] !== 42) {
+        throw new Error(`Expected archiveAndNewChat() to render the new session once, saw ${JSON.stringify(fetchCalls)}`);
+      }
+
+      if (contentTarget.innerHTML !== "panel-42") {
+        throw new Error(`Expected rendered panel markup for the new session, saw ${contentTarget.innerHTML}`);
+      }
+
+      if (controller.loading !== false) {
+        throw new Error("Expected archiveAndNewChat() to clear the loading flag");
+      }
+    }
+
+    async function runArchiveAndNewChatCreateFailureCase() {
+      const writes = [];
+      const contentTarget = { innerHTML: "" };
+      const controller = Object.create(ChatPopupController.prototype);
+
+      controller.contentTarget = contentTarget;
+      controller.state = { open: true, sessionId: 11 };
+      controller.loading = false;
+      controller.loadingMarkup = () => "loading";
+      controller.errorMarkup = () => "error";
+      controller.writeState = () => writes.push({ ...controller.state });
+      controller.archiveSession = async () => {};
+      controller.createSession = async () => {
+        throw new Error("boom");
+      };
+      controller.renderPanel = async () => {
+        throw new Error("render should not run");
+      };
+
+      global.window = {
+        console: { error() {} }
+      };
+
+      await controller.archiveAndNewChat({ preventDefault() {} });
+
+      if (controller.state.sessionId !== null) {
+        throw new Error(`Expected create failure after archive to clear the stored session id, saw ${controller.state.sessionId}`);
+      }
+
+      if (writes.length !== 1 || writes[0].sessionId !== null) {
+        throw new Error(`Expected failure path to persist a cleared session id, saw ${JSON.stringify(writes)}`);
+      }
+
+      if (contentTarget.innerHTML !== "error") {
+        throw new Error(`Expected failure path to render the error state, saw ${contentTarget.innerHTML}`);
+      }
+
+      if (controller.loading !== false) {
+        throw new Error("Expected failure path to clear the loading flag");
+      }
+    }
+
     async function run() {
       global.window = {
         console: { error() {} }
@@ -103,6 +189,8 @@ class ChatPopupControllerNodeHarness
 
       await runNewChatSuccessCase();
       await runNewChatFailureCase();
+      await runArchiveAndNewChatSuccessCase();
+      await runArchiveAndNewChatCreateFailureCase();
     }
 
     run().catch((error) => {

--- a/spec/models/chat_session_spec.rb
+++ b/spec/models/chat_session_spec.rb
@@ -80,6 +80,15 @@ RSpec.describe ChatSession do
       end
     end
 
+    describe ".visible" do
+      it "excludes archived sessions" do
+        visible = create(:chat_session, account: account, created_by: user)
+        create(:chat_session, :archived, account: account, created_by: user)
+
+        expect(described_class.visible).to eq([ visible ])
+      end
+    end
+
     describe ".idle_expired" do
       it "returns active sessions past their idle timeout" do
         expired = create(:chat_session, account: account, created_by: user, idle_timeout_at: 1.hour.ago)

--- a/spec/requests/chat_sessions_spec.rb
+++ b/spec/requests/chat_sessions_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe "ChatSessions" do
         expect(response.parsed_body["sessions"].length).to eq(1)
       end
 
+      it "does not include archived sessions in the default listing" do
+        visible = create(:chat_session, account: account, created_by: user, title: "Visible")
+        create(:chat_session, :archived, account: account, created_by: user, title: "Archived")
+
+        get chat_sessions_path(format: :json)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["sessions"].map { |session| session["id"] }).to eq([ visible.id ])
+      end
+
       it "paginates sessions" do
         26.times do |index|
           create(:chat_session, account: account, created_by: user, updated_at: index.minutes.ago)
@@ -246,6 +256,7 @@ RSpec.describe "ChatSessions" do
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("Assistant is typing")
         expect(response.body).to include("Rendered markdown")
+        expect(response.body).to include("Archive")
       end
 
       it "renders the popup variant for embedded requests" do
@@ -262,6 +273,7 @@ RSpec.describe "ChatSessions" do
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("Support chat")
+        expect(response.body).to include("Archive &amp; New Chat")
         expect(response.body).to include("New Chat")
         expect(response.body).to include("Open page")
         expect(response.body).to include("Projects - Paid")
@@ -338,6 +350,7 @@ RSpec.describe "ChatSessions" do
         get chat_session_path(chat_session), params: { display: "popup" }, headers: { "Accept" => "text/html" }
 
         expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include("Archive &amp; New Chat")
         expect(response.body).not_to include("New Chat")
       end
     end
@@ -433,6 +446,42 @@ RSpec.describe "ChatSessions" do
             "project_name" => "Acme API"
           )
         )
+      end
+    end
+  end
+
+  describe "PATCH /chat/:id/archive" do
+    let!(:chat_session) { create(:chat_session, account: account, created_by: user, title: "Current chat") }
+
+    context "when authenticated" do
+      before { sign_in user }
+
+      it "archives the session and returns json" do
+        create(:chat_message, chat_session: chat_session, role: "user", content: "Hello")
+
+        patch archive_chat_session_path(chat_session, format: :json)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["status"]).to eq("archived")
+        expect(chat_session.reload.status).to eq("archived")
+        expect(chat_session.metadata["archived_at"]).to be_present
+      end
+
+      it "redirects to another visible session for html requests" do
+        next_session = create(:chat_session, account: account, created_by: user, title: "Next chat")
+
+        patch archive_chat_session_path(chat_session)
+
+        expect(response).to redirect_to(chat_session_path(next_session))
+        expect(flash[:notice]).to eq("Chat session archived.")
+        expect(chat_session.reload.status).to eq("archived")
+      end
+
+      it "redirects back to /chat when no other visible session exists" do
+        patch archive_chat_session_path(chat_session)
+
+        expect(response).to redirect_to(chat_sessions_path)
+        expect(chat_session.reload.status).to eq("archived")
       end
     end
   end


### PR DESCRIPTION
## Summary

Implemented chat archiving on both surfaces and committed it as `6bcb730` (`feat(chat): add archive actions for page and popup chats`).

The change adds a dedicated `archive` member action and `ChatSessions::Archive` service, hides archived sessions from the normal chat list/sidebar, adds an `Archive` button on the chat page, and adds `Archive & New Chat` in the popup with Stimulus logic that archives the current session before creating and rendering a fresh one. I also added request/model/JS regression coverage for the new flow.

Verification passed with the required commands under the working Postgres env:
`bin/rails db:prepare`
`bundle exec rubocop`
`bundle exec rspec`

The full suite finished with `14238 examples, 0 failures, 7 pending`. No push was performed.

---

Closes #2415