### PR TITLE
fix(runners): cap absurd far-future rate-limit reset parses

### DIFF
--- a/lib/provider_support.rb
+++ b/lib/provider_support.rb
@@ -303,15 +303,16 @@ module ProviderSupport
 
   # Upper bound for a trusted rate-limit reset. Real provider windows top out
   # at monthly (Codex weekly; some free tiers report "Weekly/Monthly Limit
-  # Exhausted" with an absolute reset up to ~30 days out), so ~45 days
-  # comfortably covers every legitimate reset. A parse beyond it is almost
-  # certainly an artifact — e.g. the year over-bump in agent-harness's
-  # parse_resets_date_time (viamin/agent-harness#231), where "resets Apr 6,
-  # 10pm (UTC)" parsed in June became 2027 and disabled the runner for ~10
-  # months. The over-bump always adds a full year, so bogus values land ~1
-  # year out, well clear of this bound. Beyond-bound parses are treated as
-  # unparseable so the caller falls back to the short default and re-probes
-  # soon, rather than skipping the runner for months.
+  # Exhausted" with an absolute reset up to ~30 days out), so the cap must be
+  # materially above 8 days or we'd misclassify legitimate monthly resets.
+  # ~45 days comfortably covers every real window while still rejecting the
+  # year-over-bump artifact in agent-harness's parse_resets_date_time
+  # (viamin/agent-harness#231), where "resets Apr 6, 10pm (UTC)" parsed in
+  # June became 2027 and disabled the runner for ~10 months. The over-bump
+  # always adds a full year, so bogus values land ~1 year out, well clear of
+  # this bound. Beyond-bound parses are treated as unparseable so the caller
+  # falls back to the short default and re-probes soon, rather than skipping
+  # the runner for months.
   MAX_RATE_LIMIT_RESET = 45.days
 
   # Parses a rate-limit reset time from provider output using the given

--- a/lib/provider_support.rb
+++ b/lib/provider_support.rb
@@ -301,14 +301,18 @@ module ProviderSupport
       .gsub(/reset.?at:?\s*(\d+)/i, 'reset at \1')
   end
 
-  # Upper bound for a trusted rate-limit reset. Provider reset windows are
-  # short-lived (Codex's weekly limit is the longest, ~7 days); a parsed
-  # reset beyond this is almost certainly a parse artifact — e.g. the year
-  # over-bump in agent-harness's parse_resets_date_time, viamin/agent-harness#231,
-  # which turned "resets Apr 6, 10pm (UTC)" into a date ~10 months out and
-  # disabled a runner until that date. Treat such values as unparseable so
-  # the caller falls back to the short default and re-probes the runner soon.
-  MAX_RATE_LIMIT_RESET = 8.days
+  # Upper bound for a trusted rate-limit reset. Real provider windows top out
+  # at monthly (Codex weekly; some free tiers report "Weekly/Monthly Limit
+  # Exhausted" with an absolute reset up to ~30 days out), so ~45 days
+  # comfortably covers every legitimate reset. A parse beyond it is almost
+  # certainly an artifact — e.g. the year over-bump in agent-harness's
+  # parse_resets_date_time (viamin/agent-harness#231), where "resets Apr 6,
+  # 10pm (UTC)" parsed in June became 2027 and disabled the runner for ~10
+  # months. The over-bump always adds a full year, so bogus values land ~1
+  # year out, well clear of this bound. Beyond-bound parses are treated as
+  # unparseable so the caller falls back to the short default and re-probes
+  # soon, rather than skipping the runner for months.
+  MAX_RATE_LIMIT_RESET = 45.days
 
   # Parses a rate-limit reset time from provider output using the given
   # harness provider. Falls back to normalized text parsing and a 1-hour

--- a/lib/provider_support.rb
+++ b/lib/provider_support.rb
@@ -301,14 +301,28 @@ module ProviderSupport
       .gsub(/reset.?at:?\s*(\d+)/i, 'reset at \1')
   end
 
+  # Upper bound for a trusted rate-limit reset. Provider reset windows are
+  # short-lived (Codex's weekly limit is the longest, ~7 days); a parsed
+  # reset beyond this is almost certainly a parse artifact — e.g. the year
+  # over-bump in agent-harness's parse_resets_date_time, viamin/agent-harness#231,
+  # which turned "resets Apr 6, 10pm (UTC)" into a date ~10 months out and
+  # disabled a runner until that date. Treat such values as unparseable so
+  # the caller falls back to the short default and re-probes the runner soon.
+  MAX_RATE_LIMIT_RESET = 8.days
+
   # Parses a rate-limit reset time from provider output using the given
   # harness provider. Falls back to normalized text parsing and a 1-hour
-  # default. Shared by RunAgentActivity and TestAgent.
+  # default. Caps absurd far-future parses at MAX_RATE_LIMIT_RESET so a
+  # mis-parsed reset cannot disable a runner for months. Shared by
+  # RunAgentActivity and TestAgent.
   def rate_limit_reset_at(harness_provider, text)
     parsed_reset = harness_provider.parse_rate_limit_reset(text.to_s) ||
       harness_provider.parse_rate_limit_reset(normalized_rate_limit_reset_text(text)) ||
       1.hour.from_now
-    parsed_reset > Time.current ? parsed_reset : 1.hour.from_now
+    return 1.hour.from_now unless parsed_reset > Time.current
+    return 1.hour.from_now if parsed_reset > MAX_RATE_LIMIT_RESET.from_now
+
+    parsed_reset
   rescue AgentHarness::ConfigurationError, KeyError
     1.hour.from_now
   end

--- a/lib/runner_support.rb
+++ b/lib/runner_support.rb
@@ -301,14 +301,28 @@ module RunnerSupport
       .gsub(/reset.?at:?\s*(\d+)/i, 'reset at \1')
   end
 
+  # Upper bound for a trusted rate-limit reset. Provider reset windows are
+  # short-lived (Codex's weekly limit is the longest, ~7 days); a parsed
+  # reset beyond this is almost certainly a parse artifact — e.g. the year
+  # over-bump in agent-harness's parse_resets_date_time, viamin/agent-harness#231,
+  # which turned "resets Apr 6, 10pm (UTC)" into a date ~10 months out and
+  # disabled a runner until that date. Treat such values as unparseable so
+  # the caller falls back to the short default and re-probes the runner soon.
+  MAX_RATE_LIMIT_RESET = 8.days
+
   # Parses a rate-limit reset time from runner output using the given
   # harness provider. Falls back to normalized text parsing and a 1-hour
-  # default. Shared by RunAgentActivity and TestAgent.
+  # default. Caps absurd far-future parses at MAX_RATE_LIMIT_RESET so a
+  # mis-parsed reset cannot disable a runner for months. Shared by
+  # RunAgentActivity and TestAgent.
   def rate_limit_reset_at(harness_provider, text)
     parsed_reset = harness_provider.parse_rate_limit_reset(text.to_s) ||
       harness_provider.parse_rate_limit_reset(normalized_rate_limit_reset_text(text)) ||
       1.hour.from_now
-    parsed_reset > Time.current ? parsed_reset : 1.hour.from_now
+    return 1.hour.from_now unless parsed_reset > Time.current
+    return 1.hour.from_now if parsed_reset > MAX_RATE_LIMIT_RESET.from_now
+
+    parsed_reset
   rescue AgentHarness::ConfigurationError, KeyError
     1.hour.from_now
   end

--- a/lib/runner_support.rb
+++ b/lib/runner_support.rb
@@ -303,15 +303,16 @@ module RunnerSupport
 
   # Upper bound for a trusted rate-limit reset. Real provider windows top out
   # at monthly (Codex weekly; some free tiers report "Weekly/Monthly Limit
-  # Exhausted" with an absolute reset up to ~30 days out), so ~45 days
-  # comfortably covers every legitimate reset. A parse beyond it is almost
-  # certainly an artifact — e.g. the year over-bump in agent-harness's
-  # parse_resets_date_time (viamin/agent-harness#231), where "resets Apr 6,
-  # 10pm (UTC)" parsed in June became 2027 and disabled the runner for ~10
-  # months. The over-bump always adds a full year, so bogus values land ~1
-  # year out, well clear of this bound. Beyond-bound parses are treated as
-  # unparseable so the caller falls back to the short default and re-probes
-  # soon, rather than skipping the runner for months.
+  # Exhausted" with an absolute reset up to ~30 days out), so the cap must be
+  # materially above 8 days or we'd misclassify legitimate monthly resets.
+  # ~45 days comfortably covers every real window while still rejecting the
+  # year-over-bump artifact in agent-harness's parse_resets_date_time
+  # (viamin/agent-harness#231), where "resets Apr 6, 10pm (UTC)" parsed in
+  # June became 2027 and disabled the runner for ~10 months. The over-bump
+  # always adds a full year, so bogus values land ~1 year out, well clear of
+  # this bound. Beyond-bound parses are treated as unparseable so the caller
+  # falls back to the short default and re-probes soon, rather than skipping
+  # the runner for months.
   MAX_RATE_LIMIT_RESET = 45.days
 
   # Parses a rate-limit reset time from runner output using the given

--- a/lib/runner_support.rb
+++ b/lib/runner_support.rb
@@ -301,14 +301,18 @@ module RunnerSupport
       .gsub(/reset.?at:?\s*(\d+)/i, 'reset at \1')
   end
 
-  # Upper bound for a trusted rate-limit reset. Provider reset windows are
-  # short-lived (Codex's weekly limit is the longest, ~7 days); a parsed
-  # reset beyond this is almost certainly a parse artifact — e.g. the year
-  # over-bump in agent-harness's parse_resets_date_time, viamin/agent-harness#231,
-  # which turned "resets Apr 6, 10pm (UTC)" into a date ~10 months out and
-  # disabled a runner until that date. Treat such values as unparseable so
-  # the caller falls back to the short default and re-probes the runner soon.
-  MAX_RATE_LIMIT_RESET = 8.days
+  # Upper bound for a trusted rate-limit reset. Real provider windows top out
+  # at monthly (Codex weekly; some free tiers report "Weekly/Monthly Limit
+  # Exhausted" with an absolute reset up to ~30 days out), so ~45 days
+  # comfortably covers every legitimate reset. A parse beyond it is almost
+  # certainly an artifact — e.g. the year over-bump in agent-harness's
+  # parse_resets_date_time (viamin/agent-harness#231), where "resets Apr 6,
+  # 10pm (UTC)" parsed in June became 2027 and disabled the runner for ~10
+  # months. The over-bump always adds a full year, so bogus values land ~1
+  # year out, well clear of this bound. Beyond-bound parses are treated as
+  # unparseable so the caller falls back to the short default and re-probes
+  # soon, rather than skipping the runner for months.
+  MAX_RATE_LIMIT_RESET = 45.days
 
   # Parses a rate-limit reset time from runner output using the given
   # harness provider. Falls back to normalized text parsing and a 1-hour

--- a/spec/lib/provider_support_spec.rb
+++ b/spec/lib/provider_support_spec.rb
@@ -474,8 +474,18 @@ RSpec.describe ProviderSupport do
       expect(described_class.rate_limit_reset_at(harness_returning(reset), "anything")).to be_within(1.second).of(reset)
     end
 
+    it "preserves a legitimate monthly reset (Weekly/Monthly free-tier limits)" do
+      reset = 30.days.from_now
+      expect(described_class.rate_limit_reset_at(harness_returning(reset), "anything")).to be_within(1.second).of(reset)
+    end
+
     it "caps an absurd far-future parse to the 1-hour fallback (viamin/agent-harness#231)" do
       result = described_class.rate_limit_reset_at(harness_returning(10.months.from_now), "anything")
+      expect(result).to be_within(1.second).of(1.hour.from_now)
+    end
+
+    it "falls back to the 1-hour default when the parsed reset is in the past" do
+      result = described_class.rate_limit_reset_at(harness_returning(1.hour.ago), "anything")
       expect(result).to be_within(1.second).of(1.hour.from_now)
     end
   end

--- a/spec/lib/provider_support_spec.rb
+++ b/spec/lib/provider_support_spec.rb
@@ -458,4 +458,25 @@ RSpec.describe ProviderSupport do
       expect(result).to eq([ "sh", "-c", "env -u VAR1 -u VAR2 my_cmd --flag" ])
     end
   end
+
+  describe ".rate_limit_reset_at" do
+    def harness_returning(reset)
+      Class.new do
+        def initialize(reset) = @reset = reset
+        def parse_rate_limit_reset(_text) = @reset
+      end.new(reset)
+    end
+
+    around { |example| travel_to(Time.utc(2026, 6, 2, 12, 0, 0)) { example.run } }
+
+    it "preserves a legitimate near-future reset within the cap" do
+      reset = 6.days.from_now
+      expect(described_class.rate_limit_reset_at(harness_returning(reset), "anything")).to be_within(1.second).of(reset)
+    end
+
+    it "caps an absurd far-future parse to the 1-hour fallback (viamin/agent-harness#231)" do
+      result = described_class.rate_limit_reset_at(harness_returning(10.months.from_now), "anything")
+      expect(result).to be_within(1.second).of(1.hour.from_now)
+    end
+  end
 end

--- a/spec/lib/runner_support_spec.rb
+++ b/spec/lib/runner_support_spec.rb
@@ -488,6 +488,13 @@ RSpec.describe RunnerSupport do
       expect(described_class.rate_limit_reset_at(harness_returning(reset), "anything")).to be_within(1.second).of(reset)
     end
 
+    it "preserves a legitimate monthly reset (Weekly/Monthly free-tier limits)" do
+      # The cap must clear the longest real window (~monthly) so a genuine
+      # 30-day exhaustion is honoured instead of being retried hourly.
+      reset = 30.days.from_now
+      expect(described_class.rate_limit_reset_at(harness_returning(reset), "anything")).to be_within(1.second).of(reset)
+    end
+
     it "caps an absurd far-future parse to the 1-hour fallback" do
       # Regression for viamin/agent-harness#231: a reset months out must not
       # disable a runner; it falls back to the short default and re-probes.

--- a/spec/lib/runner_support_spec.rb
+++ b/spec/lib/runner_support_spec.rb
@@ -470,4 +470,44 @@ RSpec.describe RunnerSupport do
       expect(result).to eq([ "sh", "-c", "env -u VAR1 -u VAR2 my_cmd --flag" ])
     end
   end
+
+  describe ".rate_limit_reset_at" do
+    # Minimal stand-in for an AgentHarness provider: parse_rate_limit_reset
+    # returns the same configured value regardless of the text passed.
+    def harness_returning(reset)
+      Class.new do
+        def initialize(reset) = @reset = reset
+        def parse_rate_limit_reset(_text) = @reset
+      end.new(reset)
+    end
+
+    around { |example| travel_to(Time.utc(2026, 6, 2, 12, 0, 0)) { example.run } }
+
+    it "preserves a legitimate near-future reset within the cap" do
+      reset = 6.days.from_now
+      expect(described_class.rate_limit_reset_at(harness_returning(reset), "anything")).to be_within(1.second).of(reset)
+    end
+
+    it "caps an absurd far-future parse to the 1-hour fallback" do
+      # Regression for viamin/agent-harness#231: a reset months out must not
+      # disable a runner; it falls back to the short default and re-probes.
+      far_future = 10.months.from_now
+      result = described_class.rate_limit_reset_at(harness_returning(far_future), "anything")
+      expect(result).to be_within(1.second).of(1.hour.from_now)
+    end
+
+    it "falls back to the 1-hour default when the parsed reset is in the past" do
+      result = described_class.rate_limit_reset_at(harness_returning(1.hour.ago), "anything")
+      expect(result).to be_within(1.second).of(1.hour.from_now)
+    end
+
+    it "caps the real Codex year-over-bump parse of 'resets Apr 6, 10pm (UTC)'" do
+      # The live agent-harness parser turns this into 2027-04-06 (~10 months
+      # out) via parse_resets_date_time; the cap must neutralise it.
+      codex = AgentHarness.provider(:codex)
+      expect(codex.parse_rate_limit_reset("resets Apr 6, 10pm (UTC)")).to be > described_class::MAX_RATE_LIMIT_RESET.from_now
+      result = described_class.rate_limit_reset_at(codex, "You're out of usage · resets Apr 6, 10pm (UTC)")
+      expect(result).to be_within(1.second).of(1.hour.from_now)
+    end
+  end
 end

--- a/spec/lib/runner_support_spec.rb
+++ b/spec/lib/runner_support_spec.rb
@@ -510,11 +510,12 @@ RSpec.describe RunnerSupport do
 
     it "caps the real Codex year-over-bump parse of 'resets Apr 6, 10pm (UTC)'" do
       # The live agent-harness parser turns this into 2027-04-06 (~10 months
-      # out) via parse_resets_date_time; the cap must neutralise it.
+      # out) via parse_resets_date_time today; regardless of upstream parser
+      # behaviour, Paid must never store an absurd far-future reset.
       codex = AgentHarness.provider(:codex)
-      expect(codex.parse_rate_limit_reset("resets Apr 6, 10pm (UTC)")).to be > described_class::MAX_RATE_LIMIT_RESET.from_now
       result = described_class.rate_limit_reset_at(codex, "You're out of usage · resets Apr 6, 10pm (UTC)")
-      expect(result).to be_within(1.second).of(1.hour.from_now)
+      expect(result).to be > Time.current
+      expect(result).to be <= described_class::MAX_RATE_LIMIT_RESET.from_now
     end
   end
 end


### PR DESCRIPTION
## Problem

A number of agent runs were stuck showing as rate-limited — most visibly **codex rate limited until 2027-04-06** — while the Codex dashboard showed no rate limiting at all.

Root cause chain:

1. Codex emits weekly-limit reset lines like `… resets Apr 6, 10pm (UTC)`.
2. agent-harness's `parse_resets_date_time` over-bumps the year: `Apr (4) < current month Jun (6)` → it adds a year → **2027-04-06**, ~10 months out. (Upstream root cause: viamin/agent-harness#231, filed P1.)
3. `RunnerSupport#rate_limit_reset_at` trusted the parsed value verbatim — it only guarded the *past* (`parsed_reset > Time.current`), never an absurd future — and persisted it as the runner's `rate_limited_until`.
4. The runner is then skipped on every subsequent run (`runner_unavailable?` → `rate_limited?`) **without being re-probed**, and `rate_limited_until` only clears on a *successful* execution — which can never happen because the runner is always skipped first. Self-perpetuating outage until 2027.

Reproduced against the live parser:

```ruby
AgentHarness.provider(:codex).parse_rate_limit_reset("resets Apr 6, 10pm (UTC)")
# => 2027-04-06 22:00:00 UTC   (exactly the stuck stored value)
```

## Fix

Add an upper-bound sanity cap (`MAX_RATE_LIMIT_RESET = 45.days`) in `rate_limit_reset_at`. Codex's longest window (weekly) resets within ~7 days, but some free-tier providers report monthly exhaustion up to ~30 days out, so 45 days comfortably covers every legitimate reset while still catching the year-over-bump artifact (~365 days out). Beyond-bound parses are treated as unparseable and fall back to the existing 1-hour default, so the runner is re-probed within the hour and self-heals.

Applied to both `RunnerSupport` and the legacy mirror `ProviderSupport` to avoid post-rename drift.

This is the **Paid-side interim guard**; the real fix (correct year selection in `parse_resets_date_time`) lands upstream in viamin/agent-harness#231. Per CLAUDE.md, provider-specific reset parsing belongs in agent-harness, so this Paid change is defensive only and can stay as a permanent backstop.

## Also done (out of band)

- Cleared the stuck codex `RunnerState` (`rate_limited_until` 2027-04-06 → nil) so codex is usable again immediately.
- Filed upstream **viamin/agent-harness#231** as **P1**.

## Tests

- New `.rate_limit_reset_at` specs in `spec/lib/runner_support_spec.rb` and `spec/lib/provider_support_spec.rb`: preserves near-future resets, preserves legitimate monthly resets (~30 days), caps far-future parses, preserves the past→1h fallback, and an end-to-end regression using the **real Codex parser** on `"resets Apr 6, 10pm (UTC)"`.
- `163 examples, 0 failures` for the changed logic (1 unrelated pre-existing Pi failure exists on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)