### PR TITLE
feat: Phase 1: Data model for free models

### DIFF
--- a/app/models/llm_model.rb
+++ b/app/models/llm_model.rb
@@ -5,7 +5,11 @@ class LlmModel < ApplicationRecord
   CATEGORIES = %w[general coding planning review].freeze
   PROVIDERS = %w[anthropic openai google mistral meta cohere].freeze
   TIERS = %w[low mid high].freeze
+  PRICING_TIERS = %w[paid free freemium].freeze
+  DATA_TRAINING_RISKS = %w[none possible unknown].freeze
+  CATALOG_SOURCES = %w[seeded openrouter_sync manual].freeze
 
+  belongs_to :free_variant_of, class_name: "LlmModel", optional: true
   has_many :model_selections, dependent: :restrict_with_error
   has_many :configuration_bundles, dependent: :nullify
 
@@ -14,6 +18,9 @@ class LlmModel < ApplicationRecord
   validates :provider, presence: true, length: { maximum: 50 }
   validates :category, presence: true, inclusion: { in: CATEGORIES }
   validates :tier, inclusion: { in: TIERS }, allow_nil: true
+  validates :pricing_tier, inclusion: { in: PRICING_TIERS }
+  validates :data_training_risk, inclusion: { in: DATA_TRAINING_RISKS }, allow_nil: true
+  validates :catalog_source, inclusion: { in: CATALOG_SOURCES }
   validates :capability_score, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 10 }, allow_nil: true
   validates :input_cost_per_million, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
   validates :output_cost_per_million, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
@@ -23,6 +30,9 @@ class LlmModel < ApplicationRecord
   scope :by_category, ->(category) { where(category: category) }
   scope :by_capability, -> { order(Arel.sql("capability_score DESC NULLS LAST")) }
   scope :by_tier, ->(tier) { where(tier: tier) }
+  scope :by_pricing_tier, ->(pricing_tier) { where(pricing_tier: pricing_tier) }
+  scope :free, -> { by_pricing_tier("free") }
+  scope :paid, -> { by_pricing_tier("paid") }
   scope :affordable, ->(budget_cents, avg_tokens) {
     return active if budget_cents.nil?
 
@@ -41,6 +51,10 @@ class LlmModel < ApplicationRecord
     input_cost = (input_cost_per_million || 0) * BigDecimal(input_tokens.to_s) / BigDecimal("1000000")
     output_cost = (output_cost_per_million || 0) * BigDecimal(output_tokens.to_s) / BigDecimal("1000000")
     ((input_cost + output_cost) * 100).round.to_i
+  end
+
+  def free?
+    pricing_tier == "free"
   end
 
   def self.default_for_task(category)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -26,6 +26,7 @@ class Project < ApplicationRecord
   PRIORITY_TIERS = %w[P1 P2 P3].freeze
   DEFAULT_PRIORITY_LABELS = { "P1" => "P1", "P2" => "P2", "P3" => "P3" }.freeze
   ADOPTION_MODES = %w[observe_only advisory review_only full_execution].freeze
+  DATA_CLASSIFICATIONS = %w[open internal confidential restricted].freeze
   DEFAULT_SCREENSHOT_SETTINGS = {
     "enabled" => false,
     "driver" => "playwright",
@@ -239,6 +240,7 @@ class Project < ApplicationRecord
   validates :token_limit_warning_threshold,
     numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 100 }
   validates :max_execution_seconds, numericality: { only_integer: true, greater_than_or_equal_to: 60, less_than_or_equal_to: 86_400 }
+  validates :data_classification, inclusion: { in: DATA_CLASSIFICATIONS }
   validate :allowed_github_usernames_not_empty
   validate :owner_reviewer_login_is_trusted, if: -> { owner_reviewer_login.present? }
   validate :exactly_one_github_credential, if: :validate_github_credential_presence?
@@ -296,6 +298,14 @@ class Project < ApplicationRecord
 
   def deactivate!
     update!(active: false)
+  end
+
+  def confidential?
+    data_classification == "confidential"
+  end
+
+  def restricted?
+    data_classification == "restricted"
   end
 
   def label_for_stage(stage)

--- a/db/migrate/20260531194840_add_free_model_fields_to_llm_models.rb
+++ b/db/migrate/20260531194840_add_free_model_fields_to_llm_models.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AddFreeModelFieldsToLlmModels < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :llm_models, :pricing_tier, :string, default: "paid", null: false,
+      comment: "Pricing availability for this model: paid, free, or freemium."
+    add_column :llm_models, :data_training_risk, :string,
+      comment: "Whether provider terms indicate prompts may be used for training."
+    add_column :llm_models, :catalog_source, :string, default: "seeded", null: false,
+      comment: "How this model entered the catalog: seeded, openrouter_sync, or manual."
+    add_column :llm_models, :expires_at, :datetime,
+      comment: "Optional expiration time for temporary catalog entries."
+    add_reference :llm_models, :free_variant_of, null: true, index: { algorithm: :concurrently },
+      comment: "Paid model that this free model variant corresponds to."
+    safety_assured do
+      add_foreign_key :llm_models, :llm_models, column: :free_variant_of_id
+    end
+  end
+end

--- a/db/migrate/20260531194840_add_free_model_fields_to_llm_models.rb
+++ b/db/migrate/20260531194840_add_free_model_fields_to_llm_models.rb
@@ -15,7 +15,7 @@ class AddFreeModelFieldsToLlmModels < ActiveRecord::Migration[8.1]
     add_reference :llm_models, :free_variant_of, null: true, index: { algorithm: :concurrently },
       comment: "Paid model that this free model variant corresponds to."
     safety_assured do
-      add_foreign_key :llm_models, :llm_models, column: :free_variant_of_id
+      add_foreign_key :llm_models, :llm_models, column: :free_variant_of_id, validate: false
     end
   end
 end

--- a/db/migrate/20260531194841_add_data_classification_to_projects.rb
+++ b/db/migrate/20260531194841_add_data_classification_to_projects.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDataClassificationToProjects < ActiveRecord::Migration[8.1]
+  def change
+    add_column :projects, :data_classification, :string, default: "internal", null: false,
+      comment: "Sensitivity level for project data shared with model providers."
+  end
+end

--- a/db/migrate/20260531204336_validate_free_variant_of_foreign_key_on_llm_models.rb
+++ b/db/migrate/20260531204336_validate_free_variant_of_foreign_key_on_llm_models.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateFreeVariantOfForeignKeyOnLlmModels < ActiveRecord::Migration[8.1]
+  def change
+    validate_foreign_key :llm_models, :llm_models, column: :free_variant_of_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_30_075312) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_31_194841) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1321,17 +1321,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_30_075312) do
   create_table "llm_models", force: :cascade do |t|
     t.boolean "active", default: true, null: false
     t.decimal "capability_score", precision: 4, scale: 2
+    t.string "catalog_source", default: "seeded", null: false, comment: "How this model entered the catalog: seeded, openrouter_sync, or manual."
     t.string "category", limit: 50, default: "general", null: false
     t.integer "context_window"
     t.datetime "created_at", null: false
+    t.string "data_training_risk", comment: "Whether provider terms indicate prompts may be used for training."
     t.string "display_name", null: false
+    t.datetime "expires_at", comment: "Optional expiration time for temporary catalog entries."
     t.string "family", limit: 100
+    t.bigint "free_variant_of_id", comment: "Paid model that this free model variant corresponds to."
     t.decimal "input_cost_per_million", precision: 10, scale: 4
     t.jsonb "log_data"
     t.integer "max_output_tokens"
     t.jsonb "metadata", default: {}, null: false
     t.string "model_id", null: false
     t.decimal "output_cost_per_million", precision: 10, scale: 4
+    t.string "pricing_tier", default: "paid", null: false, comment: "Pricing availability for this model: paid, free, or freemium."
     t.string "provider", limit: 50, null: false
     t.boolean "supports_json_output", default: false, null: false
     t.boolean "supports_tools", default: false, null: false
@@ -1340,6 +1345,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_30_075312) do
     t.datetime "updated_at", null: false
     t.index ["active"], name: "index_llm_models_on_active"
     t.index ["category"], name: "index_llm_models_on_category"
+    t.index ["free_variant_of_id"], name: "index_llm_models_on_free_variant_of_id"
     t.index ["model_id"], name: "index_llm_models_on_model_id", unique: true
     t.index ["provider", "active"], name: "index_llm_models_on_provider_and_active"
     t.index ["provider"], name: "index_llm_models_on_provider"
@@ -1748,6 +1754,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_30_075312) do
     t.integer "completed_agent_runs_count", default: 0, null: false, comment: "Counter cache for completed agent runs"
     t.datetime "created_at", null: false
     t.bigint "created_by_id"
+    t.string "data_classification", default: "internal", null: false, comment: "Sensitivity level for project data shared with model providers."
     t.string "default_branch", default: "main", null: false
     t.string "enhance_issue_enhanced_label_name", default: "paid-enhanced", null: false
     t.string "enhance_issue_needs_input_label_name", default: "paid-needs-input", null: false
@@ -2622,6 +2629,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_30_075312) do
   add_foreign_key "knowledge_usage_stats", "projects", on_delete: :cascade
   add_foreign_key "linear_tokens", "accounts"
   add_foreign_key "linear_tokens", "users", column: "created_by_id"
+  add_foreign_key "llm_models", "llm_models", column: "free_variant_of_id"
   add_foreign_key "llm_output_metrics", "accounts", on_delete: :cascade
   add_foreign_key "llm_output_metrics", "projects", on_delete: :cascade
   add_foreign_key "llm_output_metrics", "prompt_versions", on_delete: :nullify

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_31_194841) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_31_204336) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"

--- a/spec/models/llm_model_spec.rb
+++ b/spec/models/llm_model_spec.rb
@@ -12,9 +12,28 @@ RSpec.describe LlmModel do
     it { is_expected.to validate_presence_of(:provider) }
     it { is_expected.to validate_presence_of(:category) }
     it { is_expected.to validate_inclusion_of(:category).in_array(described_class::CATEGORIES) }
+    it { is_expected.to validate_inclusion_of(:pricing_tier).in_array(described_class::PRICING_TIERS) }
+    it { is_expected.to validate_inclusion_of(:catalog_source).in_array(described_class::CATALOG_SOURCES) }
 
     it "permits a nil tier" do
       expect(build(:llm_model, tier: nil)).to be_valid
+    end
+
+    it "permits a nil data_training_risk" do
+      expect(build(:llm_model, data_training_risk: nil)).to be_valid
+    end
+
+    it "rejects an unknown data_training_risk" do
+      model = build(:llm_model, data_training_risk: "always")
+
+      expect(model).not_to be_valid
+      expect(model.errors[:data_training_risk]).to be_present
+    end
+
+    it "accepts each known data_training_risk" do
+      LlmModel::DATA_TRAINING_RISKS.each do |risk|
+        expect(build(:llm_model, data_training_risk: risk)).to be_valid
+      end
     end
 
     it "rejects an unknown tier" do
@@ -31,10 +50,38 @@ RSpec.describe LlmModel do
   end
 
   describe "associations" do
+    it { is_expected.to belong_to(:free_variant_of).class_name("LlmModel").optional }
     it { is_expected.to have_many(:model_selections) }
   end
 
   describe "scopes" do
+    describe ".free" do
+      it "returns only free models" do
+        free_model = create(:llm_model, pricing_tier: "free")
+        create(:llm_model, pricing_tier: "paid")
+
+        expect(described_class.free).to eq([ free_model ])
+      end
+    end
+
+    describe ".paid" do
+      it "returns only paid models" do
+        paid_model = create(:llm_model, pricing_tier: "paid")
+        create(:llm_model, pricing_tier: "free")
+
+        expect(described_class.paid).to eq([ paid_model ])
+      end
+    end
+
+    describe ".by_pricing_tier" do
+      it "filters by pricing tier" do
+        freemium = create(:llm_model, pricing_tier: "freemium")
+        create(:llm_model, pricing_tier: "paid")
+
+        expect(described_class.by_pricing_tier("freemium")).to eq([ freemium ])
+      end
+    end
+
     describe ".active" do
       it "returns only active models" do
         active = create(:llm_model, active: true)
@@ -80,6 +127,16 @@ RSpec.describe LlmModel do
 
       # Input: 3.0 * 1 = 3.0, Output: 15.0 * 0.1 = 1.5, Total: 4.5 => 450 cents
       expect(cost).to eq(450)
+    end
+  end
+
+  describe "#free?" do
+    it "returns true when the pricing tier is free" do
+      expect(build(:llm_model, pricing_tier: "free")).to be_free
+    end
+
+    it "returns false for non-free pricing tiers" do
+      expect(build(:llm_model, pricing_tier: "paid")).not_to be_free
     end
   end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -32,10 +32,17 @@ RSpec.describe Project do
     it { is_expected.to validate_numericality_of(:max_tokens_per_run).only_integer.is_greater_than_or_equal_to(1).is_less_than_or_equal_to(2_147_483_647).allow_nil }
     it { is_expected.to validate_numericality_of(:token_limit_warning_threshold).only_integer.is_greater_than_or_equal_to(1).is_less_than_or_equal_to(100) }
     it { is_expected.to validate_numericality_of(:max_execution_seconds).only_integer.is_greater_than_or_equal_to(60).is_less_than_or_equal_to(86_400) }
+    it { is_expected.to validate_inclusion_of(:data_classification).in_array(described_class::DATA_CLASSIFICATIONS) }
 
     it "defaults max_execution_seconds to 3600" do
       project = build(:project)
       expect(project.max_execution_seconds).to eq(3600)
+    end
+
+    it "defaults data_classification to internal" do
+      project = build(:project)
+
+      expect(project.data_classification).to eq("internal")
     end
 
     it "validates knowledge_status inclusion" do
@@ -165,6 +172,26 @@ RSpec.describe Project do
       it "returns the GitHub URL" do
         project = build(:project, owner: "viamin", repo: "paid")
         expect(project.github_url).to eq("https://github.com/viamin/paid")
+      end
+    end
+
+    describe "#confidential?" do
+      it "returns true for confidential projects" do
+        expect(build(:project, data_classification: "confidential")).to be_confidential
+      end
+
+      it "returns false for other classifications" do
+        expect(build(:project, data_classification: "internal")).not_to be_confidential
+      end
+    end
+
+    describe "#restricted?" do
+      it "returns true for restricted projects" do
+        expect(build(:project, data_classification: "restricted")).to be_restricted
+      end
+
+      it "returns false for other classifications" do
+        expect(build(:project, data_classification: "confidential")).not_to be_restricted
       end
     end
 


### PR DESCRIPTION
## Summary

Implemented and committed as `f2accb2` with `feat(models): add free model pricing metadata`.

Changes include the two schema additions in `llm_models` and `projects`, `LlmModel` pricing/data-training/catalog validations plus `free`/`paid`/`by_pricing_tier` scopes and `free?`, and `Project` data-classification validation plus `confidential?`/`restricted?`. `db/schema.rb` was regenerated from the migrations.

Verification: `bundle exec rubocop` passed, targeted model specs passed, full `bundle exec rspec` passed with `14266 examples, 0 failures, 7 pending`, and the commit hook completed successfully. In this environment I had to use writable workspace-backed Bundler/Yarn paths, and I used `PAID_SKIP_DATABASE_RUNTIME_ROLE_GUARD=true` for migration generation/migration because the provided Postgres role is a superuser guarded by the app’s runtime-role check.

---

Closes #2381