### PR TITLE
fix(pr-review): clear paid-escalated label when a PR leaves the escalated phase

### DIFF
--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -10,6 +10,7 @@ module Activities
     DEFAULT_RELATIONSHIP_PARSE_ISSUE_LIMIT = 100
     DEFAULT_RELATIONSHIP_PARSE_BUDGET_SECONDS = 30
     ISSUE_RECONCILIATION_INTERVAL = 1.hour
+    PAID_ESCALATED_LABEL = "paid-escalated"
 
     def execute(input)
       project_id = input[:project_id]
@@ -767,6 +768,12 @@ module Activities
       count = stale_prs.count
       return 0 if count.zero?
 
+      # Snapshot escalated PRs before the bulk state change. A human resolving
+      # an escalation usually merges or closes the PR directly on GitHub, which
+      # lands here rather than in MergePullRequestActivity, so this is the main
+      # path that must clear the now-stale paid-escalated label.
+      escalated_stale = stale_prs.where(pr_review_phase: "escalated").to_a
+
       merged_numbers, unmerged_numbers, unknown_numbers = partition_by_merge_status(
         client, project.full_name, stale_prs.pluck(:github_number)
       )
@@ -786,6 +793,9 @@ module Activities
       end
 
       closed_numbers = merged_numbers.size + unmerged_numbers.size
+
+      closed_set = (merged_numbers + unmerged_numbers).to_set
+      clear_stale_escalation_labels(project, client, escalated_stale.select { |pr| closed_set.include?(pr.github_number) })
 
       logger.info(
         message: "github_sync.closed_stale_pull_requests",
@@ -824,6 +834,31 @@ module Activities
       end
 
       [ merged_numbers, unmerged_numbers, unknown_numbers ]
+    end
+
+    # Clears the paid-escalated label from PRs that left the open set while
+    # still escalated. Bounded to the escalated subset so it adds at most a
+    # handful of API calls per sweep. Best-effort per PR: a failure on one PR
+    # must not abort syncing the rest.
+    def clear_stale_escalation_labels(project, client, escalated_prs)
+      return if escalated_prs.empty?
+
+      escalated_prs.each do |issue|
+        next unless issue.has_label?(PAID_ESCALATED_LABEL)
+
+        begin
+          client.remove_label_from_issue(project.full_name, issue.github_number, PAID_ESCALATED_LABEL)
+        rescue GithubClient::Error => e
+          logger.warn(
+            message: "github_sync.remove_stale_escalation_label_failed",
+            project_id: project.id,
+            pr_number: issue.github_number,
+            error: e.message
+          )
+        end
+
+        issue.update_columns(labels: issue.labels - [ PAID_ESCALATED_LABEL ], updated_at: Time.current)
+      end
     end
 
     # Mirrors reconcile_open_pull_requests for issues. Fetches all open issue

--- a/app/temporal/activities/merge_pull_request_activity.rb
+++ b/app/temporal/activities/merge_pull_request_activity.rb
@@ -15,6 +15,7 @@ module Activities
     activity_name "MergePullRequest"
 
     PAID_AUTO_MERGED_LABEL = "paid-auto-merged"
+    PAID_ESCALATED_LABEL = "paid-escalated"
     AUTO_MERGE_COMMENT = "This PR was automatically merged by paid's auto-merge feature."
 
     def execute(input)
@@ -58,8 +59,12 @@ module Activities
       end
 
       if merged
-        issue.update!(pr_review_phase: "merged")
+        had_escalated_label = issue.has_label?(PAID_ESCALATED_LABEL)
+        issue.update!(pr_review_phase: "merged", labels: issue.labels - [ PAID_ESCALATED_LABEL ])
         IssueMergeSubscriptions::Deliver.call(issue: issue, event: :merged)
+        # A merge resolves any prior escalation; strip the stale label so the
+        # closed PR isn't left flagged as escalated.
+        remove_escalated_label(provider, project, repo, pr_number) if had_escalated_label
         # Only label and comment on PRs that this activity actually merged —
         # already-merged PRs may have been merged manually by a human.
         unless pr_data.merged
@@ -103,6 +108,17 @@ module Activities
     rescue Automation::Providers::RepositoryProvider::ProviderError => e
       logger.warn(
         message: "pr_review.add_label_failed",
+        project_id: project.id,
+        pr_number: pr_number,
+        error: e.message
+      )
+    end
+
+    def remove_escalated_label(provider, project, repo, pr_number)
+      provider.remove_label(repo: repo, number: pr_number, label: PAID_ESCALATED_LABEL)
+    rescue Automation::Providers::RepositoryProvider::ProviderError => e
+      logger.warn(
+        message: "pr_review.remove_escalated_label_failed",
         project_id: project.id,
         pr_number: pr_number,
         error: e.message

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -924,6 +924,7 @@ module Activities
     def maybe_restart_draft(project, issue, pr_data)
       return false unless pr_data&.draft
 
+      had_escalated_label = issue.has_label?(PAID_ESCALATED_LABEL)
       reset_at = Time.current
       issue.update!(
         pr_review_phase: "restarted",
@@ -932,9 +933,11 @@ module Activities
         review_goal_retry_count: 0,
         review_goal_retry_reset_at: reset_at,
         operational_failure_reset_at: reset_at,
-        ci_retry_requested_at: nil
+        ci_retry_requested_at: nil,
+        labels: issue.labels - [ PAID_ESCALATED_LABEL ]
       )
 
+      remove_escalated_label_from_github(project, issue) if had_escalated_label
       invalidate_pr_progress_state(issue)
 
       logger.info(
@@ -945,6 +948,22 @@ module Activities
       )
 
       true
+    end
+
+    # Strips the paid-escalated label on GitHub when a PR leaves the escalated
+    # phase via a draft restart. Without this, the label persists on GitHub and
+    # is re-synced into the local labels array, leaving the PR visually flagged
+    # as escalated even though automation has already resumed work on it.
+    # Best-effort: a removal failure must not abort the restart.
+    def remove_escalated_label_from_github(project, issue)
+      project.client.remove_label_from_issue(project.full_name, issue.github_number, PAID_ESCALATED_LABEL)
+    rescue GithubClient::Error => e
+      logger.warn(
+        message: "pr_scanner.remove_escalated_label_failed",
+        project_id: project.id,
+        pr_number: issue.github_number,
+        error: e.message
+      )
     end
 
     def escalation_dismissed?(issue)

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -1702,6 +1702,59 @@ RSpec.describe Activities::FetchIssuesActivity do
         expect(stale_pr.reload.pr_review_phase).to eq("merged")
       end
 
+      it "clears the paid-escalated label when an escalated PR is closed outside Paid" do
+        stale_pr = create(:issue, :pull_request, project: project, github_issue_id: 5000,
+                          github_number: 50, github_state: "open", pr_review_phase: "escalated",
+                          labels: [ "paid-generated", "paid-escalated" ])
+
+        allow(github_client).to receive_messages(pull_requests: [])
+        allow(github_client).to receive(:pull_request)
+          .with(project.full_name, stale_pr.github_number)
+          .and_return(OpenStruct.new(merged_at: 1.hour.ago, merged: true))
+        allow(github_client).to receive(:remove_label_from_issue)
+
+        activity.execute(project_id: project.id)
+
+        expect(github_client).to have_received(:remove_label_from_issue)
+          .with(project.full_name, stale_pr.github_number, "paid-escalated")
+        expect(stale_pr.reload.labels).not_to include("paid-escalated")
+        expect(stale_pr.reload.pr_review_phase).to eq("merged")
+      end
+
+      it "does not call the label API when stale-closing a non-escalated PR" do
+        stale_pr = create(:issue, :pull_request, project: project, github_issue_id: 5000,
+                          github_number: 50, github_state: "open", pr_review_phase: "ready",
+                          labels: [ "paid-generated" ])
+
+        allow(github_client).to receive_messages(pull_requests: [])
+        allow(github_client).to receive(:pull_request)
+          .with(project.full_name, stale_pr.github_number)
+          .and_return(OpenStruct.new(merged_at: 1.hour.ago, merged: true))
+        allow(github_client).to receive(:remove_label_from_issue)
+
+        activity.execute(project_id: project.id)
+
+        expect(github_client).not_to have_received(:remove_label_from_issue)
+      end
+
+      it "still closes the PR when clearing the escalation label fails" do
+        stale_pr = create(:issue, :pull_request, project: project, github_issue_id: 5000,
+                          github_number: 50, github_state: "open", pr_review_phase: "escalated",
+                          labels: [ "paid-generated", "paid-escalated" ])
+
+        allow(github_client).to receive_messages(pull_requests: [])
+        allow(github_client).to receive(:pull_request)
+          .with(project.full_name, stale_pr.github_number)
+          .and_return(OpenStruct.new(merged_at: 1.hour.ago, merged: true))
+        allow(github_client).to receive(:remove_label_from_issue)
+          .and_raise(GithubClient::Error, "boom")
+
+        activity.execute(project_id: project.id)
+
+        expect(stale_pr.reload.github_state).to eq("closed")
+        expect(stale_pr.reload.pr_review_phase).to eq("merged")
+      end
+
       it "leaves stale pull requests open when GitHub merge-status lookup fails" do
         stale_pr = create(:issue, :pull_request, project: project, github_issue_id: 5000,
                           github_number: 50, github_state: "open", pr_review_phase: "ready")

--- a/spec/temporal/activities/merge_pull_request_activity_spec.rb
+++ b/spec/temporal/activities/merge_pull_request_activity_spec.rb
@@ -120,6 +120,92 @@ RSpec.describe Activities::MergePullRequestActivity do
       end
     end
 
+    context "when merging a PR that was escalated" do
+      let(:issue) do
+        create(:issue, :pull_request,
+          project: project,
+          github_number: 42,
+          pr_review_phase: "escalated",
+          labels: [ "paid-generated", described_class::PAID_ESCALATED_LABEL ])
+      end
+      let(:pr_data) do
+        Automation::Providers::Data::PullRequest.new(
+          number: 42, title: "Test", body: nil, state: :open, draft: false,
+          merged: false, mergeable: true, head_sha: "abc", head_ref: "feature",
+          base_ref: "main", author_login: "user", labels: [], created_at: Time.current,
+          updated_at: Time.current, merged_at: nil, url: "https://example.com/pr/42",
+          raw_state: "open"
+        )
+      end
+      let(:merge_result) do
+        Automation::Providers::Data::MergeResult.new(merged: true, sha: "def456", message: "Merged")
+      end
+
+      before do
+        allow(provider).to receive(:fetch_pull_request)
+          .with(repo: project.full_name, number: 42)
+          .and_return(pr_data)
+        allow(provider).to receive(:merge_pull_request).and_return(merge_result)
+        allow(provider).to receive(:add_labels)
+        allow(provider).to receive(:add_comment)
+        allow(provider).to receive(:remove_label)
+      end
+
+      it "removes the paid-escalated label on the host" do
+        activity.execute(project_id: project.id, pr_number: 42, issue_id: issue.id)
+
+        expect(provider).to have_received(:remove_label)
+          .with(repo: project.full_name, number: 42, label: described_class::PAID_ESCALATED_LABEL)
+      end
+
+      it "strips the paid-escalated label from the issue's labels" do
+        activity.execute(project_id: project.id, pr_number: 42, issue_id: issue.id)
+
+        expect(issue.reload.labels).not_to include(described_class::PAID_ESCALATED_LABEL)
+      end
+
+      it "does not abort the merge when host label removal fails" do
+        allow(provider).to receive(:remove_label)
+          .and_raise(Automation::Providers::RepositoryProvider::ProviderError, "boom")
+
+        result = activity.execute(project_id: project.id, pr_number: 42, issue_id: issue.id)
+
+        expect(result[:merged]).to be true
+        expect(issue.reload.pr_review_phase).to eq("merged")
+      end
+    end
+
+    context "when merging a PR that was not escalated" do
+      let(:pr_data) do
+        Automation::Providers::Data::PullRequest.new(
+          number: 42, title: "Test", body: nil, state: :open, draft: false,
+          merged: false, mergeable: true, head_sha: "abc", head_ref: "feature",
+          base_ref: "main", author_login: "user", labels: [], created_at: Time.current,
+          updated_at: Time.current, merged_at: nil, url: "https://example.com/pr/42",
+          raw_state: "open"
+        )
+      end
+      let(:merge_result) do
+        Automation::Providers::Data::MergeResult.new(merged: true, sha: "def456", message: "Merged")
+      end
+
+      before do
+        allow(provider).to receive(:fetch_pull_request)
+          .with(repo: project.full_name, number: 42)
+          .and_return(pr_data)
+        allow(provider).to receive(:merge_pull_request).and_return(merge_result)
+        allow(provider).to receive(:add_labels)
+        allow(provider).to receive(:add_comment)
+        allow(provider).to receive(:remove_label)
+      end
+
+      it "does not call remove_label" do
+        activity.execute(project_id: project.id, pr_number: 42, issue_id: issue.id)
+
+        expect(provider).not_to have_received(:remove_label)
+      end
+    end
+
     context "when PR is already merged" do
       let(:pr_data) do
         Automation::Providers::Data::PullRequest.new(

--- a/spec/temporal/activities/scan_paid_prs_activity_restart_label_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_restart_label_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "ostruct"
+
+# Focused coverage for the label cleanup performed by #maybe_restart_draft when
+# a PR is converted back to draft on GitHub. Without it, the paid-escalated
+# label persists on the host and is re-synced into the local labels array,
+# leaving an already-resumed PR visually flagged as escalated.
+RSpec.describe Activities::ScanPaidPrsActivity do
+  describe "#maybe_restart_draft label cleanup" do
+    let(:activity) { described_class.new }
+    let(:github_client) { instance_double(GithubClient) }
+    let(:project) { create(:project) }
+    let(:pr_data) { OpenStruct.new(draft: true) }
+
+    before do
+      allow(project).to receive(:client).and_return(github_client)
+      allow(github_client).to receive(:remove_label_from_issue)
+      # invalidate_pr_progress_state clears derived caches that are irrelevant
+      # here and require extra setup; the restart transition is the subject.
+      allow(activity).to receive(:invalidate_pr_progress_state)
+    end
+
+    context "when the PR carries the paid-escalated label" do
+      let(:issue) do
+        create(:issue, :pull_request,
+          project: project,
+          github_number: 42,
+          pr_review_phase: "escalated",
+          labels: [ "paid-generated", described_class::PAID_ESCALATED_LABEL ])
+      end
+
+      it "restarts the phase" do
+        activity.send(:maybe_restart_draft, project, issue, pr_data)
+
+        expect(issue.reload.pr_review_phase).to eq("restarted")
+      end
+
+      it "strips the label from the local labels array" do
+        activity.send(:maybe_restart_draft, project, issue, pr_data)
+
+        expect(issue.reload.labels).not_to include(described_class::PAID_ESCALATED_LABEL)
+      end
+
+      it "removes the label on GitHub" do
+        activity.send(:maybe_restart_draft, project, issue, pr_data)
+
+        expect(github_client).to have_received(:remove_label_from_issue)
+          .with(project.full_name, 42, described_class::PAID_ESCALATED_LABEL)
+      end
+
+      it "does not abort the restart when host label removal fails" do
+        allow(github_client).to receive(:remove_label_from_issue)
+          .and_raise(GithubClient::Error, "boom")
+
+        expect(activity.send(:maybe_restart_draft, project, issue, pr_data)).to be(true)
+        expect(issue.reload.pr_review_phase).to eq("restarted")
+      end
+    end
+
+    context "when the PR does not carry the paid-escalated label" do
+      let(:issue) do
+        create(:issue, :pull_request,
+          project: project,
+          github_number: 42,
+          pr_review_phase: "ready",
+          labels: [ "paid-generated" ])
+      end
+
+      it "does not call GitHub to remove the label" do
+        activity.send(:maybe_restart_draft, project, issue, pr_data)
+
+        expect(github_client).not_to have_received(:remove_label_from_issue)
+      end
+    end
+  end
+end

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -95,6 +95,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
   before do
     allow(GithubClient).to receive(:new).and_return(github_client)
     allow(github_client).to receive_messages(rate_limit_remaining!: 100, check_run_log: "")
+    allow(github_client).to receive(:remove_label_from_issue)
     allow(Github::ReviewBotInstallationToken).to receive(:configured?).and_return(true)
   end
 


### PR DESCRIPTION
## Problem

When a PR left the `escalated` phase, the `paid-escalated` label was never removed — it stayed on the PR on GitHub and got re-synced into the local `labels` array. The result: PRs that automation had already resumed work on (or that a human had merged/closed) remained visually flagged as escalated indefinitely.

Only `escalation_dismissed?` (which fires *after* a human manually removes the label) ever stripped it, so every automated exit path leaked the label.

This was surfaced while de-escalating PRs in production: some "escalated" PRs were already in draft/restarted state or already merged, yet still wore the label.

## Fix

Strip `paid-escalated` (from both the host and the local `labels` array) on every automated transition out of the escalated phase:

1. **`ScanPaidPrsActivity#maybe_restart_draft`** — escalated → restarted (PR converted back to draft on GitHub).
2. **`MergePullRequestActivity`** — Paid-initiated auto-merge of an escalated PR.
3. **`FetchIssuesActivity#close_stale_pull_requests`** — the **common** case: a human merges/closes the escalated PR directly on GitHub. Bounded to the escalated subset so it adds at most a few API calls per sweep (the sweep already makes one `pull_request` call per stale PR).

All removals are best-effort per PR — a host-side failure is logged and never aborts the restart/merge/sync.

The existing `Issue#dismiss_escalation!` path (human removes the label) already handled cleanup and is unchanged.

## Tests

- `scan_paid_prs_activity_restart_label_spec.rb` (new) — restart strips label on host + DB, survives host failure, no-op when label absent.
- `merge_pull_request_activity_spec.rb` — escalated merge strips label, doesn't abort on failure, skips the call when not escalated.
- `fetch_issues_activity_spec.rb` — escalated stale-close strips label, skips the API for non-escalated PRs, still closes the PR on removal failure.

136 examples passing across the three specs; RuboCop clean.

> Note: existing stale labels in the database/GitHub were already cleaned up out-of-band; this PR prevents the leak from recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Dependencies

Depends on #2487
Depends on #2486

Merge order is #2486 → #2487 → #2482. This PR is mostly additive (new helpers in `MergePullRequestActivity`, `FetchIssuesActivity`, and `ScanPaidPrsActivity#maybe_restart_draft`) and rebases most cleanly last, after the other two have reshaped `escalation_dismissed?` and the escalated phase/label write.
