### PR TITLE
fix(agent-runs): stop Claude --mcp-config from swallowing the prompt

### DIFF
--- a/config/initializers/agent_harness.rb
+++ b/config/initializers/agent_harness.rb
@@ -76,8 +76,17 @@ end
 
 # Suppress Claude CLI .mcp.json auto-discovery when Paid did not explicitly
 # configure any MCP servers. We pass an empty {"mcpServers": {}} config via
-# --mcp-config so the CLI emits only the requested JSON envelope.
-# TODO(#2365): remove when agent-harness >= 0.19.0 ships native MCP suppression
+# --mcp-config so the CLI emits only the requested JSON envelope, AND we
+# materialize that config file into the container via ExecutionPreparation
+# (the gem's build_execution_preparation returns nil — it writes only a host-side
+# tempfile that never reaches the agent container).
+#
+# agent-harness 0.19.0 ships native suppression, hence the < 0.19.0 gate, but
+# adopting it is NOT a simple drop: upstream still emits the buggy variadic
+# space-form (see PaidAgentHarnessAnthropicMcpConfigFlagFormPatch) and still does
+# not materialize the config into containers. Both must be handled before this
+# patch can go.
+# TODO(#2364): remove when Paid adopts agent-harness >= 0.19.0 native suppression.
 module PaidAgentHarnessAnthropicMcpSuppressionPatch
   def send_message(prompt:, **options)
     super(prompt:, **with_explicit_empty_mcp_servers(options))
@@ -94,7 +103,13 @@ module PaidAgentHarnessAnthropicMcpSuppressionPatch
     return command unless suppress_mcp_autodiscovery?(options)
 
     plan = empty_mcp_config_plan(options)
-    command[0...-1] + [ "--mcp-config", plan.fetch(:path), command.last ]
+    # Use the --flag=value form (not a space-separated "--mcp-config <path>")
+    # because Claude's --mcp-config is variadic and would otherwise swallow the
+    # trailing positional prompt. See PaidAgentHarnessAnthropicMcpConfigFlagFormPatch
+    # below for the full explanation; this branch builds the empty-config flag by
+    # hand because agent-harness 0.18.2 emits no --mcp-config flag at all when the
+    # server list is empty.
+    command[0...-1] + [ "--mcp-config=#{plan.fetch(:path)}", command.last ]
   end
 
   def build_execution_preparation(options)
@@ -146,6 +161,39 @@ if agent_harness_version < Gem::Version.new("0.19.0")
   AgentHarness::Providers::Anthropic.prepend(PaidAgentHarnessAnthropicMcpSuppressionPatch) unless
     AgentHarness::Providers::Anthropic < PaidAgentHarnessAnthropicMcpSuppressionPatch
 end
+
+# Force Claude's --mcp-config flag into the `--flag=value` form.
+#
+# The Claude CLI declares `--mcp-config <configs...>` as a *variadic* option, so
+# the space-separated form ("--mcp-config", path) that agent-harness emits right
+# before the positional prompt makes the CLI greedily consume the prompt as a
+# second config path:
+#
+#   claude ... --mcp-config /tmp/cfg.json "Reply with exactly OK."
+#   => Error: Invalid MCP configuration:
+#      MCP config file not found: /workspace/Reply with exactly OK.
+#
+# The `=value` form captures exactly one path and leaves the prompt as a clean
+# positional argument. This covers the with-servers path on 0.18.2 AND every
+# invocation on >= 0.19.0, where the gem always passes --mcp-config (the #225
+# suppression fix) but still with the buggy space-form (confirmed through v0.20.0).
+#
+# Intentionally NOT folded under the < 0.19.0 suppression gate above: that gate
+# drops exactly when the gem starts emitting this flag everywhere, which is when
+# the bug bites hardest. The guard below makes this a no-op once the gem emits a
+# single equals-form token, so it self-deactivates and is safe to leave in place.
+# TODO(#2435): remove once agent-harness ships the =value form (viamin/agent-harness#229).
+module PaidAgentHarnessAnthropicMcpConfigFlagFormPatch
+  def build_mcp_flags(mcp_servers, working_dir: nil)
+    flags = super
+    return flags unless flags.length == 2 && flags.first == "--mcp-config"
+
+    [ "--mcp-config=#{flags.last}" ]
+  end
+end
+
+AgentHarness::Providers::Anthropic.prepend(PaidAgentHarnessAnthropicMcpConfigFlagFormPatch) unless
+  AgentHarness::Providers::Anthropic < PaidAgentHarnessAnthropicMcpConfigFlagFormPatch
 
 # Backport embedding support until agent-harness ships a native public API.
 # Keep this version-gated and narrow so Paid can switch back to upstream

--- a/spec/services/runners/harness_execution_plan_spec.rb
+++ b/spec/services/runners/harness_execution_plan_spec.rb
@@ -65,18 +65,46 @@ RSpec.describe Runners::HarnessExecutionPlan do
         prompt: "Say hello"
       )
 
-      mcp_flag_index = plan.command.index("--mcp-config")
+      # claude's --mcp-config is variadic, so the flag must use the --flag=value
+      # form to avoid swallowing the trailing positional prompt.
+      mcp_flag = plan.command.find { |part| part.start_with?("--mcp-config=") }
+      mcp_config_path = mcp_flag&.delete_prefix("--mcp-config=")
 
-      expect(mcp_flag_index).to be_present
+      expect(mcp_flag).to be_present
+      expect(plan.command).not_to include("--mcp-config")
       expect(plan.command.last).to eq("Say hello")
       expect(plan.preparation).to be_a(AgentHarness::ExecutionPreparation)
       expect(plan.preparation.file_writes).to contain_exactly(
         have_attributes(
-          path: plan.command.fetch(mcp_flag_index + 1),
+          path: mcp_config_path,
           content: JSON.generate("mcpServers" => {}),
           mode: 0o600
         )
       )
+    end
+
+    # Regression guard for the variadic --mcp-config bug (viamin/agent-harness#229,
+    # cleanup tracked in #2435). The Claude CLI treats `--mcp-config <configs...>`
+    # as variadic, so a bare "--mcp-config" token immediately before the positional
+    # prompt makes the CLI swallow the prompt as a second config path. The flag must
+    # always be the single-token --flag=value form, for both the empty-server and
+    # configured-server paths. A structural assertion (rather than running the CLI)
+    # is enough: the bug is purely about argv shape.
+    [
+      [ "empty server list", {} ],
+      [ "configured stdio server",
+        { mcp_servers: [ { name: "fs", transport: "stdio", command: "x", args: [ "/ws" ] } ] } ]
+    ].each do |label, options|
+      it "never emits a bare --mcp-config token before the prompt (#{label})" do
+        allow(AgentHarness).to receive(:provider_class).and_call_original
+        allow(AgentHarness).to receive(:build_config).and_call_original
+
+        plan = described_class.for_runner_key(runner_key: "claude", prompt: "the prompt", options: options)
+
+        expect(plan.command).not_to include("--mcp-config"), "found space-form --mcp-config that swallows the prompt: #{plan.command.inspect}"
+        expect(plan.command.count { |part| part.to_s.start_with?("--mcp-config=") }).to eq(1)
+        expect(plan.command.last).to eq("the prompt")
+      end
     end
   end
 

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -4304,10 +4304,12 @@ expect(container_service).to receive(:execute).with(
           "url_servers" => []
         })
 
-        expect(container_service).to receive(:execute).with(
-          array_including("claude", "--mcp-config"),
-          hash_including(timeout: anything)
-        ).and_return(exec_success)
+        expect(container_service).to receive(:execute) do |command, options|
+          expect(command).to include("claude")
+          expect(command).to include(a_string_starting_with("--mcp-config="))
+          expect(command).not_to include("--mcp-config")
+          expect(options).to include(timeout: anything)
+        end.and_return(exec_success)
 
         activity.execute(agent_run_id: agent_run.id)
       end
@@ -4318,25 +4320,31 @@ expect(container_service).to receive(:execute).with(
           "url_servers" => [ { "name" => "pw", "transport" => "sse", "url" => "http://host:3000/sse" } ]
         })
 
-        expect(container_service).to receive(:execute).with(
-          array_including("claude", "--mcp-config"),
-          hash_including(timeout: anything)
-        ).and_return(exec_success)
+        expect(container_service).to receive(:execute) do |command, options|
+          expect(command).to include("claude")
+          expect(command).to include(a_string_starting_with("--mcp-config="))
+          expect(command).not_to include("--mcp-config")
+          expect(options).to include(timeout: anything)
+        end.and_return(exec_success)
 
         activity.execute(agent_run_id: agent_run.id)
       end
 
       it "passes an explicit empty MCP config when no servers are configured" do
         expect(container_service).to receive(:execute) do |command, options|
-          mcp_flag_index = command.index("--mcp-config")
+          # Variadic --mcp-config must use --flag=value so it does not swallow
+          # the trailing positional prompt.
+          mcp_flag = command.find { |part| part.to_s.start_with?("--mcp-config=") }
+          mcp_config_path = mcp_flag&.delete_prefix("--mcp-config=")
 
-          expect(command).to include("claude", "--mcp-config")
-          expect(mcp_flag_index).to be_present
+          expect(command).to include("claude")
+          expect(mcp_flag).to be_present
+          expect(command).not_to include("--mcp-config")
           expect(options).to include(timeout: anything)
           expect(options[:preparation]).to be_a(AgentHarness::ExecutionPreparation)
           expect(options[:preparation].file_writes).to include(
             have_attributes(
-              path: command.fetch(mcp_flag_index + 1),
+              path: mcp_config_path,
               content: JSON.generate("mcpServers" => {}),
               mode: 0o600
             )


### PR DESCRIPTION
## Problem

Claude fallback runs were failing fleet-wide with:

```
Error: Invalid MCP configuration:
MCP config file not found: /workspace/Reply with exactly OK.
```

`Reply with exactly OK.` is the preflight **prompt** — the CLI was treating it as an MCP config path.

## Root cause

The Claude CLI declares `--mcp-config <configs...>` as a **variadic** flag (confirmed in `claude --help`, v2.1.92). agent-harness emits the space-form `["--mcp-config", path]` immediately before the positional prompt, so the CLI greedily consumes the prompt as a *second* config path, resolves it against the container CWD (`/workspace`), and dies before the run starts.

PR #2419 started passing `--mcp-config` on **every** no-server Claude run (to suppress `.mcp.json` autodiscovery), which turned this latent bug into a regression affecting essentially every Claude run.

Verified against the real CLI:

```sh
printf '{"mcpServers":{}}' > /tmp/empty.json
claude --print --output-format=json --mcp-config /tmp/empty.json "Reply with exactly OK."
# => Error: MCP config file not found: /tmp/Reply with exactly OK.   (BROKEN)
claude --print --output-format=json --mcp-config=/tmp/empty.json "Reply with exactly OK."
# => {"result":"OK", ...}                                            (WORKS)
```

## Fix

Emit the single-token `--mcp-config=<path>` form, which captures exactly one path and keeps the prompt positional.

- **Empty-config suppression path** (`PaidAgentHarnessAnthropicMcpSuppressionPatch#build_command`): builds the `=value` flag by hand, because agent-harness 0.18.2 emits no flag at all when the server list is empty.
- **With-servers path + all >= 0.19.0 invocations** (`PaidAgentHarnessAnthropicMcpConfigFlagFormPatch#build_mcp_flags`, **new**): a standalone, **ungated** module that rewrites the gem's space-form to `=value`. It is deliberately kept **outside** the `< 0.19.0` suppression gate — that gate drops exactly when the gem starts emitting `--mcp-config` everywhere, and upstream still ships the buggy space-form **through v0.20.0**. Its guard makes it a no-op once the gem emits the `=value` token, so it self-deactivates and is safe to leave in place.

End-to-end verified through the subscription `sh -c` wrapper (the exact path the failing runs used), including shelljoin `\=` escaping → `"result":"OK"`.

## Regression guard

Added a structural spec asserting the produced Claude command **never** contains a bare `--mcp-config` token before the prompt (empty- and configured-server cases). A structural check is sufficient — the bug is purely about argv shape — and it does not require running the CLI in CI.

## Adoption note (#2364)

While reviewing, I confirmed adopting native suppression (>= 0.19.0) is **not** a clean drop. Two blockers, documented on #2364:

1. Upstream still emits the variadic space-form (v0.19.0 + v0.20.0) → would reintroduce this bug. Tracked upstream as **viamin/agent-harness#229**; this PR's `FlagForm` shim already guards against it.
2. Upstream `build_execution_preparation` returns `nil` → the config file is only a host-side tempfile and never reaches the agent container. Paid's suppression patch is what materializes it via `ExecutionPreparation`.

## Testing

- `bin/rspec spec/services/runners/harness_execution_plan_spec.rb spec/temporal/activities/run_agent_activity_spec.rb` → **243 examples, 0 failures**
- `bin/rubocop` on changed files → clean
- Manual: real `claude` CLI v2.1.92, both raw and subscription-wrapped commands → `"result":"OK"`

## Links

- Upstream fix: viamin/agent-harness#229
- Cleanup tracking: #2435
- Native-suppression adoption: #2364

🤖 Generated with [Claude Code](https://claude.com/claude-code)
