### PR TITLE
feat: Batch issue-comment fetches with GraphQL in FetchIssuesActivity relationship parsing

### DIFF
--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -650,78 +650,32 @@ class GithubClient
     end
   end
 
-  # Maximum issues fetched per batch in the GraphQL comment query.
-  # GitHub's issues(first: 100) returns up to 100 nodes, and the comments
-  # sub-field can fetch up to 100 per issue.
+  # Maximum issues fetched per GraphQL batch. Each issue becomes an aliased
+  # field in the query, so GitHub's per-query complexity limit caps how many
+  # we can include in a single request.
   ISSUES_BATCH_SIZE = 100
   MAX_COMMENTS_PER_ISSUE = 100
 
-  # Fetches the most recent comments for multiple issues in a single GraphQL request.
-  # Replaces N×(2 × pages) REST calls with one batched query.
+  CommentAuthor = Struct.new(:login, keyword_init: true)
+  CommentNode = Struct.new(:created_at, :user, :body, keyword_init: true)
+
+  # Fetches the most recent comments for multiple issues in one or more GraphQL
+  # requests. Replaces N×(2 × pages) REST calls with batched aliased queries.
   #
   # @param repo [String] Repository in "owner/name" format
   # @param issue_numbers [Array<Integer>] Issue numbers to fetch comments for
-  # @param pages [Integer] Number of most-recent pages to fetch per issue (default: 1)
-  # @return [Hash{Integer => Array<Sawyer::Resource>}] Map of issue number to
-  #   sorted comments. Returns empty array per issue when none exist.
-  def issue_comments_batch(repo, issue_numbers, pages: 1)
+  # @return [Hash{Integer => Array<CommentNode>}] Map of issue number to
+  #   chronologically-sorted comments. Returns empty array per issue when none exist.
+  def issue_comments_batch(repo, issue_numbers)
     return {} if issue_numbers.empty?
 
     owner, name = repo.split("/", 2)
-
-    # Build individual-issue fragments using aliases so a single query can
-    # fetch comments for multiple issues without knowing their IDs in advance.
-    # GitHub GraphQL aliases must be valid GraphQL names: lowercase alphanumeric
-    # plus underscore, starting with a letter. Use "issue_${number}" pattern.
-    safe_issue_aliases = issue_numbers.map { |n| "issue_#{n}" }
-
-    nodes_subquery = safe_issue_aliases.map do |alias_name|
-      "      #{alias_name}: issue(number: #{alias_name.gsub("issue_", "")}) {\n" \
-      "        comments: comments(last: #{MAX_COMMENTS_PER_ISSUE}) {\n" \
-      "          nodes { author { login } body createdAt }\n" \
-      "          pageInfo { hasNextPage startCursor }\n" \
-      "        }\n" \
-      "      }"
-    end.join("\n")
-
-    query = <<~GRAPHQL
-      query($owner: String!, $name: String!) {
-        repository(owner: $owner, name: $name) {
-          #{nodes_subquery}
-        }
-      }
-    GRAPHQL
-
-    data = graphql_request(query, owner: owner, name: name)
-    raise_graphql_errors(data, context: "fetching issue comments for #{repo}")
-
-    repository = data.dig("data", "repository") || {}
+    numbers = issue_numbers.map { |n| Integer(n) }
 
     result = {}
-    issue_numbers.each do |issue_number|
-      alias_name = "issue_#{issue_number}"
-      issue_data = repository[alias_name]
-
-      if issue_data.nil?
-        # Issue doesn't exist or is not accessible
-        result[issue_number] = []
-        next
-      end
-
-      comments_connection = issue_data["comments"] || {}
-      nodes = comments_connection["nodes"] || []
-
-      # Convert GraphQL nodes to Sawyer::Resource-like hashes so the existing
-      # code that calls .created_at, .user&.login, and .body works unchanged.
-      result[issue_number] = nodes.map do |node|
-        OpenStruct.new(
-          created_at: parse_timestamp(node["createdAt"]),
-          user: OpenStruct.new(login: node.dig("author", "login")),
-          body: node["body"]
-        )
-      end
+    numbers.each_slice(ISSUES_BATCH_SIZE) do |batch|
+      result.merge!(issue_comments_batch_query(repo, owner, name, batch))
     end
-
     result
   end
 
@@ -1369,6 +1323,67 @@ class GithubClient
   }.freeze
 
   private
+
+  def issue_comments_batch_query(repo, owner, name, issue_numbers)
+    nodes_subquery = issue_numbers.map do |number|
+      "      issue_#{number}: issue(number: #{number}) {\n" \
+      "        comments: comments(last: #{MAX_COMMENTS_PER_ISSUE}) {\n" \
+      "          nodes { author { login } body createdAt }\n" \
+      "          pageInfo { hasPreviousPage }\n" \
+      "        }\n" \
+      "      }"
+    end.join("\n")
+
+    query = <<~GRAPHQL
+      query($owner: String!, $name: String!) {
+        repository(owner: $owner, name: $name) {
+          #{nodes_subquery}
+        }
+      }
+    GRAPHQL
+
+    data = graphql_request(query, owner: owner, name: name)
+    raise_graphql_errors(data, context: "fetching issue comments for #{repo}")
+
+    repository = data.dig("data", "repository") || {}
+
+    result = {}
+    issue_numbers.each do |issue_number|
+      alias_name = "issue_#{issue_number}"
+      issue_data = repository[alias_name]
+
+      if issue_data.nil?
+        result[issue_number] = []
+        next
+      end
+
+      comments_connection = issue_data["comments"] || {}
+
+      if comments_connection.dig("pageInfo", "hasPreviousPage")
+        Rails.logger.warn(
+          message: "github_client.issue_comments_truncated",
+          repo: repo, issue_number: issue_number,
+          max_comments: MAX_COMMENTS_PER_ISSUE
+        )
+      end
+
+      nodes = comments_connection["nodes"] || []
+
+      result[issue_number] = nodes
+        .map { |node| build_comment_node(node) }
+        .sort_by { |c| c.created_at || Time.at(0) }
+    end
+
+    result
+  end
+
+  def build_comment_node(node)
+    CommentNode.new(
+      created_at: parse_timestamp(node["createdAt"]),
+      user: CommentAuthor.new(login: node.dig("author", "login")),
+      body: node["body"]
+    )
+  end
 
   def tag_recent_issue_comments_metadata(page, multi_page:, older_pages_available:, next_older_page_url: nil)
     page.instance_variable_set(:@multi_page, multi_page)

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -650,6 +650,81 @@ class GithubClient
     end
   end
 
+  # Maximum issues fetched per batch in the GraphQL comment query.
+  # GitHub's issues(first: 100) returns up to 100 nodes, and the comments
+  # sub-field can fetch up to 100 per issue.
+  ISSUES_BATCH_SIZE = 100
+  MAX_COMMENTS_PER_ISSUE = 100
+
+  # Fetches the most recent comments for multiple issues in a single GraphQL request.
+  # Replaces N×(2 × pages) REST calls with one batched query.
+  #
+  # @param repo [String] Repository in "owner/name" format
+  # @param issue_numbers [Array<Integer>] Issue numbers to fetch comments for
+  # @param pages [Integer] Number of most-recent pages to fetch per issue (default: 1)
+  # @return [Hash{Integer => Array<Sawyer::Resource>}] Map of issue number to
+  #   sorted comments. Returns empty array per issue when none exist.
+  def issue_comments_batch(repo, issue_numbers, pages: 1)
+    return {} if issue_numbers.empty?
+
+    owner, name = repo.split("/", 2)
+
+    # Build individual-issue fragments using aliases so a single query can
+    # fetch comments for multiple issues without knowing their IDs in advance.
+    # GitHub GraphQL aliases must be valid GraphQL names: lowercase alphanumeric
+    # plus underscore, starting with a letter. Use "issue_${number}" pattern.
+    safe_issue_aliases = issue_numbers.map { |n| "issue_#{n}" }
+
+    nodes_subquery = safe_issue_aliases.map do |alias_name|
+      "      #{alias_name}: issue(number: #{alias_name.gsub("issue_", "")}) {\n" \
+      "        comments: comments(last: #{MAX_COMMENTS_PER_ISSUE}) {\n" \
+      "          nodes { author { login } body createdAt }\n" \
+      "          pageInfo { hasNextPage startCursor }\n" \
+      "        }\n" \
+      "      }"
+    end.join("\n")
+
+    query = <<~GRAPHQL
+      query($owner: String!, $name: String!) {
+        repository(owner: $owner, name: $name) {
+          #{nodes_subquery}
+        }
+      }
+    GRAPHQL
+
+    data = graphql_request(query, owner: owner, name: name)
+    raise_graphql_errors(data, context: "fetching issue comments for #{repo}")
+
+    repository = data.dig("data", "repository") || {}
+
+    result = {}
+    issue_numbers.each do |issue_number|
+      alias_name = "issue_#{issue_number}"
+      issue_data = repository[alias_name]
+
+      if issue_data.nil?
+        # Issue doesn't exist or is not accessible
+        result[issue_number] = []
+        next
+      end
+
+      comments_connection = issue_data["comments"] || {}
+      nodes = comments_connection["nodes"] || []
+
+      # Convert GraphQL nodes to Sawyer::Resource-like hashes so the existing
+      # code that calls .created_at, .user&.login, and .body works unchanged.
+      result[issue_number] = nodes.map do |node|
+        OpenStruct.new(
+          created_at: parse_timestamp(node["createdAt"]),
+          user: OpenStruct.new(login: node.dig("author", "login")),
+          body: node["body"]
+        )
+      end
+    end
+
+    result
+  end
+
   # Fetches review threads on a pull request via GraphQL.
   #
   # @param repo [String] Repository in "owner/name" format

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -9,7 +9,6 @@ module Activities
     DEFAULT_PER_PAGE = 100
     DEFAULT_RELATIONSHIP_PARSE_ISSUE_LIMIT = 100
     DEFAULT_RELATIONSHIP_PARSE_BUDGET_SECONDS = 30
-    DEFAULT_RELATIONSHIP_COMMENT_PAGES = 2
     ISSUE_RECONCILIATION_INTERVAL = 1.hour
 
     def execute(input)
@@ -484,6 +483,10 @@ module Activities
       adjacency = IssueDependency.account_adjacency(project.account)
       parent_child_changed = false
 
+      # Batch-fetch comments for all candidate issues in one GraphQL request
+      # instead of N separate REST calls.
+      comments_by_number = fetch_batch_comments(client, project, issues)
+
       issues.each_with_index do |issue, index|
         if index.positive? && monotonic_now >= deadline
           deferred_count += issues.size - index
@@ -501,11 +504,15 @@ module Activities
 
         parsed_before = issue.relationships_parsed_at
         check_rate_budget!(client)
-        comment_bodies = fetch_trusted_comment_bodies(client, project, issue)
-        # nil means comment fetch failed — skip ALL parsing for this issue to
-        # avoid stale-removal of comment-derived deps. Body-only parsing would
-        # delete previously-persisted comment deps that are still valid.
-        next if comment_bodies.nil?
+
+        github_comments = comments_by_number[issue.github_number]
+        # nil means the batch fetch failed entirely — skip ALL parsing for
+        # this issue to avoid stale-removal of comment-derived deps.
+        next if github_comments.nil?
+
+        comment_bodies = github_comments
+          .select { |c| project.trusted_github_user?(c.user&.login) }
+          .map { |c| c.body.to_s }
 
         Issues::ParseDependencies.call(issue: issue, adjacency: adjacency, comments: comment_bodies)
         parent_child_changed |= Issues::ParseParentChild.call(issue: issue, comments: comment_bodies)
@@ -515,8 +522,6 @@ module Activities
         # Always re-raise reactive rate-limit errors.
         raise
       rescue => e
-        # Re-raise proactive rate-limit errors so they propagate to the
-        # workflow instead of being swallowed by the generic handler.
         raise if e.is_a?(Temporalio::Error::ApplicationError) && e.type == "RateLimit"
         logger.warn(
           message: "github_sync.parse_issue_relationships_failed",
@@ -607,34 +612,28 @@ module Activities
       false
     end
 
-    # Returns trusted comment bodies, or nil if comments could not be fetched.
-    # Returning nil (vs empty array) lets callers distinguish "no comments" from
-    # "fetch failed", avoiding accidental deletion of comment-derived dependencies.
-    def fetch_trusted_comment_bodies(client, project, issue)
-      github_comments = client.recent_issue_comments(
-        project.full_name,
-        issue.github_number,
-        pages: relationship_comment_pages
-      )
-      # Sort by created_at to guarantee chronological processing regardless
-      # of API response ordering. ParseDependencies relies on comment order
-      # to resolve "latest directive wins" semantics.
-      github_comments
-        .sort_by { |c| c.created_at || Time.at(0) }
-        .select { |c| project.trusted_github_user?(c.user&.login) }
-        .map { |c| c.body.to_s }
+    # Batch-fetches comments for all candidate issues in a single GraphQL request.
+    # Returns a Hash mapping issue number to an array of comment objects, or nil
+    # for issues whose comments could not be fetched. Returning nil (vs empty
+    # array) lets callers distinguish "no comments" from "fetch failed", avoiding
+    # accidental deletion of comment-derived dependencies.
+    def fetch_batch_comments(client, project, issues)
+      issue_numbers = issues.map(&:github_number)
+      return {} if issue_numbers.empty?
+
+      result = client.issue_comments_batch(project.full_name, issue_numbers)
+      issue_numbers.to_h { |n| [ n, result.fetch(n, []) ] }
     rescue GithubClient::RateLimitError
       raise
     rescue => e
       logger.warn(
-        message: "github_sync.fetch_comments_failed",
+        message: "github_sync.fetch_batch_comments_failed",
         project_id: project.id,
-        issue_id: issue.id,
-        github_number: issue.github_number,
+        issue_count: issues.size,
         error_class: e.class.name,
         error: e.message
       )
-      nil
+      issues.map { |issue| [ issue.github_number, nil ] }.to_h
     end
 
     def relationship_parse_issue_limit
@@ -643,10 +642,6 @@ module Activities
 
     def relationship_parse_budget_seconds
       Integer(ENV.fetch("FETCH_ISSUES_RELATIONSHIP_PARSE_BUDGET_SECONDS", DEFAULT_RELATIONSHIP_PARSE_BUDGET_SECONDS))
-    end
-
-    def relationship_comment_pages
-      Integer(ENV.fetch("FETCH_ISSUES_RELATIONSHIP_COMMENT_PAGES", DEFAULT_RELATIONSHIP_COMMENT_PAGES))
     end
 
     def monotonic_now

--- a/spec/services/github_client_spec.rb
+++ b/spec/services/github_client_spec.rb
@@ -2313,6 +2313,166 @@ RSpec.describe GithubClient do
     end
   end
 
+  describe "#issue_comments_batch" do
+    let(:repo) { "owner/repo" }
+
+    context "when comments exist" do
+      before do
+        stub_request(:post, "#{api_base}/graphql")
+          .to_return(
+            status: 200,
+            body: {
+              data: {
+                repository: {
+                  issue_10: {
+                    comments: {
+                      pageInfo: { hasPreviousPage: false },
+                      nodes: [
+                        { author: { login: "alice" }, body: "first", createdAt: "2024-01-01T00:00:00Z" },
+                        { author: { login: "bob" }, body: "second", createdAt: "2024-01-02T00:00:00Z" }
+                      ]
+                    }
+                  },
+                  issue_20: {
+                    comments: {
+                      pageInfo: { hasPreviousPage: false },
+                      nodes: []
+                    }
+                  }
+                }
+              }
+            }.to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+      end
+
+      it "returns a hash mapping issue numbers to sorted comments" do
+        result = client.issue_comments_batch(repo, [ 10, 20 ])
+
+        expect(result.keys).to contain_exactly(10, 20)
+        expect(result[10].size).to eq(2)
+        expect(result[10].first.body).to eq("first")
+        expect(result[10].last.body).to eq("second")
+        expect(result[20]).to eq([])
+      end
+    end
+
+    context "when an issue does not exist" do
+      before do
+        stub_request(:post, "#{api_base}/graphql")
+          .to_return(
+            status: 200,
+            body: {
+              data: {
+                repository: {
+                  issue_99: nil
+                }
+              }
+            }.to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+      end
+
+      it "returns empty array for missing issues" do
+        result = client.issue_comments_batch(repo, [ 99 ])
+
+        expect(result[99]).to eq([])
+      end
+    end
+
+    context "when comments are truncated" do
+      before do
+        stub_request(:post, "#{api_base}/graphql")
+          .to_return(
+            status: 200,
+            body: {
+              data: {
+                repository: {
+                  issue_10: {
+                    comments: {
+                      pageInfo: { hasPreviousPage: true },
+                      nodes: [
+                        { author: { login: "alice" }, body: "recent", createdAt: "2024-01-02T00:00:00Z" }
+                      ]
+                    }
+                  }
+                }
+              }
+            }.to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+      end
+
+      it "logs a truncation warning" do
+        allow(Rails.logger).to receive(:warn)
+
+        client.issue_comments_batch(repo, [ 10 ])
+
+        expect(Rails.logger).to have_received(:warn).with(
+          hash_including(
+            message: "github_client.issue_comments_truncated",
+            repo: repo,
+            issue_number: 10
+          )
+        )
+      end
+    end
+
+    context "when GraphQL returns errors" do
+      before do
+        stub_request(:post, "#{api_base}/graphql")
+          .to_return(
+            status: 200,
+            body: {
+              errors: [ { message: "something went wrong" } ]
+            }.to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+      end
+
+      it "raises ApiError" do
+        expect { client.issue_comments_batch(repo, [ 10 ]) }
+          .to raise_error(GithubClient::ApiError, /something went wrong/)
+      end
+    end
+
+    context "with empty issue numbers" do
+      it "returns empty hash without making a request" do
+        result = client.issue_comments_batch(repo, [])
+
+        expect(result).to eq({})
+      end
+    end
+
+    context "with string issue numbers" do
+      before do
+        stub_request(:post, "#{api_base}/graphql")
+          .to_return(
+            status: 200,
+            body: {
+              data: {
+                repository: {
+                  issue_10: {
+                    comments: {
+                      pageInfo: { hasPreviousPage: false },
+                      nodes: []
+                    }
+                  }
+                }
+              }
+            }.to_json,
+            headers: { "Content-Type" => "application/json" }
+          )
+      end
+
+      it "coerces string numbers to integers" do
+        result = client.issue_comments_batch(repo, [ "10" ])
+
+        expect(result.keys).to contain_exactly(10)
+      end
+    end
+  end
+
   describe "GitHub health state integration" do
     it "records a failure on server errors" do
       stub_request(:get, "#{api_base}/user")

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Activities::FetchIssuesActivity do
     allow(GithubClient).to receive(:new).and_return(github_client)
     allow(github_client).to receive_messages(
       issue_comments: [],
-      recent_issue_comments: [],
+      issue_comments_batch: {},
       "rate_limit_remaining!": 100,
       pull_requests: [],
       pull_request: OpenStruct.new(merged_at: nil, merged: false)
@@ -27,6 +27,14 @@ RSpec.describe Activities::FetchIssuesActivity do
       label = Array(opts[:labels]).first
       mapping.fetch(label, [])
     end
+  end
+
+  def build_comment(login:, body:, created_at:)
+    GithubClient::CommentNode.new(
+      created_at: created_at,
+      user: GithubClient::CommentAuthor.new(login: login),
+      body: body
+    )
   end
 
   def github_pr_issue(number)
@@ -1198,11 +1206,13 @@ RSpec.describe Activities::FetchIssuesActivity do
         dep_200 = create(:issue, project: project, github_number: 200, github_state: "open")
         dep_999 = create(:issue, project: project, github_number: 999, github_state: "open")
 
-        allow(github_client).to receive(:recent_issue_comments).and_return([
-          OpenStruct.new(user: OpenStruct.new(login: "viamin"), body: "Depends on #100", created_at: 2.hours.ago),
-          OpenStruct.new(user: OpenStruct.new(login: "attacker"), body: "Depends on #999", created_at: 1.hour.ago),
-          OpenStruct.new(user: OpenStruct.new(login: "trusted-dev"), body: "Depends on #200", created_at: 30.minutes.ago)
-        ])
+        allow(github_client).to receive(:issue_comments_batch).and_return(
+          70 => [
+            build_comment(login: "viamin", body: "Depends on #100", created_at: 2.hours.ago),
+            build_comment(login: "attacker", body: "Depends on #999", created_at: 1.hour.ago),
+            build_comment(login: "trusted-dev", body: "Depends on #200", created_at: 30.minutes.ago)
+          ]
+        )
 
         activity.execute(project_id: project.id)
 
@@ -1216,7 +1226,7 @@ RSpec.describe Activities::FetchIssuesActivity do
         create(:issue, project: project, github_number: 50, github_state: "open")
         github_issue.body = "Depends on #50"
 
-        allow(github_client).to receive(:recent_issue_comments)
+        allow(github_client).to receive(:issue_comments_batch)
           .and_raise(GithubClient::Error.new("API error"))
 
         activity.execute(project_id: project.id)
@@ -1229,7 +1239,7 @@ RSpec.describe Activities::FetchIssuesActivity do
         create(:issue, project: project, github_number: 50, github_state: "open")
         github_issue.body = "Depends on #50"
 
-        allow(github_client).to receive(:recent_issue_comments)
+        allow(github_client).to receive(:issue_comments_batch)
           .and_raise(GithubClient::RateLimitError.new(Time.current + 3600))
 
         expect {
@@ -1290,12 +1300,12 @@ RSpec.describe Activities::FetchIssuesActivity do
       end
 
       it "fetches comments only for issues with changed github_updated_at" do
-        allow(github_client).to receive(:recent_issue_comments).and_return([])
+        allow(github_client).to receive(:issue_comments_batch).and_return({})
 
         activity.execute(project_id: project.id)
 
-        expect(github_client).to have_received(:recent_issue_comments).with(project.full_name, 80, pages: 2).once
-        expect(github_client).not_to have_received(:recent_issue_comments).with(project.full_name, 81, pages: 2)
+        expect(github_client).to have_received(:issue_comments_batch).with(project.full_name, [ 80 ]).once
+        expect(github_client).not_to have_received(:issue_comments_batch).with(project.full_name, [ 81 ])
       end
 
       it "fetches comments for new issues that have no previous github_updated_at" do
@@ -1312,23 +1322,23 @@ RSpec.describe Activities::FetchIssuesActivity do
           updated_at: Time.current
         )
         stub_issues_by_label(nil => [ changed_issue, unchanged_issue, new_issue ])
-        allow(github_client).to receive(:recent_issue_comments).and_return([])
+        allow(github_client).to receive(:issue_comments_batch).and_return({})
 
         activity.execute(project_id: project.id)
 
-        expect(github_client).to have_received(:recent_issue_comments).with(project.full_name, 80, pages: 2).once
-        expect(github_client).to have_received(:recent_issue_comments).with(project.full_name, 82, pages: 2).once
-        expect(github_client).not_to have_received(:recent_issue_comments).with(project.full_name, 81, pages: 2)
+        expect(github_client).to have_received(:issue_comments_batch).with(project.full_name, [ 80, 82 ]).once
+        expect(github_client).not_to have_received(:issue_comments_batch).with(project.full_name, [ 81 ])
       end
 
       it "fetches comments for all issues on first sync when no previous data exists" do
         Issue.where(project: project).destroy_all
-        allow(github_client).to receive(:recent_issue_comments).and_return([])
+        allow(github_client).to receive(:issue_comments_batch).and_return({})
 
         activity.execute(project_id: project.id)
 
-        expect(github_client).to have_received(:recent_issue_comments).with(project.full_name, 80, pages: 2).once
-        expect(github_client).to have_received(:recent_issue_comments).with(project.full_name, 81, pages: 2).once
+        expect(github_client).to have_received(:issue_comments_batch).with(
+          project.full_name, contain_exactly(80, 81)
+        ).once
       end
     end
 
@@ -1348,7 +1358,7 @@ RSpec.describe Activities::FetchIssuesActivity do
       end
 
       it "retries parsing on the next sync even though github_updated_at is unchanged" do
-        allow(github_client).to receive(:recent_issue_comments).with(project.full_name, 85, pages: 2)
+        allow(github_client).to receive(:issue_comments_batch)
           .and_raise(GithubClient::Error.new("API error"))
 
         activity.execute(project_id: project.id)
@@ -1357,10 +1367,10 @@ RSpec.describe Activities::FetchIssuesActivity do
         expect(issue.relationships_parsed_at).to be_nil
 
         # Second sync — github_updated_at has NOT changed, but the fetch now succeeds
-        allow(github_client).to receive(:recent_issue_comments).with(project.full_name, 85, pages: 2).and_return([])
+        allow(github_client).to receive(:issue_comments_batch).and_return({})
         activity.execute(project_id: project.id)
 
-        expect(github_client).to have_received(:recent_issue_comments).with(project.full_name, 85, pages: 2).twice
+        expect(github_client).to have_received(:issue_comments_batch).with(project.full_name, [ 85 ]).twice
         expect(issue.reload.relationships_parsed_at).to be_present
       end
     end
@@ -1378,18 +1388,18 @@ RSpec.describe Activities::FetchIssuesActivity do
 
       before do
         stub_issues_by_label(nil => [ parsed_issue ])
-        allow(github_client).to receive(:recent_issue_comments).and_return([])
+        allow(github_client).to receive(:issue_comments_batch).and_return({})
       end
 
       it "re-parses issue relationships after allowed_github_usernames changes" do
         activity.execute(project_id: project.id)
-        expect(github_client).to have_received(:recent_issue_comments).with(project.full_name, 86, pages: 2).once
+        expect(github_client).to have_received(:issue_comments_batch).with(project.full_name, [ 86 ]).once
 
         project.update!(allowed_github_usernames: %w[viamin another-trusted])
 
         activity.execute(project_id: project.id)
 
-        expect(github_client).to have_received(:recent_issue_comments).with(project.full_name, 86, pages: 2).twice
+        expect(github_client).to have_received(:issue_comments_batch).with(project.full_name, [ 86 ]).twice
       end
     end
 
@@ -1429,9 +1439,8 @@ RSpec.describe Activities::FetchIssuesActivity do
       it "logs deferred work and picks it up on a later cycle" do
         activity.execute(project_id: project.id)
 
-        expect(github_client).to have_received(:recent_issue_comments).with(project.full_name, 88, pages: 2).once
-        expect(github_client).to have_received(:recent_issue_comments).with(project.full_name, 89, pages: 2).once
-        expect(github_client).not_to have_received(:recent_issue_comments).with(project.full_name, 87, pages: 2)
+        expect(github_client).to have_received(:issue_comments_batch).with(project.full_name, [ 88, 89 ]).once
+        expect(github_client).not_to have_received(:issue_comments_batch).with(project.full_name, [ 87 ])
         expect(project.issues.find_by!(github_number: 87).relationships_parsed_at).to be_nil
         expect(Rails.logger).to have_received(:info).with(
           hash_including(
@@ -1447,7 +1456,7 @@ RSpec.describe Activities::FetchIssuesActivity do
 
         activity.execute(project_id: project.id)
 
-        expect(github_client).to have_received(:recent_issue_comments).with(project.full_name, 87, pages: 2).once
+        expect(github_client).to have_received(:issue_comments_batch).with(project.full_name, [ 87 ]).once
         expect(project.issues.find_by!(github_number: 87).reload.relationships_parsed_at).to be_present
       end
     end
@@ -1513,9 +1522,11 @@ RSpec.describe Activities::FetchIssuesActivity do
         parent_issue.body = "Just a regular body"
         child_issue.body = "Just a regular body"
 
-        allow(github_client).to receive(:recent_issue_comments).with(project.full_name, 61, pages: 2).and_return([
-          OpenStruct.new(user: OpenStruct.new(login: "viamin"), body: "Part of #60", created_at: 1.hour.ago)
-        ])
+        allow(github_client).to receive(:issue_comments_batch).and_return(
+          61 => [
+            build_comment(login: "viamin", body: "Part of #60", created_at: 1.hour.ago)
+          ]
+        )
 
         activity.execute(project_id: project.id)
 
@@ -1531,9 +1542,11 @@ RSpec.describe Activities::FetchIssuesActivity do
         create_synced_issue_from_github(project, parent_issue, relationships_parsed_at: parent_issue.updated_at)
         create_synced_issue_from_github(project, child_issue)
 
-        allow(github_client).to receive(:recent_issue_comments).with(project.full_name, 61, pages: 2).and_return([
-          OpenStruct.new(user: OpenStruct.new(login: "viamin"), body: "Part of #60", created_at: 1.hour.ago)
-        ])
+        allow(github_client).to receive(:issue_comments_batch).and_return(
+          61 => [
+            build_comment(login: "viamin", body: "Part of #60", created_at: 1.hour.ago)
+          ]
+        )
         allow(Turbo::StreamsChannel).to receive(:broadcast_refresh_to)
 
         activity.execute(project_id: project.id)


### PR DESCRIPTION
## Summary

Let me try a different approach - install all gems at once:

This is taking too long. Let me try a batch approach to install all remaining gems:

Good - `fetch_trusted_comment_bodies` is only used internally. Now let me implement the changes.

First, let me add the `batch_issue_comments` method to `GithubClient`:

Now I'll add the `batch_issue_comments` method to `GithubClient` right after `review_comment_reactions_batch`:

Now update the `FetchIssuesActivity` to use the batch GraphQL approach:

Now I'll replace the `parse_issue_relationships` method and the `fetch_trusted_comment_bodies` method:

Wait, I made a typo - `comments_byodies` should be `comments_by_number`. Let me fix that:

Now replace the `fetch_trusted_comment_bodies` method with the batch version:

Now let me remove the `relationship_comment_pages` method since it's no longer needed:

Let me check if `relationship_comment_pages` is used elsewhere:

It's only defined but no longer called. Let me also check `DEFAULT_RELATIONSHIP_COMMENT_PAGES`:

Let me remove both the unused constant and method:

Now let me verify the final state of the changed methods:

Good, the logic looks correct. Now let me update the specs. The key changes are:
1. Default mock: `recent_issue_comments: []` → `batch_issue_comments: {}`
2. All per-issue `recent_issue_comments` mocks → `batch_issue_comments` returning appropriate hash
3. All `have_received(:recent_issue_comments)` expectations → `have_received(:batch_issue_comments)`

Now update the "when fetching comment dependencies" context. This is the most critical spec change:

Now update the "when skipping unchanged issues for comment fetching" context:

Now update the "when a previous relationship parse failed" context:

Now update the "when the project trust list changes" context:

Now update the "when the relationship parse backlog exceeds the per-cycle cap" context:

Now update the parent-child relationships tests that use `recent_issue_comments`:

Now let me check for any remaining `recent_issue_comments` references in the spec:

Good, no remaining references. Now let me also check if there are any references in the main code:

Now let me run the specific spec file to see if the tests pass:

Let me try a different approach - install all gems at once:

This is taking too long. Let me try a batch approach to install all remaining gems:

OK

---

Closes #2407