### PR TITLE
fix(containers): tolerate both State shapes in collector cleanup

### DIFF
--- a/app/jobs/docker_orphan_cleanup_job.rb
+++ b/app/jobs/docker_orphan_cleanup_job.rb
@@ -339,8 +339,15 @@ class DockerOrphanCleanupJob < ApplicationJob
     end
   end
 
+  # `State` shape differs by backend: Docker's list API (local/remote) returns a
+  # string ("running", "exited", ...), while the swarm backend builds a nested
+  # hash ({ "Running" => true, ... }). Tolerate both so a live collector is never
+  # misread as inactive — which would delete its in-use volume.
   def collector_container_active?(container)
-    container.info.dig("State", "Running") == true
+    state = container.info["State"]
+    return state["Running"] == true if state.is_a?(Hash)
+
+    state == "running"
   end
 
   def collector_volume_names_for(container)

--- a/spec/jobs/docker_orphan_cleanup_job_spec.rb
+++ b/spec/jobs/docker_orphan_cleanup_job_spec.rb
@@ -56,12 +56,16 @@ RSpec.describe DockerOrphanCleanupJob do
       .and_return(containers)
   end
 
-  def make_container(labels:, id: SecureRandom.hex(32), running: false, created_at: Time.current, mounts: [])
+  # `state_shape: :hash` mirrors the swarm backend (nested { "Running" => bool });
+  # `:string` mirrors Docker's list API used by the local/remote backends
+  # ("running"/"exited"). Both occur in production and must be handled.
+  def make_container(labels:, id: SecureRandom.hex(32), running: false, created_at: Time.current, mounts: [], state_shape: :hash)
+    state = state_shape == :string ? (running ? "running" : "exited") : { "Running" => running }
     instance_double(Docker::Container,
       id: id,
       info: {
         "Labels" => labels,
-        "State" => { "Running" => running },
+        "State" => state,
         "Created" => created_at.iso8601,
         "Mounts" => mounts
       },
@@ -451,6 +455,35 @@ RSpec.describe DockerOrphanCleanupJob do
         job.perform
 
         expect(container).not_to have_received(:delete)
+      end
+
+      # Regression: the list API (local/remote backends) returns State as a string,
+      # not the nested hash the swarm backend builds. A running collector reported
+      # this way must still be treated as active so its volume is not deleted.
+      it "keeps running collector containers reported with list-API string state" do
+        container = make_container(
+          labels: { "paid.resource" => "collector_container", "paid.project_id" => "42" },
+          running: true,
+          state_shape: :string
+        )
+        stub_collector_containers(container)
+
+        job.perform
+
+        expect(container).not_to have_received(:delete)
+      end
+
+      it "removes stopped collector containers reported with list-API string state" do
+        container = make_container(
+          labels: { "paid.resource" => "collector_container", "paid.project_id" => "42" },
+          running: false,
+          state_shape: :string
+        )
+        stub_collector_containers(container)
+
+        job.perform
+
+        expect(container).to have_received(:delete).with(force: true, v: true)
       end
     end
 


### PR DESCRIPTION
## Problem

`DockerOrphanCleanupJob` (the cron job that runs every 5 min to remove orphaned Docker containers and volumes) has been **crashing on every run** and never reaching its volume-cleanup phase. On one host this let ~130 GB of orphaned volumes accumulate.

The root cause is in `collector_container_active?`:

```ruby
container.info.dig("State", "Running") == true
```

This assumes the **inspect-API** shape where `State` is a nested hash. But the local and remote backends list containers via `Docker::Container.all` (the **list API**), which returns `State` as a flat string (`"running"` / `"exited"`). Calling `.dig("State", "Running")` on that throws `TypeError: String does not have #dig method`, aborting the job before volumes are cleaned.

## Why not just read it as a string

The swarm backend's `ServiceHandle` builds `info["State"]` as a nested hash (`service_state` → `{ "Running" => true, … }`). A string-only fix would silently misclassify a **running** collector on swarm as inactive, and `active_collector_volume_names_for_backend` would then delete its **in-use volume** — a worse, data-losing failure than the original crash (which at least failed safe).

## Fix

Handle both shapes:

```ruby
state = container.info["State"]
return state["Running"] == true if state.is_a?(Hash)
state == "running"
```

## Tests

The existing fixtures only covered the nested-hash shape — which is exactly why the bug shipped. Added regression specs covering the list-API **string** shape (the production shape that local/remote backends actually return) for both running and stopped collectors.

## Verification

- `bin/rspec spec/jobs/docker_orphan_cleanup_job_spec.rb` → 46 examples, 0 failures
- RuboCop clean
- Ran the fixed job manually against a live host: reclaimed ~130 GB of orphaned volumes that the crashing cron had left behind.

## Known pre-existing limitation (not addressed here)

On swarm, container labels live under `Config.Labels`, but every phase reads `info.dig("Labels", …)`, so label lookups return nil there. It fails *safe* (nothing wrongly deleted), so it's left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)