### PR TITLE
fix(pr-scanner): resume dependabot follow-up runs

### DIFF
--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -32,6 +32,11 @@ module Activities
     # a time ceiling, PRs waiting on those signals are skipped indefinitely.
     SCAN_STALENESS_MULTIPLIER = 3
     KNOWN_BOT_PREFIXES = %w[dependabot renovate github-actions].freeze
+    DEPENDENCY_UPDATE_BOT_AUTHORS = %w[
+      dependabot[bot]
+      dependabot-preview[bot]
+      renovate[bot]
+    ].freeze
     REVIEW_BOT_CLEAN_PATTERN = /generated no (?:new )?comments/i
     # Body-only review bots (currently Codex) signal "no findings" by posting
     # an *issue comment* — not a review — with text like
@@ -311,6 +316,7 @@ module Activities
 
     def authorized_for_automation_scan?(project, issue)
       return true if project.trusted_github_author?(issue.github_creator_login)
+      return true if dependency_update_bot_author?(issue.github_creator_login)
       return true if trusted_user_added_label?(project, issue, project.automation_label_name)
 
       Rails.logger.warn(
@@ -637,17 +643,20 @@ module Activities
     end
 
     # Bot-authored PRs (Dependabot, Renovate) skip review requirements.
-    # Only CI failures trigger auto-continue; green CI advances to ready.
+    # CI failures and merge conflicts trigger auto-continue; green CI advances
+    # to ready.
     def scan_bot_authored_draft_pr(project, client, issue, pr_data: nil)
       pr_data ||= fetch_pr_data(client, project, issue)
       return :skipped if pr_data.nil?
 
       checks = fetch_check_runs(client, project, pr_data)
       ci_triggers = ci_failure_triggers(checks || [])
+      conflict_triggers = check_merge_conflicts(project, pr_data)
+      triggers = ci_triggers + conflict_triggers
 
-      if ci_triggers.any?
-        log_triggers(project, issue, ci_triggers)
-        return draft_trigger_payload(issue, ci_triggers)
+      if triggers.any?
+        log_triggers(project, issue, triggers)
+        return draft_trigger_payload(issue, triggers)
       end
 
       if !checks.nil? && checks.any? && all_checks_green?(checks)
@@ -2888,6 +2897,12 @@ module Activities
     # review-skipping Dependabot path and never reviewed or auto-merged.
     def third_party_bot_author?(project, login)
       bot_user?(login) && !paid_agent_pr_author?(project, login)
+    end
+
+    def dependency_update_bot_author?(login)
+      return false if login.blank?
+
+      DEPENDENCY_UPDATE_BOT_AUTHORS.include?(login.downcase)
     end
 
     def system_generated_comment?(body)

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -158,6 +158,14 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       expect(activity.send(:paid_agent_pr_author?, project, "dependabot[bot]")).to be(false)
     end
 
+    it "only grants dependency-update trust bypass to exact bot authors" do
+      expect(activity.send(:dependency_update_bot_author?, "dependabot[bot]")).to be(true)
+      expect(activity.send(:dependency_update_bot_author?, "dependabot-preview[bot]")).to be(true)
+      expect(activity.send(:dependency_update_bot_author?, "renovate[bot]")).to be(true)
+      expect(activity.send(:dependency_update_bot_author?, "dependabot-maintainer")).to be(false)
+      expect(activity.send(:dependency_update_bot_author?, "renovate-helper")).to be(false)
+    end
+
     it "treats human authors as neither bot nor agent" do
       expect(activity.send(:third_party_bot_author?, project, "viamin")).to be(false)
       expect(activity.send(:paid_agent_pr_author?, project, "viamin")).to be(false)
@@ -4940,6 +4948,51 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         expect(automation_scan_results(result).size).to eq(1)
         trigger = automation_scan_results(result).first
         expect(trigger[:triggers].map { |t| t[:type] }).to include("ci_failure")
+      end
+
+      it "triggers ci_failure even when the automation label was not added by a trusted user" do
+        expect(github_client).not_to receive(:issue_events)
+        stub_github_for_pr(
+          draft: true,
+          author_login: "dependabot[bot]",
+          checks: [ { name: "ci", conclusion: "failure" } ],
+          review_threads: [],
+          reviews: []
+        )
+
+        result = activity.execute(project_id: project.id)
+
+        expect(automation_scan_results(result).size).to eq(1)
+        expect(automation_scan_results(result).first[:triggers].map { |t| t[:type] }).to include("ci_failure")
+      end
+
+      it "does not grant the dependency-update bypass to bot-name lookalikes" do
+        issue = Issue.find_by!(project: project, github_number: 42)
+        issue.update!(github_creator_login: "dependabot-maintainer")
+        allow(github_client).to receive(:issue_events)
+          .with(project.full_name, 42)
+          .and_return([])
+
+        result = activity.execute(project_id: project.id)
+
+        expect(automation_scan_results(result)).to be_empty
+      end
+
+      it "triggers merge-conflict follow-up before advancing to ready" do
+        project.update!(auto_fix_merge_conflicts: true)
+        stub_github_for_pr(
+          mergeable: false,
+          draft: true,
+          author_login: "dependabot[bot]",
+          checks: [ { name: "ci", conclusion: "success" } ],
+          review_threads: [],
+          reviews: []
+        )
+
+        result = activity.execute(project_id: project.id)
+
+        expect(automation_scan_results(result).size).to eq(1)
+        expect(automation_scan_results(result).first[:triggers].map { |t| t[:type] }).to include("merge_conflicts")
       end
 
       it "does not request reviews even when review is enabled" do


### PR DESCRIPTION
## Summary
- allow exact dependency-update bot authors to enter PR automation without trusted label-event provenance
- keep lookalike bot names behind the existing trusted label gate
- detect merge conflicts for draft Dependabot/Renovate PRs before they advance to ready

## Verification
- `bin/rubocop app/temporal/activities/scan_paid_prs_activity.rb spec/temporal/activities/scan_paid_prs_activity_spec.rb`
- `PAID_TEST_DATABASE=paid_test bin/rspec spec/temporal/activities/scan_paid_prs_activity_spec.rb`