### PR TITLE
fix(runners): test agent button broken for all runners

### DIFF
--- a/app/controllers/runners_controller.rb
+++ b/app/controllers/runners_controller.rb
@@ -120,7 +120,7 @@ class RunnersController < ApplicationController
       return
     end
 
-    result = resource_test_agent_service.call(resource_test_agent_arguments)
+    result = resource_test_agent_service.call(**resource_test_agent_arguments)
 
     render json: {
       success: result.success?,

--- a/spec/requests/runners_spec.rb
+++ b/spec/requests/runners_spec.rb
@@ -782,7 +782,7 @@ RSpec.describe "Runners" do
           message: "Agent is healthy",
           error_type: nil
         )
-        allow(Runners::TestAgent).to receive(:call).and_return(result)
+        allow(Runners::TestAgent).to receive(:call).with(runner: runner).and_return(result)
 
         post test_agent_runner_path(runner), headers: { "Accept" => "application/json" }
 
@@ -800,7 +800,7 @@ RSpec.describe "Runners" do
           message: "Invalid API key",
           error_type: :authentication
         )
-        allow(Runners::TestAgent).to receive(:call).and_return(result)
+        allow(Runners::TestAgent).to receive(:call).with(runner: runner).and_return(result)
 
         post test_agent_runner_path(runner), headers: { "Accept" => "application/json" }
 
@@ -819,7 +819,7 @@ RSpec.describe "Runners" do
           message: "Agent is healthy",
           error_type: nil
         )
-        allow(Runners::TestAgent).to receive(:call).and_return(result)
+        allow(Runners::TestAgent).to receive(:call).with(runner: runner).and_return(result)
 
         # The test environment uses :null_store, so use a real store
         # to exercise the atomic rate-limit logic without mutating global state.


### PR DESCRIPTION
## Summary
- The "Test Agent" button returned a 500 for every runner due to an `ArgumentError` — `resource_test_agent_arguments` returns a Hash but `TestAgent.call(...)` forwards it as a positional arg, which Ruby 3.4 does not auto-convert to kwargs.
- Adds `**` splat so the Hash is forwarded as keyword arguments.
- Tightens request spec mocks with `.with(runner: runner)` so RSpec's Ruby 3 argument matching catches positional-vs-keyword regressions in the future.

## Root cause
Commit 734ae589c refactored `Runners::TestAgent.call(runner: @runner)` into the template method `resource_test_agent_service.call(resource_test_agent_arguments)`. The `resource_test_agent_arguments` method returns `{ runner: @runner }` (a Hash), which Ruby 3.4 passes as a positional argument rather than keyword arguments.

## Test plan
- [x] `bin/rspec spec/requests/runners_spec.rb -e "test_agent"` — 5 examples, 0 failures
- [x] `bin/rubocop` on changed files — no offenses
- [x] Verified via `bin/rails runner` that the `**` splat resolves the ArgumentError

🤖 Generated with [Claude Code](https://claude.com/claude-code)