### PR TITLE
fix(github-app): fix migration failures and improve GitHub App installation UX

### DIFF
--- a/app/controllers/github_installations_controller.rb
+++ b/app/controllers/github_installations_controller.rb
@@ -3,9 +3,7 @@
 class GithubInstallationsController < ApplicationController
   include AuditLogging
 
-  before_action :set_github_installation, only: [ :repositories, :show, :check_access ]
-  before_action :set_github_installation_for_migration, only: :migrate_projects
-  before_action :set_github_installation_for_token_migration, only: :migrate_from_token
+  before_action :set_github_installation, only: [ :repositories, :show, :check_access, :migrate_projects, :migrate_from_token ]
 
   # GET /github_installations/:id/repositories
   # Returns repositories available for project creation
@@ -31,7 +29,8 @@ class GithubInstallationsController < ApplicationController
     authorize @github_installation, :show?
 
     @projects_using_installation = @github_installation.projects.includes(:created_by).order(created_at: :desc)
-    @accessible_repos_count = @github_installation.accessible_repositories.count
+    @accessible_repos = Array(@github_installation.accessible_repositories).map { |repo| repo.with_indifferent_access }
+    @accessible_repos_count = @accessible_repos.size
   end
 
   # GET /github_installations/:id/migrate
@@ -42,12 +41,9 @@ class GithubInstallationsController < ApplicationController
 
     @github_tokens = current_account.github_tokens.active.includes(:created_by, :projects).order(created_at: :desc)
     @projects = current_account.projects.where(github_token: @github_tokens).includes(:github_token).order(:name)
-    @installation_repos = normalized_repositories
 
-    # Check which repos are accessible
-    accessible_repo_ids = @installation_repos.map { |r| r["id"] }.to_set
     @project_access_status = @projects.each_with_object({}) do |project, hash|
-      hash[project.id] = accessible_repo_ids.include?(project.github_id)
+      hash[project.id] = @github_installation.covers_repository?(project.full_name)
     end
   end
 
@@ -80,8 +76,13 @@ class GithubInstallationsController < ApplicationController
       redirect_to @github_installation,
         notice: "Successfully migrated #{result.successful} project(s) to GitHub App"
     else
+      errors_summary = result.results
+        .reject(&:success?)
+        .map { |r| "#{r.project.full_name}: #{r.error}" }
+        .join("; ")
+      errors_summary = "#{errors_summary.truncate(800)}; and more" if errors_summary.length > 800
       redirect_to migrate_project_github_installation_path(@github_installation),
-        alert: "Migration completed with #{result.failed} failure(s). #{result.successful} succeeded."
+        alert: "Migration completed with #{result.failed} failure(s). #{result.successful} succeeded. Errors: #{errors_summary}"
     end
   end
 
@@ -115,14 +116,6 @@ class GithubInstallationsController < ApplicationController
 
   def set_github_installation
     @github_installation = policy_scope(GithubInstallation).find(params[:id])
-  end
-
-  def set_github_installation_for_migration
-    set_github_installation
-  end
-
-  def set_github_installation_for_token_migration
-    set_github_installation
   end
 
   def normalized_repositories

--- a/app/controllers/github_installations_controller.rb
+++ b/app/controllers/github_installations_controller.rb
@@ -29,7 +29,7 @@ class GithubInstallationsController < ApplicationController
     authorize @github_installation, :show?
 
     @projects_using_installation = @github_installation.projects.includes(:created_by).order(created_at: :desc)
-    @accessible_repos = Array(@github_installation.accessible_repositories).map { |repo| repo.with_indifferent_access }
+    @accessible_repos = Array(@github_installation.accessible_repositories).map(&:with_indifferent_access)
     @accessible_repos_count = @accessible_repos.size
   end
 

--- a/app/services/github/migration_service.rb
+++ b/app/services/github/migration_service.rb
@@ -20,7 +20,6 @@ module Github
   #   )
   class MigrationService
     class MigrationError < StandardError; end
-    class UnsupportedRepositoryError < MigrationError; end
     class InstallationAccessDeniedError < MigrationError; end
 
     attr_reader :project, :github_token, :github_installation, :actor, :options
@@ -82,6 +81,13 @@ module Github
     # @return [Result]
     def migrate
       validate_preconditions!
+
+      if project.github_installation_id == github_installation.id
+        return Result.new(success: true, project: project, previous_token_id: previous_token_id).tap do |result|
+          result.warnings = [ "Project is already using this GitHub App installation" ]
+        end
+      end
+
       verify_installation_access!
 
       perform_migration
@@ -133,11 +139,10 @@ module Github
       raise MigrationError, "github_token is required" unless github_token
       validate_preconditions!
 
-      accessible_repo_ids = accessible_installation_repo_ids
       repo_by_name = github_token.accessible_repositories.index_by { |repo| repo["full_name"] }
 
-      repo_by_name.each_with_object({}) do |(full_name, repo), result|
-        if accessible_repo_ids.include?(repo["id"])
+      repo_by_name.each_with_object({}) do |(full_name, _repo), result|
+        if github_installation.covers_repository?(full_name)
           result[full_name] = :accessible
         else
           result[full_name] = :requires_admin_action
@@ -167,28 +172,18 @@ module Github
     def verify_installation_access!
       return unless github_token
 
-      accessible_repo_ids = accessible_installation_repo_ids
-      target_repo_ids = if project
-        [ project.github_id ]
+      target_repos = if project
+        [ project.full_name ]
       else
-        github_token.projects.pluck(:github_id)
+        github_token.projects.map(&:full_name)
       end
 
-      inaccessible = target_repo_ids.reject { |id| accessible_repo_ids.include?(id) }
+      inaccessible = target_repos.reject { |name| github_installation.covers_repository?(name) }
       return if inaccessible.empty?
 
-      # For single project migrations, this is a hard error
       raise InstallationAccessDeniedError,
         "Installation does not have access to repository. " \
         "Please request repository access in the GitHub App settings."
-    end
-
-    def accessible_installation_repos
-      github_installation.accessible_repositories || []
-    end
-
-    def accessible_installation_repo_ids
-      @accessible_installation_repo_ids ||= accessible_installation_repos.map { |repo| repo["id"] }.to_set
     end
 
     def perform_migration

--- a/app/views/github_installations/show.html.erb
+++ b/app/views/github_installations/show.html.erb
@@ -13,7 +13,6 @@
       <% if policy(@github_installation).update? && @github_installation.active? %>
         <%= link_to "Migrate Projects", migrate_project_github_installation_path(@github_installation), class: "inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500" %>
       <% end %>
-      <%= link_to "Browse Repositories", repositories_github_installation_path(@github_installation), class: "inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
     </div>
   </div>
 
@@ -76,6 +75,47 @@
     <% else %>
       <div class="px-6 py-8 text-sm text-gray-500">
         No projects are using this installation yet.
+      </div>
+    <% end %>
+  </div>
+
+  <div class="mt-8 rounded-lg border border-gray-200 bg-white shadow-sm">
+    <div class="border-b border-gray-200 px-6 py-4">
+      <h2 class="text-lg font-semibold text-gray-900">Accessible Repositories</h2>
+    </div>
+
+    <% if @accessible_repos.any? %>
+      <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200">
+          <thead class="bg-gray-50">
+            <tr>
+              <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">Repository</th>
+              <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">Visibility</th>
+              <th class="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">Default Branch</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-200 bg-white">
+            <% @accessible_repos.each do |repo| %>
+              <tr>
+                <td class="px-6 py-4 text-sm font-medium text-gray-900">
+                  <%= link_to repo["full_name"], "https://github.com/#{repo["full_name"]}", target: "_blank", rel: "noopener noreferrer", class: "text-indigo-600 hover:text-indigo-500" %>
+                </td>
+                <td class="px-6 py-4 text-sm text-gray-500">
+                  <% if repo["private"] %>
+                    <span class="inline-flex items-center rounded-md bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600">Private</span>
+                  <% else %>
+                    <span class="inline-flex items-center rounded-md bg-green-50 px-2 py-1 text-xs font-medium text-green-700">Public</span>
+                  <% end %>
+                </td>
+                <td class="px-6 py-4 text-sm text-gray-500"><%= repo["default_branch"] %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    <% else %>
+      <div class="px-6 py-8 text-sm text-gray-500">
+        No repositories found. If repository selection is "all", any repository under <strong><%= @github_installation.account_login %></strong> is accessible.
       </div>
     <% end %>
   </div>

--- a/docs/migrate-project-to-github-app.md
+++ b/docs/migrate-project-to-github-app.md
@@ -1,0 +1,344 @@
+# Migrating a Project from PAT to paid-agents GitHub App
+
+This guide covers the exact steps to migrate a project currently using a Personal Access Token (PAT) to the `paid-agents` GitHub App. The app is already configured in Rails credentials.
+
+## What changes after migration
+
+- PRs and commits are authored by `paid-agents[bot]` instead of the PAT owner
+- Credentials are short-lived installation tokens (1 hour, cached 50 min) instead of a long-lived PAT
+- Rate limits become per-installation (5,000–12,500/hr) instead of per-user
+- Branch protection rules like "require non-author review" work correctly because bot ≠ human
+- Container agents continue to receive credentials through the secrets proxy (no agent changes needed)
+
+## Prerequisites
+
+### 1. Verify the paid-agents app is configured
+
+The app credentials live in Rails encrypted credentials (`paid_agent_app_id`, `paid_agent_app_private_key`, `paid_agent_app_slug`). Verify in console:
+
+```ruby
+Github::AppRegistry.configured?  # => true
+Github::AppRegistry.bot_login    # => "paid-agents[bot]"
+Github::AppRegistry.install_url  # => "https://github.com/apps/paid-agents/installations/new"
+```
+
+If `configured?` returns `false`, the app ID or private key is missing from credentials.
+
+### 2. Install the paid-agents GitHub App on the target org/account
+
+The `paid-agents` app must be installed on the GitHub org or user account that owns the target repositories. This is done on GitHub's side:
+
+1. Open the **Integrations** page (`/integrations`) in Paid
+2. Click **"Install paid-agents"** — this opens `https://github.com/apps/paid-agents/installations/new` on GitHub
+3. On GitHub, choose the org or user account to install on
+4. Choose repository access:
+   - **All repositories** — the app covers every repo in the org (simplest)
+   - **Only select repositories** — pick only the repos you want to migrate (e.g., `paid`, `rad_org`)
+5. Approve the permissions (Contents R/W, Pull requests R/W, Issues R/W, Metadata R, Checks R, Commit statuses R; Organization Members R)
+
+After installation, GitHub assigns an **installation ID** (a numeric ID). You need this to create the `GithubInstallation` record in Paid.
+
+### 3. Create the GithubInstallation record
+
+Paid does not yet have a webhook handler that auto-creates `GithubInstallation` records when the app is installed. You need to create it manually via Rails console.
+
+First, find the installation ID that GitHub assigned. You can get it from GitHub's app settings page (`github.com/settings/installations`), or query the GitHub API using the **app JWT**:
+
+```ruby
+jwt = Github::AppJwt.sign(
+  app_id: Github::AppRegistry.app_id,
+  private_key: Github::AppRegistry.private_key
+)
+
+response = Faraday.get(
+  "https://api.github.com/app/installations",
+  nil,
+  "Authorization" => "Bearer #{jwt}",
+  "Accept" => "application/vnd.github+json"
+)
+
+installations = JSON.parse(response.body)
+# Find the one matching your org:
+installations.each { |i| puts "#{i['id']} => #{i.dig('account', 'login')}" }
+```
+
+Then create the record. The steps differ depending on whether you chose **All repositories** or **Only select repositories** during the GitHub install. In both cases, you should populate `accessible_repositories` — the migration service and UI rely on it to verify which repos the installation can reach.
+
+#### All repositories
+
+When `repository_selection` is `"all"`, Paid's `covers_repository?` returns `true` for any repo under that org without consulting the `accessible_repositories` cache. However, the migration UI and service still need the repo list to verify access, so fetch it.
+
+```ruby
+account = Account.find(ACCOUNT_ID)
+installation_id = GITHUB_INSTALLATION_ID
+
+install_record = installations.find { |i| i["id"] == installation_id }
+
+jwt = Github::AppJwt.sign(
+  app_id: Github::AppRegistry.app_id,
+  private_key: Github::AppRegistry.private_key
+)
+
+token_response = Faraday.post(
+  "https://api.github.com/app/installations/#{installation_id}/access_tokens",
+  "{}",
+  "Authorization" => "Bearer #{jwt}",
+  "Accept" => "application/vnd.github+json",
+  "Content-Type" => "application/json"
+)
+installation_token = JSON.parse(token_response.body).fetch("token")
+
+repos_response = Faraday.get(
+  "https://api.github.com/installation/repositories",
+  nil,
+  "Authorization" => "Bearer #{installation_token}",
+  "Accept" => "application/vnd.github+json"
+)
+accessible_repos = JSON.parse(repos_response.body)["repositories"].map { |r|
+  {
+    "id" => r["id"],
+    "full_name" => r["full_name"],
+    "name" => r["name"],
+    "owner" => r.dig("owner", "login"),
+    "default_branch" => r["default_branch"],
+    "private" => r["private"]
+  }
+}
+
+GithubInstallation.create!(
+  account: account,
+  github_installation_id: installation_id,
+  account_login: install_record.dig("account", "login"),
+  target_type: install_record.dig("account", "type") == "Organization" ? "Organization" : "User",
+  repository_selection: install_record["repository_selection"],  # "all"
+  accessible_repositories: accessible_repos
+)
+```
+
+#### Only select repositories
+
+When `repository_selection` is `"selected"`, Paid needs the repo list to determine which repos the installation covers. You must mint an installation token and fetch the repos.
+
+```ruby
+account = Account.find(ACCOUNT_ID)
+installation_id = GITHUB_INSTALLATION_ID
+
+install_record = installations.find { |i| i["id"] == installation_id }
+
+jwt = Github::AppJwt.sign(
+  app_id: Github::AppRegistry.app_id,
+  private_key: Github::AppRegistry.private_key
+)
+
+# Mint an installation token — the app JWT alone is NOT sufficient for
+# /installation/repositories.  You must exchange the JWT for a short-lived
+# installation token first.
+token_response = Faraday.post(
+  "https://api.github.com/app/installations/#{installation_id}/access_tokens",
+  "{}",
+  "Authorization" => "Bearer #{jwt}",
+  "Accept" => "application/vnd.github+json",
+  "Content-Type" => "application/json"
+)
+installation_token = JSON.parse(token_response.body).fetch("token")
+
+# Now use the installation token to list accessible repos
+repos_response = Faraday.get(
+  "https://api.github.com/installation/repositories",
+  nil,
+  "Authorization" => "Bearer #{installation_token}",
+  "Accept" => "application/vnd.github+json"
+)
+repos_data = JSON.parse(repos_response.body)
+accessible_repos = repos_data["repositories"].map { |r|
+  {
+    "id" => r["id"],
+    "full_name" => r["full_name"],
+    "name" => r["name"],
+    "owner" => r.dig("owner", "login"),
+    "default_branch" => r["default_branch"],
+    "private" => r["private"]
+  }
+}
+
+GithubInstallation.create!(
+  account: account,
+  github_installation_id: installation_id,
+  account_login: install_record.dig("account", "login"),
+  target_type: install_record.dig("account", "type") == "Organization" ? "Organization" : "User",
+  repository_selection: install_record["repository_selection"],  # "selected"
+  accessible_repositories: accessible_repos
+)
+```
+
+### 4. Verify the installation covers the target repos
+
+```ruby
+installation = GithubInstallation.last
+
+# Check the repos you want to migrate
+installation.covers_repository?("viamin/paid")            # => true
+installation.covers_repository?("rad_org/rad_org")   # => true
+
+# Or list all covered repos
+installation.accessible_repositories.map { |r| r["full_name"] }
+```
+
+If a repo returns `false` and `repository_selection` is `"selected"`, go to GitHub's app settings (`github.com/settings/installations`) and add the repo to the installation.
+
+## Migration methods
+
+Once the `GithubInstallation` record exists and covers the target repos, choose one of three migration methods:
+
+### Option A: Per-project via the UI
+
+Best for migrating one or two projects.
+
+1. Navigate to **Projects → [project name] → Settings** (i.e., `/projects/:id/edit`)
+2. Scroll to the **"GitHub Authentication"** fieldset
+3. Select the **"Paid Agents App"** radio button
+4. You should see a green banner: *"Paid Agents App detected — Installation #XXXXX covers this repository through YOUR_ORG"*
+   - If you see an amber warning instead, the app isn't installed on that repo yet — go back to step 2 of the prerequisites
+5. Click **Save**
+
+The controller (`ProjectsController#assign_selected_github_credential`) will:
+
+- Set `project.github_token = nil`
+- Set `project.github_installation = <detected installation>`
+- Invalidate cached GitHub data
+
+Repeat for the second project.
+
+### Option B: Bulk migration via the Installations page
+
+Best when both projects use the same PAT and you want to migrate them together.
+
+1. Navigate to **GitHub Apps** (`/github_installations`)
+2. Click into the active installation
+3. Click **"Migrate Projects"** (top-right)
+4. This page shows all PAT-backed projects with access status (green check = accessible, amber = not accessible)
+5. Select the source token from the dropdown
+6. Click **Migrate** — this calls `Github::MigrationService.migrate_from_token`
+
+This migrates **all** projects using that token. If the token is used by other projects you don't want to migrate yet, use Option A or C instead.
+
+### Option C: Via Rails console
+
+Best for scripting or when you need precise control.
+
+```ruby
+account = Account.find(ACCOUNT_ID)
+installation = account.github_installations.active.first
+actor = User.find(YOUR_USER_ID)
+
+viamin = account.projects.find_by(full_name: "viamin/paid")
+rad_org = account.projects.find_by(full_name: "rad_org/rad_org")
+
+# Migrate individually
+result1 = Github::MigrationService.migrate_project(
+  project: viamin,
+  github_installation: installation,
+  actor: actor
+)
+puts "viamin: #{result1.success?} (#{result1.error || 'ok'})"
+
+result2 = Github::MigrationService.migrate_project(
+  project: rad_org,
+  github_installation: installation,
+  actor: actor
+)
+puts "rad_org: #{result2.success?} (#{result2.error || 'ok'})"
+
+# Or bulk migrate all projects on the same token
+token = viamin.github_token
+result = Github::MigrationService.migrate_from_token(
+  github_token: token,
+  github_installation: installation,
+  actor: actor
+)
+puts "Migrated #{result.successful}/#{result.total} projects"
+result.each_failed { |r| puts "  FAILED: #{r.project.full_name} — #{r.error}" }
+```
+
+The migration service (`Github::MigrationService`) does the following within a transaction:
+
+- Validates the installation is active and has access to the repo
+- Sets `project.github_token = nil`, `project.github_installation = installation`
+- Invalidates cached GitHub data
+- Records an account activity event for the audit trail
+
+## Post-migration verification
+
+```ruby
+[viamin, rad_org].each do |p|
+  p.reload
+  puts "#{p.full_name}:"
+  puts "  github_installation_id = #{p.github_installation_id}"
+  puts "  github_token_id = #{p.github_token_id.inspect}  (should be nil)"
+  puts "  credential resolves: #{p.github_credential.present?}"
+  puts "  client works: #{p.client&.repository_present?(p.full_name)}"
+  puts "  author login: #{p.github_author_login}  (should be paid-agents[bot])"
+end
+```
+
+Each project should show:
+
+- `github_installation_id` = the installation's ID (not nil)
+- `github_token_id` = nil
+- `credential resolves` = true
+- `client works` = true
+- `author login` = `paid-agents[bot]`
+
+## Rolling back
+
+If you need to revert to PAT, edit the project settings and switch back to "Personal Access Token", or use the console:
+
+```ruby
+project = Project.find(PROJECT_ID)
+token = GithubToken.find(TOKEN_ID)
+
+project.update!(github_installation: nil, github_token: token)
+```
+
+The PAT path remains fully supported — it is not deprecated.
+
+## Troubleshooting
+
+**"GitHub App is not configured"** — The `paid_agent_app_id` or `paid_agent_app_private_key` is missing from Rails credentials. Check `Github::AppRegistry.configured?`.
+
+**"Installation does not have access to repository"** — The app was installed with "Only select repositories" and the target repo was not included. Go to GitHub's app settings and add the repo.
+
+**"GitHub App installation must be active"** — The `GithubInstallation` record has `suspended_at` or `revoked_at` set. Check `installation.active?` and `installation.suspended?`/`installation.revoked?`.
+
+**"No active paid-agents installation detected"** on the project settings page — Either the `GithubInstallation` record doesn't exist yet (see step 3 of prerequisites), or it doesn't cover the project's repo. Check `installation.covers_repository?("org/repo")`.
+
+**Amber warning on project settings page but installation exists** — The installation's `accessible_repositories` cache may be stale. Re-fetch and update it (note: you need an installation token, not the app JWT):
+
+```ruby
+installation = GithubInstallation.last
+jwt = Github::AppJwt.sign(app_id: Github::AppRegistry.app_id, private_key: Github::AppRegistry.private_key)
+
+# Mint an installation token first
+token_res = Faraday.post(
+  "https://api.github.com/app/installations/#{installation.github_installation_id}/access_tokens",
+  "{}",
+  "Authorization" => "Bearer #{jwt}",
+  "Accept" => "application/vnd.github+json",
+  "Content-Type" => "application/json"
+)
+installation_token = JSON.parse(token_res.body).fetch("token")
+
+# Use the installation token to list repos
+response = Faraday.get(
+  "https://api.github.com/installation/repositories",
+  nil,
+  "Authorization" => "Bearer #{installation_token}",
+  "Accept" => "application/vnd.github+json"
+)
+repos = JSON.parse(response.body)["repositories"].map { |r|
+  { "id" => r["id"], "full_name" => r["full_name"], "name" => r["name"],
+    "owner" => r.dig("owner", "login"), "default_branch" => r["default_branch"],
+    "private" => r["private"] }
+}
+installation.update!(accessible_repositories: repos)
+```

--- a/spec/requests/github_installations_spec.rb
+++ b/spec/requests/github_installations_spec.rb
@@ -144,6 +144,27 @@ RSpec.describe "GithubInstallations" do
       expect(response).to redirect_to(migrate_project_github_installation_path(installation))
     end
 
+    it "includes per-project error details in the flash when migration fails" do
+      installation = create(:github_installation, account: account)
+      github_token = create(:github_token, account: account, created_by: user)
+      project = create(:project, account: account, created_by: user, github_token: github_token, owner: "other-org", repo: "blocked")
+
+      allow(Github::MigrationService).to receive(:migrate_from_token).and_return(
+        Github::MigrationService::BulkResult.new(
+          total: 1, successful: 0, failed: 1,
+          results: [
+            Github::MigrationService::Result.new(success: false, project: project, error: "Installation does not have access")
+          ]
+        )
+      )
+
+      post migrate_project_github_installation_path(installation), params: { github_token_id: github_token.id }
+
+      expect(response).to redirect_to(migrate_project_github_installation_path(installation))
+      expect(flash[:alert]).to include("other-org/blocked")
+      expect(flash[:alert]).to include("Installation does not have access")
+    end
+
     it "rejects inactive tokens" do
       installation = create(:github_installation, account: account)
       github_token = create(:github_token, account: account, created_by: user, revoked_at: Time.current)

--- a/spec/services/github/migration_service_spec.rb
+++ b/spec/services/github/migration_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Github::MigrationService do
       create(
         :github_installation,
         account: account,
-        accessible_repositories: [ { "id" => 101, "full_name" => "acme/accessible" } ]
+        accessible_repositories: [ { "id" => 101, "full_name" => "test-org/accessible" } ]
       )
     end
     let!(:accessible_project) do
@@ -20,6 +20,8 @@ RSpec.describe Github::MigrationService do
         account: account,
         created_by: actor,
         github_token: github_token,
+        owner: "test-org",
+        repo: "accessible",
         github_id: 101
       )
     end
@@ -29,6 +31,8 @@ RSpec.describe Github::MigrationService do
         account: account,
         created_by: actor,
         github_token: github_token,
+        owner: "test-org",
+        repo: "inaccessible",
         github_id: 202
       )
     end
@@ -72,6 +76,19 @@ RSpec.describe Github::MigrationService do
       expect(result.failed).to eq(2)
       expect(result.results.map(&:error).uniq).to eq([ "GitHub App installation must be active" ])
     end
+
+    it "returns success with a warning when a project is already migrated" do
+      accessible_project.update!(github_token: nil, github_installation: installation)
+
+      result = described_class.migrate_project(
+        project: accessible_project,
+        github_installation: installation,
+        actor: actor
+      )
+
+      expect(result).to be_success
+      expect(result.warnings).to eq([ "Project is already using this GitHub App installation" ])
+    end
   end
 
   describe ".check_accessibility" do
@@ -81,7 +98,7 @@ RSpec.describe Github::MigrationService do
       create(
         :github_installation,
         account: account,
-        accessible_repositories: [ { "id" => 1, "full_name" => "acme/accessible" } ]
+        accessible_repositories: [ { "id" => 1, "full_name" => "test-org/accessible" } ]
       )
     end
 
@@ -89,8 +106,8 @@ RSpec.describe Github::MigrationService do
       allow(Github::AppRegistry).to receive(:configured?).and_return(true)
       allow(github_token).to receive(:accessible_repositories).and_return(
         [
-          { "id" => 1, "full_name" => "acme/accessible" },
-          { "id" => 2, "full_name" => "acme/requires-admin" }
+          { "id" => 1, "full_name" => "test-org/accessible" },
+          { "id" => 2, "full_name" => "test-org/requires-admin" }
         ]
       )
     end
@@ -102,8 +119,8 @@ RSpec.describe Github::MigrationService do
       )
 
       expect(result).to eq(
-        "acme/accessible" => :accessible,
-        "acme/requires-admin" => :requires_admin_action
+        "test-org/accessible" => :accessible,
+        "test-org/requires-admin" => :requires_admin_action
       )
     end
 


### PR DESCRIPTION
## Summary

Fixes the GitHub App migration flow and improves the installation UX.

### Core fix: migration accessibility checks

The migration service and UI checked `accessible_repositories` by GitHub repo ID, which failed when the list was empty (common for "all" installs that hadn't pre-fetched repos). Both now use `GithubInstallation#covers_repository?` which handles both `"all"` and `"selected"` `repository_selection` correctly.

### Changes

**Migration service** (`app/services/github/migration_service.rb`):
- `verify_installation_access!` and `check_all_repositories` now use `covers_repository?(full_name)` instead of raw repo ID matching
- Already-migrated projects return success with a warning instead of failing
- Removed dead `UnsupportedRepositoryError` class

**Controller** (`app/controllers/github_installations_controller.rb`):
- `migrate_projects` uses `covers_repository?` for access status
- Flash message includes per-project error details (truncated at 800 chars)
- Consolidated three identical `before_action` callbacks into one

**Views** (`app/views/github_installations/show.html.erb`):
- Added accessible repositories table (repo name, visibility, default branch)
- Removed "Browse Repositories" button that linked to raw JSON API

**Tests**:
- Added test for already-migrated early return path
- Added test for per-project error details in flash message
- Updated existing tests to match `covers_repository?` semantics

**Docs**:
- Added `docs/migrate-project-to-github-app.md` — step-by-step migration guide