### PR TITLE
feat(ui): consolidate user/account menu items into email dropdown

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -83,18 +83,57 @@
               <%= link_to "Quality", quality_dashboard_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white" %>
               <%= link_to "Knowledge", knowledge_search_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white" %>
               <%= link_to "Integrations", integrations_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white" %>
-              <%= link_to "Account", account_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white" %>
               <%= link_to "Runners", runners_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white", data: { nav_section: "runners" } %>
-              <% if policy(current_account).update? %>
-                <%= link_to "Tenant", edit_tenant_configuration_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white" %>
-              <% end %>
               <% if policy(ServiceContainer).index? %>
                 <%= link_to "Services", service_containers_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white" %>
               <% end %>
-              <%= link_to "Settings", edit_user_settings_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white" %>
               <%= render "notifications/bell", account: current_account %>
-              <span class="text-sm text-gray-700 dark:text-gray-300"><%= current_user.email %></span>
-              <%= button_to "Sign out", destroy_user_session_path, method: :delete, class: "text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white" %>
+              <% user_menu_button_id = "user-menu-button" %>
+              <% user_menu_id = "user-menu" %>
+              <div class="relative" data-controller="dropdown">
+                <button type="button"
+                        id="<%= user_menu_button_id %>"
+                        class="inline-flex items-center gap-1 rounded-md px-2 py-1 text-sm text-gray-700 hover:bg-gray-50 hover:text-gray-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white"
+                        aria-haspopup="menu"
+                        aria-expanded="false"
+                        aria-controls="<%= user_menu_id %>"
+                        data-action="dropdown#toggle"
+                        data-dropdown-target="button">
+                  <span><%= current_user.email %></span>
+                  <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25 4.5a.75.75 0 0 1-1.08 0l-4.25-4.5a.75.75 0 0 1 .02-1.06Z" clip-rule="evenodd" />
+                  </svg>
+                </button>
+                <div id="<%= user_menu_id %>"
+                     class="absolute right-0 top-full z-10 mt-2 hidden min-w-48 overflow-hidden rounded-md bg-white py-1 shadow-lg ring-1 ring-black/5 dark:bg-gray-800 dark:ring-white/10"
+                     role="menu"
+                     aria-labelledby="<%= user_menu_button_id %>"
+                     data-dropdown-target="menu">
+                  <%= link_to "Settings",
+                    edit_user_settings_path,
+                    class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-700",
+                    role: "menuitem",
+                    data: { action: "dropdown#close" } %>
+                  <%= link_to "Account",
+                    account_path,
+                    class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-700",
+                    role: "menuitem",
+                    data: { action: "dropdown#close" } %>
+                  <% if policy(current_account).update? %>
+                    <%= link_to "Tenant",
+                      edit_tenant_configuration_path,
+                      class: "block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-700",
+                      role: "menuitem",
+                      data: { action: "dropdown#close" } %>
+                  <% end %>
+                  <%= button_to "Sign out",
+                    destroy_user_session_path,
+                    method: :delete,
+                    form_class: "w-full",
+                    class: "block w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-700",
+                    form: { data: { action: "submit->dropdown#close" } } %>
+                </div>
+              </div>
             <% else %>
               <%= link_to "Sign in", new_user_session_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white" %>
               <%= link_to "Sign up", new_user_registration_path, class: "ml-4 inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500" %>
@@ -141,18 +180,18 @@
             <%= link_to "Quality", quality_dashboard_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
             <%= link_to "Knowledge", knowledge_search_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
             <%= link_to "Integrations", integrations_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
-            <%= link_to "Account", account_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
             <%= link_to "Runners", runners_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
-            <% if policy(current_account).update? %>
-              <%= link_to "Tenant", edit_tenant_configuration_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
-            <% end %>
             <% if policy(ServiceContainer).index? %>
               <%= link_to "Services", service_containers_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
             <% end %>
             <%= link_to "Notifications", notifications_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
-            <%= link_to "Settings", edit_user_settings_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
             <div class="border-t border-gray-200 dark:border-gray-600 pt-3 mt-2">
               <p class="px-3 text-sm text-gray-700 dark:text-gray-300"><%= current_user.email %></p>
+              <%= link_to "Settings", edit_user_settings_path, data: { action: "mobile-menu#close" }, class: "mt-1 block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
+              <%= link_to "Account", account_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
+              <% if policy(current_account).update? %>
+                <%= link_to "Tenant", edit_tenant_configuration_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
+              <% end %>
               <%= button_to "Sign out", destroy_user_session_path, method: :delete, class: "mt-1 block w-full rounded-md px-3 py-2 text-left text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
             </div>
           <% else %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -131,6 +131,7 @@
                     method: :delete,
                     form_class: "w-full",
                     class: "block w-full px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-700",
+                    role: "menuitem",
                     form: { data: { action: "submit->dropdown#close" } } %>
                 </div>
               </div>

--- a/spec/lib/dropdown_controller_node_harness_spec.rb
+++ b/spec/lib/dropdown_controller_node_harness_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require "open3"
+require "rails_helper"
+
+class DropdownControllerNodeHarness
+  SCRIPT = <<~JAVASCRIPT
+    const fs = require("node:fs");
+
+    const source = fs.readFileSync("app/javascript/controllers/dropdown_controller.js", "utf8");
+    const transformed = source
+      .replace('import { Controller } from "@hotwired/stimulus"', "class Controller {}")
+      .replace("export default class extends Controller {", "return class DropdownController extends Controller {");
+
+    const DropdownController = new Function(transformed)();
+
+    function buildClassList(initial = []) {
+      const classes = new Set(initial);
+
+      return {
+        add(name) {
+          classes.add(name);
+        },
+        contains(name) {
+          return classes.has(name);
+        },
+        remove(name) {
+          classes.delete(name);
+        }
+      };
+    }
+
+    function buildController() {
+      const listeners = {};
+      const menu = {
+        classList: buildClassList()
+      };
+      const button = {
+        attributes: {},
+        setAttribute(name, value) {
+          this.attributes[name] = value;
+        }
+      };
+      const insideNode = {};
+
+      global.document = {
+        addEventListener(name, listener) {
+          listeners[name] = listener;
+        },
+        removeEventListener(name, listener) {
+          if (listeners[name] === listener) delete listeners[name];
+        }
+      };
+
+      const controller = Object.create(DropdownController.prototype);
+      controller.menuTarget = menu;
+      controller.buttonTarget = button;
+      controller.hasMenuTarget = true;
+      controller.hasButtonTarget = true;
+      controller.element = {
+        contains(node) {
+          return node === insideNode;
+        }
+      };
+
+      return { button, controller, insideNode, listeners, menu };
+    }
+
+    function runHarness() {
+      const harness = buildController();
+      harness.controller.connect();
+
+      if (!harness.menu.classList.contains("hidden")) {
+        throw new Error("Expected connect() to close the menu");
+      }
+
+      if (harness.button.attributes["aria-expanded"] !== "false") {
+        throw new Error(`Expected connect() to collapse the button, saw ${harness.button.attributes["aria-expanded"]}`);
+      }
+
+      const toggleEvent = {
+        prevented: false,
+        stopped: false,
+        preventDefault() {
+          this.prevented = true;
+        },
+        stopPropagation() {
+          this.stopped = true;
+        }
+      };
+
+      harness.controller.toggle(toggleEvent);
+
+      if (!toggleEvent.prevented || !toggleEvent.stopped) {
+        throw new Error("Expected toggle() to stop the triggering click event");
+      }
+
+      if (harness.menu.classList.contains("hidden")) {
+        throw new Error("Expected toggle() to open the menu");
+      }
+
+      if (harness.button.attributes["aria-expanded"] !== "true") {
+        throw new Error(`Expected open menu aria-expanded=true, saw ${harness.button.attributes["aria-expanded"]}`);
+      }
+
+      harness.listeners.click({ target: harness.insideNode });
+
+      if (harness.menu.classList.contains("hidden")) {
+        throw new Error("Expected inside clicks to keep the menu open");
+      }
+
+      harness.listeners.click({ target: {} });
+
+      if (!harness.menu.classList.contains("hidden")) {
+        throw new Error("Expected outside clicks to close the menu");
+      }
+
+      harness.controller.open();
+      harness.listeners.keydown({ key: "Escape" });
+
+      if (!harness.menu.classList.contains("hidden")) {
+        throw new Error("Expected Escape to close the menu");
+      }
+
+      harness.controller.open();
+      harness.listeners["turbo:before-visit"]();
+
+      if (!harness.menu.classList.contains("hidden")) {
+        throw new Error("Expected turbo:before-visit to close the menu");
+      }
+
+      harness.controller.disconnect();
+
+      if (Object.keys(harness.listeners).length !== 0) {
+        throw new Error(`Expected disconnect() to remove document listeners, saw ${Object.keys(harness.listeners)}`);
+      }
+    }
+
+    runHarness();
+  JAVASCRIPT
+
+  def self.run
+    Open3.capture3("node", "-e", SCRIPT, chdir: Rails.root.to_s)
+  end
+end
+
+RSpec.describe DropdownControllerNodeHarness, :no_db do
+  it "opens and closes menus through the shared dropdown controller lifecycle" do
+    stdout, stderr, status = described_class.run
+
+    expect(status.success?).to be(true), <<~MESSAGE
+      Node regression harness failed.
+      stdout:
+      #{stdout}
+      stderr:
+      #{stderr}
+    MESSAGE
+  end
+end

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -808,7 +808,7 @@ RSpec.describe "AgentRuns" do
 
         expect(response.body).to include(">Retry</button>")
         expect(response.body).not_to include("Retry options")
-        expect(response.body).not_to include('role="menu"')
+        expect(response.body).not_to include('aria-label="Retry options"')
       end
 
       it "shows a deleted runner entry label for missing routed fallback attempts" do

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -44,6 +44,38 @@ RSpec.describe "Dashboard" do
         expect(mobile_settings_link.text.strip).to eq("Settings")
       end
 
+      it "renders the user email dropdown in the desktop navbar" do
+        get dashboard_path
+
+        doc = Nokogiri::HTML(response.body)
+        menu_button = doc.at_css("#user-menu-button")
+        menu = doc.at_css("#user-menu")
+
+        expect(menu_button).to be_present
+        expect(menu_button.text).to include(user.email)
+        expect(menu_button["aria-expanded"]).to eq("false")
+
+        expect(menu).to be_present
+        expect(menu["class"]).to include("hidden")
+        menu_labels = menu.css("a, form button").map { |node| node.text.strip }
+
+        expect(menu_labels).to include("Settings", "Account", "Sign out")
+        expect(menu.css("a").map { |node| node["data-action"] }).to all(eq("dropdown#close"))
+      end
+
+      it "removes settings and account actions from the desktop top-level nav" do
+        get dashboard_path
+
+        doc = Nokogiri::HTML(response.body)
+        desktop_nav = doc.at_xpath("//nav//div[contains(@class, 'hidden') and contains(@class, 'md:flex')]")
+        top_level_labels = desktop_nav.xpath("./a|./form/button").map { |node| node.text.strip }
+
+        expect(top_level_labels).not_to include("Settings")
+        expect(top_level_labels).not_to include("Account")
+        expect(top_level_labels).not_to include("Tenant")
+        expect(top_level_labels).not_to include("Sign out")
+      end
+
       it "shows the run phase breakdown section via metrics frame" do
         get dashboard_metrics_path(time_range: "cumulative")
 

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -58,8 +58,10 @@ RSpec.describe "Dashboard" do
         expect(menu).to be_present
         expect(menu["class"]).to include("hidden")
         menu_labels = menu.css("a, form button").map { |node| node.text.strip }
+        menu_roles = menu.css("a, form button").map { |node| node["role"] }
 
         expect(menu_labels).to include("Settings", "Account", "Sign out")
+        expect(menu_roles).to all(eq("menuitem"))
         expect(menu.css("a").map { |node| node["data-action"] }).to all(eq("dropdown#close"))
       end
 


### PR DESCRIPTION
## Summary

Implemented the navbar change in [app/views/layouts/application.html.erb](/workspace/app/views/layouts/application.html.erb): the user email is now the desktop trigger for a dropdown containing `Settings`, `Account`, conditional `Tenant`, and `Sign out`, and those items were removed from the desktop top-level nav. Mobile access is preserved by grouping the same actions under the email section in the mobile menu.

I added coverage in [spec/requests/dashboard_spec.rb](/workspace/spec/requests/dashboard_spec.rb), a new shared-controller Node harness in [spec/lib/dropdown_controller_node_harness_spec.rb](/workspace/spec/lib/dropdown_controller_node_harness_spec.rb), and tightened a brittle existing assertion in [spec/requests/agent_runs_spec.rb](/workspace/spec/requests/agent_runs_spec.rb) so the new global dropdown doesn’t break an unrelated retry-menu spec.

Verification I completed:
`bundle exec rubocop`
`DB_HOST=... PAID_*_DATABASE=... bundle exec rspec`
Full suite rerun: `14252 examples, 0 failures, 7 pending`

The remaining gap is the actual `git commit`: I started `git commit -m "feat(ui): consolidate account menu into email dropdown"`, but the repo hook is still running its own long `rspec` pass and had not finished by the time I had to respond, so the changes are still staged rather than committed.

---

Closes #2412