### PR TITLE
fix(clarifying-questions): make answer round-trip work for GitHub App projects

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -474,6 +474,20 @@ class Project < ApplicationRecord
     trusted_github_author_logins.include?(login.downcase)
   end
 
+  # True when +login+ is this project's own GitHub App bot identity
+  # (e.g. "paid-agents[bot]"). Returns false for PAT-backed projects, which
+  # have no bot identity. Use ONLY to re-admit Paid's own structured marker
+  # comments (enhancement questions, clarifying answers) that Paid authored as
+  # the bot — never to trust arbitrary bot comments as human input, which is
+  # why #trusted_github_user? deliberately excludes the bot. The bot login is
+  # unspoofable: only Paid's GitHub App can author content as it.
+  def paid_bot_author?(login)
+    return false if login.blank?
+
+    bot_login = github_author_login
+    bot_login.present? && login.downcase == bot_login.downcase
+  end
+
   # Returns the effective token limit per agent run at the project/account level.
   # Resolution: project override → account default.
   # NOTE: For full resolution (including user settings and global default),

--- a/app/services/clarifying_questions/clear_needs_input.rb
+++ b/app/services/clarifying_questions/clear_needs_input.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module ClarifyingQuestions
+  # Clears an issue's "needs input" marker once its clarifying questions have
+  # been answered: removes the needs-input label on GitHub and resets
+  # paid_state so the "Answer Questions" button disappears and the issue
+  # re-enters the pipeline.
+  #
+  # Idempotent (a no-op unless the issue is currently awaiting input) and
+  # best-effort: a GitHub failure is logged but still updates local state, and
+  # the next sync reconciles the label via
+  # FetchIssuesActivity#detect_needs_input_label_removals. The label removed is
+  # the enhancement needs-input label (what EnhanceIssueActivity adds and what
+  # Issue#needs_input? checks), not the no-output label.
+  class ClearNeedsInput
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(project:, issue:)
+      @project = project
+      @issue = issue
+    end
+
+    def call
+      return unless issue.needs_input?
+
+      label = project.enhance_issue_needs_input_label_name
+      remove_label(label)
+      issue.update!(paid_state: "new", labels: Array(issue.labels) - [ label ])
+    end
+
+    private
+
+    attr_reader :project, :issue
+
+    def remove_label(label)
+      project.client&.remove_label_from_issue(project.full_name, issue.github_number, label)
+    rescue GithubClient::Error => e
+      Rails.logger.warn(
+        message: "clarifying_questions.remove_needs_input_label_failed",
+        issue_number: issue.github_number,
+        label: label,
+        error: e.message
+      )
+    end
+  end
+end

--- a/app/services/clarifying_questions/comment_admission.rb
+++ b/app/services/clarifying_questions/comment_admission.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module ClarifyingQuestions
+  # Decides whether a GitHub issue comment may enter the clarifying-questions
+  # flow. Admits trusted human collaborators OR Paid's own enhancement/answer
+  # marker comments authored by the project's GitHub App bot — app-backed
+  # projects post those as the bot, which Project#trusted_github_user?
+  # deliberately excludes as an untrusted prompt-injection channel.
+  #
+  # Scoped to clarifying questions only: it never broadens the comment trust
+  # used for arbitrary conversation in prompts (see
+  # Prompts::BuildForIssue.fetch_trusted_comments). Safe because the bot login
+  # is unspoofable — only Paid's GitHub App can author content as it — and the
+  # admitted content originates from Paid itself (LLM-generated questions, or
+  # answers submitted by an authenticated operator with update access).
+  module CommentAdmission
+    module_function
+
+    def admissible?(project:, comment:)
+      login = comment.user&.login
+      project.trusted_github_user?(login) || paid_marker_comment?(project, login, comment)
+    end
+
+    def paid_marker_comment?(project, login, comment)
+      return false unless project.paid_bot_author?(login)
+
+      body = comment.body.to_s
+      body.include?(Parse::ENHANCEMENT_MARKER) || body.include?(Load::ANSWER_MARKER)
+    end
+  end
+end

--- a/app/services/clarifying_questions/ingest_answers.rb
+++ b/app/services/clarifying_questions/ingest_answers.rb
@@ -74,12 +74,8 @@ module ClarifyingQuestions
     def issue_comments
       @issue_comments ||= begin
         comments = @injected_comments || github_client.issue_comments(project.full_name, issue.github_number)
-        comments.select { |comment| trusted_comment?(comment) }
+        comments.select { |comment| CommentAdmission.admissible?(project: project, comment: comment) }
       end
-    end
-
-    def trusted_comment?(comment)
-      project.trusted_github_user?(comment.user&.login)
     end
 
     def parse_answers(body)

--- a/app/services/clarifying_questions/load.rb
+++ b/app/services/clarifying_questions/load.rb
@@ -104,8 +104,8 @@ module ClarifyingQuestions
     # knowledge base and clear the issue's needs-input marker so the stale
     # "Answer Questions" button disappears. Returns [] (no pending questions).
     def reconcile_answered
-      ingest_answers
-      ClearNeedsInput.call(project: project, issue: issue)
+      ingested = ingest_answers
+      ClearNeedsInput.call(project: project, issue: issue) if ingested
       []
     end
 

--- a/app/services/clarifying_questions/load.rb
+++ b/app/services/clarifying_questions/load.rb
@@ -20,10 +20,7 @@ module ClarifyingQuestions
         return body_questions unless github_available?
 
         enhancement_comment = latest_enhancement_comment
-        if answered_after_latest_questions?(body_questions:, enhancement_comment:)
-          ingest_answers
-          return []
-        end
+        return reconcile_answered if answered_after_latest_questions?(body_questions:, enhancement_comment:)
 
         return body_questions
       end
@@ -31,10 +28,7 @@ module ClarifyingQuestions
       return [] unless github_available?
 
       enhancement_comment = latest_enhancement_comment
-      if answered_after_latest_questions?(body_questions:, enhancement_comment:)
-        ingest_answers
-        return []
-      end
+      return reconcile_answered if answered_after_latest_questions?(body_questions:, enhancement_comment:)
       return [] unless enhancement_comment
 
       Parse.call(comment_body: comment_body(enhancement_comment))
@@ -103,11 +97,16 @@ module ClarifyingQuestions
 
     def issue_comments
       @issue_comments ||= project.client.issue_comments(project.full_name, issue.github_number)
-        .select { |comment| trusted_comment?(comment) }
+        .select { |comment| CommentAdmission.admissible?(project: project, comment: comment) }
     end
 
-    def trusted_comment?(comment)
-      project.trusted_github_user?(comment.user&.login)
+    # The clarifying questions have been answered: ingest the answers into the
+    # knowledge base and clear the issue's needs-input marker so the stale
+    # "Answer Questions" button disappears. Returns [] (no pending questions).
+    def reconcile_answered
+      ingest_answers
+      ClearNeedsInput.call(project: project, issue: issue)
+      []
     end
 
     def ingest_answers

--- a/app/services/clarifying_questions/submit_answers.rb
+++ b/app/services/clarifying_questions/submit_answers.rb
@@ -16,8 +16,9 @@ module ClarifyingQuestions
 
     def call
       validate_answers!
-      client = github_client
-      client.add_comment(project.full_name, issue.github_number, formatted_comment)
+      result = github_client.add_comment(project.full_name, issue.github_number, formatted_comment)
+      ClearNeedsInput.call(project: project, issue: issue)
+      result
     end
 
     private
@@ -50,7 +51,7 @@ module ClarifyingQuestions
     end
 
     def github_client
-      project.github_token&.client
+      project.client
     end
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -689,6 +689,17 @@ RSpec.describe Project do
         expect(project.trusted_github_user?(bot_login)).to be false
       end
 
+      it "identifies the app bot as Paid's own author for marker re-admission" do
+        expect(project.paid_bot_author?(bot_login)).to be true
+        expect(project.paid_bot_author?(bot_login.upcase)).to be true
+      end
+
+      it "does not treat allowlisted humans or others as the Paid bot" do
+        expect(project.paid_bot_author?("viamin")).to be false
+        expect(project.paid_bot_author?("attacker")).to be false
+        expect(project.paid_bot_author?(nil)).to be false
+      end
+
       it "still trusts allowlisted humans for both comments and authorship" do
         expect(project.trusted_github_user?("viamin")).to be true
         expect(project.trusted_github_author?("viamin")).to be true
@@ -705,6 +716,10 @@ RSpec.describe Project do
       it "does not trust the bot as either author or commenter" do
         expect(project.trusted_github_author?(bot_login)).to be false
         expect(project.trusted_github_user?(bot_login)).to be false
+      end
+
+      it "has no Paid bot identity to re-admit (returns false)" do
+        expect(project.paid_bot_author?(bot_login)).to be false
       end
     end
   end

--- a/spec/requests/projects/clarifying_questions_spec.rb
+++ b/spec/requests/projects/clarifying_questions_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe "Projects::ClarifyingQuestions" do
   describe "POST /projects/:project_id/issues/:issue_id/clarifying_questions" do
     before do
       allow(github_client).to receive(:add_comment).and_return(double(html_url: "https://github.com/test"))
+      allow(github_client).to receive(:remove_label_from_issue)
     end
 
     context "when all answers are provided" do
@@ -86,6 +87,23 @@ RSpec.describe "Projects::ClarifyingQuestions" do
         expect(response).to redirect_to(project_path(project))
         follow_redirect!
         expect(response.body).to include("Answers posted to GitHub issue")
+      end
+
+      it "clears the needs-input marker so the Answer Questions button disappears" do
+        needs_input_label = project.enhance_issue_needs_input_label_name
+
+        post project_issue_clarifying_questions_path(project, issue), params: {
+          questions: [ "What is the expected behavior?", "Should this be behind a flag?" ],
+          answers: [ "X is a feature", "Yes, by default" ]
+        }
+
+        expect(github_client).to have_received(:remove_label_from_issue).with(
+          project.full_name, issue.github_number, needs_input_label
+        )
+        issue.reload
+        expect(issue.paid_state).to eq("new")
+        expect(issue.needs_input?).to be false
+        expect(issue.labels).not_to include(needs_input_label)
       end
     end
 

--- a/spec/services/clarifying_questions/clear_needs_input_spec.rb
+++ b/spec/services/clarifying_questions/clear_needs_input_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ClarifyingQuestions::ClearNeedsInput, :no_db do
+  let(:github_client) { instance_double(GithubClient, remove_label_from_issue: nil) }
+  let(:project) do
+    double(
+      client: github_client,
+      full_name: "paid/app",
+      enhance_issue_needs_input_label_name: "paid-needs-input"
+    )
+  end
+  let(:issue) do
+    double(
+      github_number: 1964,
+      needs_input?: true,
+      labels: [ "paid-needs-input", "P2" ],
+      update!: true
+    )
+  end
+
+  describe ".call" do
+    it "removes the needs-input label on GitHub" do
+      described_class.call(project: project, issue: issue)
+
+      expect(github_client).to have_received(:remove_label_from_issue).with(
+        "paid/app", 1964, "paid-needs-input"
+      )
+    end
+
+    it "resets paid_state and drops the label locally" do
+      described_class.call(project: project, issue: issue)
+
+      expect(issue).to have_received(:update!).with(paid_state: "new", labels: [ "P2" ])
+    end
+
+    context "when the issue is not awaiting input" do
+      let(:issue) { double(needs_input?: false) }
+
+      it "is a no-op" do
+        described_class.call(project: project, issue: issue)
+
+        expect(github_client).not_to have_received(:remove_label_from_issue)
+      end
+    end
+
+    context "when the project has no GitHub client" do
+      before { allow(project).to receive(:client).and_return(nil) }
+
+      it "still resets local state" do
+        described_class.call(project: project, issue: issue)
+
+        expect(issue).to have_received(:update!).with(paid_state: "new", labels: [ "P2" ])
+      end
+    end
+
+    context "when removing the GitHub label fails" do
+      before do
+        allow(github_client).to receive(:remove_label_from_issue)
+          .and_raise(GithubClient::Error.new("boom"))
+      end
+
+      it "logs and still resets local state" do
+        described_class.call(project: project, issue: issue)
+
+        expect(issue).to have_received(:update!).with(paid_state: "new", labels: [ "P2" ])
+      end
+    end
+  end
+end

--- a/spec/services/clarifying_questions/comment_admission_spec.rb
+++ b/spec/services/clarifying_questions/comment_admission_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ClarifyingQuestions::CommentAdmission, :no_db do
+  let(:project) do
+    double.tap do |p|
+      allow(p).to receive(:trusted_github_user?) { |login| login == "viamin" }
+      allow(p).to receive(:paid_bot_author?) { |login| login == "paid-agents[bot]" }
+    end
+  end
+
+  def comment(login:, body:)
+    double(user: double(login: login), body: body)
+  end
+
+  describe ".admissible?" do
+    it "admits comments from trusted humans regardless of content" do
+      c = comment(login: "viamin", body: "just a normal comment")
+      expect(described_class.admissible?(project: project, comment: c)).to be true
+    end
+
+    it "rejects comments from untrusted humans" do
+      c = comment(login: "attacker", body: "hello")
+      expect(described_class.admissible?(project: project, comment: c)).to be false
+    end
+
+    it "admits the app bot's enhancement marker comment" do
+      c = comment(login: "paid-agents[bot]", body: "<!-- paid:enhance-issue -->\n## Clarifying questions")
+      expect(described_class.admissible?(project: project, comment: c)).to be true
+    end
+
+    it "admits the app bot's clarifying-answers marker comment" do
+      c = comment(login: "paid-agents[bot]", body: "<!-- paid:clarifying-answers -->\n**A1:** yes")
+      expect(described_class.admissible?(project: project, comment: c)).to be true
+    end
+
+    it "rejects the app bot's non-marker comments (general bot chatter)" do
+      c = comment(login: "paid-agents[bot]", body: "Opened a pull request for this issue.")
+      expect(described_class.admissible?(project: project, comment: c)).to be false
+    end
+
+    it "rejects a spoofed marker from an untrusted human (unspoofable bot login required)" do
+      c = comment(login: "attacker", body: "<!-- paid:clarifying-answers -->\n**A1:** malicious")
+      expect(described_class.admissible?(project: project, comment: c)).to be false
+    end
+
+    it "handles a missing comment author" do
+      c = double(user: nil, body: "<!-- paid:clarifying-answers -->")
+      expect(described_class.admissible?(project: project, comment: c)).to be false
+    end
+  end
+end

--- a/spec/services/clarifying_questions/load_spec.rb
+++ b/spec/services/clarifying_questions/load_spec.rb
@@ -304,6 +304,7 @@ RSpec.describe ClarifyingQuestions::Load, :no_db do
           created_at: 1.minute.ago
         )
         allow(github_client).to receive(:issue_comments).and_return([ answers_comment ])
+        allow(ClarifyingQuestions::IngestAnswers).to receive(:call).and_return(true)
       end
 
       it "self-heals the stale needs-input marker so the button disappears" do
@@ -347,6 +348,8 @@ RSpec.describe ClarifyingQuestions::Load, :no_db do
       end
 
       it "logs and still returns an empty array" do
+        expect(ClarifyingQuestions::ClearNeedsInput).not_to receive(:call)
+
         expect(described_class.call(project: project, issue: issue)).to eq([])
 
         expect(logger).to have_received(:warn).with(
@@ -355,6 +358,37 @@ RSpec.describe ClarifyingQuestions::Load, :no_db do
             issue_id: 42
           )
         )
+      end
+    end
+
+    context "when answer ingestion returns nil (no qa pairs ingested)" do
+      before do
+        enhancement_comment = double(
+          body: comment_body,
+          user: double(login: trusted_login),
+          created_at: 2.minutes.ago
+        )
+        answers_comment = double(
+          body: <<~COMMENT,
+            <!-- paid:clarifying-answers -->
+
+            ## Clarifying question answers
+
+            **Q1: What is the expected behavior?**
+            **A1:** Use the wizard flow.
+          COMMENT
+          user: double(login: trusted_login),
+          created_at: 1.minute.ago
+        )
+
+        allow(github_client).to receive(:issue_comments).and_return([ enhancement_comment, answers_comment ])
+        allow(ClarifyingQuestions::IngestAnswers).to receive(:call).and_return(nil)
+      end
+
+      it "does not clear needs_input so the issue stays blocked" do
+        expect(ClarifyingQuestions::ClearNeedsInput).not_to receive(:call)
+
+        expect(described_class.call(project: project, issue: issue)).to eq([])
       end
     end
 

--- a/spec/services/clarifying_questions/load_spec.rb
+++ b/spec/services/clarifying_questions/load_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe ClarifyingQuestions::Load, :no_db do
       id: 42,
       body: issue_body,
       github_number: 1964,
-      github_updated_at: 2.minutes.ago
+      github_updated_at: 2.minutes.ago,
+      needs_input?: false
     )
   end
   let(:comment_body) do
@@ -37,6 +38,7 @@ RSpec.describe ClarifyingQuestions::Load, :no_db do
   before do
     allow(github_client).to receive(:issue_comments).and_return([])
     allow(project).to receive(:trusted_github_user?) { |login| login == trusted_login }
+    allow(project).to receive(:paid_bot_author?).and_return(false)
   end
 
   describe ".call" do
@@ -240,6 +242,74 @@ RSpec.describe ClarifyingQuestions::Load, :no_db do
 
       it "ignores the spoofed answers marker" do
         expect(described_class.call(project: project, issue: issue)).to eq([ "What is the expected behavior?" ])
+      end
+    end
+
+    context "when the answers marker is authored by the project's GitHub App bot" do
+      let(:bot_login) { "paid-agents[bot]" }
+      let(:issue_body) do
+        <<~COMMENT
+          <!-- paid:enhance-issue -->
+
+          ## Clarifying questions
+          1. What is the expected behavior?
+        COMMENT
+      end
+
+      before do
+        allow(project).to receive(:paid_bot_author?) { |login| login == bot_login }
+
+        answers_comment = double(
+          body: <<~COMMENT,
+            <!-- paid:clarifying-answers -->
+
+            ## Clarifying question answers
+
+            **Q1: What is the expected behavior?**
+            **A1:** Use the wizard flow.
+          COMMENT
+          user: double(login: bot_login),
+          created_at: 1.minute.ago
+        )
+
+        allow(github_client).to receive(:issue_comments).and_return([ answers_comment ])
+      end
+
+      it "treats the questions as answered (the bot answer comment is honored)" do
+        expect(described_class.call(project: project, issue: issue)).to eq([])
+      end
+    end
+
+    context "when the questions have been answered" do
+      let(:issue_body) do
+        <<~COMMENT
+          <!-- paid:enhance-issue -->
+
+          ## Clarifying questions
+          1. What is the expected behavior?
+        COMMENT
+      end
+
+      before do
+        answers_comment = double(
+          body: <<~COMMENT,
+            <!-- paid:clarifying-answers -->
+
+            ## Clarifying question answers
+
+            **Q1: What is the expected behavior?**
+            **A1:** Use the wizard flow.
+          COMMENT
+          user: double(login: trusted_login),
+          created_at: 1.minute.ago
+        )
+        allow(github_client).to receive(:issue_comments).and_return([ answers_comment ])
+      end
+
+      it "self-heals the stale needs-input marker so the button disappears" do
+        expect(ClarifyingQuestions::ClearNeedsInput).to receive(:call).with(project: project, issue: issue)
+
+        expect(described_class.call(project: project, issue: issue)).to eq([])
       end
     end
 

--- a/spec/services/clarifying_questions/submit_answers_spec.rb
+++ b/spec/services/clarifying_questions/submit_answers_spec.rb
@@ -4,16 +4,16 @@ require "rails_helper"
 
 RSpec.describe ClarifyingQuestions::SubmitAnswers, :no_db do
   let(:github_client) { instance_double(GithubClient) }
-  let(:github_token) { double(client: github_client) }
   let(:project) do
     double(
-      github_token: github_token,
+      client: github_client,
       full_name: "paid/app"
     )
   end
   let(:issue) do
     double(
-      github_number: 1964
+      github_number: 1964,
+      needs_input?: false
     )
   end
 
@@ -125,7 +125,7 @@ RSpec.describe ClarifyingQuestions::SubmitAnswers, :no_db do
 
     context "when GitHub access is not configured" do
       before do
-        allow(project).to receive(:github_token).and_return(nil)
+        allow(project).to receive(:client).and_return(nil)
       end
 
       it "raises ArgumentError before attempting to post" do
@@ -138,6 +138,61 @@ RSpec.describe ClarifyingQuestions::SubmitAnswers, :no_db do
         }.to raise_error(ArgumentError, /GitHub access is not configured/)
 
         expect(github_client).not_to have_received(:add_comment)
+      end
+    end
+
+    context "when the issue is awaiting input" do
+      let(:issue) do
+        double(
+          github_number: 1964,
+          needs_input?: true,
+          labels: [ "paid-needs-input", "P2" ]
+        )
+      end
+
+      before do
+        allow(project).to receive(:enhance_issue_needs_input_label_name).and_return("paid-needs-input")
+        allow(github_client).to receive(:remove_label_from_issue)
+        allow(issue).to receive(:update!)
+      end
+
+      it "removes the needs-input label on GitHub after posting answers" do
+        described_class.call(
+          project: project,
+          issue: issue,
+          questions_and_answers: [ { question: "Q1?", answer: "A1" } ]
+        )
+
+        expect(github_client).to have_received(:remove_label_from_issue).with(
+          project.full_name, issue.github_number, "paid-needs-input"
+        )
+      end
+
+      it "resets paid_state and drops the label locally so the button disappears" do
+        described_class.call(
+          project: project,
+          issue: issue,
+          questions_and_answers: [ { question: "Q1?", answer: "A1" } ]
+        )
+
+        expect(issue).to have_received(:update!).with(
+          paid_state: "new", labels: [ "P2" ]
+        )
+      end
+
+      it "still clears state when GitHub label removal fails" do
+        allow(github_client).to receive(:remove_label_from_issue)
+          .and_raise(GithubClient::Error.new("boom"))
+
+        described_class.call(
+          project: project,
+          issue: issue,
+          questions_and_answers: [ { question: "Q1?", answer: "A1" } ]
+        )
+
+        expect(issue).to have_received(:update!).with(
+          paid_state: "new", labels: [ "P2" ]
+        )
       end
     end
   end


### PR DESCRIPTION
## Problem

On GitHub **App-backed** projects, the clarifying-questions flow was broken end to end:

1. Submitting answers raised **"GitHub access is not configured for this project."** — `SubmitAnswers` only honored a PAT (`project.github_token`), ignoring the App installation.
2. Even once posted, the answers were **filtered out**: Paid posts the enhancement (questions) and answers comments as the `paid-agents[bot]` identity, which the human allowlist (`Project#trusted_github_user?`) deliberately excludes — so they never reached the next agent run.
3. After answering, the **"Answer Questions" button lingered** on the issues list and errored with *"No clarifying questions found"* on click, because the `needs_input` state/label was never cleared.

## Fix

- **GitHub auth:** `SubmitAnswers` resolves the client via `project.client` (PAT *or* App installation token).
- **Trust round-trip:** new `Project#paid_bot_author?` + `ClarifyingQuestions::CommentAdmission` re-admit Paid's own marker-bearing comments authored by the **unspoofable** app bot, scoped to the clarifying-questions flow only. The prompt-builder's comment trust (`fetch_trusted_comments`) is **unchanged** — answers reach the agent via the knowledge-artifact path (`IngestAnswers`), not as raw conversation.
- **Stale button:** new `ClarifyingQuestions::ClearNeedsInput` clears the `needs_input` marker (label on GitHub + `paid_state`) once questions are answered. It runs on submit and **self-heals already-answered issues** when `Load` reconciles them. The no-output `needs_input` case (issues that never had questions) is left untouched, so they aren't wrongly re-queued.

## Security

`CommentAdmission` admits a comment only if it's from a trusted human **or** carries a Paid marker AND is authored by the project's app-bot login (which only Paid's GitHub App can produce). Spoofed markers from untrusted users are still rejected (covered by spec).

## Verification

Confirmed against live data (project 21, issue #12):
```
BEFORE: paid_state="needs_input" needs_input?=true  labels=["paid-needs-input","P2"]
AFTER:  paid_state="new"         needs_input?=false labels=["P2"]
```

Tests: **544 examples, 0 failures** across the affected specs; RuboCop clean. New specs for `CommentAdmission` (incl. spoofing), `ClearNeedsInput` (incl. GitHub-failure / nil-client), `Load` self-heal, and an end-to-end request-spec assertion.

## Out of scope

Issues marked `needs_input` by a *no-output run* (never had questions) still show the "Answer Questions" button — the button text is wrong for that state. That's a separate UX/labeling concern, not the stale-marker bug fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)