### PR TITLE
feat(chat): send tool schemas and format tool round-trips via AgentHarness::Conversation (RDR-028 chat-loop T2)

### DIFF
--- a/app/services/chat_sessions/build_llm_client.rb
+++ b/app/services/chat_sessions/build_llm_client.rb
@@ -100,15 +100,16 @@ module ChatSessions
         @provider_type = provider_type
       end
 
-      def call(conversation, on_chunk: nil)
+      def call(conversation, tools: nil, on_chunk: nil)
         messages = format_messages(conversation)
+        formatted_tools = format_tools(tools)
 
         stream_callback = build_stream_callback(on_chunk) if on_chunk
 
         response = if stream_callback
-          @transport.chat(messages: messages, model: model, stream: true, &stream_callback)
+          @transport.chat(messages: messages, model: model, tools: formatted_tools, stream: true, &stream_callback)
         else
-          @transport.chat(messages: messages, model: model, stream: false)
+          @transport.chat(messages: messages, model: model, tools: formatted_tools, stream: false)
         end
 
         {
@@ -127,15 +128,79 @@ module ChatSessions
       end
 
       def format_messages(conversation)
-        conversation.filter_map do |msg|
-          content = msg[:content]
-          next nil if content.nil?
+        conversation_object = build_conversation_object(conversation)
+        return conversation_object.to_openai_messages if @provider_type == :openai_compatible
 
-          entry = { role: msg[:role].to_s, content: content }
-          entry[:tool_call_id] = msg[:tool_call_id].to_s if msg[:tool_call_id].present?
-          entry[:tool_name] = msg[:tool_name].to_s if msg[:tool_name].present?
-          entry
+        anthropic_messages(conversation_object)
+      end
+
+      def build_conversation_object(conversation)
+        system_prompt, remaining_messages = extract_system_prompt(conversation)
+        AgentHarness::Conversation.new(system_prompt: system_prompt).tap do |conversation_object|
+          remaining_messages.each do |message|
+            next if skip_message?(message)
+
+            conversation_object.add_message(
+              message[:role],
+              normalize_content(message[:content], role: message[:role]),
+              tool_calls: message[:tool_calls],
+              tool_call_id: message[:tool_call_id],
+              tool_name: message[:tool_name],
+              tool_result: message[:content]
+            )
+          end
         end
+      end
+
+      def anthropic_messages(conversation_object)
+        formatted = conversation_object.to_anthropic_messages
+        return formatted[:messages] unless formatted[:system].present?
+
+        [ { role: "system", content: formatted[:system] } ] + formatted[:messages]
+      end
+
+      def extract_system_prompt(conversation)
+        first_message = conversation.first
+        return [ nil, conversation ] unless first_message && first_message[:role].to_s == "system"
+
+        [ first_message[:content], conversation.drop(1) ]
+      end
+
+      def skip_message?(message)
+        message[:content].nil? && message[:tool_calls].blank?
+      end
+
+      def normalize_content(content, role:)
+        return JSON.generate(content) if role.to_s == "tool" && !content.nil? && !content.is_a?(String)
+
+        content
+      end
+
+      def format_tools(definitions)
+        return nil if definitions.blank?
+
+        definitions.map do |definition|
+          if @provider_type == :anthropic
+            {
+              name: hash_value(definition, :name),
+              description: hash_value(definition, :description),
+              input_schema: hash_value(definition, :inputSchema)
+            }
+          else
+            {
+              type: "function",
+              function: {
+                name: hash_value(definition, :name),
+                description: hash_value(definition, :description),
+                parameters: hash_value(definition, :inputSchema)
+              }
+            }
+          end
+        end
+      end
+
+      def hash_value(hash, key)
+        hash[key] || hash[key.to_s]
       end
     end
   end

--- a/app/services/chat_sessions/build_llm_client.rb
+++ b/app/services/chat_sessions/build_llm_client.rb
@@ -140,13 +140,14 @@ module ChatSessions
           remaining_messages.each do |message|
             next if skip_message?(message)
 
+            normalized = normalize_content(message[:content], role: message[:role])
             conversation_object.add_message(
               message[:role],
-              normalize_content(message[:content], role: message[:role]),
+              normalized,
               tool_calls: message[:tool_calls],
               tool_call_id: message[:tool_call_id],
               tool_name: message[:tool_name],
-              tool_result: message[:content]
+              tool_result: normalized
             )
           end
         end

--- a/app/services/chat_sessions/build_llm_client.rb
+++ b/app/services/chat_sessions/build_llm_client.rb
@@ -138,7 +138,7 @@ module ChatSessions
         system_prompt, remaining_messages = extract_system_prompt(conversation)
         AgentHarness::Conversation.new(system_prompt: system_prompt).tap do |conversation_object|
           remaining_messages.each do |message|
-            next if skip_message?(message)
+            next if message[:role].to_s == "system" || skip_message?(message)
 
             normalized = normalize_content(message[:content], role: message[:role])
             conversation_object.add_message(
@@ -161,10 +161,14 @@ module ChatSessions
       end
 
       def extract_system_prompt(conversation)
-        first_message = conversation.first
-        return [ nil, conversation ] unless first_message && first_message[:role].to_s == "system"
+        system_messages = conversation.filter_map do |message|
+          next unless message[:role].to_s == "system"
+          next if message[:content].blank?
 
-        [ first_message[:content], conversation.drop(1) ]
+          message[:content]
+        end
+
+        [ system_messages.presence&.join("\n\n"), conversation ]
       end
 
       def skip_message?(message)

--- a/app/services/chat_sessions/send_message.rb
+++ b/app/services/chat_sessions/send_message.rb
@@ -82,10 +82,28 @@ module ChatSessions
 
       messages.map do |msg|
         { role: msg.role, content: conversation_content_for(msg) }.tap do |entry|
-          entry[:tool_call_id] = msg.tool_call_id if msg.tool_call_id.present?
-          entry[:tool_name] = msg.tool_name if msg.tool_name.present?
+          if assistant_tool_call_message?(msg)
+            entry[:tool_calls] = [
+              {
+                id: msg.tool_call_id,
+                name: msg.tool_name,
+                arguments: msg.tool_arguments
+              }
+            ]
+          else
+            entry[:tool_call_id] = msg.tool_call_id if msg.tool_call_id.present?
+            entry[:tool_name] = msg.tool_name if msg.tool_name.present?
+          end
         end
       end
+    end
+
+    def assistant_tool_call_message?(message)
+      message.role == "assistant" &&
+        message.content.blank? &&
+        message.tool_call_id.present? &&
+        message.tool_name.present? &&
+        message.tool_arguments.present?
     end
 
     def conversation_content_for(message)
@@ -140,17 +158,21 @@ module ChatSessions
     end
 
     def invoke_llm_client(conversation, chunk_callback)
-      return llm_client.call(conversation) unless on_chunk
-
-      if llm_client_supports_chunk_callback?
-        llm_client.call(conversation, on_chunk: chunk_callback)
-      else
-        llm_client.call(conversation)
-      end
+      call_llm_client(
+        conversation,
+        include_tools: llm_client_supports_tools?,
+        include_on_chunk: on_chunk && llm_client_supports_chunk_callback?,
+        chunk_callback: chunk_callback
+      )
     rescue ArgumentError => error
-      raise error unless unsupported_on_chunk_callback?(error)
+      raise error unless unsupported_llm_client_keyword?(error)
 
-      llm_client.call(conversation)
+      call_llm_client(
+        conversation,
+        include_tools: false,
+        include_on_chunk: on_chunk && llm_client_supports_chunk_callback? && !unsupported_on_chunk_callback?(error),
+        chunk_callback: chunk_callback
+      )
     end
 
     def replay_response_content(response, chunk_callback)
@@ -163,10 +185,40 @@ module ChatSessions
       error.message.include?("unknown keyword: :on_chunk") || error.message.match?(/wrong number of arguments/)
     end
 
+    def unsupported_tools_keyword?(error)
+      error.message.include?("unknown keyword: :tools") || error.message.match?(/wrong number of arguments/)
+    end
+
+    def unsupported_llm_client_keyword?(error)
+      unsupported_on_chunk_callback?(error) || unsupported_tools_keyword?(error)
+    end
+
     def llm_client_supports_chunk_callback?
+      llm_client_supports_keyword?(:on_chunk)
+    end
+
+    def llm_client_supports_tools?
+      llm_client_supports_keyword?(:tools)
+    end
+
+    def llm_client_supports_keyword?(keyword)
       llm_client.method(:call).parameters.any? do |kind, name|
-        (kind == :keyrest) || ([ :key, :keyreq ].include?(kind) && name == :on_chunk)
+        (kind == :keyrest) || ([ :key, :keyreq ].include?(kind) && name == keyword)
       end
+    end
+
+    def call_llm_client(conversation, include_tools:, include_on_chunk:, chunk_callback:)
+      kwargs = {}
+      kwargs[:tools] = tool_definitions if include_tools
+      kwargs[:on_chunk] = chunk_callback if include_on_chunk
+
+      return llm_client.call(conversation, **kwargs) if kwargs.any?
+
+      llm_client.call(conversation)
+    end
+
+    def tool_definitions
+      @tool_definitions ||= PaidMcpServer.new(session: chat_session, user: chat_session.created_by).tool_definitions
     end
 
     def persist_assistant_response(response)

--- a/spec/services/chat_sessions/build_llm_client_spec.rb
+++ b/spec/services/chat_sessions/build_llm_client_spec.rb
@@ -258,6 +258,27 @@ RSpec.describe ChatSessions::BuildLlmClient, type: :service do
         expect(result[:tokens_output]).to eq(10)
       end
 
+      it "folds later system messages into the system prompt" do
+        allow(transport).to receive(:chat).and_return(response)
+
+        client.call([
+          { role: "system", content: "You are helpful." },
+          { role: "user", content: "Find the issue" },
+          { role: "system", content: "## Added Project Context: Paid" },
+          { role: "user", content: "What did you find?" }
+        ])
+
+        expect(transport).to have_received(:chat).with(
+          hash_including(
+            messages: [
+              { role: "system", content: "You are helpful.\n\n## Added Project Context: Paid" },
+              { role: "user", content: [ { type: "text", text: "Find the issue" } ] },
+              { role: "user", content: [ { type: "text", text: "What did you find?" } ] }
+            ]
+          )
+        )
+      end
+
       it "streams text chunks through on_chunk callback" do
         chunks_received = []
 
@@ -359,6 +380,27 @@ RSpec.describe ChatSessions::BuildLlmClient, type: :service do
           expect(kwargs[:model]).to eq(model)
           expect(kwargs[:stream]).to be(false)
         end
+      end
+
+      it "folds later system messages into the system prompt" do
+        allow(transport).to receive(:chat).and_return(response)
+
+        client.call([
+          { role: "system", content: "You are helpful." },
+          { role: "user", content: "Find the issue" },
+          { role: "system", content: "## Added Project Context: Paid" },
+          { role: "user", content: "What did you find?" }
+        ])
+
+        expect(transport).to have_received(:chat).with(
+          hash_including(
+            messages: [
+              { role: "system", content: "You are helpful.\n\n## Added Project Context: Paid" },
+              { role: "user", content: "Find the issue" },
+              { role: "user", content: "What did you find?" }
+            ]
+          )
+        )
       end
 
       it "returns nil tools when no definitions are provided" do

--- a/spec/services/chat_sessions/build_llm_client_spec.rb
+++ b/spec/services/chat_sessions/build_llm_client_spec.rb
@@ -169,16 +169,19 @@ RSpec.describe ChatSessions::BuildLlmClient, type: :service do
   end
 
   describe described_class::HttpClient do
-    let(:transport) { instance_double(AgentHarness::TextTransport) }
-    let(:model) { "claude-sonnet-4-20250514" }
-    let(:client) { described_class.new(transport: transport, model: model, provider_type: :anthropic) }
-
-    let(:conversation) do
+    let(:tool_definitions) do
       [
-        { role: "system", content: "You are helpful." },
-        { role: "user", content: "Hello" },
-        { role: "assistant", content: "Hi there!" },
-        { role: "user", content: "How are you?" }
+        {
+          name: "search",
+          description: "Search the project",
+          inputSchema: {
+            type: "object",
+            properties: {
+              query: { type: "string" }
+            },
+            required: [ "query" ]
+          }
+        }
       ]
     end
 
@@ -192,85 +195,179 @@ RSpec.describe ChatSessions::BuildLlmClient, type: :service do
       )
     end
 
-    it "calls transport.chat with formatted messages" do
-      allow(transport).to receive(:chat).and_return(response)
-
-      result = client.call(conversation)
-
-      expect(transport).to have_received(:chat) do |**kwargs|
-        messages = kwargs[:messages]
-        expect(messages).to include({ role: "system", content: "You are helpful." })
-        expect(messages).to include({ role: "user", content: "How are you?" })
-        expect(kwargs[:model]).to eq(model)
-        expect(kwargs[:stream]).to be(false)
+    context "with an Anthropic transport" do
+      let(:transport) { instance_double(AgentHarness::TextTransport) }
+      let(:model) { "claude-sonnet-4-20250514" }
+      let(:client) { described_class.new(transport: transport, model: model, provider_type: :anthropic) }
+      let(:conversation) do
+        [
+          { role: "system", content: "You are helpful." },
+          { role: "user", content: "Find the issue" },
+          {
+            role: "assistant",
+            content: "Let me search.",
+            tool_calls: [ { id: "toolu_1", name: "search", arguments: { query: "issue" } } ]
+          },
+          { role: "tool", content: '{"results":[]}', tool_call_id: "toolu_1", tool_name: "search" },
+          { role: "user", content: "What did you find?" }
+        ]
       end
-      expect(result[:content]).to eq("I'm doing well!")
-      expect(result[:model]).to eq("claude-sonnet-4-20250514")
-      expect(result[:tokens_input]).to eq(20)
-      expect(result[:tokens_output]).to eq(10)
+      let(:expected_messages) do
+        [
+          { role: "system", content: "You are helpful." },
+          { role: "user", content: [ { type: "text", text: "Find the issue" } ] },
+          {
+            role: "assistant",
+            content: [
+              { type: "text", text: "Let me search." },
+              { type: "tool_use", id: "toolu_1", name: "search", input: { query: "issue" } }
+            ]
+          },
+          {
+            role: "user",
+            content: [ { type: "tool_result", tool_use_id: "toolu_1", content: '{"results":[]}' } ]
+          },
+          { role: "user", content: [ { type: "text", text: "What did you find?" } ] }
+        ]
+      end
+      let(:expected_tools) do
+        [
+          {
+            name: "search",
+            description: "Search the project",
+            input_schema: tool_definitions.first[:inputSchema]
+          }
+        ]
+      end
+
+      it "passes anthropic-formatted messages and tools to the transport" do
+        allow(transport).to receive(:chat).and_return(response)
+
+        result = client.call(conversation, tools: tool_definitions)
+
+        expect(transport).to have_received(:chat) do |**kwargs|
+          expect(kwargs[:messages]).to eq(expected_messages)
+          expect(kwargs[:tools]).to eq(expected_tools)
+          expect(kwargs[:model]).to eq(model)
+          expect(kwargs[:stream]).to be(false)
+        end
+
+        expect(result[:content]).to eq("I'm doing well!")
+        expect(result[:model]).to eq("claude-sonnet-4-20250514")
+        expect(result[:tokens_input]).to eq(20)
+        expect(result[:tokens_output]).to eq(10)
+      end
+
+      it "streams text chunks through on_chunk callback" do
+        chunks_received = []
+
+        allow(transport).to receive(:chat) do |**_opts, &block|
+          block.call({ type: :text, content: "Hello" })
+          block.call({ type: :text, content: " world" })
+          block.call({ type: :usage, input_tokens: 10, output_tokens: 5 })
+          block.call({ type: :done })
+          response
+        end
+
+        client.call(conversation, on_chunk: ->(chunk) { chunks_received << chunk })
+
+        expect(chunks_received).to eq([ "Hello", " world" ])
+      end
+
+      it "returns nil tools when none are defined" do
+        allow(transport).to receive(:chat).and_return(response)
+
+        client.call(conversation, tools: [])
+
+        expect(transport).to have_received(:chat).with(hash_including(tools: nil))
+      end
+
+      it "passes tool_calls from response metadata" do
+        tool_response = instance_double(AgentHarness::Response,
+          output: "Let me search.",
+          model: "claude-sonnet-4-20250514",
+          input_tokens: 15,
+          output_tokens: 5,
+          metadata: { tool_calls: [ { id: "tc_1", name: "search", arguments: '{"q":"test"}' } ] }
+        )
+        allow(transport).to receive(:chat).and_return(tool_response)
+
+        result = client.call(conversation)
+
+        expect(result[:tool_calls]).to eq([ { id: "tc_1", name: "search", arguments: '{"q":"test"}' } ])
+      end
     end
 
-    it "streams text chunks through on_chunk callback" do
-      chunks_received = []
-
-      allow(transport).to receive(:chat) do |**opts, &block|
-        block.call({ type: :text, content: "Hello" })
-        block.call({ type: :text, content: " world" })
-        block.call({ type: :usage, input_tokens: 10, output_tokens: 5 })
-        block.call({ type: :done })
-        response
+    context "with an OpenAI-compatible transport" do
+      let(:transport) { instance_double(AgentHarness::OpenAICompatibleTransport) }
+      let(:model) { "gpt-4o" }
+      let(:client) { described_class.new(transport: transport, model: model, provider_type: :openai_compatible) }
+      let(:conversation) do
+        [
+          { role: "system", content: "You are helpful." },
+          { role: "user", content: "Find the issue" },
+          {
+            role: "assistant",
+            content: "Let me search.",
+            tool_calls: [ { id: "call_1", name: "search", arguments: { query: "issue" } } ]
+          },
+          { role: "tool", content: '{"results":[]}', tool_call_id: "call_1", tool_name: "search" },
+          { role: "assistant", content: nil },
+          { role: "user", content: "What did you find?" }
+        ]
+      end
+      let(:expected_messages) do
+        [
+          { role: "system", content: "You are helpful." },
+          { role: "user", content: "Find the issue" },
+          {
+            role: "assistant",
+            content: "Let me search.",
+            tool_calls: [
+              {
+                id: "call_1",
+                type: "function",
+                function: { name: "search", arguments: '{"query":"issue"}' }
+              }
+            ]
+          },
+          { role: "tool", content: '{"results":[]}', tool_call_id: "call_1" },
+          { role: "user", content: "What did you find?" }
+        ]
+      end
+      let(:expected_tools) do
+        [
+          {
+            type: "function",
+            function: {
+              name: "search",
+              description: "Search the project",
+              parameters: tool_definitions.first[:inputSchema]
+            }
+          }
+        ]
       end
 
-      client.call(conversation, on_chunk: ->(chunk) { chunks_received << chunk })
+      it "passes openai-formatted messages and tools to the transport" do
+        allow(transport).to receive(:chat).and_return(response)
 
-      expect(chunks_received).to eq([ "Hello", " world" ])
-    end
+        client.call(conversation, tools: tool_definitions)
 
-    it "filters out nil-content messages" do
-      conversation_with_nil = conversation + [ { role: "tool", content: nil } ]
-
-      allow(transport).to receive(:chat).and_return(response)
-
-      client.call(conversation_with_nil)
-
-      expect(transport).to have_received(:chat) do |**kwargs|
-        expect(kwargs[:messages].size).to eq(4)
-        expect(kwargs[:messages].map { |m| m[:content] }).to all(be_present)
+        expect(transport).to have_received(:chat) do |**kwargs|
+          expect(kwargs[:messages]).to eq(expected_messages)
+          expect(kwargs[:tools]).to eq(expected_tools)
+          expect(kwargs[:model]).to eq(model)
+          expect(kwargs[:stream]).to be(false)
+        end
       end
-    end
 
-    it "preserves tool_call_id and tool_name metadata in formatted messages" do
-      conversation_with_tools = conversation + [
-        { role: "assistant", content: "Let me search.", tool_call_id: "tc_1", tool_name: "search" },
-        { role: "tool", content: '{"results":[]}', tool_call_id: "tc_1", tool_name: "search" }
-      ]
+      it "returns nil tools when no definitions are provided" do
+        allow(transport).to receive(:chat).and_return(response)
 
-      allow(transport).to receive(:chat).and_return(response)
+        client.call(conversation, tools: nil)
 
-      client.call(conversation_with_tools)
-
-      expect(transport).to have_received(:chat) do |**kwargs|
-        tool_msg = kwargs[:messages].find { |m| m[:tool_call_id] == "tc_1" && m[:role] == "assistant" }
-        expect(tool_msg).to include(tool_call_id: "tc_1", tool_name: "search", content: "Let me search.")
-
-        result_msg = kwargs[:messages].find { |m| m[:role] == "tool" }
-        expect(result_msg).to include(tool_call_id: "tc_1", tool_name: "search", content: '{"results":[]}')
+        expect(transport).to have_received(:chat).with(hash_including(tools: nil))
       end
-    end
-
-    it "passes tool_calls from response metadata" do
-      tool_response = instance_double(AgentHarness::Response,
-        output: "Let me search.",
-        model: "claude-sonnet-4-20250514",
-        input_tokens: 15,
-        output_tokens: 5,
-        metadata: { tool_calls: [ { id: "tc_1", name: "search", arguments: '{"q":"test"}' } ] }
-      )
-      allow(transport).to receive(:chat).and_return(tool_response)
-
-      result = client.call(conversation)
-
-      expect(result[:tool_calls]).to eq([ { id: "tc_1", name: "search", arguments: '{"q":"test"}' } ])
     end
   end
 end

--- a/spec/services/chat_sessions/send_message_spec.rb
+++ b/spec/services/chat_sessions/send_message_spec.rb
@@ -32,6 +32,27 @@ RSpec.describe ChatSessions::SendMessage do
       end
     end.new
   end
+  let(:tool_definitions) do
+    [
+      {
+        name: "search",
+        description: "Search the project",
+        inputSchema: { type: "object", properties: { query: { type: "string" } } }
+      }
+    ]
+  end
+  let(:expected_assistant_tool_call_entry) do
+    {
+      content: nil,
+      tool_calls: [
+        {
+          id: "call_1",
+          name: "search",
+          arguments: { "query" => "test" }
+        }
+      ]
+    }
+  end
 
   describe ".call" do
     it "persists the user message" do
@@ -231,6 +252,36 @@ RSpec.describe ChatSessions::SendMessage do
       expect(chunks.length).to be > 1
     end
 
+    it "passes tool definitions when the llm client supports tools" do
+      tool_aware_client = Class.new do
+        attr_reader :seen_tools
+
+        def initialize(response)
+          @response = response
+        end
+
+        def call(_conversation, tools: nil)
+          @seen_tools = tools
+          @response
+        end
+      end.new(llm_response)
+      mcp_server = instance_double(PaidMcpServer, tool_definitions: tool_definitions)
+      allow(PaidMcpServer).to receive(:new).and_return(mcp_server)
+
+      described_class.call(chat_session: chat_session, content: "Hello", llm_client: tool_aware_client)
+
+      expect(tool_aware_client.seen_tools).to eq(tool_definitions)
+    end
+
+    it "falls back when the llm client does not support tools" do
+      mcp_server = instance_double(PaidMcpServer, tool_definitions: tool_definitions)
+      allow(PaidMcpServer).to receive(:new).and_return(mcp_server)
+
+      expect {
+        described_class.call(chat_session: chat_session, content: "Hello", llm_client: llm_client)
+      }.not_to raise_error
+    end
+
     context "with tool calls in response" do
       let(:tool_llm_response) do
         {
@@ -282,14 +333,7 @@ RSpec.describe ChatSessions::SendMessage do
 
         follow_up_client = instance_double(Proc)
         allow(follow_up_client).to receive(:call) do |conversation|
-          tool_entry = conversation.find { |message| message[:role] == "tool" }
-
-          expect(tool_entry).to include(
-            content: { "status" => "not_implemented" },
-            tool_call_id: "call_1",
-            tool_name: "search"
-          )
-
+          expect_follow_up_tool_round_trip(conversation)
           llm_response
         end
 
@@ -298,5 +342,19 @@ RSpec.describe ChatSessions::SendMessage do
         expect(follow_up_client).to have_received(:call)
       end
     end
+  end
+
+  def expect_follow_up_tool_round_trip(conversation)
+    assistant_tool_call_entry = conversation.find do |message|
+      message[:role] == "assistant" && message[:tool_calls].present?
+    end
+    tool_entry = conversation.find { |message| message[:role] == "tool" }
+
+    expect(assistant_tool_call_entry).to include(expected_assistant_tool_call_entry)
+    expect(tool_entry).to include(
+      content: { "status" => "not_implemented" },
+      tool_call_id: "call_1",
+      tool_name: "search"
+    )
   end
 end


### PR DESCRIPTION
## Summary

Enable tool-calling in API-mode chat by passing provider-formatted tool schemas to the LLM and serializing message/tool round-trips through `AgentHarness::Conversation`. Without this, models that support tool use (e.g. glm-5.1) reply in prose instead of emitting structured tool calls, because `HttpClient#call` never sent `tools:` and `format_messages` dropped the tool-call structure providers require.

## Changes

### Services — `ChatSessions::BuildLlmClient` (`app/services/chat_sessions/build_llm_client.rb`)

- **`HttpClient#call`** now accepts a `tools:` keyword argument and forwards formatted definitions to `transport.chat`
- **Replaced `format_messages`** with `build_conversation_object` that maps the generic message array into an `AgentHarness::Conversation`, extracting the leading system message as `system_prompt:`
- **Provider-aware serialization**: calls `to_openai_messages` for `:openai_compatible` providers and `to_anthropic_messages` for `:anthropic`, prepending the system message so `TextTransport` can re-partition it into `body[:system]`
- **`format_tools`** translates MCP `inputSchema` into provider-native tool definitions:
  - Anthropic: `{name:, description:, input_schema:}`
  - OpenAI: `{type: "function", function: {name:, description:, parameters:}}`
  - Returns `nil` for empty definitions so transports omit the key
- Preserved `invoke_llm_client` capability-sniffing with `ArgumentError` fallback for test doubles that don't accept `tools:`

### Services — `ChatSessions::SendMessage` (`app/services/chat_sessions/send_message.rb`)

- Passes `tools:` through to `HttpClient#call`
- Persisted assistant tool-call messages are now included as `tool_calls[]` on follow-up turns

### Tests

- Updated `spec/services/chat_sessions/build_llm_client_spec.rb` — asserts `tools:` reaches the stubbed transport for both providers, validates `to_openai_messages`/`to_anthropic_messages` shapes including tool round-trips, and covers `format_tools` output per provider
- Updated `spec/services/chat_sessions/send_message_spec.rb` — covers tool forwarding through the send path

## Design Decisions

- **Delegate all message formatting to `AgentHarness::Conversation`** rather than hand-rolling provider-specific grouping in Paid. This follows the CLAUDE.md principle that provider-specific interpretation belongs in `agent-harness`, and leverages the `add_message` / `to_*_messages` API already shipped in agent-harness 0.20.0.
- **Anthropic system message prepended to serialized messages** — `to_anthropic_messages` excludes system messages by design, so we prepend `{role: "system", content:}` after serialization to let `TextTransport` extract it into the separate `body[:system]` field Anthropic's API expects.
- **`format_tools` returns `nil` instead of `[]`** for empty tool sets — both transports already omit `nil`-valued keys, so this avoids sending an empty `tools: []` that some providers reject.

---

Closes #2444