### PR TITLE
chore: remove accidentally-committed worktree gitlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,9 @@ spec/.examples.txt
 # Ignore agent workspace directory (used for Docker container testing)
 /agent-workspace/
 
+# Local git worktrees (per-developer scratch checkouts; never tracked)
+/.worktrees/
+
 # Session-specific working memory (ephemeral, per-developer)
 WORKLOG.md
 


### PR DESCRIPTION
## What

`.worktrees/pr1925` was committed into `main` as a **gitlink** (mode `160000`) back in #1925, when a local git worktree directory got accidentally staged. It is **not** a configured submodule (there is no `.gitmodules`), and the commit it references (`7c470c9a2`) no longer exists in the repo — so it showed up as a permanently-"deleted" path in `git status` once the worktree directory was cleaned up.

## Change

- Remove the stray gitlink `.worktrees/pr1925`.
- Add `/.worktrees/` to `.gitignore` so per-developer worktree checkouts (the convention used in this repo) can never be tracked again.

No code or runtime behavior is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)