### PR TITLE
feat: Chat continuation incorrectly requires configured API-key runner for existing previous chat

### DIFF
--- a/app/services/chat_sessions/build_llm_client.rb
+++ b/app/services/chat_sessions/build_llm_client.rb
@@ -13,7 +13,7 @@ module ChatSessions
     end
 
     def call
-      provider = chat_session.runner
+      provider = resolved_runner
       raise LlmClientConfigurationError, missing_runner_message unless provider
 
       api_key = provider.effective_api_secret
@@ -32,6 +32,18 @@ module ChatSessions
     private
 
     attr_reader :chat_session
+
+    def resolved_runner
+      provider = chat_session.runner
+      return provider if provider&.api_key?
+      return fallback_runner if provider.nil? || provider.subscription?
+
+      provider
+    end
+
+    def fallback_runner
+      Runner.kept_only.api_key.for_chat.where(user: chat_session.created_by).ordered.first
+    end
 
     def anthropic_client(api_key)
       transport = AgentHarness::TextTransport.new(api_key: api_key)

--- a/spec/services/chat_sessions/build_llm_client_spec.rb
+++ b/spec/services/chat_sessions/build_llm_client_spec.rb
@@ -68,28 +68,60 @@ RSpec.describe ChatSessions::BuildLlmClient, type: :service do
     end
 
     context "with a subscription runner (no API key)" do
-      it "raises a setup error" do
+      it "falls back to the creator's configured API key runner" do
         runner = user.runners.find_or_create_by!(runner_key: "cursor", auth_type: "subscription")
+        api_key_record = create(:provider_api_key, user: user, api_key: "sk-ant-fallback", api_service_type: "anthropic")
+        fallback_runner = create(:runner, :api_key,
+          user: user,
+          runner_key: "kilocode",
+          provider_api_key: api_key_record,
+          config: { "kilocode" => { "api_provider" => "anthropic", "model" => "claude-sonnet-4-20250514" } }
+        )
         chat_session = create(:chat_session, account: account, created_by: user, runner: runner)
+
+        client = described_class.call(chat_session: chat_session)
+
+        expect(client).to be_a(described_class::HttpClient)
+        expect(client.model).to eq("claude-sonnet-4-20250514")
+        expect(fallback_runner.effective_api_secret).to eq("sk-ant-fallback")
+      end
+    end
+
+    context "without a runner" do
+      it "falls back to the creator's configured API key runner" do
+        chat_session = create(:chat_session, account: account, created_by: user)
+        api_key_record = create(:provider_api_key, user: user, api_key: "sk-or-fallback", api_service_type: "openrouter")
+        create(:runner, :api_key,
+          user: user,
+          runner_key: "opencode",
+          provider_api_key: api_key_record,
+          config: { "opencode" => { "api_provider" => "openrouter", "model" => "moonshotai/kimi-k2" } }
+        )
+
+        client = described_class.call(chat_session: chat_session)
+
+        expect(client).to be_a(described_class::HttpClient)
+        expect(client.model).to eq("gpt-4o")
+      end
+    end
+
+    context "with an API key runner missing its secret" do
+      it "raises a setup error for the selected runner" do
+        api_key_record = create(:provider_api_key, user: user, api_key: "sk-ant-test-key", api_service_type: "anthropic")
+        runner = create(:runner, :api_key,
+          user: user,
+          runner_key: "kilocode",
+          provider_api_key: api_key_record,
+          config: { "kilocode" => { "api_provider" => "anthropic", "model" => "claude-sonnet-4-20250514" } }
+        )
+        chat_session = create(:chat_session, account: account, created_by: user, runner: runner)
+        allow(runner).to receive(:effective_api_secret).and_return(nil)
 
         expect {
           described_class.call(chat_session: chat_session)
         }.to raise_error(
           ChatSessions::LlmClientConfigurationError,
           "Chat runner #{runner.display_name} is missing an API key. Choose a chat-enabled runner with a configured API key."
-        )
-      end
-    end
-
-    context "without a runner" do
-      it "raises a setup error" do
-        chat_session = create(:chat_session, account: account, created_by: user)
-
-        expect {
-          described_class.call(chat_session: chat_session)
-        }.to raise_error(
-          ChatSessions::LlmClientConfigurationError,
-          "Chat requires a configured API-key runner. Add a chat-enabled runner with an API key and select it for this session."
         )
       end
     end


### PR DESCRIPTION
## Summary

Adjusted chat client resolution so resumed legacy chats no longer fail just because the stored session runner is missing or subscription-backed. In [app/services/chat_sessions/build_llm_client.rb](/workspace/app/services/chat_sessions/build_llm_client.rb), the resolver now falls back to the chat creator’s current chat-enabled API-key runner when the session has no runner or only a subscription runner, while still raising the explicit misconfiguration error if a selected API-key runner itself has no secret. I updated [spec/services/chat_sessions/build_llm_client_spec.rb](/workspace/spec/services/chat_sessions/build_llm_client_spec.rb) to cover both fallback cases and the retained hard failure for a broken API-key runner.

Validation passed with `bin/rails db:prepare`, `bundle exec rubocop`, and `bundle exec rspec` using the provided Postgres service via explicit `DB_HOST`/`DB_USERNAME`/`DB_PASSWORD` env vars. The suite finished with `14242 examples, 0 failures, 7 pending` from existing repo pending specs. Commit created: `3da51ad` (`fix(chat): resume legacy chats with api runner fallback`).

---

Closes #2422