### PR TITLE
chore(dev): reap orphaned worktree databases to prevent connection exhaustion

### DIFF
--- a/bin/dev-update
+++ b/bin/dev-update
@@ -354,9 +354,30 @@ stop_overmind() {
   fi
 }
 
+# Drop databases left behind by removed git worktrees. bin/setup creates a
+# worktree's databases via bin/ensure-worktree-databases but nothing reaps them
+# when the worktree goes away, so they accumulate and exhaust Postgres
+# connection slots. Best-effort: a prune failure must never abort an auto-update,
+# so it runs inside an `if` (which the ERR trap ignores) and only logs warnings.
+prune_worktree_databases() {
+  log "Pruning orphaned worktree databases..."
+  local output
+  if output="$(bin/prune-worktree-databases --force 2>&1)"; then
+    log_command_output "prune-worktree-databases" "$output"
+  else
+    log "Warning: prune-worktree-databases failed; continuing with update."
+    log_command_output "prune-worktree-databases" "$output"
+  fi
+}
+
 run_setup() {
   log "Running bin/setup --skip-server..."
-  STARTUP_CLEANUP_KILL_ALL="$STARTUP_CLEANUP_KILL_ALL" bin/setup --skip-server
+  local status=0
+  STARTUP_CLEANUP_KILL_ALL="$STARTUP_CLEANUP_KILL_ALL" bin/setup --skip-server || status=$?
+  # Mirror bin/setup's worktree-database creation by reaping orphans, but only
+  # after a clean setup — the DB is in a known-good state and Ruby is available.
+  [ "$status" -eq 0 ] && prune_worktree_databases
+  return "$status"
 }
 
 start_dev() {

--- a/bin/prune-worktree-databases
+++ b/bin/prune-worktree-databases
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Drops PostgreSQL databases left behind by removed git worktrees.
+#
+# Worktree databases are created on demand by bin/ensure-worktree-databases
+# (paid_development / paid_development_cable / paid_test plus a branch-derived
+# suffix), but nothing drops them when the worktree goes away. They accumulate
+# and consume connection slots against the shared dev Postgres, which surfaces
+# as "remaining connection slots are reserved" and stalls agent runs.
+#
+# This reaps any worktree-suffixed paid database whose git worktree no longer
+# exists. The keep set is computed by re-running the exact name derivation in
+# Paid::WorktreeDatabaseNames for every live `git worktree`, so the canonical
+# base databases and any in-use worktree databases are always preserved.
+#
+# The tool fails closed: if the live-worktree set cannot be derived, it refuses
+# to drop anything rather than risk deleting an in-use database.
+#
+# Usage:
+#   bin/prune-worktree-databases            # dry run: list what would be dropped
+#   bin/prune-worktree-databases --force    # actually drop them
+set -euo pipefail
+
+APP_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$APP_ROOT" || exit 1
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  bin/prune-worktree-databases            # dry run: list what would be dropped
+  bin/prune-worktree-databases --force    # actually drop them
+USAGE
+}
+
+FORCE=0
+for arg in "$@"; do
+  case "$arg" in
+    --force|-f) FORCE=1 ;;
+    --dry-run|-n) FORCE=0 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: ${arg@Q}" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+# Canonical databases that must never be dropped, independent of the live
+# worktree derivation. This is a safety floor: even if the derivation returns a
+# partial set, the four base databases stay protected.
+readonly BASE_DATABASES=(paid_development paid_development_cable paid_test paid_test_cable)
+
+# Worktree databases are created from sanitized identifiers (letters, digits,
+# underscores) by bin/ensure-worktree-databases. Anything outside that charset
+# is not a database this tool created, so it is never dropped — which also
+# closes SQL-identifier injection through datname into the DROP statement.
+readonly SAFE_IDENTIFIER='^[A-Za-z0-9_]+$'
+
+# Databases that belong to a live worktree (including the main checkout's base
+# names). Derived by the same module bin/ensure-worktree-databases uses, so the
+# names match exactly — including the 63-char truncation of long suffixes.
+# Exits non-zero (and prints nothing) if git or Ruby fails, so the caller can
+# fail closed.
+keep_names() {
+  ruby <<'RUBY'
+require File.expand_path("config/worktree_database_names", Dir.pwd)
+require "open3"
+
+bases = %w[paid_development paid_development_cable paid_test paid_test_cable]
+out, status = Open3.capture2("git", "worktree", "list", "--porcelain")
+abort "git worktree list failed" unless status.success?
+
+roots = out.lines.filter_map do |line|
+  line.start_with?("worktree ") ? line.split(" ", 2)[1].strip : nil
+end
+abort "no git worktrees found" if roots.empty?
+
+names = roots.flat_map do |root|
+  bases.map { |base| Paid::WorktreeDatabaseNames.database_name(base, app_root: root) }
+end
+
+puts names.uniq
+RUBY
+}
+
+# Admin connection resolution, mirroring bin/ensure-worktree-databases: prefer
+# explicit admin creds, then the devcontainer's postgres superuser.
+APP_DB_HOST="${DB_HOST:-postgres}"
+ADMIN_DB_USER="${DB_ADMIN_USERNAME:-${POSTGRES_USER:-postgres}}"
+ADMIN_DB_PASSWORD="${DB_ADMIN_PASSWORD:-${POSTGRES_PASSWORD:-postgres}}"
+ADMIN_DB_HOST="${DB_ADMIN_HOST:-$APP_DB_HOST}"
+MAINTENANCE_DB="${DB_ADMIN_DATABASE:-postgres}"
+
+admin_psql() {
+  PGPASSWORD="$ADMIN_DB_PASSWORD" psql -h "$ADMIN_DB_HOST" -U "$ADMIN_DB_USER" \
+    -d "$MAINTENANCE_DB" -v ON_ERROR_STOP=1 -q --no-align --tuples-only "$@"
+}
+
+# Candidate databases plus their active connection counts, in one round trip.
+# Rows: "datname|active_connections". The bare base names (paid_development,
+# paid_test) never match the trailing-underscore pattern, and non-worktree
+# databases (e.g. paid_migfix_dev) do not share the prefix, so both are excluded
+# structurally; the base *_cable names match but are protected by the keep set.
+candidate_rows() {
+  admin_psql -c "SELECT d.datname, count(a.pid)
+                 FROM pg_database d
+                 LEFT JOIN pg_stat_activity a ON a.datname = d.datname
+                 WHERE d.datname LIKE 'paid\_development\_%'
+                    OR d.datname LIKE 'paid\_test\_%'
+                 GROUP BY d.datname
+                 ORDER BY d.datname"
+}
+
+# Build the keep set, failing closed. A failure here (git/Ruby error) must never
+# collapse the safelist to empty and escalate into dropping in-use databases.
+if ! keep_output="$(keep_names)"; then
+  echo "ERROR: failed to derive live worktree databases (git or Ruby error)." >&2
+  echo "Refusing to prune so in-use databases are never dropped." >&2
+  exit 1
+fi
+
+declare -A KEEP_SET=()
+kept=0
+while IFS= read -r name; do
+  [[ -z "$name" ]] && continue
+  KEEP_SET["$name"]=1
+  kept=$((kept + 1))
+done <<<"$keep_output"
+
+if [[ "$kept" -eq 0 ]]; then
+  echo "ERROR: live worktree derivation returned no databases; refusing to prune." >&2
+  exit 1
+fi
+
+# Safety floor: protect the canonical base databases unconditionally.
+for name in "${BASE_DATABASES[@]}"; do KEEP_SET["$name"]=1; done
+
+if ! cand_output="$(candidate_rows)"; then
+  echo "ERROR: could not query candidate databases from PostgreSQL." >&2
+  exit 1
+fi
+
+REAP=()
+declare -A REAP_CONNS=()
+while IFS='|' read -r db conns; do
+  [[ -z "$db" ]] && continue
+  [[ -n "${KEEP_SET[$db]:-}" ]] && continue
+  if [[ ! "$db" =~ $SAFE_IDENTIFIER ]]; then
+    echo "Skipping unrecognized database name (not created by this tool): ${db@Q}" >&2
+    continue
+  fi
+  REAP+=("$db")
+  REAP_CONNS["$db"]="$conns"
+done <<<"$cand_output"
+
+echo "Live worktree databases kept: ${kept}"
+if [[ "${#REAP[@]}" -eq 0 ]]; then
+  echo "No orphaned worktree databases found. Nothing to prune."
+  exit 0
+fi
+
+echo "Orphaned worktree databases to drop: ${#REAP[@]}"
+for db in "${REAP[@]}"; do
+  echo "  - ${db} (${REAP_CONNS[$db]} active connection(s))"
+done
+
+if [[ "$FORCE" -ne 1 ]]; then
+  echo
+  echo "Dry run. Re-run with --force to drop the databases above."
+  exit 0
+fi
+
+echo
+dropped=0
+failed=0
+for db in "${REAP[@]}"; do
+  if admin_psql -c "DROP DATABASE IF EXISTS \"$db\" WITH (FORCE)" >/dev/null; then
+    echo "Dropped ${db}"
+    dropped=$((dropped + 1))
+  else
+    echo "FAILED to drop ${db}" >&2
+    failed=$((failed + 1))
+  fi
+done
+
+echo "Done. Dropped ${dropped}/${#REAP[@]} orphaned worktree database(s)."
+if [[ "$failed" -gt 0 ]]; then
+  echo "${failed} database(s) could not be dropped." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Why

Recent agent runs were timing out. Root cause was PostgreSQL **connection-slot exhaustion** on the shared dev Postgres: worktree databases are created on demand by `bin/ensure-worktree-databases` (`paid_development` / `_cable` / `_test` plus a branch-derived suffix) but **nothing drops them when the worktree goes away**. They accumulated (70+ orphans observed) and, combined with Temporal's own ~67 connections, pushed total usage to the `max_connections` ceiling.

When the `paid` app can't get a connection, the agent heartbeat-writer thread can't stream output, runs hang well past their `time_limit` (one ran ~10h against a 3600s cap), and the stale detector — also starved — only sweeps them much later. Confirmed fingerprint over 7 days: 12 runs failed with `remaining connection slots are reserved`, 23 swept as `Stale run detected`, 8 overran the time limit by >2×.

## What

- **`bin/prune-worktree-databases`** (new) — derives the keep set by re-running the exact `Paid::WorktreeDatabaseNames` derivation for every live `git worktree`, then drops any `paid_(development|test)*` database not in that set. Dry-run by default; `--force` to drop.
- **`bin/dev-update`** — wires a best-effort prune into `run_setup` (the seam both full-restart paths flow through), gated on a clean `bin/setup`, so paid auto-updates reap orphans as the mirror of setup creating them. ERR-trap-safe: a prune failure never aborts an update.

## Safety

- **Fails closed**: if the live-worktree set can't be derived (git/Ruby error), it aborts and drops nothing rather than risk deleting an in-use database. An unconditional base-DB safety floor protects the four canonical databases regardless.
- **Identifier validation**: every reap candidate is checked against the creation charset (`^[A-Za-z0-9_]+$`) before any `DROP`, closing SQL-identifier injection via `datname`; unrecognized names are skipped with a warning.
- Candidate connection counts are fetched in a single query (no per-DB `psql` fan-out).

## Testing

ShellCheck-clean. Manually verified:
- Dry-run lists orphans with connection counts; `--force` drops only orphans.
- Base DBs (`paid_development`, `paid_test`, `*_cable`) and non-worktree DBs (`paid_migfix_dev*`) always survive.
- **Fail-closed**: with `git` forced to fail, the run aborts (exit 1) and drops nothing — planted orphan + base DBs all survive.
- A hyphenated candidate name is skipped, not dropped.

> Note: the underlying capacity fix (devcontainer `max_connections=200`) already shipped in #2484 — this PR removes the source of the pressure so it doesn't creep back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)