### PR TITLE
fix(agent-runs): preserve manual queue priority

### DIFF
--- a/app/jobs/process_run_queue_job.rb
+++ b/app/jobs/process_run_queue_job.rb
@@ -49,6 +49,7 @@ class ProcessRunQueueJob < ApplicationJob
       skipped_ids = Set.new
       blocked_project_ids = Set.new
       blocked_user_ids = Set.new
+      started_priority_by_project = {}
       @user_capacity = {}  # { user_id => { active: count, max: limit } }
 
       loop do
@@ -65,6 +66,11 @@ class ProcessRunQueueJob < ApplicationJob
         )
 
         break unless next_run
+
+        if lower_priority_than_claimed_or_started_project_run?(next_run, started_priority_by_project)
+          blocked_project_ids.add(next_run.project_id)
+          next
+        end
 
         if (github_state = unavailable_github_state(next_run.project.github_health_endpoint))
           blocked_project_ids.add(next_run.project_id)
@@ -111,6 +117,7 @@ class ProcessRunQueueJob < ApplicationJob
           consecutive_failures = 0
           starts_count += 1
           record_started_run(user)
+          record_started_project_priority(next_run, started_priority_by_project)
           break if starts_count >= MAX_STARTS_PER_PERFORM
         else
           consecutive_failures += 1
@@ -158,6 +165,32 @@ class ProcessRunQueueJob < ApplicationJob
   def record_started_run(user)
     cap = @user_capacity[user.id]
     cap[:active] += 1 if cap
+  end
+
+  def record_started_project_priority(agent_run, started_priority_by_project)
+    priority = queue_priority_for(agent_run)
+    existing = started_priority_by_project[agent_run.project_id]
+    started_priority_by_project[agent_run.project_id] = priority if existing.nil? || priority < existing
+  end
+
+  def lower_priority_than_claimed_or_started_project_run?(agent_run, started_priority_by_project)
+    current_priority = queue_priority_for(agent_run)
+    started_priority = started_priority_by_project[agent_run.project_id]
+    return true if started_priority && current_priority > started_priority
+
+    AgentRun
+      .queued_with_priority
+      .where(project_id: agent_run.project_id)
+      .where.not(temporal_workflow_id: nil)
+      .where("#{AgentRun::QUEUE_PRIORITY_CASE_SQL} < ?", current_priority)
+      .exists?
+  end
+
+  def queue_priority_for(agent_run)
+    value = agent_run.read_attribute(:queue_priority)
+    return value.to_i unless value.nil?
+
+    AgentRun::QUEUE_PRIORITIES.keys.index(agent_run.queue_priority_tier) || AgentRun::QUEUE_PRIORITIES.size
   end
 
   def start_claimed_run(agent_run)

--- a/spec/jobs/process_run_queue_job_spec.rb
+++ b/spec/jobs/process_run_queue_job_spec.rb
@@ -125,6 +125,42 @@ RSpec.describe ProcessRunQueueJob do
       expect(auto_continue.reload.status).to eq("queued")
     end
 
+    it "does not start lower-priority work from the same project after claiming a manual run" do
+      project = create(:project)
+      project.created_by.settings.update!(max_concurrent_runs: 2)
+      manual = create(:agent_run, :queued, :manual, project: project, goal: "review", source_pull_request_number: 42,
+        created_at: 2.minutes.ago)
+      p1_issue = create(:issue, project: project, labels: [ "P1" ])
+      p1_run = create(:agent_run, :queued, :automatic, project: project, issue: p1_issue, created_at: 1.minute.ago)
+
+      started_ids = []
+      allow(temporal_client).to receive(:start_workflow) do |_wf, input, **_opts|
+        started_ids << input[:agent_run_id]
+        workflow_handle
+      end
+
+      described_class.new.perform
+
+      expect(started_ids).to eq([ manual.id ])
+      expect(manual.reload.temporal_workflow_id).to be_present
+      expect(p1_run.reload.temporal_workflow_id).to be_nil
+    end
+
+    it "does not start lower-priority work while a manual run from the same project is claimed" do
+      project = create(:project)
+      project.created_by.settings.update!(max_concurrent_runs: 2)
+      create(:agent_run, :queued, :manual, project: project, goal: "review", source_pull_request_number: 42,
+        temporal_workflow_id: AgentRun::CLAIMED_SENTINEL)
+      p1_issue = create(:issue, project: project, labels: [ "P1" ])
+      p1_run = create(:agent_run, :queued, :automatic, project: project, issue: p1_issue)
+
+      expect(temporal_client).not_to receive(:start_workflow)
+
+      described_class.new.perform
+
+      expect(p1_run.reload.temporal_workflow_id).to be_nil
+    end
+
     it "marks run as failed and continues when workflow start fails" do
       failing_run = create(:agent_run, :queued, created_at: 2.minutes.ago)
       good_run = create(:agent_run, :queued, created_at: 1.minute.ago)


### PR DESCRIPTION
## Summary
- prevent lower-priority same-project runs from starting while a higher-priority run is claimed or just started
- add regressions for manual review runs blocking same-project P1 work until the manual workflow leaves the claimed queue state

## Verification
- `RAILS_ENV=test bin/rails db:prepare && bin/rspec spec/jobs/process_run_queue_job_spec.rb`
- `bin/rubocop app/jobs/process_run_queue_job.rb spec/jobs/process_run_queue_job_spec.rb`