### PR TITLE
feat(agent-runs): per-runner startup timeout for create_pr goals

### DIFF
--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -879,9 +879,9 @@ module Activities
       user_settings&.max_execution_seconds || agent_run.project.max_execution_seconds
     end
 
-    def effective_startup_timeout(agent_run:, heartbeat:, effective_idle_timeout:, effective_timeout:)
-      startup_base = if agent_run.create_pr_goal?
-        CREATE_PR_RUNNER_STARTUP_TIMEOUTS.fetch(agent_run.agent_type, DEFAULT_AGENT_STARTUP_TIMEOUT)
+    def effective_startup_timeout(runner_key:, heartbeat:, effective_idle_timeout:, effective_timeout:, create_pr_goal:)
+      startup_base = if create_pr_goal
+        CREATE_PR_RUNNER_STARTUP_TIMEOUTS.fetch(runner_key, DEFAULT_AGENT_STARTUP_TIMEOUT)
       else
         heartbeat.idle_timeout_for(effective_idle_timeout) ||
           effective_idle_timeout ||
@@ -1184,10 +1184,11 @@ module Activities
         user_settings&.create_pr_idle_timeout_seconds || DEFAULT_CREATE_PR_IDLE_TIMEOUT
       end
       startup_timeout = effective_startup_timeout(
-        agent_run: agent_run,
+        runner_key: runner,
         heartbeat: heartbeat,
         effective_idle_timeout: effective_idle_timeout,
-        effective_timeout: effective_timeout
+        effective_timeout: effective_timeout,
+        create_pr_goal: agent_run.create_pr_goal?
       )
 
       # Periodic heartbeats during container execution complement the

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -83,6 +83,23 @@ module Activities
     DEFAULT_REVIEW_GOAL_IDLE_TIMEOUT = 300  # 5 minutes without output = stuck
     DEFAULT_CREATE_PR_IDLE_TIMEOUT = 360   # 6 minutes without output = stuck
     DEFAULT_AGENT_STARTUP_TIMEOUT = 360    # 6 minutes without first output = stuck
+
+    # Per-runner startup timeouts for create_pr goals, tuned from observed data.
+    # Completed run p90s: claude_code 28.5m, codex 42.6m, kilocode 38.7m,
+    # opencode 48.2m, pi 48.2m. Startup timeout must be long enough for the
+    # runner to produce first output on complex tasks.
+    #
+    # Only applied for create_pr goals where the data supports longer windows.
+    # Other goals (review, issue) retain the original idle-timeout-based
+    # startup behavior since they have not shown the same timeout pathology.
+    CREATE_PR_RUNNER_STARTUP_TIMEOUTS = {
+      "claude_code" => 1800, # 30 min — p90 of completed is 28.5 min
+      "codex"       => 2700, # 45 min — p90 of completed is 42.6 min
+      "kilocode"    => 2400, # 40 min — p90 of completed is 38.7 min
+      "opencode"    => 3000, # 50 min — p90 of completed is 48.2 min
+      "pi"          => 3000  # 50 min — p90 of completed is 48.2 min
+    }.freeze
+
     PREFLIGHT_TIMEOUT_SECONDS = 10
     DIRECT_OUTBOUND_PREFLIGHT_TIMEOUT_SECONDS = 30
     PREFLIGHT_TIMEOUT_CIRCUIT_BREAKER_THRESHOLD = 3
@@ -862,11 +879,14 @@ module Activities
       user_settings&.max_execution_seconds || agent_run.project.max_execution_seconds
     end
 
-    def effective_startup_timeout(heartbeat:, effective_idle_timeout:, effective_timeout:)
-      startup_base =
+    def effective_startup_timeout(agent_run:, heartbeat:, effective_idle_timeout:, effective_timeout:)
+      startup_base = if agent_run.create_pr_goal?
+        CREATE_PR_RUNNER_STARTUP_TIMEOUTS.fetch(agent_run.agent_type, DEFAULT_AGENT_STARTUP_TIMEOUT)
+      else
         heartbeat.idle_timeout_for(effective_idle_timeout) ||
-        effective_idle_timeout ||
-        DEFAULT_AGENT_STARTUP_TIMEOUT
+          effective_idle_timeout ||
+          DEFAULT_AGENT_STARTUP_TIMEOUT
+      end
 
       [ startup_base, effective_timeout ].compact.min
     end
@@ -1164,6 +1184,7 @@ module Activities
         user_settings&.create_pr_idle_timeout_seconds || DEFAULT_CREATE_PR_IDLE_TIMEOUT
       end
       startup_timeout = effective_startup_timeout(
+        agent_run: agent_run,
         heartbeat: heartbeat,
         effective_idle_timeout: effective_idle_timeout,
         effective_timeout: effective_timeout

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -2722,7 +2722,7 @@ expect(container_service).to receive(:execute).with(
         expect(agent_run.runners_attempted.first["diagnostics"]).to include(
           "timeout_type" => "idle",
           "effective_timeout_seconds" => 3600,
-          "startup_timeout_seconds" => 360,
+          "startup_timeout_seconds" => described_class::CREATE_PR_RUNNER_STARTUP_TIMEOUTS["claude_code"],
           "idle_timeout_seconds" => 360,
           "heartbeat_supported" => true
         )
@@ -3124,7 +3124,7 @@ expect(container_service).to receive(:execute).with(
     end
 
     context "when goal is create_pr" do
-      it "uses the default agent timeout with create_pr idle_timeout" do
+      it "uses the default agent timeout with runner-specific startup_timeout and create_pr idle_timeout" do
         project.update!(max_execution_seconds: 86_400)
         allow(container_service).to receive(:execute).and_return(exec_success)
         allow(git_ops).to receive_messages(head_sha: "sha123", commit_uncommitted_changes: false, has_changes_since?: false)
@@ -3133,7 +3133,7 @@ expect(container_service).to receive(:execute).with(
           anything,
           hash_including(
             timeout: AGENT_TIMEOUT_DEFAULT,
-            startup_timeout: described_class::DEFAULT_AGENT_STARTUP_TIMEOUT,
+            startup_timeout: described_class::CREATE_PR_RUNNER_STARTUP_TIMEOUTS["claude_code"],
             idle_timeout: described_class::DEFAULT_CREATE_PR_IDLE_TIMEOUT
           )
         ).and_return(exec_success)
@@ -3187,7 +3187,7 @@ expect(container_service).to receive(:execute).with(
           anything,
           hash_including(
             timeout: AGENT_TIMEOUT_DEFAULT,
-            startup_timeout: described_class::DEFAULT_AGENT_STARTUP_TIMEOUT,
+            startup_timeout: described_class::CREATE_PR_RUNNER_STARTUP_TIMEOUTS["kilocode"],
             idle_timeout: described_class::DEFAULT_CREATE_PR_IDLE_TIMEOUT,
             heartbeat_path: "/tmp/paid-heartbeat-test/.paid-heartbeat"
           )
@@ -3206,7 +3206,7 @@ expect(container_service).to receive(:execute).with(
           anything,
           hash_including(
             timeout: AGENT_TIMEOUT_DEFAULT,
-            startup_timeout: described_class::DEFAULT_AGENT_STARTUP_TIMEOUT,
+            startup_timeout: described_class::CREATE_PR_RUNNER_STARTUP_TIMEOUTS["opencode"],
             idle_timeout: described_class::DEFAULT_CREATE_PR_IDLE_TIMEOUT,
             heartbeat_path: "/tmp/paid-heartbeat-test/.paid-heartbeat"
           )
@@ -3228,7 +3228,7 @@ expect(container_service).to receive(:execute).with(
           anything,
           hash_including(
             timeout: AGENT_TIMEOUT_DEFAULT,
-            startup_timeout: expected_idle,
+            startup_timeout: described_class::CREATE_PR_RUNNER_STARTUP_TIMEOUTS["codex"],
             idle_timeout: expected_idle,
             heartbeat_path: "/tmp/paid-heartbeat-test/.paid-heartbeat"
           )
@@ -3237,7 +3237,7 @@ expect(container_service).to receive(:execute).with(
         activity.execute(agent_run_id: agent_run.id)
       end
 
-      it "honors longer user-configured startup windows" do
+      it "uses runner-specific startup timeout regardless of user idle timeout" do
         agent_run.update!(agent_type: "codex")
         project.update!(max_execution_seconds: 86_400)
         user.settings.update!(create_pr_idle_timeout_seconds: 420)
@@ -3245,14 +3245,14 @@ expect(container_service).to receive(:execute).with(
         allow(container_service).to receive(:execute).and_return(exec_success)
         allow(git_ops).to receive_messages(head_sha: "sha123", commit_uncommitted_changes: false, has_changes_since?: false)
 
-        expected_startup = 420 * Containers::HeartbeatSetup::COARSE_HEARTBEAT_IDLE_TIMEOUT_MULTIPLIER
+        expected_idle = 420 * Containers::HeartbeatSetup::COARSE_HEARTBEAT_IDLE_TIMEOUT_MULTIPLIER
 
         expect(container_service).to receive(:execute).with(
           anything,
           hash_including(
             timeout: AGENT_TIMEOUT_DEFAULT,
-            startup_timeout: expected_startup,
-            idle_timeout: expected_startup
+            startup_timeout: described_class::CREATE_PR_RUNNER_STARTUP_TIMEOUTS["codex"],
+            idle_timeout: expected_idle
           )
         ).and_return(exec_success)
 
@@ -3269,7 +3269,7 @@ expect(container_service).to receive(:execute).with(
           anything,
           hash_including(
             timeout: AGENT_TIMEOUT_DEFAULT,
-            startup_timeout: described_class::DEFAULT_AGENT_STARTUP_TIMEOUT,
+            startup_timeout: described_class::CREATE_PR_RUNNER_STARTUP_TIMEOUTS["claude_code"],
             idle_timeout: described_class::DEFAULT_CREATE_PR_IDLE_TIMEOUT,
             heartbeat_path: Containers::HeartbeatSetup::CONTAINER_HEARTBEAT_PATH
           )


### PR DESCRIPTION
## Summary

Tune startup timeouts per runner for `create_pr` goals based on observed completion data. The previous uniform 360s (6 min) startup timeout was killing runs before they could produce first output on complex tasks.

## Problem

1,358 `create_pr` runs (25% of all failures) died with `startup_timeout` at 360 seconds. Analysis of completed runs shows p90 durations far exceed 6 minutes:

| Runner | Completed p90 | Old Startup Timeout |
|--------|--------------|-------------------|
| claude_code | 28.5 min | 6 min |
| codex | 42.6 min | 6 min |
| kilocode | 38.7 min | 6 min |
| opencode | 48.2 min | 6 min |
| pi | 48.2 min | 6 min |

## Changes

- Add `CREATE_PR_RUNNER_STARTUP_TIMEOUTS` constant tuned to ~p90 of completed runs per runner
- `effective_startup_timeout` uses runner-specific values for `create_pr` goals only
- Non-create_pr goals (review, issue, enhance, analyze) retain original heartbeat-based startup behavior
- Unknown runners fall back to `DEFAULT_AGENT_STARTUP_TIMEOUT` (360s)

| Runner | New Startup Timeout |
|--------|-------------------|
| claude_code | 30 min |
| codex | 45 min |
| kilocode | 40 min |
| opencode | 50 min |
| pi | 50 min |

## Test Plan

- [x] All 235 run_agent_activity specs pass
- [x] Lint clean
- [x] Non-create_pr goals verified to retain original behavior (heartbeat-based)

## Related

- Data analysis context: `/tmp/create_pr_investigation_context.md`