### PR TITLE
feat: Mobile chat button overlaps the trigger agent run submit button

### DIFF
--- a/app/views/projects/agent_runs/new.html.erb
+++ b/app/views/projects/agent_runs/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title) { "Trigger Agent Run - #{@project.name} - Paid" } %>
 
-<div class="mx-auto max-w-2xl px-4 py-8 sm:px-6 lg:px-8">
+<div class="mx-auto max-w-2xl px-4 pb-28 pt-8 sm:px-6 sm:pb-8 lg:px-8">
   <div class="mb-6">
     <%= link_to back_link_path(project_path(@project)), class: "inline-flex items-center text-sm font-medium text-gray-500 hover:text-gray-700" do %>
       <svg class="mr-1 h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -989,6 +989,17 @@ RSpec.describe "AgentRuns" do
         expect(response.body).to include("Claude")
       end
 
+      it "adds extra mobile bottom spacing for the floating chat button" do
+        get new_project_agent_run_path(project)
+
+        doc = Nokogiri::HTML(response.body)
+        container = doc.at_css("main > div.mx-auto.max-w-2xl")
+
+        expect(container).not_to be_nil
+        expect(container["class"]).to include("pb-28")
+        expect(container["class"]).to include("sm:pb-8")
+      end
+
       it "includes goal-toggle Stimulus wiring" do
         create(:issue, :pull_request, project: project, github_number: 20, title: "Wiring PR")
         get new_project_agent_run_path(project)


### PR DESCRIPTION
## Summary

Adjusted the trigger-agent-run page so it keeps extra bottom space on mobile, which prevents the fixed chat launcher from covering the submit row. The page container in [app/views/projects/agent_runs/new.html.erb](/workspace/app/views/projects/agent_runs/new.html.erb:3) now uses `pb-28` on small screens and returns to normal spacing at `sm` and up. I also added a request spec in [spec/requests/agent_runs_spec.rb](/workspace/spec/requests/agent_runs_spec.rb:992) to assert that mobile spacing remains in place.

Validation passed: `bundle install`, `yarn install`, `bin/rails db:prepare`, `bundle exec rubocop`, and `bundle exec rspec`. The pre-commit hook also passed and the worktree is clean. Commit: `2baa36e` (`fix(agent-runs): add mobile spacing for trigger form`).

---

Closes #2423