### PR TITLE
fix(runners): omit empty provider override from opencode.json for built-in providers

### DIFF
--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -1179,14 +1179,17 @@ class Runner < ApplicationRecord
       env["OPENAI_BASE_URL"] = api_config[:base_url]
     end
 
+    metadata_config = {}
+    unless provider_config.empty?
+      metadata_config["provider"] = { opencode_api_provider => provider_config }
+    end
+
     AgentHarness::ProviderRuntime.new(
       model: model_id,
       env: env,
       unset_env: %w[OPENAI_HEADER_X_AGENT_RUN_ID OPENAI_HEADER_X_PROXY_TOKEN],
       metadata: {
-        config: {
-          "provider" => { opencode_api_provider => provider_config }
-        }
+        config: metadata_config
       }
     )
   end

--- a/spec/models/runner_spec.rb
+++ b/spec/models/runner_spec.rb
@@ -1003,7 +1003,7 @@ RSpec.describe Runner do
         "OPENAI_BASE_URL" => "https://openrouter.ai/api/v1"
       )
       expect(runtime.unset_env).to include("OPENAI_HEADER_X_AGENT_RUN_ID", "OPENAI_HEADER_X_PROXY_TOKEN")
-      expect(runtime.metadata[:config]["provider"]).to eq({ "openrouter" => {} })
+      expect(runtime.metadata[:config]).not_to have_key("provider")
     end
 
     it "qualifies zai_coding models with runner prefix" do
@@ -1024,7 +1024,7 @@ RSpec.describe Runner do
         "ZAI_CODING_API_KEY" => "sk-zai-secret",
         "OPENAI_BASE_URL" => "https://api.z.ai/api/coding/paas/v4"
       )
-      expect(runtime.metadata[:config]["provider"]).to eq({ "zai_coding" => {} })
+      expect(runtime.metadata[:config]).not_to have_key("provider")
     end
 
     it "qualifies zai models with runner prefix" do

--- a/spec/services/runners/harness_execution_plan_spec.rb
+++ b/spec/services/runners/harness_execution_plan_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe Runners::HarnessExecutionPlan do
 
       expect(plan.preparation.file_writes.first.path).to eq("~/.config/opencode/opencode.json")
       parsed = JSON.parse(plan.preparation.file_writes.first.content)
-      expect(parsed["provider"]).to eq({ "openrouter" => {} })
+      expect(parsed).not_to have_key("provider")
       expect(parsed["model"]).to eq("openrouter/moonshotai/kimi-k2-0905")
       expect(parsed).not_to have_key("baseURL")
     end

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -1362,14 +1362,13 @@ RSpec.describe Activities::RunAgentActivity do
     expect(execute_calls.third.first[0..6]).to eq([ "env", "-u", "OPENAI_HEADER_X_AGENT_RUN_ID", "-u", "OPENAI_HEADER_X_PROXY_TOKEN", "opencode", "run" ])
     expect(execute_calls.second.second[:env]).to include("OPENAI_BASE_URL" => "https://openrouter.ai/api/v1")
     expect(execute_calls.third.second[:env]).to include("OPENAI_BASE_URL" => "https://openrouter.ai/api/v1")
-    expect(JSON.parse(execute_calls.second.second[:preparation].file_writes.first.content)).to include(
-      "provider" => { "openrouter" => {} },
-      "model" => "moonshotai/kimi-k2-0905"
-    )
-    expect(JSON.parse(execute_calls.third.second[:preparation].file_writes.first.content)).to include(
-      "provider" => { "openrouter" => {} },
-      "model" => "moonshotai/kimi-k2-0905"
-    )
+    second_config = JSON.parse(execute_calls.second.second[:preparation].file_writes.first.content)
+    third_config = JSON.parse(execute_calls.third.second[:preparation].file_writes.first.content)
+
+    expect(second_config).to include("model" => "moonshotai/kimi-k2-0905")
+    expect(second_config).not_to have_key("provider")
+    expect(third_config).to include("model" => "moonshotai/kimi-k2-0905")
+    expect(third_config).not_to have_key("provider")
   end
 
   def expect_resolved_model_attempts(agent_run, opencode_runner)


### PR DESCRIPTION
## Problem

The Opencode Deepseek runner fails with:

```
Preflight check failed: Runner model not found error:
Error: Model not found: deepseek-v4-pro/.
ProviderModelNotFoundError data: { providerID: "deepseek-v4-pro", modelID: "", suggestions: [] }
```

## Root Cause

`Runner#opencode_runner_runtime` always included `provider: {"deepseek": {}}` in the generated `opencode.json`, even when the provider config was empty. opencode treats this as a **custom provider override** that replaces the built-in "deepseek" provider with an empty one, wiping its model catalog.

opencode's `getModel` then:
1. Strips the matching `"deepseek/"` prefix from model `"deepseek/deepseek-v4-pro"` → `"deepseek-v4-pro"`
2. Re-parses the bare string — no `/` found, so the entire thing becomes the provider ID
3. Fails with `providerID: "deepseek-v4-pro", modelID: ""`

## Fix

Only emit the `provider` config in opencode.json metadata when `provider_config` is non-empty (i.e., when there's actual custom configuration like a custom `baseURL`). Built-in providers (deepseek, openrouter, openai, xai, zai, zai_coding, mistral) don't need a provider entry — opencode already knows their base URLs and model catalogs.

Providers that need custom config (e.g., MiniMax using `@ai-sdk/anthropic` with a non-standard `baseURL`) continue to get their provider config emitted correctly.

## Before (broken)

```json
{
  "provider": {"deepseek": {}},
  "model": "deepseek/deepseek-v4-pro"
}
```

## After (working)

```json
{
  "model": "deepseek/deepseek-v4-pro"
}
```

## Testing

- All 276 runner-related tests pass (0 failures)
- MiniMax provider config with `baseURL` is still emitted correctly
- Pre-commit lint passes clean