### PR TITLE
fix(temporal): size DB pool for agent heartbeat connections + auto-correct at boot

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -30,6 +30,12 @@ services:
 
   postgres:
     image: postgres:16.14
+    # This single container is shared by Temporal (temporal/temporal_visibility),
+    # the app, the GoodJob worker, the temporal worker, and every active git
+    # worktree's databases. The default max_connections=100 is exhausted under
+    # that combined load; 200 gives headroom. Production sets max_connections at
+    # its own DB layer (see docs/WORKER_POOL_TUNING.md).
+    command: postgres -c max_connections=200
     restart: unless-stopped
     networks:
     - default

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -1920,10 +1920,21 @@ module Activities
       tenant_account_id = Current.account&.id
 
       # Wrap the worker thread in Rails executor and ActiveRecord connection
-      # pool management. The executor handles autoloading/reloading and the
-      # with_connection block ensures the DB connection is checked out only
-      # for the duration of the work and returned to the pool afterward,
-      # preventing connection-pool exhaustion from long-running activities.
+      # pool management. The executor handles autoloading/reloading; the
+      # with_connection block scopes the worker thread's DB connection and
+      # returns it to the pool when the run finishes.
+      #
+      # NOTE: this connection is intentionally held for the full duration of
+      # the run, not just discrete writes. The wrapped work streams agent
+      # output to the DB on every chunk (Containers::Provision#log_output),
+      # so a tighter scope would either thrash the pool (checkout/checkin per
+      # chunk) or drop the per-connection tenant RLS context that
+      # TenantContext sets via `SET paid.current_account_id`. This worker
+      # thread therefore runs concurrently with the activity's main thread and
+      # consumes a second connection per in-flight run — accounted for in
+      # Paid::TemporalWorkerConfig#agent_heartbeat_connections when sizing the
+      # pool. Do not narrow this scope without also batching the streaming
+      # writes and re-applying tenant context across reconnects.
       worker = Thread.new do
         executor = Rails.application.executor if defined?(Rails) && Rails.respond_to?(:application) && Rails.application.respond_to?(:executor)
         work = proc { yield }

--- a/bin/temporal_worker
+++ b/bin/temporal_worker
@@ -89,10 +89,48 @@ puts "Poll worker concurrency: workflows=#{poll_workflow_slots} activities=#{pol
      "workflow_polls=#{poll_workflow_task_polls}" unless worker_mode == "agent"
 
 if db_pool < min_required_pool
-  warn "WARNING: DB_POOL (#{db_pool}) is less than the recommended minimum " \
+  warn "WARNING: DB_POOL (#{db_pool}) is less than the required minimum " \
        "(#{min_required_pool}) for selected activity_slots=#{selected_activity_slots} " \
-       "in #{worker_mode} mode. " \
-       "Increase DB_POOL or reduce activity concurrency to avoid connection exhaustion."
+       "in #{worker_mode} mode (agent activities hold two connections each)."
+
+  # Auto-correct rather than booting under-provisioned: an undersized pool
+  # surfaces as "could not obtain a connection from the pool" mid-run, which
+  # fails live agent runs. Resizing the primary pool here is safe — worker
+  # threads have not started yet, so no connections are in flight. If the
+  # resize cannot be applied, refuse to boot rather than fail runs later.
+  resized = begin
+    db_config = ActiveRecord::Base.connection_db_config
+    resized_config = ActiveRecord::DatabaseConfigurations::HashConfig.new(
+      db_config.env_name, db_config.name, db_config.configuration_hash.merge(pool: min_required_pool)
+    )
+    # Replace the registry entry as well as the live pool. A bare
+    # establish_connection resizes the live pool but leaves
+    # ActiveRecord::Base.configurations stale at DB_POOL, which would silently
+    # revert the size on any later reconnect-by-name. Keep one source of truth.
+    configs = ActiveRecord::Base.configurations.configurations
+    configs.reject! { |c| c.env_name == db_config.env_name && c.name == db_config.name }
+    configs << resized_config
+    ActiveRecord::Base.establish_connection(resized_config)
+    # Verify against the live pool's actual capacity (db_config#pool is
+    # deprecated in Rails 8.1 in favour of #max_connections).
+    ActiveRecord::Base.connection_pool.size >= min_required_pool
+  rescue => error
+    warn "ERROR: failed to resize DB pool: #{error.class}: #{error.message}"
+    false
+  end
+
+  if resized
+    warn "Auto-corrected primary DB pool size: #{db_pool} -> #{min_required_pool}. " \
+         "Set DB_POOL >= #{min_required_pool} to make this explicit, or reduce " \
+         "TEMPORAL_ACTIVITY_SLOTS to need fewer connections. NOTE: this raises the " \
+         "connections this process opens — ensure the database server's max_connections " \
+         "covers the sum across all web/worker processes (see docs/WORKER_POOL_TUNING.md)."
+  else
+    warn "FATAL: DB_POOL (#{db_pool}) is below the required minimum (#{min_required_pool}) " \
+         "and the pool could not be resized automatically. Increase DB_POOL or reduce " \
+         "activity concurrency to avoid connection exhaustion."
+    exit 1
+  end
 end
 
 shutdown_cancellation, request_shutdown = Temporalio::Cancellation.new

--- a/docs/SCALING.md
+++ b/docs/SCALING.md
@@ -150,9 +150,10 @@ so more slots improve throughput linearly up to the DB connection and Docker hos
 **Pool sizing constraints:**
 
 - `async_server` mode: `DB_POOL >= RAILS_MAX_THREADS + GOOD_JOB_MAX_THREADS`
-- Temporal worker in `agent` mode: `DB_POOL >= TEMPORAL_ACTIVITY_SLOTS + TEMPORAL_LOCAL_ACTIVITY_SLOTS + 2`
+- Temporal worker in `agent` mode: `DB_POOL >= TEMPORAL_ACTIVITY_SLOTS + TEMPORAL_LOCAL_ACTIVITY_SLOTS + TEMPORAL_ACTIVITY_SLOTS + 2`
 - Temporal worker in `poll` mode: `DB_POOL >= TEMPORAL_POLL_ACTIVITY_SLOTS + TEMPORAL_POLL_LOCAL_ACTIVITY_SLOTS + 2`
-- Temporal worker in `both` mode: `DB_POOL >= (TEMPORAL_ACTIVITY_SLOTS + TEMPORAL_LOCAL_ACTIVITY_SLOTS + TEMPORAL_POLL_ACTIVITY_SLOTS + TEMPORAL_POLL_LOCAL_ACTIVITY_SLOTS) + 4`
+- Temporal worker in `both` mode: `DB_POOL >= (TEMPORAL_ACTIVITY_SLOTS + TEMPORAL_LOCAL_ACTIVITY_SLOTS + TEMPORAL_POLL_ACTIVITY_SLOTS + TEMPORAL_POLL_LOCAL_ACTIVITY_SLOTS) + TEMPORAL_ACTIVITY_SLOTS + 4`
+- Each agent activity holds **two** connections (its main thread + a heartbeat worker thread that streams output to the DB), so `TEMPORAL_ACTIVITY_SLOTS` is counted twice. `bin/temporal_worker` auto-corrects the pool at boot if `DB_POOL` is below the minimum.
 - Total connections across all processes must not exceed PostgreSQL `max_connections`
 
 ### Agent Containers

--- a/docs/WORKER_POOL_TUNING.md
+++ b/docs/WORKER_POOL_TUNING.md
@@ -82,16 +82,32 @@ one concurrent agent execution (container launch, monitoring, teardown). Activit
 are I/O-bound (waiting on Docker and LLM APIs), so more slots improve throughput
 linearly up to the database connection limit.
 
-**Key constraint**:
+**Key constraint** (each agent activity slot holds **two** connections — see below):
 
 - `TEMPORAL_WORKER_MODE=poll`:
   `DB_POOL >= TEMPORAL_POLL_ACTIVITY_SLOTS + TEMPORAL_POLL_LOCAL_ACTIVITY_SLOTS + 2`
 - `TEMPORAL_WORKER_MODE=agent`:
-  `DB_POOL >= TEMPORAL_ACTIVITY_SLOTS + TEMPORAL_LOCAL_ACTIVITY_SLOTS + 2`
+  `DB_POOL >= TEMPORAL_ACTIVITY_SLOTS + TEMPORAL_LOCAL_ACTIVITY_SLOTS + TEMPORAL_ACTIVITY_SLOTS + 2`
 - `TEMPORAL_WORKER_MODE=both`:
-  `DB_POOL >= (TEMPORAL_ACTIVITY_SLOTS + TEMPORAL_LOCAL_ACTIVITY_SLOTS + TEMPORAL_POLL_ACTIVITY_SLOTS + TEMPORAL_POLL_LOCAL_ACTIVITY_SLOTS) + 4`
+  `DB_POOL >= (TEMPORAL_ACTIVITY_SLOTS + TEMPORAL_LOCAL_ACTIVITY_SLOTS + TEMPORAL_POLL_ACTIVITY_SLOTS + TEMPORAL_POLL_LOCAL_ACTIVITY_SLOTS) + TEMPORAL_ACTIVITY_SLOTS + 4`
 
-The extra headroom covers heartbeat and polling threads for the selected worker set.
+The fixed `+2`/`+4` headroom covers the Temporal SDK's polling and internal threads
+for the selected worker set. The additional `TEMPORAL_ACTIVITY_SLOTS` term is separate:
+it accounts for `RunAgentActivity`'s heartbeat worker thread, which streams agent output
+to the database throughout the run and holds its own connection concurrently with the
+activity's main thread — so each in-flight agent run consumes two connections. `bin/temporal_worker` computes this
+minimum via `Paid::TemporalWorkerConfig.min_required_db_pool` and **auto-corrects the
+primary pool size at boot** if `DB_POOL` is below it (refusing to start only if the
+resize fails). Setting `DB_POOL` at or above the minimum avoids the boot-time resize.
+
+**Server-side ceiling**: `DB_POOL` governs one process's pool, but every process
+(web, GoodJob, each Temporal worker) opens its own connections against the *same*
+PostgreSQL server, which has its own `max_connections` cap. The sum of all process
+pools — plus Temporal's own server connections — must stay under `max_connections`,
+or runs fail with `remaining connection slots are reserved` / `too many clients`.
+The devcontainer raises this to 200 (`.devcontainer/compose.yaml`); **production must
+set `max_connections` at its own database layer** (managed-DB parameter group or
+`postgresql.conf`) — the devcontainer change does not affect it.
 
 ### Workflow Slots
 

--- a/docs/runbooks/scaling.md
+++ b/docs/runbooks/scaling.md
@@ -126,9 +126,10 @@ in "pending" state.
 3. Verify DB pool can support new slot count:
 
    ```bash
-   # With TEMPORAL_WORKER_MODE=agent:
-   # DB_POOL >= TEMPORAL_ACTIVITY_SLOTS + TEMPORAL_LOCAL_ACTIVITY_SLOTS + 2
-   # 8 + 4 + 2 = 14, so DB_POOL=20 is sufficient
+   # With TEMPORAL_WORKER_MODE=agent (agent activities hold TWO connections each,
+   # so the agent-slot count is added twice):
+   # DB_POOL >= TEMPORAL_ACTIVITY_SLOTS + TEMPORAL_LOCAL_ACTIVITY_SLOTS + TEMPORAL_ACTIVITY_SLOTS + 2
+   # 8 + 4 + 8 + 2 = 22, so DB_POOL must be >= 22 (DB_POOL=20 is NOT enough)
    ```
 
 4. If the Docker host is out of memory for more containers:
@@ -267,9 +268,11 @@ in "pending" state.
 1. Check the worker startup log for the specific validation error
 2. Common fix: increase `DB_POOL` to satisfy
    the requirement for the mode you are running:
-   `agent => TEMPORAL_ACTIVITY_SLOTS + TEMPORAL_LOCAL_ACTIVITY_SLOTS + 2`,
+   `agent => TEMPORAL_ACTIVITY_SLOTS + TEMPORAL_LOCAL_ACTIVITY_SLOTS + TEMPORAL_ACTIVITY_SLOTS + 2`,
    `poll => TEMPORAL_POLL_ACTIVITY_SLOTS + TEMPORAL_POLL_LOCAL_ACTIVITY_SLOTS + 2`,
-   `both => both pools combined + 4`
+   `both => both pools combined + TEMPORAL_ACTIVITY_SLOTS + 4`
+   (agent activities hold two connections each — see docs/WORKER_POOL_TUNING.md).
+   `bin/temporal_worker` auto-corrects the pool at boot if `DB_POOL` is below this.
 
 ### Symptom: GoodJob Cron Jobs Running Multiple Times
 

--- a/lib/paid/temporal_worker_config.rb
+++ b/lib/paid/temporal_worker_config.rb
@@ -34,6 +34,18 @@ module Paid
       validate_worker_mode!(worker_mode) == "both" ? 4 : 2
     end
 
+    # RunAgentActivity (a regular agent-queue activity) spawns a heartbeat
+    # worker thread that holds its own DB connection for the entire run —
+    # it streams agent output to the DB on every chunk, so the connection
+    # cannot be released mid-run without thrashing the pool or losing the
+    # per-connection tenant RLS context. That worker thread runs concurrently
+    # with the activity's main thread, so each agent activity slot consumes
+    # two connections, not one. Local/poll activities do not spawn this
+    # thread. Only the agent (non-local) pool is affected.
+    def agent_heartbeat_connections(worker_mode:, agent_activity_slots:)
+      %w[agent both].include?(validate_worker_mode!(worker_mode)) ? agent_activity_slots : 0
+    end
+
     def min_required_db_pool(worker_mode:, agent_activity_slots:, agent_local_activity_slots:,
                              poll_activity_slots:, poll_local_activity_slots:)
       selected_activity_slots(
@@ -42,7 +54,9 @@ module Paid
         agent_local_activity_slots: agent_local_activity_slots,
         poll_activity_slots: poll_activity_slots,
         poll_local_activity_slots: poll_local_activity_slots
-      ) + selected_pool_overhead(worker_mode: worker_mode)
+      ) +
+        agent_heartbeat_connections(worker_mode: worker_mode, agent_activity_slots: agent_activity_slots) +
+        selected_pool_overhead(worker_mode: worker_mode)
     end
   end
 end

--- a/spec/lib/paid/temporal_worker_config_spec.rb
+++ b/spec/lib/paid/temporal_worker_config_spec.rb
@@ -53,12 +53,30 @@ RSpec.describe Paid::TemporalWorkerConfig do
       }
     end
 
-    it "adds two connections of overhead for a single worker mode" do
-      expect(described_class.min_required_db_pool(worker_mode: "agent", **slots)).to eq(12)
+    it "budgets a second connection per agent activity plus overhead in agent mode" do
+      # selected (4 + 6) + heartbeat workers (4) + overhead (2)
+      expect(described_class.min_required_db_pool(worker_mode: "agent", **slots)).to eq(16)
     end
 
-    it "adds four connections of overhead when both worker sets run together" do
-      expect(described_class.min_required_db_pool(worker_mode: "both", **slots)).to eq(19)
+    it "budgets agent heartbeat connections and four overhead when both worker sets run together" do
+      # selected (4 + 6 + 3 + 2) + heartbeat workers (4) + overhead (4)
+      expect(described_class.min_required_db_pool(worker_mode: "both", **slots)).to eq(23)
+    end
+
+    it "does not budget heartbeat connections in poll mode (no agent activities)" do
+      # selected (3 + 2) + heartbeat workers (0) + overhead (2)
+      expect(described_class.min_required_db_pool(worker_mode: "poll", **slots)).to eq(7)
+    end
+  end
+
+  describe ".agent_heartbeat_connections" do
+    it "reserves one connection per agent activity slot in agent and both modes" do
+      expect(described_class.agent_heartbeat_connections(worker_mode: "agent", agent_activity_slots: 4)).to eq(4)
+      expect(described_class.agent_heartbeat_connections(worker_mode: "both", agent_activity_slots: 4)).to eq(4)
+    end
+
+    it "reserves none in poll mode" do
+      expect(described_class.agent_heartbeat_connections(worker_mode: "poll", agent_activity_slots: 4)).to eq(0)
     end
   end
 end


### PR DESCRIPTION
## Problem

Temporal-orchestrated agent runs were intermittently failing with **`could not obtain a connection from the pool`** (an `OPERATIONAL_FAILURE_KEYWORDS` match in `AgentRun`), more frequently as concurrency grew.

Root cause: `RunAgentActivity#with_periodic_heartbeat` spawns a **heartbeat worker thread** that streams agent output to the DB on every chunk (`Containers::Provision#log_output`) and therefore holds its own connection for the *entire* run — concurrently with the activity's main thread (which queries the DB each heartbeat via `check_infinite_loop!`). So **each in-flight agent run consumes two connections**, but `Paid::TemporalWorkerConfig.min_required_db_pool` budgeted only one per activity slot. With several agent runs executing at once, the temporal worker's pool was undersized and ran dry.

In this devcontainer the gap was concrete: `DB_POOL=10`, `TEMPORAL_WORKER_MODE` defaulting to `both` → real minimum is **20**, so the worker booted under-provisioned.

## Changes

- **`lib/paid/temporal_worker_config.rb`** — add `agent_heartbeat_connections` and fold it into `min_required_db_pool`, so agent activity slots count two connections each (agent/both modes only; poll activities never run `RunAgentActivity`). Worst-case (all agent slots running `RunAgentActivity`) is treated as the minimum — a safe over-estimate; pool size is a ceiling with lazy checkout, so idle connection count is unchanged.
- **`bin/temporal_worker`** — the under-provisioning check now **auto-corrects** the primary pool at boot (rebuilds the named `HashConfig`, refreshes `ActiveRecord::Base.configurations` so the size isn't silently reverted on a later reconnect-by-name, and re-establishes the connection). It exits fatally only if the resize fails. Logs prominently that this raises the process's connection count and that server `max_connections` must cover the sum across processes.
- **`app/temporal/activities/run_agent_activity.rb`** — document *why* the heartbeat worker holds its connection for the whole run (per-chunk streaming writes + per-connection tenant RLS context), so the scope isn't narrowed into pool thrash later.
- **`.devcontainer/compose.yaml`** — raise dev Postgres `max_connections` 100 → 200. The single container is shared by Temporal, the app, GoodJob, the temporal worker, and every active git worktree's DBs; raising the per-process pool without raising the server ceiling would just trade pool-timeout errors for server-side `too many clients`. *(Separate commit; production sets this at its own DB layer.)*
- **Docs** — sync the pool-sizing formula and worked examples across `WORKER_POOL_TUNING.md`, `SCALING.md`, and `docs/runbooks/scaling.md`, plus the server-side ceiling note.

## Testing

- `spec/lib/paid/temporal_worker_config_spec.rb` updated/extended (agent=16, both=23, poll=7); 11 examples, 0 failures.
- Auto-correct mechanism verified live against the running database: live pool resized 10 → 20, registry consistent, queries succeed, and the size survives a reconnect-by-name.
- `bin/lint --changed` clean; pre-commit hooks pass.

## Review

Self-reviewed plus an independent review pass. Fixed: deprecated `db_config#pool` on the load-bearing verification (now `connection_pool.size`), a stale `configurations` registry footgun, and out-of-date sizing docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)