### PR TITLE
fix: eagerly require Paid::ExceptionNotifier in initializer

### DIFF
--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -2,6 +2,8 @@
 
 return if Rails.env.test?
 
+require_relative "../../lib/paid/exception_notifier"
+
 ExceptionNotification.configure do |config|
   config.ignored_exceptions += %w[
     ActionController::RoutingError


### PR DESCRIPTION
## Problem

`bin/setup` and `bin/rails runner` fail with:

```
NameError: uninitialized constant Paid::ExceptionNotifier
  config/initializers/exception_notification.rb:13
```

## Root Cause

`config.autoload_lib` adds `lib/` to `autoload_paths`, but the main Zeitwerk autoloader doesn't actually `push_dir(lib)` until the `setup_main_autoloader` finisher initializer runs — which is **after** all user-defined initializers. The `exception_notification.rb` initializer references `Paid::ExceptionNotifier` (in `lib/paid/`) before the autoloader can resolve it.

The `return if Rails.env.test?` guard meant CI never exercised this code path, so the regression went undetected.

## Fix

Add an explicit `require_relative` for the notifier class before it's referenced, matching the established pattern in `config/application.rb:26` for `Database::QueryMonitor`.

## Testing

- `bin/setup` completes successfully
- `bin/rails runner 'puts "OK"'` boots cleanly
- 24 unit + 12 integration specs for exception notification all pass
- `bin/lint --changed` clean