### PR TITLE
feat: Add Faraday HTTP cache middleware with ETag support to GithubClient

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem "csv"
 gem "octokit"
 
 gem "faraday-retry"
+gem "faraday-http-cache"
 
 # Temporal workflow orchestration [https://temporal.io]
 # Defer loading — 139 MB gem with native Rust extensions only needed for

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,6 +207,8 @@ GEM
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
+    faraday-http-cache (2.7.0)
+      faraday (>= 0.8)
     faraday-multipart (1.2.0)
       multipart-post (~> 2.0)
     faraday-net_http (3.4.2)
@@ -687,6 +689,7 @@ DEPENDENCIES
   exception_notification (~> 5.0)
   factory_bot_rails
   faker
+  faraday-http-cache
   faraday-retry
   fasterer
   fixture_kit
@@ -802,6 +805,7 @@ CHECKSUMS
   factory_bot_rails (6.5.1) sha256=d3cc4851eae4dea8a665ec4a4516895045e710554d2b5ac9e68b94d351bc6d68
   faker (3.8.0) sha256=c147b308df73a90f27a4fc84f18d4c22ef0ad9c2a64b2b61c86fd0ca71753efc
   faraday (2.14.2) sha256=73ccb9994a9e8648f010e32eca2ae82e41c57860aa10932cda29418b9e0223ad
+  faraday-http-cache (2.7.0) sha256=cd7ac4bbe6c08592ea7af6655f98b2f76c4db0bad31bf40340df5aad719f0d89
   faraday-multipart (1.2.0) sha256=7d89a949693714176f612323ca13746a2ded204031a6ba528adee788694ef757
   faraday-net_http (3.4.2) sha256=f147758260d3526939bf57ecf911682f94926a3666502e24c69992765875906c
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -1499,10 +1499,9 @@ class GithubClient
 
   def http_cache_options
     {
-      store: Rails.cache,
+      store: TokenNamespacedStore.new(Rails.cache, cache_token_digest),
       shared_cache: false,
-      serializer: JSON,
-      cache_key: ->(url, _request_options) { "github_http_cache:#{cache_token_digest}:#{url}" }
+      serializer: JSON
     }
   end
 
@@ -1628,5 +1627,30 @@ class GithubClient
       message: "github_client.health_state_record_failed",
       error: e.message
     )
+  end
+
+  class TokenNamespacedStore
+    def initialize(store, namespace)
+      @store = store
+      @namespace = namespace
+    end
+
+    def read(key)
+      @store.read(namespaced_key(key))
+    end
+
+    def write(key, value, **options)
+      @store.write(namespaced_key(key), value, **options)
+    end
+
+    def delete(key)
+      @store.delete(namespaced_key(key))
+    end
+
+    private
+
+    def namespaced_key(key)
+      "#{@namespace}:#{key}"
+    end
   end
 end

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "octokit"
+require "digest"
 require "faraday/retry"
 require "faraday/http_cache"
 
@@ -1399,8 +1400,7 @@ class GithubClient
   def configure_middleware
     client.middleware = Faraday::RackBuilder.new do |builder|
       builder.use Faraday::HttpCache,
-        store: Rails.cache,
-        serializer: Marshal
+        **http_cache_options
       builder.use Faraday::Retry::Middleware,
         max: RETRY_MAX,
         interval: RETRY_INTERVAL,
@@ -1470,9 +1470,6 @@ class GithubClient
 
   def build_graphql_connection(with_retry:)
     Faraday.new(url: "https://api.github.com") do |f|
-      f.use Faraday::HttpCache,
-        store: Rails.cache,
-        serializer: Marshal
       f.request :json
       if with_retry
         f.request :retry,
@@ -1498,6 +1495,18 @@ class GithubClient
       f.response :raise_error
       f.adapter Faraday.default_adapter
     end
+  end
+
+  def http_cache_options
+    {
+      store: Rails.cache,
+      serializer: JSON,
+      cache_key: ->(url, _request_options) { "github_http_cache:#{cache_token_digest}:#{url}" }
+    }
+  end
+
+  def cache_token_digest
+    @cache_token_digest ||= Digest::SHA256.hexdigest(client.access_token.to_s)
   end
 
   def pull_request_node_id(repo, number)

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -70,6 +70,7 @@ class GithubClient
   # @param health_endpoint [String] Stable health-state key for the auth principal
   # @param options [Hash] Additional Octokit client options
   def initialize(token:, health_endpoint: GithubHealthState::DEFAULT_ENDPOINT, **options)
+    @token = token
     @client = Octokit::Client.new(
       access_token: token,
       auto_paginate: false,
@@ -1506,7 +1507,7 @@ class GithubClient
   end
 
   def cache_token_digest
-    @cache_token_digest ||= Digest::SHA256.hexdigest(client.access_token.to_s)
+    @cache_token_digest ||= Digest::SHA256.hexdigest(@token.to_s)
   end
 
   def pull_request_node_id(repo, number)

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -2,6 +2,7 @@
 
 require "octokit"
 require "faraday/retry"
+require "faraday/http_cache"
 
 # GitHub API client wrapper with error handling and rate limit awareness.
 #
@@ -1397,6 +1398,9 @@ class GithubClient
 
   def configure_middleware
     client.middleware = Faraday::RackBuilder.new do |builder|
+      builder.use Faraday::HttpCache,
+        store: Rails.cache,
+        serializer: Marshal
       builder.use Faraday::Retry::Middleware,
         max: RETRY_MAX,
         interval: RETRY_INTERVAL,
@@ -1466,6 +1470,9 @@ class GithubClient
 
   def build_graphql_connection(with_retry:)
     Faraday.new(url: "https://api.github.com") do |f|
+      f.use Faraday::HttpCache,
+        store: Rails.cache,
+        serializer: Marshal
       f.request :json
       if with_retry
         f.request :retry,

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -1500,6 +1500,7 @@ class GithubClient
   def http_cache_options
     {
       store: Rails.cache,
+      shared_cache: false,
       serializer: JSON,
       cache_key: ->(url, _request_options) { "github_http_cache:#{cache_token_digest}:#{url}" }
     }

--- a/spec/services/github_client_spec.rb
+++ b/spec/services/github_client_spec.rb
@@ -22,16 +22,22 @@ RSpec.describe GithubClient do
       expect(client.send(:http_cache_options)[:serializer]).to eq(JSON)
     end
 
-    it "scopes REST cache keys by token digest" do
-      url = "https://api.github.com/user"
-      request_options = nil
+    it "scopes REST cache store by token digest" do
+      store = client.send(:http_cache_options)[:store]
+      other_store = other_client.send(:http_cache_options)[:store]
 
-      cache_key = client.send(:http_cache_options)[:cache_key].call(url, request_options)
-      other_cache_key = other_client.send(:http_cache_options)[:cache_key].call(url, request_options)
+      expect(store).to be_a(GithubClient::TokenNamespacedStore)
+      expect(other_store).to be_a(GithubClient::TokenNamespacedStore)
 
-      expect(cache_key).to eq("github_http_cache:#{Digest::SHA256.hexdigest(token)}:#{url}")
-      expect(other_cache_key).to eq("github_http_cache:#{Digest::SHA256.hexdigest(other_token)}:#{url}")
-      expect(cache_key).not_to eq(other_cache_key)
+      underlying = ActiveSupport::Cache::MemoryStore.new
+      token_a = Digest::SHA256.hexdigest(token)
+      token_b = Digest::SHA256.hexdigest(other_token)
+      scoped_a = GithubClient::TokenNamespacedStore.new(underlying, token_a)
+      scoped_b = GithubClient::TokenNamespacedStore.new(underlying, token_b)
+
+      scoped_a.write("test_key", "value_a")
+      expect(scoped_a.read("test_key")).to eq("value_a")
+      expect(scoped_b.read("test_key")).to be_nil
     end
 
     it "adds HTTP caching only to the REST connection" do

--- a/spec/services/github_client_spec.rb
+++ b/spec/services/github_client_spec.rb
@@ -14,6 +14,35 @@ RSpec.describe GithubClient do
     stub_const("GithubClient::RETRY_BACKOFF_FACTOR", 1)
   end
 
+  describe "HTTP cache configuration" do
+    let(:other_token) { "ghp_other_test_token_1234567890123456789012" }
+    let(:other_client) { described_class.new(token: other_token, health_endpoint: health_endpoint) }
+
+    it "uses JSON serialization for cached REST responses" do
+      expect(client.send(:http_cache_options)[:serializer]).to eq(JSON)
+    end
+
+    it "scopes REST cache keys by token digest" do
+      url = "https://api.github.com/user"
+      request_options = nil
+
+      cache_key = client.send(:http_cache_options)[:cache_key].call(url, request_options)
+      other_cache_key = other_client.send(:http_cache_options)[:cache_key].call(url, request_options)
+
+      expect(cache_key).to eq("github_http_cache:#{Digest::SHA256.hexdigest(token)}:#{url}")
+      expect(other_cache_key).to eq("github_http_cache:#{Digest::SHA256.hexdigest(other_token)}:#{url}")
+      expect(cache_key).not_to eq(other_cache_key)
+    end
+
+    it "adds HTTP caching only to the REST connection" do
+      rest_handlers = client.client.middleware.handlers.map(&:klass)
+      graphql_handlers = client.send(:graphql_connection).builder.handlers.map(&:klass)
+
+      expect(rest_handlers).to include(Faraday::HttpCache)
+      expect(graphql_handlers).not_to include(Faraday::HttpCache)
+    end
+  end
+
   describe "#validate_token" do
     context "when token is valid" do
       before do


### PR DESCRIPTION
## Summary

OK

Now let me add the `faraday-http-cache` gem to the Gemfile and install it.

Bundle install succeeded. Now let me check the Gemfile.lock was updated and proceed with the implementation.

Now let me look at the faraday-http-cache gem's API to understand how to configure it properly:

---

Closes #2405