### PR TITLE
fix(chat): sending a message can incorrectly fail with 'Claude is missing an API key' even when another chat-enabled provider is configured

### DIFF
--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -531,6 +531,15 @@ class Runner < ApplicationRecord
     owner.runners.kept_only.for_chat.where(runner_key: executable_keys).ordered.first
   end
 
+  def self.first_configured_chat_enabled_for_owner(owner)
+    return unless owner
+
+    executable_keys = RunnerSupport.container_executable_runner_keys
+    owner.runners.kept_only.for_chat.where(runner_key: executable_keys).ordered.find do |runner|
+      runner.effective_api_secret.present?
+    end
+  end
+
   def self.display_name_for(runner_key)
     return "Unknown" if runner_key.blank?
 

--- a/app/services/chat_sessions/build_llm_client.rb
+++ b/app/services/chat_sessions/build_llm_client.rb
@@ -40,7 +40,10 @@ module ChatSessions
       fallback_runner = Runner.first_configured_chat_enabled_for_owner(chat_session.created_by)
       return runner unless fallback_runner && fallback_runner != runner
 
-      chat_session.update!(runner: fallback_runner)
+      # A runner fallback can also invalidate a provider-specific saved model
+      # (for example, Claude -> OpenAI-compatible), so persist the corrected
+      # runner/model pair together before building the client.
+      chat_session.update!(runner: fallback_runner, model: default_model_for(fallback_runner))
       fallback_runner
     end
 
@@ -54,7 +57,7 @@ module ChatSessions
       service_type = provider_service_type(provider)
       config = Runner::DIRECT_OUTBOUND_API_PROVIDERS.values.find { |c| c[:service_type] == service_type }
       base_url = config&.dig(:base_url) || "https://api.openai.com/v1"
-      model = chat_session.model || "gpt-4o"
+      model = chat_session.model || default_model_for(provider)
 
       transport = AgentHarness::OpenAICompatibleTransport.new(
         base_url: base_url,
@@ -76,6 +79,16 @@ module ChatSessions
 
     def provider_service_type(provider)
       provider.provider_api_key&.api_service_type || provider.required_api_service_type
+    end
+
+    def default_model_for(provider)
+      provider.direct_outbound_model_id.presence || default_model_for_service_type(provider_service_type(provider))
+    end
+
+    def default_model_for_service_type(service_type)
+      return AgentHarness::TextTransport::DEFAULT_MODEL if service_type == ANTHROPIC_SERVICE_TYPE
+
+      "gpt-4o"
     end
 
     class HttpClient

--- a/app/services/chat_sessions/build_llm_client.rb
+++ b/app/services/chat_sessions/build_llm_client.rb
@@ -13,7 +13,7 @@ module ChatSessions
     end
 
     def call
-      provider = chat_session.runner
+      provider = resolved_runner
       raise LlmClientConfigurationError, missing_runner_message unless provider
 
       api_key = provider.effective_api_secret
@@ -32,6 +32,17 @@ module ChatSessions
     private
 
     attr_reader :chat_session
+
+    def resolved_runner
+      runner = chat_session.runner
+      return runner if runner&.effective_api_secret.present?
+
+      fallback_runner = Runner.first_configured_chat_enabled_for_owner(chat_session.created_by)
+      return runner unless fallback_runner && fallback_runner != runner
+
+      chat_session.update!(runner: fallback_runner)
+      fallback_runner
+    end
 
     def anthropic_client(api_key)
       transport = AgentHarness::TextTransport.new(api_key: api_key)

--- a/app/services/chat_sessions/create.rb
+++ b/app/services/chat_sessions/create.rb
@@ -107,7 +107,7 @@ module ChatSessions
     end
 
     def default_runner_for_user
-      Runner.first_chat_enabled_for_owner(user)
+      Runner.first_configured_chat_enabled_for_owner(user) || Runner.first_chat_enabled_for_owner(user)
     end
   end
 end

--- a/spec/services/chat_sessions/build_llm_client_spec.rb
+++ b/spec/services/chat_sessions/build_llm_client_spec.rb
@@ -81,6 +81,25 @@ RSpec.describe ChatSessions::BuildLlmClient, type: :service do
       end
     end
 
+    context "with an unconfigured runner and another configured chat runner" do
+      it "falls back to the configured runner and persists it on the session" do
+        unavailable_runner = user.runners.find_or_create_by!(runner_key: "claude", auth_type: "subscription")
+        api_key_record = create(:provider_api_key, user: user, api_key: "sk-openrouter-test", api_service_type: "openrouter")
+        fallback_runner = create(:runner, :api_key,
+          user: user,
+          runner_key: "opencode",
+          provider_api_key: api_key_record,
+          config: { "opencode" => { "api_provider" => "openrouter", "model" => "moonshotai/kimi-k2" } }
+        )
+        chat_session = create(:chat_session, account: account, created_by: user, runner: unavailable_runner)
+
+        client = described_class.call(chat_session: chat_session)
+
+        expect(client).to be_a(described_class::HttpClient)
+        expect(chat_session.reload.runner).to eq(fallback_runner)
+      end
+    end
+
     context "without a runner" do
       it "raises a setup error" do
         chat_session = create(:chat_session, account: account, created_by: user)

--- a/spec/services/chat_sessions/build_llm_client_spec.rb
+++ b/spec/services/chat_sessions/build_llm_client_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe ChatSessions::BuildLlmClient, type: :service do
     end
 
     context "with an unconfigured runner and another configured chat runner" do
-      it "falls back to the configured runner and persists it on the session" do
+      it "falls back to the configured runner and persists a compatible model on the session" do
         unavailable_runner = user.runners.find_or_create_by!(runner_key: "claude", auth_type: "subscription")
         api_key_record = create(:provider_api_key, user: user, api_key: "sk-openrouter-test", api_service_type: "openrouter")
         fallback_runner = create(:runner, :api_key,
@@ -91,12 +91,19 @@ RSpec.describe ChatSessions::BuildLlmClient, type: :service do
           provider_api_key: api_key_record,
           config: { "opencode" => { "api_provider" => "openrouter", "model" => "moonshotai/kimi-k2" } }
         )
-        chat_session = create(:chat_session, account: account, created_by: user, runner: unavailable_runner)
+        chat_session = create(:chat_session,
+          account: account,
+          created_by: user,
+          runner: unavailable_runner,
+          model: "claude-sonnet-4-20250514"
+        )
 
         client = described_class.call(chat_session: chat_session)
 
         expect(client).to be_a(described_class::HttpClient)
         expect(chat_session.reload.runner).to eq(fallback_runner)
+        expect(chat_session.model).to eq("moonshotai/kimi-k2")
+        expect(client.model).to eq("moonshotai/kimi-k2")
       end
     end
 

--- a/spec/services/chat_sessions/create_spec.rb
+++ b/spec/services/chat_sessions/create_spec.rb
@@ -72,6 +72,22 @@ RSpec.describe ChatSessions::Create do
       expect(session.runner).not_to eq(non_chat_runner)
     end
 
+    it "prefers a configured API-key runner when one is available" do
+      default_runner = user.runners.find_by!(runner_key: "claude")
+      api_key_record = create(:provider_api_key, user: user, api_key: "sk-openrouter-test", api_service_type: "openrouter")
+      configured_runner = create(:runner, :api_key,
+        user: user,
+        runner_key: "opencode",
+        provider_api_key: api_key_record,
+        config: { "opencode" => { "api_provider" => "openrouter", "model" => "moonshotai/kimi-k2" } }
+      )
+
+      session = described_class.call(account: account, user: user)
+
+      expect(session.runner).to eq(configured_runner)
+      expect(session.runner).not_to eq(default_runner)
+    end
+
     it "accepts provider_id as a legacy alias for runner_id" do
       runner = create(:runner, user: user)
       session = described_class.call(


### PR DESCRIPTION
## Summary

Updated chat runner resolution so chat no longer hard-fails on an unconfigured default when another usable API-key runner exists. New sessions now prefer a configured chat runner with an API key, and `ChatSessions::BuildLlmClient` will fall back to a configured runner for existing sessions and persist that correction on the session.

Coverage was added for both paths in `spec/services/chat_sessions/create_spec.rb` and `spec/services/chat_sessions/build_llm_client_spec.rb`. `bundle exec rubocop` passed, `bundle exec rspec` passed (`14251 examples, 0 failures, 7 pending`), and the change is committed as `271e2cf` with message `fix(chat): prefer configured chat runners with API keys`.

`bin/rails db:prepare` required explicit DB host credentials in this environment because the multi-DB config was not picking up `DATABASE_URL` alone; it succeeded with `DB_HOST=paid-svc-a3-s1-postgres DB_USERNAME=agent DB_PASSWORD=agent`.

---

Closes #2424