### PR TITLE
fix(chat): remove "Need Help?" and "Support Chat" labels from chat widget

### DIFF
--- a/app/views/chat_sessions/_popup.html.erb
+++ b/app/views/chat_sessions/_popup.html.erb
@@ -6,7 +6,6 @@
   <div class="border-b border-slate-200 bg-[radial-gradient(circle_at_top,_rgba(99,102,241,0.14),_transparent_55%),linear-gradient(180deg,_#ffffff_0%,_#f8fafc_100%)] px-5 py-4">
     <div class="flex items-start justify-between gap-4">
       <div class="min-w-0">
-        <p class="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500">Support chat</p>
         <h2 class="mt-1 truncate text-base font-semibold text-slate-900"><%= chat_session_title(chat_session) %></h2>
         <div class="mt-2 flex flex-wrap items-center gap-2 text-xs text-slate-500">
           <% if page_context["project_name"].present? %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -215,7 +215,6 @@
                 </svg>
               </span>
               <span class="text-left">
-                <span class="block text-[0.7rem] font-medium uppercase tracking-[0.18em] text-slate-300">Need help?</span>
                 <span class="block">Open chat</span>
               </span>
             </button>

--- a/spec/requests/chat_sessions_spec.rb
+++ b/spec/requests/chat_sessions_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe "ChatSessions" do
         get chat_session_path(chat_session), params: { display: "popup" }, headers: { "Accept" => "text/html" }
 
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include("Support chat")
+        expect(response.body).to include("Untitled chat")
         expect(response.body).to include("Archive &amp; New Chat")
         expect(response.body).to include("New Chat")
         expect(response.body).to include("Open page")


### PR DESCRIPTION
## Summary

Removed the help/support-oriented labels from the chat widget and updated the request spec to match the new popup header state.

Checks completed:
- `bundle install` with repo-local `vendor/bundle`
- `yarn install` with repo-local cache
- `bin/rails db:prepare`
- `bundle exec rubocop`
- `bundle exec rspec`
- pre-commit hook lint/tests during commit

Commit created: `91a392b` `fix(chat): remove help-oriented widget labels`

---

Closes #2398