### PR TITLE
feat: [P2] knowledge: NameError

### DIFF
--- a/app/services/knowledge/collector_runner.rb
+++ b/app/services/knowledge/collector_runner.rb
@@ -96,7 +96,7 @@ module Knowledge
       collector_run.mark_completed!(count: count)
 
       { collector_type: collector_type, status: "completed", artifacts_count: count }
-    rescue SkipCollector => e
+    rescue Knowledge::SkipCollector => e
       if collector_run&.persisted?
         collector_run.mark_skipped!(
           reason: e.reason,

--- a/spec/services/knowledge/collector_runner_spec.rb
+++ b/spec/services/knowledge/collector_runner_spec.rb
@@ -203,6 +203,24 @@ RSpec.describe Knowledge::CollectorRunner do
         described_class.register("test_collector", test_collector_class)
       end
 
+      def register_lazy_skip_collector(skipped_exception)
+        lazy_skip_collector_class = Class.new(Knowledge::BaseCollector) do
+          define_method(:tool_version) { nil }
+
+          define_method(:collect) do
+            raise skipped_exception
+          end
+
+          define_method(:collector_type) do
+            "lazy_skip_collector"
+          end
+        end
+
+        described_class.reset_registry!
+        described_class.register("lazy_skip_collector", lazy_skip_collector_class)
+        described_class.register("test_collector", test_collector_class)
+      end
+
       it "marks the collector run as skipped with a reason" do
         result = described_class.call(project: project, commit_sha: commit_sha)
 
@@ -214,6 +232,26 @@ RSpec.describe Knowledge::CollectorRunner do
         expect(skipped_run.status).to eq("skipped")
         expect(skipped_run.error_message).to eq("maat binary not found")
         expect(skipped_run.artifacts_count).to eq(0)
+      end
+
+      it "rescues skips when SkipCollector must be resolved from the Knowledge namespace" do
+        skip_collector_class = Knowledge::SkipCollector
+        skipped_exception = skip_collector_class.new("maat binary not found")
+        register_lazy_skip_collector(skipped_exception)
+
+        hide_const("Knowledge::SkipCollector")
+        allow(Knowledge).to receive(:const_missing).and_wrap_original do |original, name|
+          name == :SkipCollector ? skip_collector_class : original.call(name)
+        end
+
+        result = described_class.call(project: project, commit_sha: commit_sha)
+
+        skipped_result = result[:results].find { |run| run[:collector_type] == "lazy_skip_collector" }
+        expect(skipped_result).to include(
+          status: "skipped",
+          reason: "maat binary not found",
+          preserve_existing_artifacts: false
+        )
       end
 
       it "does not block other collectors" do


### PR DESCRIPTION
## Summary

Fixes a `NameError` that crashed knowledge collector runs whenever a collector raised `SkipCollector`. The rescue clause referenced an unqualified constant that Ruby resolved within `Knowledge::CollectorRunner`, where it does not exist, turning an intended skip into a fatal `uninitialized constant Knowledge::CollectorRunner::SkipCollector` error (#2476).

## Changes

- **Services** — In `app/services/knowledge/collector_runner.rb`, change the `rescue SkipCollector` clause in `run_single_collector` to use the fully-qualified `Knowledge::SkipCollector` so the constant resolves correctly and the collector is skipped as intended instead of raising.

## Design Decisions

- The exception class lives at `Knowledge::SkipCollector`, not nested under `CollectorRunner`. Using the fully-qualified name keeps the rescue robust regardless of the lexical scope Ruby uses for constant lookup, matching how the constant is defined and referenced elsewhere.

---

Closes #2476