### PR TITLE
docs(runners): cite agent-harness#231 in rate-limit clamp workaround

### DIFF
--- a/lib/provider_support.rb
+++ b/lib/provider_support.rb
@@ -21,7 +21,7 @@ module ProviderSupport
 
   # Upper bound on how far in the future a parsed rate-limit reset is trusted.
   #
-  # WORKAROUND (remove when agent-harness reset parsing is fixed): the gem's
+  # WORKAROUND (remove when viamin/agent-harness#231 lands): the gem's
   # shared "resets <Mon> <day>" parser infers the year by month comparison
   # (`year += 1 if month < current_month`), so a reset like "resets Jan 15"
   # seen mid-year is read as ~10-11 months out. Codex emits these, and the

--- a/lib/runner_support.rb
+++ b/lib/runner_support.rb
@@ -21,7 +21,7 @@ module RunnerSupport
 
   # Upper bound on how far in the future a parsed rate-limit reset is trusted.
   #
-  # WORKAROUND (remove when agent-harness reset parsing is fixed): the gem's
+  # WORKAROUND (remove when viamin/agent-harness#231 lands): the gem's
   # shared "resets <Mon> <day>" parser infers the year by month comparison
   # (`year += 1 if month < current_month`), so a reset like "resets Jan 15"
   # seen mid-year is read as ~10-11 months out. Codex emits these, and the


### PR DESCRIPTION
## What

Comment-only follow-up to #2466. Adds the upstream tracking issue reference (`viamin/agent-harness#231`) to the `MAX_RATE_LIMIT_RESET_SECONDS` `WORKAROUND` comment in both `RunnerSupport` and `ProviderSupport`.

## Why

#2466 added an interim Paid-side ceiling guard for an upstream year-inference bug in agent-harness's `resets <Mon> <day>` parser, but the workaround comment said only "remove when agent-harness reset parsing is fixed" without naming the issue. The upstream root cause is tracked in `viamin/agent-harness#231` (filed P1 via the now-closed #2451). Citing it keeps the guard's eventual removal traceable.

No behavior change — the 8-day ceiling and all logic are untouched.

## Context

This carries over the one piece of #2451 not already in merged #2466. #2451 has been closed as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)