### PR TITLE
fix(notifications): add missing consecutive_provider_transient_outages keyword to ProgressState::Result

### DIFF
--- a/app/services/notifications/rules/pr_followup_limit_reached.rb
+++ b/app/services/notifications/rules/pr_followup_limit_reached.rb
@@ -72,6 +72,7 @@ module Notifications
           indexed[progress_state_key(issue_id)] = PullRequests::ProgressState::Result.new(
             consecutive_unsuccessful_automatic_runs: entry[:consecutive_unsuccessful_automatic_runs] || entry["consecutive_unsuccessful_automatic_runs"] || 0,
             consecutive_operational_failures: entry[:consecutive_operational_failures] || entry["consecutive_operational_failures"] || 0,
+            consecutive_provider_transient_outages: entry[:consecutive_provider_transient_outages] || entry["consecutive_provider_transient_outages"] || 0,
             last_meaningful_progress_at: entry[:last_meaningful_progress_at] || entry["last_meaningful_progress_at"],
             latest_automatic_run_at: entry[:latest_automatic_run_at] || entry["latest_automatic_run_at"],
             latest_unsuccessful_run_at: entry[:latest_unsuccessful_run_at] || entry["latest_unsuccessful_run_at"],

--- a/spec/services/notifications/rules/pr_followup_limit_reached_spec.rb
+++ b/spec/services/notifications/rules/pr_followup_limit_reached_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Notifications::Rules::PrFollowupLimitReached do
       PullRequests::ProgressState::Result.new(
         consecutive_unsuccessful_automatic_runs: 3,
         consecutive_operational_failures: 0,
+        consecutive_provider_transient_outages: 0,
         last_meaningful_progress_at: nil,
         latest_automatic_run_at: nil,
         latest_unsuccessful_run_at: 4.hours.ago,
@@ -48,6 +49,7 @@ RSpec.describe Notifications::Rules::PrFollowupLimitReached do
         PullRequests::ProgressState::Result.new(
           consecutive_unsuccessful_automatic_runs: 3,
           consecutive_operational_failures: 0,
+          consecutive_provider_transient_outages: 0,
           last_meaningful_progress_at: nil,
           latest_automatic_run_at: nil,
           latest_unsuccessful_run_at: 4.hours.ago,
@@ -114,6 +116,7 @@ RSpec.describe Notifications::Rules::PrFollowupLimitReached do
         PullRequests::ProgressState::Result.new(
           consecutive_unsuccessful_automatic_runs: 3,
           consecutive_operational_failures: 0,
+          consecutive_provider_transient_outages: 0,
           last_meaningful_progress_at: nil,
           latest_automatic_run_at: nil,
           latest_unsuccessful_run_at: 10.minutes.ago,
@@ -130,6 +133,7 @@ RSpec.describe Notifications::Rules::PrFollowupLimitReached do
         PullRequests::ProgressState::Result.new(
           consecutive_unsuccessful_automatic_runs: 3,
           consecutive_operational_failures: 0,
+          consecutive_provider_transient_outages: 0,
           last_meaningful_progress_at: nil,
           latest_automatic_run_at: nil,
           latest_unsuccessful_run_at: nil,
@@ -153,6 +157,7 @@ RSpec.describe Notifications::Rules::PrFollowupLimitReached do
       PullRequests::ProgressState::Result.new(
         consecutive_unsuccessful_automatic_runs: 2,
         consecutive_operational_failures: 0,
+        consecutive_provider_transient_outages: 0,
         last_meaningful_progress_at: nil,
         latest_automatic_run_at: nil,
         latest_unsuccessful_run_at: 4.hours.ago,
@@ -181,6 +186,7 @@ RSpec.describe Notifications::Rules::PrFollowupLimitReached do
       PullRequests::ProgressState::Result.new(
         consecutive_unsuccessful_automatic_runs: 2,
         consecutive_operational_failures: 0,
+        consecutive_provider_transient_outages: 0,
         last_meaningful_progress_at: nil,
         latest_automatic_run_at: nil,
         latest_unsuccessful_run_at: 4.hours.ago,

--- a/spec/services/notifications/rules/stalled_draft_pr_spec.rb
+++ b/spec/services/notifications/rules/stalled_draft_pr_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Notifications::Rules::StalledDraftPr do
       PullRequests::ProgressState::Result.new(
         consecutive_unsuccessful_automatic_runs: 3,
         consecutive_operational_failures: 0,
+        consecutive_provider_transient_outages: 0,
         last_meaningful_progress_at: nil,
         latest_automatic_run_at: nil,
         latest_unsuccessful_run_at: 4.hours.ago,
@@ -42,6 +43,7 @@ RSpec.describe Notifications::Rules::StalledDraftPr do
       PullRequests::ProgressState::Result.new(
         consecutive_unsuccessful_automatic_runs: 2,
         consecutive_operational_failures: 0,
+        consecutive_provider_transient_outages: 0,
         last_meaningful_progress_at: nil,
         latest_automatic_run_at: nil,
         latest_unsuccessful_run_at: 4.hours.ago,


### PR DESCRIPTION
## Problem

The test suite is red on `main` ([run 27388539781](https://github.com/viamin/paid/actions/runs/27388539781/job/80940862919)). 19 examples across two notification-rule specs fail with:

```
ArgumentError: missing keyword: :consecutive_provider_transient_outages
```

## Root cause

PR #2541 (`fix(escalation): suppress breaker escalation for pure provider/infra transient outages`) added a **required** `consecutive_provider_transient_outages` keyword to the `PullRequests::ProgressState::Result` `Data` class, but missed two construction sites that don't go through `ProgressState#call`:

1. **Production bug** — `Notifications::Rules::PrFollowupLimitReached#index_progress_states` reconstructs `Result` from serialized workflow payloads. Without the new keyword it raises `ArgumentError` at runtime whenever the rule runs with serialized `progress_states`, not just in tests.
2. **Spec breakage** — the `PrFollowupLimitReached` and `StalledDraftPr` specs build `Result` directly (8 sites).

## Fix

- `index_progress_states` now reads `consecutive_provider_transient_outages` from the payload, defaulting to `0` (consistent with the sibling fields).
- All 8 direct `Result.new` spec sites pass `consecutive_provider_transient_outages: 0`.

The production path is covered by the existing "prefers scan-derived progress state" and "accepts string issue ids from serialized workflow payloads" tests, which exercise `index_progress_states` and now pass.

## Verification

```
$ bin/rspec spec/services/notifications/rules/pr_followup_limit_reached_spec.rb \
            spec/services/notifications/rules/stalled_draft_pr_spec.rb
19 examples, 0 failures

$ bin/rspec spec/services/pull_requests/progress_state_spec.rb
23 examples, 0 failures
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)