### PR TITLE
fix(devcontainer): stabilize tool installs for non-root setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,7 +32,7 @@ RUN set -e; \
   && . /etc/os-release \
   && printf 'Types: deb\nURIs: https://apt.postgresql.org/pub/repos/apt\nSuites: %s-pgdg\nArchitectures: %s\nComponents: main\nSigned-By: /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc\n' "$VERSION_CODENAME" "$(dpkg --print-architecture)" > /etc/apt/sources.list.d/pgdg.sources \
   && apt-get update -qq \
-  && apt-get install -y build-essential cmake shellcheck tmux libpq-dev postgresql-client-16=16.14-1.pgdg12+1 \
+  && apt-get install -y build-essential cmake python3-pip shellcheck tmux libpq-dev postgresql-client-16=16.14-1.pgdg12+1 \
   && rm -rf /var/lib/apt/lists/*
 
 # Install chromium separately for better layer caching (updates more frequently)

--- a/scripts/install-from-contract.sh
+++ b/scripts/install-from-contract.sh
@@ -16,6 +16,120 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+LOCAL_BIN_DIR="${HOME}/.local/bin"
+LOCAL_SHARE_DIR="${HOME}/.local/share"
+export PATH="${LOCAL_BIN_DIR}:${PATH}"
+
+ensure_user_local_dirs() {
+  mkdir -p "$LOCAL_BIN_DIR" "$LOCAL_SHARE_DIR"
+}
+
+path_is_writable_or_creatable() {
+  local path="$1"
+  local parent_dir
+
+  if [ -e "$path" ]; then
+    [ -w "$path" ]
+    return
+  fi
+
+  parent_dir="$(dirname "$path")"
+  [ -d "$parent_dir" ] && [ -w "$parent_dir" ]
+}
+
+prefer_user_local_path() {
+  local path="$1"
+  local fallback_path
+
+  case "$path" in
+    /usr/local/bin/*)
+      fallback_path="${LOCAL_BIN_DIR}/$(basename "$path")"
+      ;;
+    /opt/uv/tools)
+      fallback_path="${LOCAL_SHARE_DIR}/uv/tools"
+      ;;
+    /opt/uv/python)
+      fallback_path="${LOCAL_SHARE_DIR}/uv/python"
+      ;;
+    /opt/cursor-agent)
+      fallback_path="${LOCAL_SHARE_DIR}/cursor-agent"
+      ;;
+    *)
+      printf '%s\n' "$path"
+      return
+  esac
+
+  if path_is_writable_or_creatable "$path"; then
+    printf '%s\n' "$path"
+    return
+  fi
+
+  ensure_user_local_dirs
+  printf '%s\n' "$fallback_path"
+}
+
+rewrite_install_command_for_user_paths() {
+  local command="$1"
+
+  if [ ! -w /usr/local/bin ]; then
+    command="${command//\/usr\/local\/bin/${LOCAL_BIN_DIR}}"
+  fi
+
+  if [ ! -w /opt ]; then
+    command="${command//\/opt\/uv\/tools/${LOCAL_SHARE_DIR}\/uv\/tools}"
+    command="${command//\/opt\/uv\/python/${LOCAL_SHARE_DIR}\/uv\/python}"
+  fi
+
+  printf '%s\n' "$command"
+}
+
+rewrite_uv_command_if_needed() {
+  local command="$1"
+
+  if command -v uv > /dev/null 2>&1; then
+    printf '%s\n' "$command"
+    return
+  fi
+
+  if python3 -m uv --help > /dev/null 2>&1; then
+    command="${command// uv tool install/ python3 -m uv tool install}"
+  fi
+
+  printf '%s\n' "$command"
+}
+
+rewrite_pip_command_if_needed() {
+  local command="$1"
+
+  if python3 -m pip --version > /dev/null 2>&1; then
+    printf '%s\n' "$command"
+    return
+  fi
+
+  if command -v pip3 > /dev/null 2>&1; then
+    command="${command//python3 -m pip/pip3}"
+  fi
+
+  printf '%s\n' "$command"
+}
+
+ensure_pip_available() {
+  if python3 -m pip --version > /dev/null 2>&1; then
+    return
+  fi
+
+  if command -v pip3 > /dev/null 2>&1; then
+    return
+  fi
+
+  if python3 -m ensurepip --upgrade > /dev/null 2>&1; then
+    return
+  fi
+
+  echo "ERROR: Python pip is required for uv_tool providers." >&2
+  echo "Rebuild the devcontainer image so python3-pip is installed, then rerun the postCreateCommand." >&2
+  exit 1
+}
 
 # Wait for bundle install to complete before calling bundle exec.
 # In devcontainer postCreateCommand, entries run in parallel, so bin/setup
@@ -61,14 +175,17 @@ if [ -n "$ARTIFACT_URL" ]; then
   fi
 
   echo "Installing $PROVIDER via artifact (SHA256 verified)"
-  mkdir -p /tmp/cursor-install /opt/cursor-agent "$(dirname "$GLOBAL_PATH")"
+  INSTALL_ROOT=$(prefer_user_local_path /opt/cursor-agent)
+  GLOBAL_PATH=$(prefer_user_local_path "$GLOBAL_PATH")
+
+  mkdir -p /tmp/cursor-install "$INSTALL_ROOT" "$(dirname "$GLOBAL_PATH")"
   curl -fsSL "$ARTIFACT_URL" -o /tmp/cursor-artifact.tar.gz
   echo "$ARTIFACT_SHA256  /tmp/cursor-artifact.tar.gz" | sha256sum -c -
   tar -xzf /tmp/cursor-artifact.tar.gz -C /tmp
-  cp -R /tmp/dist-package/. /opt/cursor-agent/
-  test -f "/opt/cursor-agent/$BINARY_NAME"
-  chmod +x "/opt/cursor-agent/$BINARY_NAME"
-  ln -sf "/opt/cursor-agent/$BINARY_NAME" "$GLOBAL_PATH"
+  cp -R /tmp/dist-package/. "$INSTALL_ROOT/"
+  test -f "$INSTALL_ROOT/$BINARY_NAME"
+  chmod +x "$INSTALL_ROOT/$BINARY_NAME"
+  ln -sf "$INSTALL_ROOT/$BINARY_NAME" "$GLOBAL_PATH"
   rm -rf /tmp/cursor-artifact.tar.gz /tmp/dist-package
   echo "$PROVIDER installed at $GLOBAL_PATH"
 else
@@ -99,6 +216,10 @@ else
       exit 1
     fi
     echo "Installing $PROVIDER via uv_tool"
+    ensure_pip_available
+    INSTALL_COMMAND=$(rewrite_install_command_for_user_paths "$INSTALL_COMMAND")
+    INSTALL_COMMAND=$(rewrite_pip_command_if_needed "$INSTALL_COMMAND")
+    INSTALL_COMMAND=$(rewrite_uv_command_if_needed "$INSTALL_COMMAND")
     eval "$INSTALL_COMMAND"
     ;;
 


### PR DESCRIPTION
## Summary
- install `python3-pip` in the devcontainer image so `uv_tool` providers can bootstrap reliably
- keep contract-owned install paths when they are writable, but fall back to user-local paths for non-root devcontainer installs
- add clearer pip and uv bootstrap handling so first-run failures are actionable instead of cryptic

## Verification
- `bash -n scripts/install-from-contract.sh`
- `shellcheck scripts/install-from-contract.sh`
- `bash scripts/install-from-contract.sh cursor`
- `bash scripts/install-from-contract.sh aider`