### PR TITLE
fix(agent-runs): use canonical runner_key for startup timeout lookup

### DIFF
--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -92,8 +92,10 @@ module Activities
     # Only applied for create_pr goals where the data supports longer windows.
     # Other goals (review, issue) retain the original idle-timeout-based
     # startup behavior since they have not shown the same timeout pathology.
+    # Keyed by canonical runner_key (matching Runner#runner_key / AGENT_TYPE_TO_RUNNER
+    # values) so lookups work for both primary and fallback runners without aliases.
     CREATE_PR_RUNNER_STARTUP_TIMEOUTS = {
-      "claude_code" => 1800, # 30 min — p90 of completed is 28.5 min
+      "claude"      => 1800, # 30 min — p90 of completed is 28.5 min
       "codex"       => 2700, # 45 min — p90 of completed is 42.6 min
       "kilocode"    => 2400, # 40 min — p90 of completed is 38.7 min
       "opencode"    => 3000, # 50 min — p90 of completed is 48.2 min
@@ -893,7 +895,7 @@ module Activities
 
     def effective_startup_timeout(runner_key:, heartbeat:, effective_idle_timeout:, effective_timeout:, create_pr_goal:)
       startup_base = if create_pr_goal
-        CREATE_PR_RUNNER_STARTUP_TIMEOUTS.fetch(runner_key, DEFAULT_AGENT_STARTUP_TIMEOUT)
+        CREATE_PR_RUNNER_STARTUP_TIMEOUTS.fetch(canonical_runner(runner_key), DEFAULT_AGENT_STARTUP_TIMEOUT)
       else
         heartbeat.idle_timeout_for(effective_idle_timeout) ||
           effective_idle_timeout ||

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -2915,7 +2915,7 @@ expect(container_service).to receive(:execute).with(
         expect(agent_run.runners_attempted.first["diagnostics"]).to include(
           "timeout_type" => "idle",
           "effective_timeout_seconds" => 3600,
-          "startup_timeout_seconds" => described_class::CREATE_PR_RUNNER_STARTUP_TIMEOUTS["claude_code"],
+          "startup_timeout_seconds" => described_class::CREATE_PR_RUNNER_STARTUP_TIMEOUTS["claude"],
           "idle_timeout_seconds" => 360,
           "heartbeat_supported" => true
         )
@@ -3326,7 +3326,7 @@ expect(container_service).to receive(:execute).with(
           anything,
           hash_including(
             timeout: AGENT_TIMEOUT_DEFAULT,
-            startup_timeout: described_class::CREATE_PR_RUNNER_STARTUP_TIMEOUTS["claude_code"],
+            startup_timeout: described_class::CREATE_PR_RUNNER_STARTUP_TIMEOUTS["claude"],
             idle_timeout: described_class::DEFAULT_CREATE_PR_IDLE_TIMEOUT
           )
         ).and_return(exec_success)
@@ -3462,7 +3462,7 @@ expect(container_service).to receive(:execute).with(
           anything,
           hash_including(
             timeout: AGENT_TIMEOUT_DEFAULT,
-            startup_timeout: described_class::CREATE_PR_RUNNER_STARTUP_TIMEOUTS["claude_code"],
+            startup_timeout: described_class::CREATE_PR_RUNNER_STARTUP_TIMEOUTS["claude"],
             idle_timeout: described_class::DEFAULT_CREATE_PR_IDLE_TIMEOUT,
             heartbeat_path: Containers::HeartbeatSetup::CONTAINER_HEARTBEAT_PATH
           )


### PR DESCRIPTION
## Summary

- **Root cause**: `CREATE_PR_RUNNER_STARTUP_TIMEOUTS` was keyed by `"claude_code"`, but `runner_command_key()` returns `"claude"` for fallback runners. The `.fetch` miss caused fallback-to-claude runs to get 360s (6 min) startup timeout instead of the configured 1800s (30 min).
- **Impact**: 24 of the 44 startup timeouts in the last 24 hours were caused by this mismatch — ~35% of all `create_pr` timeouts. 43 of 44 startup timeouts occurred on the `claude` runner.
- **Fix**: Rekeys the hash to use canonical `runner_key` values (matching `Runner#runner_key` / `AGENT_TYPE_TO_RUNNER`) and normalizes via `canonical_runner()` at the lookup site so primary and fallback runners resolve identically. No duplicate hash entries to drift.

## Test plan

- [x] Existing `run_agent_activity_spec.rb` tests pass (240 examples, 0 failures)
- [ ] Monitor `create_pr` startup timeout rate after deploy — expect ~35% reduction in timeouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)