### PR TITLE
fix(containers): enforce startup timeout from an authoritative clock (#2502)

### DIFF
--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -40,12 +40,6 @@ module Containers
     # transport error as a timeout. Kept small to avoid false reclassification.
     DOCKER_TIMEOUT_SKEW_TOLERANCE = 0.5
 
-    # How often (seconds) the startup heartbeat thread touches the host-side
-    # heartbeat file before the agent produces its first stdout. Must be well
-    # below DEFAULT_AGENT_STARTUP_TIMEOUT / DEFAULT_*_IDLE_TIMEOUT so a fresh
-    # touch is always visible to the watchdog before either timer fires.
-    STARTUP_HEARTBEAT_INTERVAL_SECONDS = 30
-
     # Base error for all container service errors
     class Error < StandardError; end
 
@@ -109,7 +103,7 @@ module Containers
       :container, :mutex, :output_received_ref, :last_activity_ref,
       :exec_completed_ref, :timeout_reason_setter,
       :startup_timeout, :idle_timeout, :wall_clock_timeout, :started_at_ref,
-      :heartbeat_path, :startup_heartbeat_expired_ref,
+      :heartbeat_path,
       keyword_init: true
     )
 
@@ -386,11 +380,9 @@ module Containers
       exec_completed = false
       timeout_reason = nil # :startup, :idle, or :wall_clock, set by watchdog
       timeout_reason_ref = -> { timeout_reason }
-      startup_heartbeat_expired = false
       abort_matched_output = nil # set when an abort_pattern matches stderr
       stdout_abort_buffer = +""
       watchdog = nil
-      startup_heartbeat = nil
       streaming_event_processor = build_streaming_event_processor(command)
       streaming_abort_triggered = false
       streaming_abort_event_type = nil
@@ -419,17 +411,11 @@ module Containers
         idle_timeout: idle_timeout,
         wall_clock_timeout: timeout,
         started_at_ref: -> { started_at },
-        heartbeat_path: heartbeat_path,
-        startup_heartbeat_expired_ref: -> { startup_heartbeat_expired }
+        heartbeat_path: heartbeat_path
       )
 
       begin
         watchdog = start_watchdog(watchdog_ctx)
-        if startup_timeout
-          startup_heartbeat = start_startup_heartbeat(
-            watchdog_mutex, -> { output_received }, -> { exec_completed }, startup_timeout
-          ) { watchdog_mutex.synchronize { startup_heartbeat_expired = true } }
-        end
 
         exec_result = backend.exec_in_container(container, cmd_array, **exec_options) do |stream_type, chunk|
           watchdog_mutex.synchronize do
@@ -682,7 +668,6 @@ module Containers
       ensure
         watchdog_mutex.synchronize { exec_completed = true }
         stop_watchdog(watchdog)
-        stop_startup_heartbeat(startup_heartbeat)
         # Persist turn metrics even on error paths so partial progress is recorded.
         safe_flush_streaming_metrics(streaming_event_processor)
         if cleanup_steps&.any?
@@ -2527,19 +2512,10 @@ module Containers
         [ now - last_activity_at, now - tc.started_at ]
       end
 
-      # Fold in heartbeat activity using the same rules as the watchdog:
-      # a file touched during the current exec counts as output, and the
-      # startup/idle elapsed window shrinks to the heartbeat's age.
-      # A fresh heartbeat also suppresses wall-clock timeout.
-      heartbeat_fresh = heartbeat_age && heartbeat_age <= elapsed_since_start
-      if heartbeat_fresh
-        output_received = true
-        elapsed_since_activity = heartbeat_age if heartbeat_age < elapsed_since_activity
-      end
-
-      # Check startup/idle before wall-clock to match the watchdog's precedence —
-      # more specific timeouts take priority over the catch-all wall-clock.
-      if !output_received && tc.startup_timeout && elapsed_since_activity >= tc.startup_timeout
+      # Startup is enforced from the authoritative wall clock (elapsed_since_start),
+      # never shrunk by heartbeat freshness — matching the watchdog. A no-output
+      # run past startup_timeout is a stuck startup regardless of the heartbeat file.
+      if !output_received && tc.startup_timeout && elapsed_since_start >= tc.startup_timeout
         raise StartupTimeoutError.new(
           "No output received within #{tc.startup_timeout} seconds",
           diagnostics: timeout_diagnostics_from_elapsed(
@@ -2550,7 +2526,19 @@ module Containers
             heartbeat_age
           )
         )
-      elsif output_received && tc.idle_timeout && elapsed_since_activity >= tc.idle_timeout
+      end
+
+      # Fold in heartbeat activity for idle/wall-clock using the same rules as
+      # the watchdog: a file touched during the current exec counts as output,
+      # and the idle elapsed window shrinks to the heartbeat's age. A fresh
+      # heartbeat also suppresses wall-clock timeout.
+      heartbeat_fresh = heartbeat_age && heartbeat_age <= elapsed_since_start
+      if heartbeat_fresh
+        output_received = true
+        elapsed_since_activity = heartbeat_age if heartbeat_age < elapsed_since_activity
+      end
+
+      if output_received && tc.idle_timeout && elapsed_since_activity >= tc.idle_timeout
         raise IdleTimeoutError.new(
           "No output received for #{tc.idle_timeout} seconds after last activity",
           diagnostics: timeout_diagnostics_from_elapsed(
@@ -2630,36 +2618,38 @@ module Containers
                 false
               else
                 now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-                elapsed = now - ctx.last_activity_ref.call
                 total_elapsed = now - ctx.started_at_ref.call
                 output_received = ctx.output_received_ref.call
 
-                # A heartbeat file touched during the current exec counts as
-                # activity equivalent to stdout output, so a working-but-silent
-                # agent does not trip startup/idle timeouts. A fresh heartbeat
-                # also suppresses wall-clock timeout — actively working agents
-                # (making tool calls) should never be killed by time limits alone.
-                # Cost and token limits serve as the primary execution ceiling.
-                #
-                # However, when the startup heartbeat has expired and the agent
-                # never produced real output, the heartbeat file is stale — its
-                # mtime just reflects the last startup-heartbeat touch, not real
-                # agent activity. Treating it as fresh would add a full
-                # idle_timeout window on top of the startup_timeout, doubling
-                # the actual wait vs what is reported/configured.
-                heartbeat_fresh = heartbeat_age && heartbeat_age <= total_elapsed
-                startup_hb_expired = ctx.startup_heartbeat_expired_ref&.call
-                if heartbeat_fresh && !(startup_hb_expired && !output_received)
-                  output_received = true
-                  elapsed = heartbeat_age if heartbeat_age < elapsed
-                end
-
-                reason = if !output_received && ctx.startup_timeout && elapsed >= ctx.startup_timeout
+                # The startup timeout is enforced from a single authoritative
+                # clock: if no real stdout/stderr has been received within
+                # startup_timeout of exec start, the agent is stuck in startup
+                # and is killed now. Heartbeat-file freshness must NOT extend
+                # this window — a file kept fresh past startup_timeout (or one
+                # that only goes stale much later) previously suppressed the
+                # :startup decision for up to the wall-clock cap, then fired it
+                # with a huge elapsed still labeled "within startup_timeout".
+                reason = if !output_received && ctx.startup_timeout && total_elapsed >= ctx.startup_timeout
                   :startup
-                elsif output_received && ctx.idle_timeout && elapsed >= ctx.idle_timeout
-                  :idle
-                elsif ctx.wall_clock_timeout && total_elapsed >= ctx.wall_clock_timeout && !heartbeat_fresh
-                  :wall_clock
+                else
+                  # Once real output flows (or the agent is actively touching the
+                  # heartbeat file), a fresh heartbeat counts as activity: it
+                  # suppresses idle timeout and, for actively-working agents,
+                  # wall-clock timeout. A heartbeat touched during the current
+                  # exec has age <= total_elapsed; one left over from before
+                  # exec started does not and is ignored.
+                  elapsed = now - ctx.last_activity_ref.call
+                  heartbeat_fresh = heartbeat_age && heartbeat_age <= total_elapsed
+                  if heartbeat_fresh
+                    output_received = true
+                    elapsed = heartbeat_age if heartbeat_age < elapsed
+                  end
+
+                  if output_received && ctx.idle_timeout && elapsed >= ctx.idle_timeout
+                    :idle
+                  elsif ctx.wall_clock_timeout && total_elapsed >= ctx.wall_clock_timeout && !heartbeat_fresh
+                    :wall_clock
+                  end
                 end
 
                 if reason
@@ -2805,55 +2795,6 @@ module Containers
       unless watchdog.join(1)
         log_system("container.watchdog.zombie", message: "Watchdog thread did not terminate within 1s")
       end
-    end
-
-    # Periodically touches the host-side heartbeat file until the agent produces
-    # its first stdout or the exec completes. Prevents the startup timeout from
-    # firing during Claude's silent MCP initialization phase (e.g. Playwright or
-    # other repo-local MCP servers starting before the first tool call).
-    # Only active when the heartbeat file is accessible on the host filesystem —
-    # returns nil for remote/volume-backed backends where heartbeat_host_path is nil.
-    #
-    # The thread runs for at most +startup_timeout+ seconds. After that, the
-    # heartbeat file goes stale (no more touches) and the optional
-    # +on_expired+ block is called so the watchdog can distinguish a stale
-    # startup heartbeat from a genuinely active agent. This lets the startup
-    # timeout fire promptly instead of waiting an additional idle_timeout
-    # window.
-    def start_startup_heartbeat(mutex, output_received_ref, exec_completed_ref, startup_timeout, &on_expired)
-      host_path = heartbeat_host_path
-      return nil unless host_path.present?
-
-      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + startup_timeout
-
-      Thread.new do
-        loop do
-          if Process.clock_gettime(Process::CLOCK_MONOTONIC) >= deadline
-            log_system("container.startup_heartbeat.deadline_reached",
-              startup_timeout: startup_timeout,
-              message: "Agent produced no output within startup_timeout; startup timeout will fire")
-            on_expired&.call
-            break
-          end
-          break if mutex.synchronize { exec_completed_ref.call || output_received_ref.call }
-          FileUtils.touch(host_path) rescue nil
-          sleep startup_heartbeat_interval_seconds
-        end
-      end
-    end
-
-    def stop_startup_heartbeat(thread)
-      return unless thread&.alive?
-
-      thread.kill
-      unless thread.join(1)
-        log_system("container.startup_heartbeat.zombie",
-          message: "Startup heartbeat thread did not terminate within 1s")
-      end
-    end
-
-    def startup_heartbeat_interval_seconds
-      STARTUP_HEARTBEAT_INTERVAL_SECONDS
     end
 
     # Simple result object for method returns

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -2880,12 +2880,41 @@ RSpec.describe Containers::Provision do
         expect(container_stopped.true?).to be false
       end
 
-      it "suppresses startup timeout while heartbeat file is touched before any output" do
-        allow(mock_container).to receive(:exec) do |_cmd, **_opts, &block|
-          10.times do
-            FileUtils.touch(heartbeat_path)
-            sleep 0.05
+      it "does not suppress startup timeout when a fresh heartbeat has no real output (regression #2502)" do
+        # A heartbeat file kept continuously fresh while the agent produces NO
+        # stdout/stderr must NOT extend the startup window. The authoritative
+        # clock fires :startup at ~startup_timeout regardless of heartbeat
+        # freshness — previously this suppressed startup for up to the
+        # wall-clock cap, then mislabeled the kill as "within startup_timeout".
+        allow(mock_container).to receive(:exec) do |_cmd, **_opts, &_block|
+          Timeout.timeout(5) do
+            until container_stopped.true?
+              FileUtils.touch(heartbeat_path)
+              sleep 0.01
+            end
           end
+          [ [], [], 137 ]
+        end
+
+        expect {
+          service.execute(
+            "waiting_on_llm",
+            timeout: 10,
+            startup_timeout: 0.2,
+            heartbeat_path: heartbeat_path
+          )
+        }.to raise_error(described_class::StartupTimeoutError) do |error|
+          # Fired from the authoritative clock near startup_timeout, nowhere
+          # near the 10s wall-clock cap.
+          expect(error.diagnostics[:elapsed_seconds]).to be < 1
+        end
+      end
+
+      it "does not fire startup when output arrives after a silent delay within startup_timeout" do
+        # Preserves the legitimate "silent MCP init then produces output" case:
+        # output before startup_timeout keeps the run alive.
+        allow(mock_container).to receive(:exec) do |_cmd, **_opts, &block|
+          sleep 0.2
           block.call(:stdout, "finally output\n") if block
           [ [ "finally output\n" ], [], 0 ]
         end
@@ -2893,7 +2922,7 @@ RSpec.describe Containers::Provision do
         result = service.execute(
           "waiting_on_llm",
           timeout: 10,
-          startup_timeout: 0.2,
+          startup_timeout: 1.0,
           heartbeat_path: heartbeat_path
         )
         expect(result).to be_success
@@ -3013,92 +3042,35 @@ RSpec.describe Containers::Provision do
       end
     end
 
-    context "with startup heartbeat thread" do
-      before do
-        allow(service).to receive(:startup_heartbeat_interval_seconds).and_return(0.01)
-      end
-
-      it "prevents startup timeout during silent MCP initialization by touching heartbeat_host_path" do
-        host_path = service.heartbeat_host_path
-        skip "startup heartbeat only active when heartbeat_host_path is set" unless host_path.present?
-
-        allow(mock_container).to receive(:exec) do |_cmd, **_opts, &block|
-          # Simulate ~0.4s silent startup (MCP init) before producing output.
-          # startup_timeout (1.0s) is long enough to cover the silent period,
-          # and the startup heartbeat keeps the idle timeout from firing.
-          sleep 0.4
-          block.call(:stdout, "finally started\n") if block
-          [ [ "finally started\n" ], [], 0 ]
+    context "with startup timeout enforced from the authoritative clock" do
+      it "labels a no-output run that also blew past wall-clock as startup, not wall-clock" do
+        # Defect #2 from issue #2502: :startup must take precedence so a no-output
+        # run is never mislabeled wall_clock. The long poll interval forces the
+        # first evaluation to happen after BOTH deadlines have elapsed, proving
+        # startup wins regardless of ordering.
+        allow(service).to receive(:watchdog_poll_interval).and_return(10)
+        allow(mock_container).to receive(:exec) do |_cmd, **_opts, &_block|
+          sleep 0.25
+          [ [], [], 0 ]
         end
 
-        result = service.execute(
-          "claude_with_mcp",
-          timeout: 10,
-          startup_timeout: 1.0,
-          heartbeat_path: host_path
-        )
-        expect(result).to be_success
-        expect(container_stopped.true?).to be false
+        expect {
+          service.execute("hung_no_output", timeout: 0.2, startup_timeout: 0.1)
+        }.to raise_error(described_class::StartupTimeoutError)
       end
 
-      it "stops touching once first stdout is received, allowing idle timeout to apply normally" do
-        host_path = service.heartbeat_host_path
-        skip "startup heartbeat only active when heartbeat_host_path is set" unless host_path.present?
-
+      it "applies idle timeout normally once first output is received" do
+        # After real output, the run is no longer in the startup window; a
+        # subsequent stall trips the idle timeout (not startup).
         allow(mock_container).to receive(:exec) do |_cmd, **_opts, &block|
           block.call(:stdout, "initial output\n") if block
-          # Simulate long idle after first output — idle timeout should fire
           Timeout.timeout(5) { sleep 0.01 until container_stopped.true? }
           [ [ "initial output\n" ], [], 137 ]
         end
 
         expect {
-          service.execute(
-            "claude_then_idle",
-            timeout: 10,
-            startup_timeout: 2,
-            idle_timeout: 0.1,
-            heartbeat_path: host_path
-          )
+          service.execute("then_idle", timeout: 10, startup_timeout: 2, idle_timeout: 0.1)
         }.to raise_error(described_class::IdleTimeoutError)
-      end
-
-      it "fires startup timeout after startup_timeout deadline elapses with no output" do
-        host_path = service.heartbeat_host_path
-        skip "startup heartbeat only active when heartbeat_host_path is set" unless host_path.present?
-
-        allow(mock_container).to receive(:exec) do |_cmd, **_opts, &_block|
-          # Never produces output — simulates a completely hung MCP initialization.
-          Timeout.timeout(5) { sleep 0.01 until container_stopped.true? }
-          [ [], [], 137 ]
-        end
-
-        # When no output is received, the startup timeout fires promptly after
-        # the startup heartbeat deadline passes — no additional idle_timeout
-        # window is added.
-        expect {
-          service.execute(
-            "claude_mcp_hung",
-            timeout: 10,
-            startup_timeout: 0.2,
-            idle_timeout: 0.1,
-            heartbeat_path: host_path
-          )
-        }.to raise_error(described_class::StartupTimeoutError)
-      end
-
-      it "returns nil from start_startup_heartbeat when heartbeat_host_path is absent" do
-        allow(service).to receive(:heartbeat_host_path).and_return(nil)
-
-        result = service.send(
-          :start_startup_heartbeat,
-          Mutex.new,
-          -> { false },
-          -> { false },
-          1
-        )
-
-        expect(result).to be_nil
       end
     end
   end


### PR DESCRIPTION
Closes #2502

## Problem

Many `create_pr` agent runs ended with `timeout` and `startup_timeout: No output received within 360 seconds`, but their actual wall-clock duration was far longer than 360s — up to **4615s (~77 min)**. **525 of ~1002 (52%) overran the stated 360s**, including a cluster at the 3600s wall-clock cap still labeled `startup_timeout`. While these runs hang they hold a Docker container **and** DB connections, directly amplifying the connection-slot exhaustion tracked in #2500 / #2484 (~112 hours of wasted container + connection time over 14 days).

## Root cause

In the watchdog, the `:startup` decision used a mutable `elapsed` value that heartbeat-file freshness kept shrinking, plus an `output_received` flag the same logic flipped. The freshness check (`heartbeat_age <= total_elapsed`) is not a real freshness check — it just means "touched at some point after exec started," which stays true forever. While the file read fresh, `:startup` was suppressed; when it finally went stale/unreadable, `:startup` fired with a huge `elapsed` but the message still hard-coded "within 360 seconds." Separately, `:startup` was checked before `:wall_clock`, so a no-output run reaching the 3600s cap was mislabeled `startup_timeout`.

## Fix

- **Authoritative startup clock.** The watchdog now fires `:startup` when no real stdout/stderr has been received and `total_elapsed >= startup_timeout`, with **no** heartbeat influence. Heartbeat freshness only feeds the idle / wall-clock branches. Because `effective_startup_timeout = min(idle_timeout, wall_clock)`, a `:startup` always fires at/before the wall-clock cap with an accurate message, and never causes a premature `:idle`.
- **`check_deadline_exceeded!`** mirrors the same authoritative-startup precedence for the exec-returns-between-ticks path.
- **Removed the now-redundant startup heartbeat thread** (`start_startup_heartbeat`, `stop_startup_heartbeat`, `startup_heartbeat_interval_seconds`, the `startup_heartbeat_expired` flag/ref, the `WatchdogContext` field, and the interval constant). It existed only to keep the heartbeat file fresh during startup — which the authoritative clock no longer consults. `heartbeat_host_path` stays (still used for idle-suppression via the agent's PostToolUse hook).

The downstream `claude_silent_startup_heartbeat_failure?` reclassification in `run_agent_activity.rb` still applies — runs now just die at ~`startup_timeout` instead of ~4600s.

## Tests

- New watchdog **regression test**: a continuously-fresh heartbeat with **zero** stdout still fires `StartupTimeoutError` at ~`startup_timeout` (asserts `elapsed_seconds < 1`, nowhere near the 10s wall-clock cap).
- New **label-precedence test** (exercises `check_deadline_exceeded!`): a no-output run past both deadlines raises `StartupTimeoutError`, not `TimeoutError`.
- New silent-delay-then-output test (output before `startup_timeout` => success).
- Removed tests tied to the deleted thread; existing idle / wall-clock heartbeat tests unchanged.
- `bin/rspec spec/services/containers/provision_spec.rb` (201 examples), the `run_agent_activity` reclassification context, and reconnect/heartbeat specs all pass; `bin/rubocop` clean.

## Out of scope

Ask #3 from the issue — investigating *why* so many genuine zero-output `create_pr` runs occur (a possible runner-startup health problem) — warrants its own investigation. Also noted but not addressed: for container-visible (volume-backed) heartbeats the watchdog does a per-poll `docker exec stat`; this fix already cuts that ~12× by killing stuck runs at `startup_timeout` instead of the wall-clock cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)