### PR TITLE
fix(agent-runs): cancel orphaned queued runs when their issue is resolved

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -1627,17 +1627,19 @@ class AgentRun < ApplicationRecord
     end
   end
 
-  def cancel!
+  def cancel!(error: nil)
     with_lock do
       reload
       if finished?
         false
       else
-        update!(
+        attributes = {
           status: "cancelled",
           completed_at: Time.current,
           duration_seconds: duration
-        )
+        }
+        attributes[:error_message] = error if error
+        update!(attributes)
       end
     end
   end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -63,6 +63,7 @@ class Issue < ApplicationRecord
   after_update_commit :broadcast_changed_sections
   after_update_commit :enqueue_newly_unblocked_dependents, if: :github_just_closed?
   after_update_commit :enqueue_self_if_became_auto_pick_eligible, if: :auto_pick_recheck_needed?
+  after_update_commit :cancel_orphaned_queued_runs, if: :work_no_longer_needed?
   after_commit :update_project_last_github_activity_at, on: [ :create, :update ]
 
   scope :by_paid_state, ->(state) { where(paid_state: state) }
@@ -530,6 +531,45 @@ class Issue < ApplicationRecord
 
   def github_just_closed?
     saved_change_to_github_state? && github_state == "closed"
+  end
+
+  # An issue that just finished (paid_state -> completed) or was closed on
+  # GitHub will never need the agent runs still sitting unclaimed in its queue:
+  # those runs target work that is already done. Nothing else cancels them, so
+  # they leak as permanently "queued" rows (observed: create_pr runs stuck 17+
+  # days, each also holding a unique-active-run slot for its issue).
+  def work_no_longer_needed?
+    (saved_change_to_paid_state? && paid_state == "completed") || github_just_closed?
+  end
+
+  # Cancel only unclaimed runs (no Temporal workflow yet) — claimed/running
+  # runs are mid-flight and handled by the normal lifecycle. Reviews are
+  # PR-scoped rather than issue-scoped, so they keep their own retry/limit
+  # handling and are left alone.
+  def cancel_orphaned_queued_runs
+    reason = "Issue resolved (paid_state=#{paid_state}, github_state=#{github_state}); " \
+             "unclaimed queued run no longer needed"
+
+    agent_runs.waiting.where.not(goal: "review").find_each do |run|
+      next unless run.cancel!(error: reason)
+
+      Rails.logger.info(
+        message: "agent_run.cancelled_issue_resolved",
+        issue_id: id,
+        issue_number: github_number,
+        project_id: project_id,
+        agent_run_id: run.id,
+        goal: run.goal,
+        paid_state: paid_state
+      )
+    rescue => e
+      Rails.logger.error(
+        message: "agent_run.cancel_orphaned_failed",
+        issue_id: id,
+        agent_run_id: run.id,
+        error: e.message
+      )
+    end
   end
 
   def enqueue_newly_unblocked_dependents

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -551,7 +551,19 @@ class Issue < ApplicationRecord
              "unclaimed queued run no longer needed"
 
     agent_runs.waiting.where.not(goal: "review").find_each do |run|
-      next unless run.cancel!(error: reason)
+      # Re-check under the row lock: AgentRun.claim_next_queued_run can claim
+      # this run (status still "queued", temporal_workflow_id -> CLAIMED_SENTINEL)
+      # in the window between the scope query and here. cancel! only guards on
+      # finished?, so without this check we would mark a just-claimed run
+      # cancelled while its workflow/container start up — the exact orphan this
+      # callback exists to prevent. Skip it; the normal lifecycle owns it now.
+      cancelled = run.with_lock do
+        next false unless run.status == "queued" && run.temporal_workflow_id.nil?
+
+        run.cancel!(error: reason)
+      end
+
+      next unless cancelled
 
       Rails.logger.info(
         message: "agent_run.cancelled_issue_resolved",

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -496,6 +496,68 @@ RSpec.describe Issue do
     end
   end
 
+  describe "cancelling orphaned queued runs when work is no longer needed" do
+    it "cancels an unclaimed queued run when the issue becomes completed" do
+      issue = create(:issue, paid_state: "in_progress", github_state: "open")
+      run = create(:agent_run, project: issue.project, issue: issue, goal: "create_pr",
+                              status: "queued", temporal_workflow_id: nil)
+
+      issue.update!(paid_state: "completed")
+
+      expect(run.reload.status).to eq("cancelled")
+      expect(run.error_message).to include("Issue resolved")
+    end
+
+    it "cancels an unclaimed queued run when the issue is closed on GitHub" do
+      issue = create(:issue, paid_state: "in_progress", github_state: "open")
+      run = create(:agent_run, project: issue.project, issue: issue, goal: "create_pr",
+                              status: "queued", temporal_workflow_id: nil)
+
+      issue.update!(github_state: "closed")
+
+      expect(run.reload.status).to eq("cancelled")
+    end
+
+    it "leaves claimed queued runs alone (a Temporal workflow owns them)" do
+      issue = create(:issue, paid_state: "in_progress", github_state: "open")
+      run = create(:agent_run, project: issue.project, issue: issue, goal: "create_pr",
+                              status: "queued", temporal_workflow_id: "workflow-123")
+
+      issue.update!(paid_state: "completed")
+
+      expect(run.reload.status).to eq("queued")
+    end
+
+    it "leaves running runs alone" do
+      issue = create(:issue, paid_state: "in_progress", github_state: "open")
+      run = create(:agent_run, :running, project: issue.project, issue: issue, goal: "create_pr")
+
+      issue.update!(paid_state: "completed")
+
+      expect(run.reload.status).to eq("running")
+    end
+
+    it "leaves review-goal runs alone (PR-scoped, not issue-scoped)" do
+      issue = create(:issue, paid_state: "in_progress", github_state: "open")
+      run = create(:agent_run, project: issue.project, issue: issue, goal: "review",
+                              source_pull_request_number: 42, status: "queued", temporal_workflow_id: nil)
+
+      issue.update!(paid_state: "completed")
+
+      expect(run.reload.status).to eq("queued")
+    end
+
+    it "does not touch queued runs on unrelated paid_state transitions" do
+      issue = create(:issue, paid_state: "new", github_state: "open")
+      run = create(:agent_run, project: issue.project, issue: issue, goal: "create_pr",
+                              status: "queued", temporal_workflow_id: nil)
+
+      issue.update!(paid_state: "in_progress")
+
+      expect(run.reload.status).to eq("queued")
+    end
+  end
+
   describe "instance methods" do
     describe "#github_url" do
       it "returns the GitHub issue URL for issues" do

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -528,6 +528,16 @@ RSpec.describe Issue do
       expect(run.reload.status).to eq("queued")
     end
 
+    it "leaves a run that was just claimed (sentinel workflow id) alone" do
+      issue = create(:issue, paid_state: "in_progress", github_state: "open")
+      run = create(:agent_run, project: issue.project, issue: issue, goal: "create_pr",
+                              status: "queued", temporal_workflow_id: AgentRun::CLAIMED_SENTINEL)
+
+      issue.update!(paid_state: "completed")
+
+      expect(run.reload.status).to eq("queued")
+    end
+
     it "leaves running runs alone" do
       issue = create(:issue, paid_state: "in_progress", github_state: "open")
       run = create(:agent_run, :running, project: issue.project, issue: issue, goal: "create_pr")


### PR DESCRIPTION
## Problem

Unclaimed queued agent runs (`status=queued`, `temporal_workflow_id IS NULL`) leak forever when their issue is completed or closed by other means before the run is ever claimed. Nothing cancels them, so they pile up as permanently `queued` rows.

Found while investigating the "Superseded by newer run" failures (a resolved one-time bulk cleanup of a stuck queue). The live remnant: **10 `create_pr` runs queued 4–17 days** (oldest `05-19`), all for issues already `paid_state='completed'` (most `github_state='closed'`). Each also holds a `(project_id, issue_id, goal)` unique-active-run slot, and this is the same backlog dynamic that fed the larger queue-drain incident.

The stale detector only sweeps **claimed** runs (`stale_claimed = queued.where.not(temporal_workflow_id: nil)`), so never-claimed queued runs were covered by nothing.

## Fix

Address it at the source rather than adding another timeout-based sweep: when an issue becomes resolved, cancel its dead queued work.

- **`Issue#cancel_orphaned_queued_runs`** — `after_update_commit`, gated on `work_no_longer_needed?` (`paid_state -> completed`, or closed on GitHub). Cancels only `waiting` runs (no Temporal workflow); claimed/running runs are left to the normal lifecycle. **Review goals are PR-scoped, not issue-scoped**, so they're excluded and keep their own retry/limit handling.
- **`AgentRun#cancel!`** gains an optional `error:` (mirroring `timeout!`) to record the cancellation reason. Backward compatible — all existing callers pass no args.

Cancelled runs get status `cancelled` (not `failed`), keeping failure metrics clean.

## Testing

- 6 new `issue_spec` examples: cancels on completion and on GitHub close; leaves claimed, running, and review runs alone; ignores unrelated transitions. Full `issue_spec` (202) and `agent_run_spec` `cancel` (12) green; RuboCop clean.
- Backfilled the 10 existing leaked runs through the same `cancel!` path in the dev DB; **0 orphaned and 0 stale (>3d) queued runs remain.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)