### PR TITLE
feat(chat): add read-only tool-definition filter to Tools::Registry (RDR-028 chat-loop T1)

### DIFF
--- a/app/mcp/tools/registry.rb
+++ b/app/mcp/tools/registry.rb
@@ -49,7 +49,11 @@ module Tools
       end
 
       def definitions_for(user:)
-        tool_hash.values.select { |klass| tool_available_to?(klass, user:) }.map(&:definition)
+        definitions_for_classes(available_tool_classes_for(user:))
+      end
+
+      def read_only_definitions_for(user:)
+        definitions_for_classes(available_tool_classes_for(user:).reject(&:write_operation?))
       end
 
       def all
@@ -67,6 +71,14 @@ module Tools
 
       def tool_available_to?(klass, user:)
         klass.available_to?(user:)
+      end
+
+      def available_tool_classes_for(user:)
+        tool_hash.values.select { |klass| tool_available_to?(klass, user:) }
+      end
+
+      def definitions_for_classes(tool_classes)
+        tool_classes.map(&:definition)
       end
     end
   end

--- a/spec/mcp/tools/registry_spec.rb
+++ b/spec/mcp/tools/registry_spec.rb
@@ -3,6 +3,24 @@
 require "rails_helper"
 
 RSpec.describe Tools::Registry do
+  let(:write_tool_names) do
+    %w[
+      trigger_agent_run
+      cancel_agent_run
+      invite_account_member
+      update_account_membership
+      remove_account_membership
+      update_user_settings
+      update_tenant_settings
+      create_provider_api_key
+      update_provider_api_key
+      remove_provider_api_key
+      create_mcp_server_definition
+      update_mcp_server_definition
+      remove_mcp_server_definition
+    ]
+  end
+
   describe ".definitions_for" do
     it "includes write tools for a user with a project-level member role" do
       account = create(:account)
@@ -37,6 +55,32 @@ RSpec.describe Tools::Registry do
         "create_mcp_server_definition",
         "update_mcp_server_definition"
       )
+    end
+  end
+
+  describe ".read_only_definitions_for" do
+    it "returns every authorized read-only tool definition and excludes write tools" do
+      account = create(:account)
+      project = create(:project, account: account)
+      user = create(:user, :owner, account: account)
+      create(:project_membership, :member, user: user, project: project)
+
+      definitions = described_class.read_only_definitions_for(user: user)
+      definition_names = definitions.map { |definition| definition[:name] }
+      expected_names = described_class.all.select { |klass|
+        klass.available_to?(user:) && !klass.write_operation?
+      }.map(&:tool_name)
+
+      expect(definition_names).to match_array(expected_names)
+      expect(definition_names & write_tool_names).to be_empty
+    end
+  end
+
+  describe "write-operation audit" do
+    it "flags the known write tools" do
+      flagged_write_tools = described_class.all.select(&:write_operation?).map(&:tool_name)
+
+      expect(flagged_write_tools).to match_array(write_tool_names)
     end
   end
 end


### PR DESCRIPTION
## Summary

Added `Tools::Registry.read_only_definitions_for(user:)` in [app/mcp/tools/registry.rb](/workspace/app/mcp/tools/registry.rb:51) by reusing the existing authorization path and filtering authorized classes on `write_operation?`, while leaving `definitions_for` unchanged. I also expanded [spec/mcp/tools/registry_spec.rb](/workspace/spec/mcp/tools/registry_spec.rb:5) to cover the read-only filter and to audit the known write tools.

Verification:
- `bundle _4.0.12_ install`
- `DB_HOST=paid-svc-a3-s1-postgres DB_PORT=5432 DB_USERNAME=agent DB_PASSWORD=agent bundle _4.0.12_ exec bin/rails db:prepare`
- `DB_HOST=paid-svc-a3-s1-postgres DB_PORT=5432 DB_USERNAME=agent DB_PASSWORD=agent bundle _4.0.12_ exec rubocop` passed
- `DB_HOST=paid-svc-a3-s1-postgres DB_PORT=5432 DB_USERNAME=agent DB_PASSWORD=agent bundle _4.0.12_ exec rspec spec/mcp/tools` passed
- `DB_HOST=paid-svc-a3-s1-postgres DB_PORT=5432 DB_USERNAME=agent DB_PASSWORD=agent bundle _4.0.12_ exec rspec` failed with 16 pre-existing failures outside this change area, including:
  - `spec/services/runners/harness_execution_plan_spec.rb:59`
  - `spec/temporal/activities/run_agent_activity_spec.rb:4333`
  - `spec/lib/provider_support_spec.rb:214`
  - `spec/scripts/install_contract_scripts_spec.rb:25`
  - multiple failures in `spec/services/knowledge/embeddings/generate_spec.rb`

I attempted to commit with `feat(chat): add read-only tool registry definitions`, but the commit hook runs RSpec and is blocked by those unrelated suite failures. The two modified files are still staged and uncommitted.

---

Closes #2443