### PR TITLE
fix(test): stop forwarding an empty BUNDLE_PATH to install-contract subprocess

### DIFF
--- a/spec/scripts/install_contract_scripts_spec.rb
+++ b/spec/scripts/install_contract_scripts_spec.rb
@@ -10,7 +10,11 @@ RSpec.describe InstallContractScripts, :no_db do
   subject(:install_wrapper_source) { Rails.root.join("scripts/install-from-contract.sh").read }
 
   def run_script(script_path, provider)
-    Open3.capture3({ "BUNDLE_PATH" => ENV["BUNDLE_PATH"].to_s }, "bundle", "exec", "ruby", script_path, provider, chdir: Rails.root.to_s)
+    # The subprocess inherits this process's environment (including bundler's
+    # BUNDLE_* config and .bundle/config via chdir), so no env needs to be
+    # forwarded explicitly. Passing BUNDLE_PATH manually previously coerced an
+    # unset value to "", which broke gem resolution in the child.
+    Open3.capture3("bundle", "exec", "ruby", script_path, provider, chdir: Rails.root.to_s)
   end
 
   it "keeps codex installs scriptless by default" do


### PR DESCRIPTION
## Problem

The `InstallContractScripts` specs spawn `bundle exec ruby <script>` in a subprocess and forwarded the bundle path as:

```ruby
{ "BUNDLE_PATH" => ENV["BUNDLE_PATH"].to_s }
```

When `BUNDLE_PATH` is **unset** (e.g. a devcontainer that uses rvm's default gem location at `/usr/local/rvm/gems/default`), `.to_s` coerces `nil` to `""`. Passing `BUNDLE_PATH=""` forces the child bundler to resolve gems against an empty path, failing for the **entire** bundle:

```
Bundler::GemNotFound: Could not find rails-8.1.3, propshaft-1.3.2, pg-1.6.3 ... in locally installed gems
```

Reproduction confirmed it's the empty string specifically:
- `BUNDLE_PATH=""` → exit 1, `GemNotFound`
- `BUNDLE_PATH` unset → exit 0

## Change

Drop the env hash entirely. The subprocess already **inherits** this process's environment — including bundler's `BUNDLE_*` vars and `.bundle/config` (resolved via `chdir: Rails.root`) — so nothing needs to be forwarded explicitly. This both fixes the failure and removes the `nil`→`""` footgun permanently.

Verified the hash was a no-op before removing it:
- `BUNDLE_PATH` unset → child resolves to rvm default ✅
- `BUNDLE_PATH` set → child inherits the same value automatically ✅
- CI `.bundle/config` path → child reads it via `chdir` ✅ (the old `.to_s` would have `""`-overridden this too)

## Testing

- `bin/rspec spec/scripts/install_contract_scripts_spec.rb` → **4 examples, 0 failures**
- `bin/rspec --only-failures` → **0 failures** (whole suite clean)
- `rubocop` clean on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)