### PR TITLE
fix(test): disable built-in log rotation in test env

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -18,6 +18,14 @@ Rails.application.configure do
   # While tests run files are not watched, reloading is not necessary.
   config.enable_reloading = false
 
+  # Disable Rails' built-in log rotation (shift_age/shift_size). The 8.1
+  # framework defaults enable rotation at 100 MB for local envs, but under
+  # parallel test workers the rotation lock contends across processes and
+  # fails ("log rotation inter-process lock failed ... test.log"), and once
+  # test.log is renamed to test.log.0 the recreation can leave it missing.
+  # Mirrors the same opt-out in config/environments/development.rb.
+  config.log_file_size = nil
+
   # Eager loading loads your entire application. When running a single test locally,
   # this is usually not necessary, and can slow down your test suite. However, it's
   # recommended that you enable it in continuous integration systems to ensure eager


### PR DESCRIPTION
## Problem

`bin/rspec` spams this line and eventually hangs:

```
log rotation inter-process lock failed. No such file or directory @ rb_sysopen - /workspaces/paid/log/test.log
```

`config.load_defaults 8.1` enables Rails' built-in log rotation at 100 MB for local environments. Under parallel RSpec workers, every process contends on the same `log/test.log` rotation lock — the cross-process lock fails, the file gets renamed to `test.log.0` (an exactly-100 MB file), and recreation can leave `test.log` missing. Every subsequent write then re-triggers the error.

The `development.rb` env already opts out of this (`config.log_file_size = nil`, with a comment describing the same failure mode), but `test.rb` never got the same treatment.

## Fix

Set `config.log_file_size = nil` in the test environment, mirroring the existing development opt-out.

## Verification

- `bin/rspec` boots and runs with no rotation errors; `test.log` stays a single file (no `.0` rename).
- Ran a real spec file (`spec/models/pre_commit_requirement_spec.rb`, 48 examples) clean, with normal log output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)