### PR TITLE
fix(agent-runs): recover rate-limited runs in place so create_pr stops churning

### DIFF
--- a/app/jobs/stale_run_detector_job.rb
+++ b/app/jobs/stale_run_detector_job.rb
@@ -60,6 +60,7 @@ class StaleRunDetectorJob < ApplicationJob
     resolved = 0
     unclaimed = 0
     requeued = 0
+    reactivated = 0
     skipped = 0
     recovered_orphans = 0
 
@@ -107,6 +108,21 @@ class StaleRunDetectorJob < ApplicationJob
       )
     end
 
+    rate_limited_due_runs.find_each do |agent_run|
+      case recover_rate_limited_run(agent_run)
+      when :reactivated
+        reactivated += 1
+      when :exhausted
+        resolved += 1
+      end
+    rescue => e
+      Rails.logger.error(
+        message: "stale_run_detector.resolve_failed",
+        agent_run_id: agent_run.id,
+        error: e.message
+      )
+    end
+
     recovered_orphans = recover_orphaned_in_progress_issues
 
     duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - job_started_at) * 1000).round
@@ -115,12 +131,13 @@ class StaleRunDetectorJob < ApplicationJob
       resolved: resolved,
       unclaimed: unclaimed,
       requeued: requeued,
+      reactivated: reactivated,
       skipped: skipped,
       recovered_orphans: recovered_orphans,
       duration_ms: duration_ms
     )
 
-    ProcessRunQueueJob.perform_later if resolved > 0 || unclaimed > 0 || requeued > 0 || recovered_orphans > 0
+    ProcessRunQueueJob.perform_later if resolved > 0 || unclaimed > 0 || requeued > 0 || reactivated > 0 || recovered_orphans > 0
   end
 
   private
@@ -136,10 +153,22 @@ class StaleRunDetectorJob < ApplicationJob
       .where.not(issue_id: nil)
       .select(:issue_id)
 
+    # Issues with a rate-limited run awaiting in-place re-queue are NOT orphaned:
+    # recover_rate_limited_run reactivates them once their recovery window
+    # elapses. rate_limited is not in UNFINISHED_STATUSES, so without this guard
+    # an issue whose run is waiting out a multi-minute circuit-breaker window
+    # would be reset to "new" here and auto-pick would mint a duplicate,
+    # superseding run — the churn this change exists to prevent.
+    awaiting_recovery_issue_ids = AgentRun.rate_limited
+      .where.not(rate_limited_until: nil)
+      .where.not(issue_id: nil)
+      .select(:issue_id)
+
     count = 0
 
     Issue.where(paid_state: "in_progress")
       .where.not(id: active_issue_ids)
+      .where.not(id: awaiting_recovery_issue_ids)
       .where("updated_at < ?", ORPHANED_IN_PROGRESS_AGE.ago)
       .find_each do |issue|
       issue.with_lock do
@@ -171,6 +200,10 @@ class StaleRunDetectorJob < ApplicationJob
   def recoverable_orphaned_issue?(issue)
     return false unless issue.paid_state == "in_progress"
     return false if AgentRun.where(issue: issue, status: AgentRun::UNFINISHED_STATUSES).exists?
+    # A rate-limited run with a recovery time is awaiting in-place re-queue, not
+    # orphaned (defends against a sibling becoming due between the query and the
+    # locked re-check).
+    return false if AgentRun.rate_limited.where(issue: issue).where.not(rate_limited_until: nil).exists?
     return false if orphaned_enhance_issue_recheck?(issue)
 
     true
@@ -212,6 +245,109 @@ class StaleRunDetectorJob < ApplicationJob
   # Runs stuck in "paused" whose pause timestamp is before the threshold.
   def stale_paused_runs(threshold)
     AgentRun.paused.where("paused_at < ?", threshold)
+  end
+
+  # Runs parked in "rate_limited" (runner unavailable / transient infra) whose
+  # recovery window has elapsed. Nothing else re-queues these, so without this
+  # pass "rate_limited" is effectively terminal.
+  def rate_limited_due_runs
+    AgentRun.rate_limited_due
+  end
+
+  # True when another active (queued/running/paused) run already holds either of
+  # this run's unique slots. Mirrors both idx_agent_runs_unique_active_issue and
+  # idx_agent_runs_unique_active_pr — a run can carry both an issue_id and a
+  # source_pull_request_number, so check each present slot independently rather
+  # than only the first.
+  def active_sibling_exists?(agent_run)
+    scope = AgentRun.where(project_id: agent_run.project_id, goal: agent_run.goal,
+      status: AgentRun::UNFINISHED_STATUSES).where.not(id: agent_run.id)
+    return true if agent_run.issue_id && scope.where(issue_id: agent_run.issue_id).exists?
+    return true if agent_run.source_pull_request_number &&
+      scope.where(source_pull_request_number: agent_run.source_pull_request_number).exists?
+
+    false
+  end
+
+  # Re-queues a rate-limited run whose recovery window has passed, in place,
+  # without minting a new run (the existing run keeps the issue's active-run
+  # slot, so no superseding duplicate is created). The run has no live workflow
+  # or container at this point, so no cancellation/cleanup is required.
+  #
+  # Returns :reactivated when re-queued, :exhausted when the requeue budget is
+  # spent (left terminally failed so the problem surfaces), or :skip otherwise.
+  def recover_rate_limited_run(agent_run)
+    agent_run.with_lock do
+      agent_run.reload
+      return :skip unless agent_run.status == "rate_limited"
+      return :skip if agent_run.rate_limited_until.blank? || agent_run.rate_limited_until > Time.current
+
+      if agent_run.stale_requeue_count >= AgentRun::MAX_RATE_LIMITED_REQUEUES
+        agent_run.update!(
+          status: "failed",
+          completed_at: Time.current,
+          error_message: "Runner unavailable: retry limit reached (#{AgentRun::MAX_RATE_LIMITED_REQUEUES}); #{agent_run.error_message}".truncate(500),
+          duration_seconds: agent_run.duration
+        )
+        agent_run.log!("system",
+          "Rate-limited run retry limit reached (#{AgentRun::MAX_RATE_LIMITED_REQUEUES}), staying failed")
+        if (issue = agent_run.issue)
+          # Review-goal failures restore "completed" (the PR work succeeded; only
+          # the review follow-up failed) so auto-pick/PR scanning is not blocked —
+          # consistent with resolve_stale_run and MarkAgentRunFailedActivity.
+          target_state = agent_run.review_goal? ? "completed" : "failed"
+          issue.update!(paid_state: target_state) unless issue.paid_state == target_state
+        end
+        Rails.logger.warn(
+          message: "stale_run_detector.rate_limited_exhausted",
+          agent_run_id: agent_run.id,
+          project_id: agent_run.project_id,
+          stale_requeue_count: agent_run.stale_requeue_count
+        )
+        return :exhausted
+      end
+
+      # If another active run already owns this issue/PR slot
+      # (idx_agent_runs_unique_active_*), re-queuing would violate the unique
+      # index. Leave this run terminally failed; the active sibling carries the
+      # work. Check before updating — a constraint violation here would abort the
+      # surrounding with_lock transaction and prevent in-place recovery.
+      if active_sibling_exists?(agent_run)
+        agent_run.update!(
+          status: "failed",
+          completed_at: Time.current,
+          error_message: "Superseded by another active run during recovery".truncate(500),
+          duration_seconds: agent_run.duration
+        )
+        log_skip(agent_run, "active_sibling_exists")
+        return :skip
+      end
+
+      agent_run.update!(
+        status: "queued",
+        stale_requeue_count: agent_run.stale_requeue_count + 1,
+        stale_skip_count: 0,
+        started_at: nil,
+        completed_at: nil,
+        duration_seconds: nil,
+        rate_limited_until: nil,
+        temporal_workflow_id: nil,
+        temporal_run_id: nil,
+        service_environment: nil,
+        container_id: nil,
+        service_container_ids: []
+      )
+      agent_run.log!("system",
+        "Rate-limited run re-queued by stale run detector " \
+        "(attempt #{agent_run.stale_requeue_count}/#{AgentRun::MAX_RATE_LIMITED_REQUEUES})")
+      Rails.logger.info(
+        message: "stale_run_detector.reactivated_rate_limited_run",
+        agent_run_id: agent_run.id,
+        project_id: agent_run.project_id,
+        stale_requeue_count: agent_run.stale_requeue_count
+      )
+      :reactivated
+    end
   end
 
   # Attempts to unclaim a stale claimed queued run.

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -112,6 +112,11 @@ class AgentRun < ApplicationRecord
   DEFAULT_MAX_TOKENS_PER_RUN = 10_000_000
   MAX_STALE_REQUEUES = 2
   MAX_STALE_SKIPS = 3
+  # Maximum times a run parked in "rate_limited" (runner unavailable / transient
+  # infra) may be re-queued in place before it is left terminally failed.
+  # Reuses the stale_requeue_count column. Higher than MAX_STALE_REQUEUES because
+  # runner-availability windows (rate limits, open circuits) are expected to clear.
+  MAX_RATE_LIMITED_REQUEUES = 5
   CLAIMED_SENTINEL = "claimed"
   SMOKE_TEST_CUSTOM_PROMPT = "smoke_test"
   STALE_CLAIMED_TIMEOUT = 15.minutes
@@ -294,6 +299,12 @@ class AgentRun < ApplicationRecord
   scope :auth_expired, -> { where(status: "auth_expired") }
   scope :paused, -> { where(status: "paused") }
   scope :rate_limited, -> { where(status: "rate_limited") }
+  # Rate-limited runs whose recovery window has elapsed and are therefore due to
+  # be re-queued in place. StaleRunDetectorJob reactivates these — without it,
+  # rate_limited is effectively terminal (no other code path re-queues it).
+  scope :rate_limited_due, ->(now = Time.current) {
+    rate_limited.where.not(rate_limited_until: nil).where(rate_limited_until: ..now)
+  }
   scope :active, -> { where(status: ACTIVE_STATUSES) }
   scope :capacity_inflight, -> { running.or(claimed) }
   scope :finished, -> { where(status: FINISHED_STATUSES) }
@@ -1706,6 +1717,15 @@ class AgentRun < ApplicationRecord
 
   def rate_limited?
     status == "rate_limited"
+  end
+
+  # True when the run is parked in "rate_limited" with a recovery time set,
+  # meaning it is awaiting an in-place re-queue (StaleRunDetectorJob) rather than
+  # being terminally failed. Callers use this to avoid arming issue-level
+  # re-enqueue (which would mint a duplicate, superseding run) while the existing
+  # run is simply waiting for a runner to free up.
+  def recoverable_rate_limited?
+    rate_limited? && rate_limited_until.present?
   end
 
   # Returns true when the container is retained for post-failure diagnostics.

--- a/app/temporal/activities/mark_agent_run_failed_activity.rb
+++ b/app/temporal/activities/mark_agent_run_failed_activity.rb
@@ -34,8 +34,21 @@ module Activities
       # marking it "failed" — the underlying PR work succeeded; only the
       # follow-up review run failed. Using "completed" keeps auto-pick
       # unblocked and lets the scanner re-evaluate the PR on the next cycle.
+      #
+      # Recoverable rate-limited runs (runner unavailable / transient infra,
+      # awaiting an in-place re-queue by StaleRunDetectorJob) keep the issue
+      # "in_progress": flipping it to "failed" would arm the auto-pick re-enqueue
+      # pump and mint a duplicate run that supersedes this one — the churn loop
+      # that caused hundreds of wasted runs per issue.
       if agent_run.issue && agent_run.status.in?(AgentRun::FAILURE_STATUSES)
-        target_state = agent_run.review_goal? ? "completed" : "failed"
+        target_state =
+          if agent_run.recoverable_rate_limited?
+            "in_progress"
+          elsif agent_run.review_goal?
+            "completed"
+          else
+            "failed"
+          end
         if agent_run.issue.paid_state != target_state
           agent_run.issue.update!(paid_state: target_state)
         end

--- a/spec/jobs/stale_run_detector_job_spec.rb
+++ b/spec/jobs/stale_run_detector_job_spec.rb
@@ -643,5 +643,88 @@ RSpec.describe StaleRunDetectorJob do
         described_class.perform_now
       end
     end
+
+    context "with rate-limited runs due for recovery" do
+      let(:project) { create(:project) }
+
+      it "re-queues a rate-limited run whose recovery window has elapsed" do
+        run = create(:agent_run, :rate_limited, rate_limited_until: 1.minute.ago)
+
+        described_class.perform_now
+
+        run.reload
+        expect(run.status).to eq("queued")
+        expect(run.rate_limited_until).to be_nil
+        expect(run.stale_requeue_count).to eq(1)
+      end
+
+      it "does not touch a rate-limited run whose recovery window is in the future" do
+        run = create(:agent_run, :rate_limited, rate_limited_until: 5.minutes.from_now)
+
+        described_class.perform_now
+
+        expect(run.reload.status).to eq("rate_limited")
+      end
+
+      it "leaves the issue in_progress when re-queuing (does not arm re-enqueue)" do
+        issue = create(:issue, :in_progress, project: project)
+        create(:agent_run, :rate_limited, project: project, issue: issue, rate_limited_until: 1.minute.ago)
+
+        described_class.perform_now
+
+        expect(issue.reload.paid_state).to eq("in_progress")
+      end
+
+      it "terminally fails a rate-limited run that exhausts its requeue budget" do
+        issue = create(:issue, :in_progress, project: project)
+        run = create(:agent_run, :rate_limited, project: project, issue: issue,
+          rate_limited_until: 1.minute.ago,
+          stale_requeue_count: AgentRun::MAX_RATE_LIMITED_REQUEUES)
+
+        described_class.perform_now
+
+        expect(run.reload.status).to eq("failed")
+        expect(issue.reload.paid_state).to eq("failed")
+      end
+
+      it "restores the issue to completed (not failed) when an exhausted run is a review goal" do
+        issue = create(:issue, :in_progress, :pull_request, project: project)
+        run = create(:agent_run, :rate_limited, :review_goal, project: project, issue: issue,
+          rate_limited_until: 1.minute.ago,
+          stale_requeue_count: AgentRun::MAX_RATE_LIMITED_REQUEUES)
+
+        described_class.perform_now
+
+        expect(run.reload.status).to eq("failed")
+        expect(issue.reload.paid_state).to eq("completed")
+      end
+
+      it "does not let orphan recovery reset an issue whose run awaits a future recovery window" do
+        issue = create(:issue, :in_progress, project: project,
+          updated_at: (described_class::ORPHANED_IN_PROGRESS_AGE + 5.minutes).ago)
+        run = create(:agent_run, :rate_limited, project: project, issue: issue,
+          rate_limited_until: 30.minutes.from_now)
+
+        described_class.perform_now
+
+        # The run is still waiting; orphan recovery must NOT yank the issue to
+        # "new" (which would mint a duplicate, superseding run).
+        expect(issue.reload.paid_state).to eq("in_progress")
+        expect(run.reload.status).to eq("rate_limited")
+      end
+
+      it "fails the run when an active sibling already owns the issue" do
+        issue = create(:issue, :in_progress, project: project)
+        rate_limited = create(:agent_run, :rate_limited, project: project, issue: issue,
+          goal: "create_pr", rate_limited_until: 1.minute.ago)
+        # An active (queued) run already holds the unique active-issue slot.
+        create(:agent_run, :queued, project: project, issue: issue, goal: "create_pr")
+
+        described_class.perform_now
+
+        expect(rate_limited.reload.status).to eq("failed")
+        expect(rate_limited.error_message).to include("Superseded by another active run")
+      end
+    end
   end
 end

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -453,6 +453,16 @@ RSpec.describe AgentRun do
       end
     end
 
+    describe ".rate_limited_due" do
+      it "returns only rate_limited runs whose recovery window has elapsed" do
+        due = create(:agent_run, :rate_limited, rate_limited_until: 1.minute.ago)
+        create(:agent_run, :rate_limited, rate_limited_until: 5.minutes.from_now)
+        create(:agent_run, :rate_limited, rate_limited_until: nil)
+
+        expect(described_class.rate_limited_due).to contain_exactly(due)
+      end
+    end
+
     describe ".auth_expired" do
       it "returns only auth_expired runs" do
         auth_expired_run = create(:agent_run, :auth_expired)
@@ -1391,6 +1401,26 @@ RSpec.describe AgentRun do
         agent_run = build(:agent_run, :failed)
 
         expect(agent_run.rate_limited?).to be false
+      end
+    end
+
+    describe "#recoverable_rate_limited?" do
+      it "is true for a rate_limited run with a recovery time set" do
+        agent_run = build(:agent_run, :rate_limited, rate_limited_until: 2.minutes.from_now)
+
+        expect(agent_run.recoverable_rate_limited?).to be true
+      end
+
+      it "is false for a rate_limited run without a recovery time" do
+        agent_run = build(:agent_run, :rate_limited, rate_limited_until: nil)
+
+        expect(agent_run.recoverable_rate_limited?).to be false
+      end
+
+      it "is false for a failed run" do
+        agent_run = build(:agent_run, :failed)
+
+        expect(agent_run.recoverable_rate_limited?).to be false
       end
     end
 

--- a/spec/temporal/activities/mark_agent_run_failed_activity_spec.rb
+++ b/spec/temporal/activities/mark_agent_run_failed_activity_spec.rb
@@ -46,6 +46,20 @@ RSpec.describe Activities::MarkAgentRunFailedActivity do
       expect(issue.reload.paid_state).to eq("completed")
     end
 
+    it "keeps the issue in_progress for recoverable rate-limited runs" do
+      issue = create(:issue, :in_progress, project: project)
+      agent_run = create(:agent_run, :running, project: project, issue: issue)
+      # Runner exhaustion parks the run as rate_limited with a recovery time.
+      agent_run.rate_limit!(error: "All runners exhausted (will retry)", reset_at: 2.minutes.from_now)
+
+      activity.execute(agent_run_id: agent_run.id, error: "All runners exhausted (will retry)")
+
+      # Must NOT flip to "failed" — that arms the re-enqueue pump and mints a
+      # duplicate, superseding run while this one awaits in-place retry.
+      expect(issue.reload.paid_state).to eq("in_progress")
+      expect(agent_run.reload.status).to eq("rate_limited")
+    end
+
     it "does not overwrite timeout status but updates issue state" do
       issue = create(:issue, :in_progress, project: project)
       agent_run = create(:agent_run, :running, project: project, issue: issue)


### PR DESCRIPTION
## Problem

`create_pr` agent runs were completing at **~8.7%** (244 of 2,817 over 7 days). Failures formed a self-amplifying churn loop:

1. A run fails for an **infra/availability** reason (no runner, transient infra).
2. `MarkAgentRunFailedActivity` flips `issue.paid_state = "failed"`.
3. That arms `issue.auto_pick_recheck_needed?` → `ReenqueueEligibleJob` → a **new** run.
4. The unique index `idx_agent_runs_unique_active_issue` forces retiring the old queued run ("Superseded by newer run" — 1,474 of these, **1,465 never even started**). Loop. Single issues reached 266 runs while already having a merged PR.

Two decisive architecture findings:
- **`rate_limited` runs are never reactivated** — no cron/job/scope re-queues them; `ProcessRunQueueJob` only scopes `queued`. So the gentle "park as `rate_limited`" path silently **strands** runs (`RequeueInfraFailureActivity`'s own comment claiming otherwise is wrong).
- `runner_step_reached = true` is set *before* `RunAgentActivity`, so the existing infra-requeue ensure-block never covers in-activity exhaustion.

## Changes

Two coordinated changes, reusing existing primitives (no migration, no new states):

1. **`StaleRunDetectorJob`** — new `recover_rate_limited_run` pass: re-queues `rate_limited` runs whose `rate_limited_until` has elapsed back to `queued` (the genuinely-missing reactivation; also fixes the latent stranding). Bounded by `MAX_RATE_LIMITED_REQUEUES=5` via `stale_requeue_count`; over budget → terminal `failed`. The existing run keeps the issue's active-run slot, so no superseding duplicate is minted. Orphan recovery now **excludes** issues whose run is awaiting recovery.
2. **`MarkAgentRunFailedActivity`** — for a `recoverable_rate_limited?` run, keep `issue.paid_state = "in_progress"` instead of flipping to `"failed"`, so the re-enqueue/supersede pump is not armed while the same run awaits its in-place retry.

New on `AgentRun`: `MAX_RATE_LIMITED_REQUEUES`, scope `rate_limited_due`, `#recoverable_rate_limited?`.

Net effect: an availability/pre-runner-infra blip parks the run, the issue stays `in_progress` (no duplicate minted, no supersede churn), `StaleRunDetectorJob` re-queues the **same** run when the window clears, and it completes once a runner frees — bounded so persistent problems still surface as `failed`.

## Correctness details (from self-review)

- **Orphan-recovery interaction (critical):** a `rate_limited` run pending recovery is not `UNFINISHED`, and the issue stays `in_progress` without bumping `updated_at`, so orphan recovery would have reset it to `"new"` after 15 min and minted a duplicate. Now excluded (query + locked re-check guard).
- **`active_sibling_exists?`** checks **both** the issue and PR unique slots (a run may carry both `issue_id` and `source_pull_request_number`), avoiding a `RecordNotUnique` that would abort the `with_lock` transaction.
- **Review-goal exhaustion** restores the issue to `"completed"` (the PR work succeeded; only the review follow-up failed), consistent with `resolve_stale_run` / `MarkAgentRunFailedActivity`.

## Deliberately deferred (follow-up)

Routing the genuine "All runners exhausted: <list>" path (`RunAgentActivity` branch 3, ~390/7d) to recovery. That branch mixes transient infra errors with real agent failures and can't cleanly distinguish them; blanket-retry would wrongly retry real failures (e.g. a false-rate-limit prompt echo) and breaks tested semantics. Follow-up: tag `RunnerInfraExecutionError` attempts and recover only those. Pairs with #2458–#2461 (transient outages treated as terminal).

## Tests

All green. Added:
- `agent_run_spec`: `.rate_limited_due`, `#recoverable_rate_limited?`.
- `mark_agent_run_failed_activity_spec`: recoverable rate-limited keeps issue `in_progress`.
- `stale_run_detector_job_spec`: reactivate due / skip future window / keep issue `in_progress` / exhaust budget → `failed` / review-goal exhaustion → `completed` / active-sibling → `failed` / orphan recovery does not clobber a run awaiting a future window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)