### PR TITLE
fix(runners): align OpenCode MiniMax provider config with 1.3.x and stop proxy-token leak

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ gem "qdrant-ruby", require: false
 gem "aws-sdk-s3", require: false
 
 # Unified interface for AI agent CLIs [https://github.com/viamin/agent-harness]
-gem "agent-harness", "~> 0.20.0"
+gem "agent-harness", "~> 0.22.4"
 
 # Runtime model registry for canonical model metadata, pricing, and capabilities.
 gem "ruby_llm", "~> 1.15"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     afm (1.0.0)
-    agent-harness (0.20.0)
+    agent-harness (0.22.4)
       logger (>= 1.6, < 2.0)
     ast (2.4.3)
     avo (4.0.0.beta.41)
@@ -670,7 +670,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  agent-harness (~> 0.20.0)
+  agent-harness (~> 0.22.4)
   avo (= 4.0.0.beta.41)
   aws-sdk-s3
   bootsnap
@@ -752,7 +752,7 @@ CHECKSUMS
   activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   afm (1.0.0) sha256=5bd4d6f6241e7014ef090985ec6f4c3e9745f6de0828ddd58bc1efdd138f4545
-  agent-harness (0.20.0) sha256=31a9bfe5eec23c293d514ab9b1826c094b6d79887b351d36cf0d1077ff503bd8
+  agent-harness (0.22.4) sha256=0a7f3a3497c0fb3cca1ba18dd723ade4c9bdd12d97ddcf320de511bc5aae8946
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   avo (4.0.0.beta.41) sha256=3c0ebe1e4206c89098478dedade31a91e2441035d4cef8581ccef90b8d44126f
   avo-icons (0.1.5) sha256=e9f03c268d52bb0dedf7530bfb0e968c2ef79bf9aa911c86b65364c16ae7ffc5
@@ -773,7 +773,7 @@ CHECKSUMS
   brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   browser (6.2.0) sha256=281d5295788825c9396427c292c2d2be0a5c91875c93c390fde6e5d61a5ace2d
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
-  bundler (4.0.13) sha256=19f08be7f27022cf0b89f27da0b044ae075e8270a9ef44ad248a932614e1ca3b
+  bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   chartkick (5.2.1) sha256=2848d7de87189f30f28d077eb0bbdebc8a1f0f6f81de1ded95008fe564369949
@@ -989,4 +989,4 @@ CHECKSUMS
   zeitwerk (2.8.2) sha256=7212a61311083c604184b1ea2574b9aa05cd14f855a0841c06985cabe9181d12
 
 BUNDLED WITH
-  4.0.13
+  4.0.14

--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -32,8 +32,15 @@ class Runner < ApplicationRecord
   # service type required for authentication.
   # Each entry carries an adapter hint so config generators can distinguish
   # OpenAI-compatible endpoints from providers with a native SDK (Anthropic).
-  # The opencode_npm / kilocode_api keys default to the openai-compatible
-  # adapter and are overridden only for Anthropic.
+  # Key contracts consumed by opencode_runner_runtime / opencode_qualified_model:
+  #   - opencode_npm: drives BOTH SDK selection and base-URL routing. When it is
+  #     "@ai-sdk/anthropic", the base URL goes to ANTHROPIC_BASE_URL and "npm" is
+  #     injected into the provider config; otherwise the base URL goes to
+  #     OPENAI_BASE_URL. Defaults to the openai-compatible adapter.
+  #   - opencode_model_provider: names the provider-config block AND the model
+  #     prefix (e.g. "minimax/<model>"). Required for any @ai-sdk/anthropic entry.
+  #   - env_var: overrides the auto-derived "<SERVICE_TYPE>_API_KEY" name (MiniMax
+  #     authenticates via ANTHROPIC_API_KEY despite its "minimax" service type).
   DIRECT_OUTBOUND_API_PROVIDERS = {
     "openrouter" => { label: "OpenRouter", base_url: "https://openrouter.ai/api/v1", service_type: "openrouter",
                       opencode_model_provider: "openrouter" },
@@ -49,7 +56,8 @@ class Runner < ApplicationRecord
     "mistral" => { label: "Mistral", base_url: "https://api.mistral.ai/v1", service_type: "mistral",
                    opencode_model_provider: "mistral" },
     "minimax" => { label: "MiniMax", base_url: "https://api.minimax.io/anthropic/v1", service_type: "minimax",
-                   env_var: "ANTHROPIC_API_KEY", opencode_npm: "@ai-sdk/anthropic", kilocode_provider_id: "anthropic" },
+                   env_var: "ANTHROPIC_API_KEY", opencode_npm: "@ai-sdk/anthropic", kilocode_provider_id: "anthropic",
+                   opencode_model_provider: "minimax" },
     "xai" => { label: "xAI", base_url: "https://api.x.ai/v1", service_type: "xai",
                opencode_model_provider: "xai" },
     "zai" => { label: "z.ai", base_url: "https://api.z.ai/api/paas/v4", service_type: "zai",
@@ -1227,23 +1235,40 @@ class Runner < ApplicationRecord
     env = { env_var => effective_api_secret.to_s }
 
     # Providers using @ai-sdk/anthropic receive their base URL through the
-    # provider config (OPENAI_BASE_URL is only read by the OpenAI-compatible SDK).
+    # ANTHROPIC_BASE_URL env var and declare their SDK via the provider config
+    # "npm" field.  OpenCode 1.3.x rejects unrecognized keys like "baseURL" in
+    # provider configs, so the URL must go through the environment.
+    # OPENAI_BASE_URL is only read by the OpenAI-compatible SDK.
     provider_config = {}
-    if api_config[:opencode_npm] == "@ai-sdk/anthropic" && api_config[:base_url]
-      provider_config["baseURL"] = api_config[:base_url]
+    if api_config[:opencode_npm] == "@ai-sdk/anthropic"
+      provider_config["npm"] = api_config[:opencode_npm]
+      env["ANTHROPIC_BASE_URL"] = api_config[:base_url] if api_config[:base_url]
     elsif api_config[:base_url]
       env["OPENAI_BASE_URL"] = api_config[:base_url]
     end
 
     metadata_config = {}
     unless provider_config.empty?
-      metadata_config["provider"] = { opencode_api_provider => provider_config }
+      # provider_config is only populated for @ai-sdk/anthropic entries, which
+      # always declare opencode_model_provider. fetch (not ||) so a future entry
+      # that forgets it fails loudly instead of silently mislabeling the block.
+      provider_key = api_config.fetch(:opencode_model_provider)
+      metadata_config["provider"] = { provider_key => provider_config }
     end
 
     AgentHarness::ProviderRuntime.new(
       model: model_id,
       env: env,
-      unset_env: %w[OPENAI_HEADER_X_AGENT_RUN_ID OPENAI_HEADER_X_PROXY_TOKEN],
+      # Strip the Paid secrets-proxy headers that provision.rb seeds as baseline
+      # env. A direct-outbound runtime talks to the provider's own endpoint, so
+      # forwarding the per-run proxy token would leak it to a third party. The
+      # ANTHROPIC_* pair matters once ANTHROPIC_BASE_URL is redirected to a
+      # direct @ai-sdk/anthropic endpoint (e.g. MiniMax); OPENAI_* is the same
+      # concern for the OpenAI-compatible providers.
+      unset_env: %w[
+        OPENAI_HEADER_X_AGENT_RUN_ID OPENAI_HEADER_X_PROXY_TOKEN
+        ANTHROPIC_HEADER_X_AGENT_RUN_ID ANTHROPIC_HEADER_X_PROXY_TOKEN
+      ],
       metadata: {
         config: metadata_config
       }

--- a/app/services/runners/test_agent.rb
+++ b/app/services/runners/test_agent.rb
@@ -306,7 +306,7 @@ module Runners
           error_type: error_type,
           message: translated_message.presence || display_message
         )
-      elsif harness_error_type.present? && (!smoke_test_output_success?(output) || !smoke_test_output_success?(message))
+      elsif harness_error_type.present? && ((output.present? && !smoke_test_output_success?(output)) || !smoke_test_output_success?(message))
         translated_message = translate_and_extract_error(failure_message)
 
         Result.new(

--- a/spec/models/runner_spec.rb
+++ b/spec/models/runner_spec.rb
@@ -1110,15 +1110,40 @@ RSpec.describe Runner do
 
       runtime = minimax_runner.agent_harness_runner_runtime
 
-      expect(runtime.model).to eq("MiniMax-M2.7")
-      expect(runtime.env).to include("ANTHROPIC_API_KEY" => "sk-minimax-secret")
+      expect(runtime.model).to eq("minimax/MiniMax-M2.7")
+      expect(runtime.env).to include(
+        "ANTHROPIC_API_KEY" => "sk-minimax-secret",
+        "ANTHROPIC_BASE_URL" => "https://api.minimax.io/anthropic/v1"
+      )
       expect(runtime.env).not_to have_key("OPENAI_BASE_URL")
       expect(runtime.metadata[:config]["provider"]).to eq(
-        { "minimax" => { "baseURL" => "https://api.minimax.io/anthropic/v1" } }
+        { "minimax" => { "npm" => "@ai-sdk/anthropic" } }
       )
+      # Paid proxy headers must be stripped so the per-run token never reaches MiniMax.
+      expect(runtime.unset_env).to include("ANTHROPIC_HEADER_X_AGENT_RUN_ID", "ANTHROPIC_HEADER_X_PROXY_TOKEN")
     end
 
-    it "leaves MiniMax highspeed models unqualified" do
+    it "configures the native Anthropic provider through the @ai-sdk/anthropic SDK" do
+      anthropic_key = create(:provider_api_key, user: user, api_service_type: "anthropic", api_key: "sk-ant-secret")
+      anthropic_runner = create(
+        :runner,
+        user: user,
+        runner_key: "opencode",
+        auth_type: "api_key",
+        provider_api_key: anthropic_key,
+        config: { "opencode" => { "api_provider" => "anthropic", "model" => "claude-sonnet-4-5" } }
+      )
+
+      runtime = anthropic_runner.agent_harness_runner_runtime
+
+      expect(runtime.model).to eq("anthropic/claude-sonnet-4-5")
+      expect(runtime.env).to include("ANTHROPIC_API_KEY" => "sk-ant-secret", "ANTHROPIC_BASE_URL" => "https://api.anthropic.com")
+      expect(runtime.env).not_to have_key("OPENAI_BASE_URL")
+      expect(runtime.metadata[:config]["provider"]).to eq({ "anthropic" => { "npm" => "@ai-sdk/anthropic" } })
+      expect(runtime.unset_env).to include("ANTHROPIC_HEADER_X_PROXY_TOKEN")
+    end
+
+    it "qualifies MiniMax highspeed models with the minimax provider prefix" do
       minimax_key = create(:provider_api_key, user: user, api_service_type: "minimax", api_key: "sk-minimax-hs")
       minimax_runner = create(
         :runner,
@@ -1131,11 +1156,14 @@ RSpec.describe Runner do
 
       runtime = minimax_runner.agent_harness_runner_runtime
 
-      expect(runtime.model).to eq("MiniMax-M2.7-highspeed")
-      expect(runtime.env).to include("ANTHROPIC_API_KEY" => "sk-minimax-hs")
+      expect(runtime.model).to eq("minimax/MiniMax-M2.7-highspeed")
+      expect(runtime.env).to include(
+        "ANTHROPIC_API_KEY" => "sk-minimax-hs",
+        "ANTHROPIC_BASE_URL" => "https://api.minimax.io/anthropic/v1"
+      )
       expect(runtime.env).not_to have_key("OPENAI_BASE_URL")
       expect(runtime.metadata[:config]["provider"]).to eq(
-        { "minimax" => { "baseURL" => "https://api.minimax.io/anthropic/v1" } }
+        { "minimax" => { "npm" => "@ai-sdk/anthropic" } }
       )
     end
 


### PR DESCRIPTION
## What & why

OpenCode 1.3.x rejects the unrecognized `baseURL` key in provider configs, which broke direct-outbound MiniMax runs. `@ai-sdk/anthropic` providers (MiniMax + native Anthropic) now pass the base URL via the `ANTHROPIC_BASE_URL` env var and declare their SDK through the provider-config `npm` field. Models are qualified with the `opencode_model_provider` prefix (e.g. `minimax/MiniMax-M2.7`).

## Changes

- **Provider config (`runner.rb`):** `baseURL` key → `ANTHROPIC_BASE_URL` env + `npm` provider-config field for `@ai-sdk/anthropic` providers; `minimax/` model qualification via `opencode_model_provider`.
- **🔒 Proxy-token leak fix (P1):** direct-outbound runtimes now strip the `ANTHROPIC_HEADER_X_AGENT_RUN_ID` / `ANTHROPIC_HEADER_X_PROXY_TOKEN` headers that `provision.rb` seeds as baseline env. Without this, redirecting `ANTHROPIC_BASE_URL` to a third-party endpoint (MiniMax / api.anthropic.com) would forward the per-run Paid proxy token to that third party. Symmetric with the existing `OPENAI_HEADER_X_*` strip.
- **Hardening:** dead `|| opencode_api_provider` fallback → `fetch` (fail loudly on a misconfigured future provider); documented the `DIRECT_OUTBOUND_API_PROVIDERS` key contracts; smoke-test result classification guard.
- **Deps:** `agent-harness 0.20.0 → 0.22.4`, `bundler 4.0.13 → 4.0.14`.

## Tests

- New spec for the native Anthropic opencode runtime; updated MiniMax expectations; new `unset_env` proxy-header assertions.
- `runner_spec` + `test_agent_spec`: **191 examples, 0 failures**. Broader blast radius (`run_agent_activity`, `harness_execution_plan`, `test_agent`, `provision`): **523 examples, 0 failures**. Rubocop clean.

## Reviewer note (secret boundary)

The leak's final hop — whether OpenCode's `@ai-sdk/anthropic` forwards `ANTHROPIC_HEADER_X_*` env as request headers — is inferred from the existing OPENAI precedent, not directly observed. The fix is correct regardless (a direct-outbound runtime should never carry proxy headers), but worth a confirming look.

## Follow-up (out of scope)

`pi_runner_runtime` carries the same OPENAI-only `unset_env`; if `pi` ever routes `ANTHROPIC_BASE_URL` direct it would have the same latent leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)