### PR TITLE
feat: Implement Paid::ExceptionNotifier custom notifier (RDR-039 T2)

### DIFF
--- a/lib/paid/exception_notifier.rb
+++ b/lib/paid/exception_notifier.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Paid
+  class ExceptionNotifier
+    DEFAULT_SUBSYSTEM = "general"
+    MAX_MESSAGE_LENGTH = 10_000
+    MAX_BACKTRACE_FRAMES = 20
+
+    def call(exception, options = {})
+      data = normalized_hash(options&.fetch(:data, {}))
+      account = data[:account] || Current.account
+      return nil unless account
+
+      context = pinned_context(data)
+
+      HandleExceptionJob.perform_later(
+        account_id: account.id,
+        exception_class: exception.class.name,
+        exception_message: safe_message(exception).truncate(MAX_MESSAGE_LENGTH),
+        exception_backtrace: exception.backtrace&.first(MAX_BACKTRACE_FRAMES),
+        context: context
+      )
+    rescue => e
+      Rails.logger.error(
+        message: "exception_notifier.notify_failed",
+        original_exception: exception.class.name,
+        notifier_error: e.message
+      )
+      nil
+    end
+
+    private
+
+    def pinned_context(data)
+      extra_context = normalized_hash(data[:context]).except(:subsystem, :project_id)
+
+      {
+        subsystem: data[:subsystem] || DEFAULT_SUBSYSTEM,
+        project_id: data[:project_id]
+      }.merge(extra_context)
+    end
+
+    def normalized_hash(value)
+      value.to_h.deep_symbolize_keys
+    end
+
+    def safe_message(exception)
+      exception.message.to_s
+    rescue
+      "[#{exception.class.name} message raised]"
+    end
+  end
+end

--- a/lib/paid/exception_notifier.rb
+++ b/lib/paid/exception_notifier.rb
@@ -12,10 +12,11 @@ module Paid
       return nil unless account
 
       context = pinned_context(data)
+      exception_class = serialized_exception_class(exception)
 
       HandleExceptionJob.perform_later(
         account_id: account.id,
-        exception_class: exception.class.name,
+        exception_class: exception_class,
         exception_message: safe_message(exception).truncate(MAX_MESSAGE_LENGTH),
         exception_backtrace: exception.backtrace&.first(MAX_BACKTRACE_FRAMES),
         context: context
@@ -47,7 +48,11 @@ module Paid
     def safe_message(exception)
       exception.message.to_s
     rescue
-      "[#{exception.class.name} message raised]"
+      "[#{serialized_exception_class(exception)} message raised]"
+    end
+
+    def serialized_exception_class(exception)
+      exception.class.name || exception.class.superclass&.name || RuntimeError.name
     end
   end
 end

--- a/spec/lib/paid/exception_notifier_spec.rb
+++ b/spec/lib/paid/exception_notifier_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Paid::ExceptionNotifier do
       )
     end
 
-    it "falls back when exception.message itself raises" do
+    it "falls back when exception.message itself raises for anonymous exception classes" do
       Current.account = account
 
       broken_exception = Class.new(StandardError) do
@@ -108,8 +108,8 @@ RSpec.describe Paid::ExceptionNotifier do
         notifier.call(broken_exception, data: { subsystem: "knowledge" })
       }.to have_enqueued_job(HandleExceptionJob).with(
         hash_including(
-          exception_class: broken_exception.class.name,
-          exception_message: "[#{broken_exception.class.name} message raised]"
+          exception_class: "StandardError",
+          exception_message: "[StandardError message raised]"
         )
       )
     end

--- a/spec/lib/paid/exception_notifier_spec.rb
+++ b/spec/lib/paid/exception_notifier_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Paid::ExceptionNotifier do
+  include ActiveJob::TestHelper
+
+  subject(:notifier) { described_class.new }
+
+  let(:account) { create(:account) }
+  let(:project) { create(:project, account: account) }
+  let(:exception) { RuntimeError.new("boom") }
+
+  around do |example|
+    original_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :test
+    clear_enqueued_jobs
+    Current.account = nil
+
+    example.run
+  ensure
+    clear_enqueued_jobs
+    Current.account = nil
+    ActiveJob::Base.queue_adapter = original_adapter
+  end
+
+  def last_job_args
+    enqueued_jobs.last[:args].first
+  end
+
+  def last_job_context
+    last_job_args["context"].except("_aj_symbol_keys").symbolize_keys
+  end
+
+  describe "#call" do
+    it "enqueues HandleExceptionJob with truncated exception payload and merged context" do
+      Current.account = account
+      exception.set_backtrace(Array.new(25) { |index| "frame-#{index}" })
+      long_message = "x" * 10_500
+      allow(exception).to receive(:message).and_return(long_message)
+
+      notifier.call(exception, data: notification_data(request_id: "req-123"))
+
+      expect(last_job_args["account_id"]).to eq(account.id)
+      expect(last_job_args["exception_class"]).to eq("RuntimeError")
+      expect(last_job_args["exception_message"]).to eq(long_message.truncate(10_000))
+      expect(last_job_args["exception_backtrace"]).to eq(Array.new(20) { |index| "frame-#{index}" })
+      expect(last_job_context).to eq({
+        subsystem: "knowledge",
+        project_id: project.id,
+        request_id: "req-123"
+      })
+    end
+
+    it "returns nil without enqueueing when no account is available" do
+      result = nil
+
+      expect {
+        result = notifier.call(exception, data: { subsystem: "knowledge", project_id: project.id })
+      }.not_to have_enqueued_job(HandleExceptionJob)
+
+      expect(result).to be_nil
+    end
+
+    it "does not allow nested context to override pinned subsystem or project_id" do
+      Current.account = account
+
+      notifier.call(
+        exception,
+        data: notification_data(
+          request_id: "req-456",
+          context: { subsystem: "general", project_id: -1, request_id: "req-456" }
+        )
+      )
+
+      expect(last_job_context).to eq({
+        subsystem: "knowledge",
+        project_id: project.id,
+        request_id: "req-456"
+      })
+    end
+
+    it "swallows internal notifier failures and logs them" do
+      Current.account = account
+      allow(HandleExceptionJob).to receive(:perform_later).and_raise("enqueue failed")
+      allow(Rails.logger).to receive(:error)
+
+      expect(notifier.call(exception, data: { subsystem: "knowledge" })).to be_nil
+      expect(Rails.logger).to have_received(:error).with(
+        hash_including(
+          message: "exception_notifier.notify_failed",
+          original_exception: "RuntimeError",
+          notifier_error: "enqueue failed"
+        )
+      )
+    end
+
+    it "falls back when exception.message itself raises" do
+      Current.account = account
+
+      broken_exception = Class.new(StandardError) do
+        def message
+          raise "broken message"
+        end
+      end.new
+
+      expect {
+        notifier.call(broken_exception, data: { subsystem: "knowledge" })
+      }.to have_enqueued_job(HandleExceptionJob).with(
+        hash_including(
+          exception_class: broken_exception.class.name,
+          exception_message: "[#{broken_exception.class.name} message raised]"
+        )
+      )
+    end
+
+    it "truncates backtrace to the first 20 frames" do
+      Current.account = account
+      exception.set_backtrace(Array.new(30) { |index| "line-#{index}" })
+
+      notifier.call(exception, data: { subsystem: "knowledge" })
+
+      job = enqueued_jobs.last
+      expect(job[:args].first["exception_backtrace"]).to eq(Array.new(20) { |index| "line-#{index}" })
+    end
+  end
+
+  def notification_data(request_id:, context: { request_id: })
+    {
+      subsystem: "knowledge",
+      project_id: project.id,
+      context: context
+    }
+  end
+end


### PR DESCRIPTION
## Summary

Implemented the custom notifier in [lib/paid/exception_notifier.rb](/workspace/lib/paid/exception_notifier.rb) and added focused coverage in [spec/lib/paid/exception_notifier_spec.rb](/workspace/spec/lib/paid/exception_notifier_spec.rb). The notifier pulls `account` from `data[:account]` or `Current.account`, pins `subsystem`/`project_id`, strips those keys from nested context before merging, truncates message/backtrace at the enqueue boundary, uses a `safe_message` fallback, enqueues `HandleExceptionJob`, and swallows/logs any internal failure with `exception_notifier.notify_failed`.

Verification passed: `bundle exec rubocop` and `bundle exec rspec` both ran green against the repo, with the existing 7 pending specs only. `db:prepare` also completed once Rails was given the explicit DB env this workspace needs (`DB_HOST=paid-svc-a3-s1-postgres DB_USERNAME=agent DB_PASSWORD=agent`).

Committed on the current feature branch as `aae43ce` with message `feat(exception-handler): add Paid exception notifier`.

---

Closes #2389