### PR TITLE
fix(devcontainer): make local port overrides configurable

### DIFF
--- a/.devcontainer/.env.example
+++ b/.devcontainer/.env.example
@@ -1,0 +1,3 @@
+# Copy to .devcontainer/.env to override devcontainer port bindings locally.
+PAID_WEB_PORT=3000
+PAID_TEMPORAL_UI_PORT=8080

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -30,12 +30,16 @@ services:
     # Use a non-root user for all processes.
     user: vscode
 
-    # Expose port 3000 for external access (e.g., Tailscale)
+    # Expose Rails for external access (e.g., Tailscale).
+    # Override the app/host port in .devcontainer/.env.
     ports:
-    - "3000:3000"
+    - "${PAID_WEB_PORT:-3000}:${PAID_WEB_PORT:-3000}"
+    environment:
+      PORT: "${PAID_WEB_PORT:-3000}"
+      PAID_PROXY_PORT: "${PAID_WEB_PORT:-3000}"
+      PAID_WEB_PORT: "${PAID_WEB_PORT:-3000}"
+      PAID_TEMPORAL_UI_PORT: "${PAID_TEMPORAL_UI_PORT:-8080}"
 
-    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
-    # (Adding the "ports" property to this file will not forward from a Codespace.)
     depends_on:
       postgres:
         condition: service_healthy
@@ -101,9 +105,9 @@ services:
         condition: service_healthy
     environment:
       - TEMPORAL_ADDRESS=temporal:7233
-      - TEMPORAL_CORS_ORIGINS=http://localhost:3000
+      - TEMPORAL_CORS_ORIGINS=http://localhost:${PAID_WEB_PORT:-3000}
     ports:
-    - "8080:8080"
+    - "${PAID_TEMPORAL_UI_PORT:-8080}:8080"
     networks:
     - default
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -66,12 +66,10 @@
     // GitHub CLI Extensions - Share extensions between host and container
     "source=${localEnv:HOME}/.local/share/gh,target=/home/vscode/.local/share/gh,type=bind,consistency=cached"
   ],
-  // Use 'forwardPorts' to make a list of ports inside the container available locally.
-  // Note: If you need to expose port 3000, prefer using compose.yaml `ports` instead of
-  // forwardPorts, because forwardPorts binds to 127.0.0.1 which blocks Tailscale tunnel access.
-  "forwardPorts": [
-    8080
-  ],
+  // Host-accessible app ports are published in compose.yaml instead of
+  // forwardPorts because forwardPorts binds to 127.0.0.1, which blocks
+  // Tailscale tunnel access and would bypass the local port overrides in
+  // .devcontainer/.env.
   // Configure tool-specific properties.
   // "customizations": {},
   // Uncomment to connect as root instead. More info: https://containers.dev/implementors/json_reference/#remoteUser.
@@ -184,6 +182,9 @@
         "remote.autoForwardPorts": false,
         "remote.portsAttributes": {
           "3000": {
+            "onAutoForward": "ignore"
+          },
+          "5000": {
             "onAutoForward": "ignore"
           },
           "*": {

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@
 # Ignore all environment files except the example.
 /.env*
 !/.env.example
+/.devcontainer/.env
+!/.devcontainer/.env.example
 *.local.json
 
 # Ignore all logfiles and tempfiles.


### PR DESCRIPTION
## Summary
- Make the devcontainer Rails port configurable through PAID_WEB_PORT, keeping Puma, Docker publishing, and PAID_PROXY_PORT aligned
- Make Temporal UI publishing configurable through PAID_TEMPORAL_UI_PORT and align Temporal CORS with the Rails port
- Document local overrides in .devcontainer/.env.example and ignore the local .devcontainer/.env file
- Keep host-accessible app ports in Compose instead of devcontainer forwardPorts to preserve Tailscale access and local overrides

## Validation
- docker compose -f .devcontainer/compose.yaml config
- env -u PAID_WEB_PORT -u PAID_TEMPORAL_UI_PORT docker compose -f .devcontainer/compose.yaml config
- ruby -e 'require "json"; s = File.read(".devcontainer/devcontainer.json"); s = s.lines.reject { |line| line.lstrip.start_with?("//") }.join; JSON.parse(s); abort("missing trailing newline") unless File.binread(".devcontainer/devcontainer.json").end_with?("\n"); puts "devcontainer ok"'
- git diff --check -- .devcontainer/compose.yaml .devcontainer/devcontainer.json .devcontainer/.env.example .gitignore
- curl -L http://localhost:5000/
