### PR TITLE
fix(scheduler): block lower-priority runs while higher-priority work is in flight

### DIFF
--- a/app/jobs/process_run_queue_job.rb
+++ b/app/jobs/process_run_queue_job.rb
@@ -69,7 +69,7 @@ class ProcessRunQueueJob < ApplicationJob
 
         break unless next_run
 
-        if lower_priority_than_claimed_or_started_project_run?(next_run, started_priority_by_project)
+        if lower_priority_than_inflight_or_started_project_run?(next_run, started_priority_by_project)
           blocked_project_ids.add(next_run.project_id)
           next
         end
@@ -200,15 +200,19 @@ class ProcessRunQueueJob < ApplicationJob
     started_priority_by_project[agent_run.project_id] = priority if existing.nil? || priority < existing
   end
 
-  def lower_priority_than_claimed_or_started_project_run?(agent_run, started_priority_by_project)
+  # Blocks a queued run from starting when the same project still has
+  # higher-priority work in flight — whether already running or merely
+  # claimed-but-not-yet-started — or started higher-priority work earlier in
+  # this pass. This keeps priority strict within a project: e.g. a P2 must
+  # wait while any P1 for the project is running or queued-and-claimed.
+  def lower_priority_than_inflight_or_started_project_run?(agent_run, started_priority_by_project)
     current_priority = queue_priority_for(agent_run)
     started_priority = started_priority_by_project[agent_run.project_id]
     return true if started_priority && current_priority > started_priority
 
     AgentRun
-      .queued_with_priority
+      .inflight_with_priority
       .where(project_id: agent_run.project_id)
-      .where.not(temporal_workflow_id: nil)
       .where("#{AgentRun::QUEUE_PRIORITY_CASE_SQL} < ?", current_priority)
       .exists?
   end

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -1168,6 +1168,16 @@ class AgentRun < ApplicationRecord
       )
   }
 
+  # Scope over in-flight runs (running + claimed-queued) exposing the same
+  # queue_priority expression as queued_with_priority via QUEUE_LATERAL_JOIN.
+  # Used by the queue processor to keep a lower-priority run from starting
+  # while a higher-priority run for the same project is still in flight —
+  # whether merely claimed or already running. No fair-share CTEs are joined
+  # because callers filter on queue_priority alone (not the full QUEUE_ORDER).
+  scope :inflight_with_priority, -> {
+    capacity_inflight.joins(QUEUE_LATERAL_JOIN)
+  }
+
   def self.project_active_counts_cte
     capacity_inflight
       .select("project_id, COUNT(*) AS project_active_count")

--- a/spec/jobs/process_run_queue_job_spec.rb
+++ b/spec/jobs/process_run_queue_job_spec.rb
@@ -161,6 +161,97 @@ RSpec.describe ProcessRunQueueJob do
       expect(p1_run.reload.temporal_workflow_id).to be_nil
     end
 
+    it "does not start lower-priority work while higher-priority work from the same project is running" do
+      project = create(:project)
+      user = project.created_by
+      user.settings.update!(max_concurrent_runs: 10)
+
+      3.times do |i|
+        p1_issue = create(:issue, project: project, github_number: 100 + i, labels: [ "P1" ])
+        create(:agent_run, :running, project: project, trigger_type: "automatic", issue: p1_issue)
+      end
+      p2_issue = create(:issue, project: project, github_number: 200, labels: [ "P2" ])
+      p2_run = create(:agent_run, :queued, project: project, trigger_type: "automatic", issue: p2_issue)
+
+      expect(temporal_client).not_to receive(:start_workflow)
+
+      described_class.new.perform
+
+      expect(p2_run.reload.temporal_workflow_id).to be_nil
+    end
+
+    it "does not let paused or completed higher-priority work block lower-priority work" do
+      project = create(:project)
+      user = project.created_by
+      user.settings.update!(max_concurrent_runs: 10)
+
+      # A P1 blocked/paused (e.g. quality pause or awaiting input) and a P1
+      # whose run already finished (PR now sitting in review) are not in
+      # flight, so neither should preempt runnable lower-priority work.
+      paused_p1 = create(:issue, project: project, github_number: 1, labels: [ "P1" ])
+      create(:agent_run, :paused, project: project, trigger_type: "automatic", issue: paused_p1)
+      done_p1 = create(:issue, project: project, github_number: 2, labels: [ "P1" ])
+      create(:agent_run, :completed, project: project, trigger_type: "automatic", issue: done_p1)
+
+      p2_issue = create(:issue, project: project, github_number: 3, labels: [ "P2" ])
+      p2_run = create(:agent_run, :queued, project: project, trigger_type: "automatic", issue: p2_issue)
+
+      expect(temporal_client).to receive(:start_workflow).with(
+        Workflows::AgentExecutionWorkflow,
+        hash_including(agent_run_id: p2_run.id),
+        hash_including(task_queue: "paid-agent-tasks")
+      ).and_return(workflow_handle)
+
+      described_class.new.perform
+
+      expect(p2_run.reload.temporal_workflow_id).to be_present
+    end
+
+    it "lets a queued run start when only lower-priority work is in flight" do
+      project = create(:project)
+      user = project.created_by
+      user.settings.update!(max_concurrent_runs: 10)
+
+      # A lower-priority auto-pick run is in flight; it must not block higher-priority queued work.
+      create(:agent_run, :running, project: project, trigger_type: "automatic")
+      p2_issue = create(:issue, project: project, github_number: 200, labels: [ "P2" ])
+      p2_run = create(:agent_run, :queued, project: project, trigger_type: "automatic", issue: p2_issue)
+
+      expect(temporal_client).to receive(:start_workflow).with(
+        Workflows::AgentExecutionWorkflow,
+        hash_including(agent_run_id: p2_run.id),
+        hash_including(task_queue: "paid-agent-tasks")
+      ).and_return(workflow_handle)
+
+      described_class.new.perform
+
+      expect(p2_run.reload.temporal_workflow_id).to be_present
+    end
+
+    it "does not block equal-priority queued work (a running P1 allows another queued P1 to start)" do
+      project = create(:project)
+      user = project.created_by
+      user.settings.update!(max_concurrent_runs: 10)
+
+      # The guard blocks only STRICTLY higher-priority in-flight work (`<`), so
+      # a second P1 must still be allowed to start alongside a running P1 —
+      # otherwise a project could never run two same-tier items concurrently.
+      running_p1 = create(:issue, project: project, github_number: 10, labels: [ "P1" ])
+      create(:agent_run, :running, project: project, trigger_type: "automatic", issue: running_p1)
+      queued_p1 = create(:issue, project: project, github_number: 11, labels: [ "P1" ])
+      p1_run = create(:agent_run, :queued, project: project, trigger_type: "automatic", issue: queued_p1)
+
+      expect(temporal_client).to receive(:start_workflow).with(
+        Workflows::AgentExecutionWorkflow,
+        hash_including(agent_run_id: p1_run.id),
+        hash_including(task_queue: "paid-agent-tasks")
+      ).and_return(workflow_handle)
+
+      described_class.new.perform
+
+      expect(p1_run.reload.temporal_workflow_id).to be_present
+    end
+
     it "marks run as failed and continues when workflow start fails" do
       failing_run = create(:agent_run, :queued, created_at: 2.minutes.ago)
       good_run = create(:agent_run, :queued, created_at: 1.minute.ago)


### PR DESCRIPTION
## Problem

`ProcessRunQueueJob`'s within-project priority guard only blocked a queued run when a higher-priority run for the same project was **queued-and-claimed** — it ignored runs that were already **running**. Once a project's P1 runs transitioned `queued → running`, a queued P2 was no longer blocked and could start ahead of that project's still-incomplete P1 work.

Observed in production on PR #2558: a fresh **P2 issue** run was claimed while several **P1** runs for the same project were in flight.

## Fix

- Add `AgentRun.inflight_with_priority` — a scope over `capacity_inflight` (running **+** claimed-queued) that exposes the same `queue_priority` expression via `QUEUE_LATERAL_JOIN`.
- The guard (`lower_priority_than_inflight_or_started_project_run?`) now consults that scope, so a queued run waits while the same project has **any strictly-higher-priority** run in flight — whether running or claimed.

Paused or finished work is intentionally **not** treated as in flight, so it does not block lower-priority work:

- a PR awaiting CI/review → its `create_pr` run is `completed`
- quality-paused work → `paused`
- needs-input/no-output → finished statuses

Only genuinely active or about-to-start higher-priority work blocks — i.e. work that could actually be picked up.

## Behavior notes

- Strict `<`: equal-tier work is **not** blocked (a running P1 still allows a second queued P1 to start), preserving same-tier concurrency.
- Within a single project, lower-priority slots may sit idle while higher-priority work is in flight — the intended strict-priority tradeoff. Cross-project, freed slots still go to other projects via the unchanged `QUEUE_ORDER` round-robin.

## Tests

`spec/jobs/process_run_queue_job_spec.rb`:

- running higher-priority work blocks a queued lower-priority run;
- paused/completed higher-priority work does **not** block;
- only-lower-priority in flight does **not** block;
- **equal-tier** (running P1 allows a queued P1) — guards the strict `<` (mutation-verified: flipping to `<=` fails this test).

## Related

- Companion to scheduler issues #2561 (per-user concurrency not enforced) and #2563 (runner-agnostic queue / late-binding). This change is independent of both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
