### PR TITLE
fix(containers): pin codex subscription model config

### DIFF
--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -1065,11 +1065,19 @@ module Containers
       return unless File.file?(source_file)
 
       content = File.read(source_file)
-      sanitized = strip_codex_project_sections(content)
+      sanitized = sanitize_codex_host_config(content)
       write_container_file("/home/agent/.codex/config.toml", sanitized)
       log_system("container.codex_config_sanitized")
     rescue Docker::Error::DockerError, SystemCallError => e
       log_system("container.codex_config_sanitization_failed", error: e.message)
+    end
+
+    def sanitize_codex_host_config(toml)
+      sanitized = strip_codex_project_sections(toml)
+      sanitized = strip_codex_top_level_model_settings(sanitized)
+      model_id = codex_container_model_id
+
+      model_id.present? ? %(model = "#{toml_string_escape(model_id)}"\n#{sanitized}) : sanitized
     end
 
     def strip_codex_project_sections(toml)
@@ -1091,6 +1099,27 @@ module Containers
 
         false
       end.join
+    end
+
+    def strip_codex_top_level_model_settings(toml)
+      in_top_level = true
+      toml.lines.reject do |line|
+        in_top_level = false if line.match?(/\A\s*\[/)
+        in_top_level && line.match?(/\A\s*model(?:_reasoning_effort)?\s*=/)
+      end.join
+    end
+
+    def codex_container_model_id
+      tier = agent_run&.model_selection&.tier.presence ||
+        agent_run&.model_selection&.llm_model&.tier.presence ||
+        "mid"
+      defaults = Runners::DefaultTierModelIds.call(runner_key: "codex")
+
+      [ tier, "mid", "high", "low" ].uniq.filter_map { |candidate| defaults[candidate] }.first
+    end
+
+    def toml_string_escape(value)
+      JSON.generate(value.to_s)[1...-1]
     end
 
     # Appends the Codex notify hook to config.toml inside the container.

--- a/docs/rdrs/RDR-040-runner-model-compatibility-contracts.md
+++ b/docs/rdrs/RDR-040-runner-model-compatibility-contracts.md
@@ -1,0 +1,218 @@
+# RDR-040: Runner Model Compatibility Contracts
+
+> Revise during planning; lock at implementation. If wrong, abandon code and iterate RDR.
+
+## Metadata
+
+- **Status**: Draft
+- **Date**: 2026-06-13
+- **Priority**: P1
+- **Related RDRs**: RDR-007 (Agent CLI Abstraction), RDR-008 (Model Selection Strategy), RDR-034 (Tier-Based Runner Fallback), RDR-038 (Free Models Catalog and Runner)
+
+## Problem Statement
+
+Paid currently treats model selection and runner execution compatibility as loosely coupled concerns. The model catalog can mark an OpenAI model active, while the Codex CLI installed in the Paid agent image may not support that model. A recent Codex fallback failure exposed this gap: a subscription-auth Codex container inherited a host `~/.codex/config.toml` default of `gpt-5.5`, but the agent image's pinned Codex CLI rejected that model before the agent could start.
+
+The immediate fix pins subscription-auth Codex containers to Paid's active Codex-compatible model instead of inheriting host model defaults. That is a guardrail, not a full architecture. Paid needs a durable compatibility contract so unsupported models are rejected before scheduling and before runner fallback burns capacity.
+
+## Context
+
+### Current Architecture
+
+- Paid owns `LlmModel` records, including active state, provider, cost, capability score, category, and `low` / `mid` / `high` tier labels.
+- Paid's selectors choose a desired model or tier based on task complexity, project policy, budget, quality recovery, and runner settings.
+- `agent-harness` owns provider CLI command construction, runtime preparation, parsing, error classification, installation contracts, and supported CLI version ranges.
+- Agent images install runner CLIs from `agent-harness` installation contracts. For Codex, the installed harness version pins CLI support to a narrow version range.
+- Direct-outbound runners such as OpenCode and Pi have additional model constraints because model IDs are scoped to a specific upstream provider configuration.
+
+### Observed Failure Mode
+
+Agent run `26774` failed before real work started:
+
+1. The first fallback runner timed out during smoke preflight.
+2. Codex failed preflight with "The 'gpt-5.5' model requires a newer version of Codex."
+3. Claude then exited with `137`, exhausting the fallback chain.
+
+The important lesson is not only that the container inherited the wrong host config. The deeper issue is that model use was not validated against the actual runner executable and auth mode before execution.
+
+## Recommendation
+
+Introduce a two-layer model compatibility contract:
+
+1. **`agent-harness` owns runner capability and compatibility facts.**
+   - Supported CLI version requirement.
+   - Auth modes supported by the provider.
+   - Concrete supported model IDs when the provider can know them.
+   - Explicit unsupported model IDs or patterns when support is version-dependent.
+   - A runtime validation API such as `supports_model?(model_id:, auth_type:, cli_version:, runtime:)`.
+   - Optional model aliases or migrations when the provider CLI has first-class migration behavior.
+
+2. **Paid owns tier policy and model routing.**
+   - `low`, `mid`, and `high` remain Paid product concepts tied to cost, quality, task complexity, budgets, data policy, and fallback behavior.
+   - Paid maps tiers to model candidates from `LlmModel`.
+   - Paid filters and validates those candidates through the runner compatibility contract before saving runner settings, selecting defaults, or starting an agent run.
+
+This keeps the boundary clean: `agent-harness` says what a runner can execute; Paid decides what should be used for a customer task.
+
+## Proposed Design
+
+### Compatibility API
+
+Add an `agent-harness` provider API with a shape like:
+
+```ruby
+compatibility = AgentHarness.provider(:codex).model_compatibility(
+  model_id: "gpt-5.1",
+  auth_type: :subscription,
+  cli_version: "0.122.0",
+  runtime: provider_runtime
+)
+```
+
+Return a structured result:
+
+```ruby
+{
+  supported: true,
+  reason: nil,
+  replacement_model_id: nil,
+  source: "codex_cli_contract",
+  cli_requirement: ">= 0.122.0, < 0.123.0"
+}
+```
+
+For unsupported cases:
+
+```ruby
+{
+  supported: false,
+  reason: "model requires a newer Codex CLI",
+  replacement_model_id: "gpt-5.1",
+  source: "codex_cli_contract",
+  cli_requirement: ">= 0.122.0, < 0.123.0"
+}
+```
+
+### Paid Services
+
+Add a Paid-side service, tentatively `Runners::ModelCompatibility`, responsible for:
+
+- Resolving the runner's harness provider.
+- Passing runner key, auth type, configured runtime, and installed CLI contract to `agent-harness`.
+- Applying compatibility filtering to `Runners::DefaultTierModelIds`.
+- Validating runner `tier_models` and project/tenant model overrides.
+- Producing user-facing failure messages when a configured model cannot run.
+
+Update model selection and runner resolution so compatibility is checked before preflight:
+
+- `Models::Select` should select from compatible candidates for the run's runner when a concrete runner is known.
+- `Runners::ResolveTierModel` should reject or skip tier mappings unsupported by the selected runner.
+- `ProcessRunQueueJob` / late-binding work should consider runner compatibility when choosing a runnable runner.
+- `Models::DetectBrokenRunnerModels` should become a backstop, not the first place the system learns a model is unsupported.
+
+### User Experience
+
+Unsupported configurations should surface in settings and run history:
+
+- Runner settings should flag "Model unsupported by installed Codex CLI" rather than saving a broken mapping silently.
+- Agent run logs should show "No compatible Codex model for mid tier" instead of generic "All runners exhausted" where possible.
+- Dashboards should report compatibility drift between active `LlmModel` records and installed runner contracts.
+
+## Alternatives Considered
+
+### Alternative 1: Let `agent-harness` Own Tier Mapping
+
+`agent-harness` would expose `low`, `mid`, and `high` models per provider, and Paid would consume those directly.
+
+Rejected as the primary design. Tiers are product policy, not execution mechanics. Paid's tiers encode cost, task complexity, quality recovery, account policy, and routing trade-offs. Moving tier meaning into `agent-harness` would couple product decisions to CLI adapters and make cross-runner comparisons harder.
+
+### Alternative 2: Keep Only Paid's `LlmModel` Catalog
+
+Paid would continue selecting active provider models and rely on preflight failures to catch unsupported runner/model combinations.
+
+Rejected. This preserves the current failure mode: user-visible agent runs burn queue time and fallback attempts before discovering that a model cannot execute.
+
+### Alternative 3: Runtime `codex update`
+
+Paid containers would self-update Codex at startup so newer host defaults are more likely to work.
+
+Rejected for production runner execution. Runtime self-update bypasses the image build's audited install contract, weakens reproducibility, and can change command semantics, auth behavior, config parsing, or JSONL output without a matching `agent-harness` update.
+
+### Alternative 4: Strip All Host Codex Model Settings Only
+
+This is the current tactical fix. It prevents host defaults from poisoning container runs, but it does not validate Paid-selected models against runner support.
+
+Accepted as a short-term guardrail, not the strategic solution.
+
+## Trade-offs and Consequences
+
+### Positive Consequences
+
+- Unsupported model choices fail at configuration or scheduling time, not after a container is provisioned.
+- Runner fallback becomes more reliable because fallback candidates are filtered by actual execution capability.
+- Product tier policy remains in Paid, where budget, quality, and customer policy context exists.
+- `agent-harness` remains the single source of truth for CLI-specific behavior and version compatibility.
+
+### Negative Consequences
+
+- Paid and `agent-harness` need a richer API contract and coordinated releases.
+- Some providers cannot know all model availability statically because account entitlements vary.
+- Compatibility checks may require a mix of static contracts and smoke/runtime validation.
+- Existing `LlmModel` rows may need migration or drift reports when they are active but incompatible with installed runner contracts.
+
+### Risks and Mitigations
+
+- **Risk**: Compatibility metadata becomes stale.
+  - **Mitigation**: Run model health checks that compare active Paid catalog entries against installed runner contracts and recent runtime errors.
+- **Risk**: Tier semantics drift between Paid and provider metadata.
+  - **Mitigation**: Keep tier definitions in Paid and treat provider tiers as optional hints only.
+- **Risk**: Providers expose model support dynamically by account.
+  - **Mitigation**: Model compatibility API should support "unknown" and "requires runtime check" outcomes, not only boolean supported/unsupported.
+- **Risk**: Fallback chains shrink when strict compatibility filtering is introduced.
+  - **Mitigation**: Surface "no compatible runner" explicitly and continue investing in late-bound runner selection.
+
+## Implementation Plan
+
+1. Add `agent-harness` compatibility metadata for Codex.
+   - Start with installed CLI version requirement and known unsupported/newer-model cases.
+   - Expose structured compatibility results.
+
+2. Add Paid `Runners::ModelCompatibility`.
+   - Wrap harness compatibility in a Paid service.
+   - Normalize runner key, auth mode, runtime, and selected model.
+
+3. Filter default tier model mappings.
+   - Update `Runners::DefaultTierModelIds` to choose the best active model per tier that is compatible with the target runner.
+   - Preserve Paid's fallback behavior when a tier has no compatible model.
+
+4. Validate configured tier mappings.
+   - Reject runner `tier_models` that cannot run on the selected runner/auth mode.
+   - Add remediation copy for users.
+
+5. Apply compatibility before execution.
+   - Update `Runners::ResolveTierModel` and run queue binding to skip incompatible runner/model pairs.
+   - Prefer a compatible fallback runner over a preferred runner with an incompatible model.
+
+6. Add observability.
+   - Extend broken-runner model detection to file compatibility drift findings.
+   - Add dashboard signals for active models unsupported by installed runner contracts.
+
+## Validation
+
+### Tests
+
+- Codex subscription runner rejects a model requiring a newer CLI before container preflight.
+- Codex subscription runner maps `mid` to the highest compatible active Paid model.
+- Project-required model fails with a clear compatibility error when unsupported by the runner.
+- Runner fallback skips incompatible runners and selects a compatible alternative.
+- Direct-outbound runner tier models remain constrained to their configured provider/model pair.
+
+### Operational Checks
+
+- Agent image contract tests assert the installed Codex CLI satisfies the `agent-harness` requirement.
+- Model health checks report active catalog models incompatible with installed runner contracts.
+- Recent failure detector should show decreasing "requires newer version of Codex" occurrences after rollout.
+
+## Decision
+
+Proceed with the two-layer compatibility contract. Do not move tier ownership wholesale into `agent-harness`. Keep Paid responsible for tier policy and model routing; make `agent-harness` authoritative for runner execution compatibility.

--- a/docs/rdrs/README.md
+++ b/docs/rdrs/README.md
@@ -104,6 +104,7 @@ For more information, see the [RDR methodology](https://github.com/cwensel/rdr).
 | RDR | Title | Status | Priority |
 |-----|-------|--------|----------|
 | [RDR-025](RDR-025-runner-quota-tracking.md) | Runner Quota Tracking and Quota-Aware Routing | Implemented | Medium |
+| [RDR-040](RDR-040-runner-model-compatibility-contracts.md) | Runner Model Compatibility Contracts | Draft | P1 |
 
 ### Semantic Understanding
 

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -1351,9 +1351,11 @@ RSpec.describe Containers::Provision do
       let(:codex_config_dir) { Dir.mktmpdir("codex-config") }
 
       before do
+        create(:llm_model, :openai, model_id: "gpt-5.1", tier: "mid", capability_score: 9.0)
         File.write(File.join(codex_config_dir, "auth.json"), "{}")
         File.write(File.join(codex_config_dir, "config.toml"), <<~TOML)
           model = "gpt-5"
+          model_reasoning_effort = "medium"
 
           [projects."/workspaces/paid"]
           trust_level = "trusted"
@@ -1418,7 +1420,9 @@ RSpec.describe Containers::Provision do
             satisfy { |cmd|
               decoded = decoded_base64_content(cmd)
               cmd.include?("/home/agent/.codex/config.toml") &&
-                decoded.include?('model = "gpt-5"') &&
+                decoded.include?('model = "gpt-5.1"') &&
+                !decoded.include?('model = "gpt-5"') &&
+                !decoded.include?("model_reasoning_effort") &&
                 decoded.include?("[features]") &&
                 !decoded.include?("[projects")
             }
@@ -1462,8 +1466,9 @@ RSpec.describe Containers::Provision do
       let(:codex_local_dir) { Dir.mktmpdir("codex-local") }
 
       before do
+        create(:llm_model, :openai, model_id: "gpt-5.1", tier: "mid", capability_score: 9.0)
         File.write(File.join(codex_local_dir, "auth.json"), '{"refresh_token":"test-token"}')
-        File.write(File.join(codex_local_dir, "config.toml"), "model = \"gpt-5\"")
+        File.write(File.join(codex_local_dir, "config.toml"), "model = \"gpt-5\"\nmodel_reasoning_effort = \"medium\"")
 
         allow(ENV).to receive(:fetch).and_call_original
         allow(ENV).to receive(:[]).and_call_original
@@ -1513,7 +1518,9 @@ RSpec.describe Containers::Provision do
         expect(mock_container).to have_received(:exec).with(
           [ "sh", "-lc", satisfy { |cmd|
             cmd.include?("/home/agent/.codex/config.toml") &&
-              decoded_base64_content(cmd).include?('model = "gpt-5"')
+              decoded_base64_content(cmd).include?('model = "gpt-5.1"') &&
+              !decoded_base64_content(cmd).include?('model = "gpt-5"') &&
+              !decoded_base64_content(cmd).include?("model_reasoning_effort")
           } ],
           user: "agent"
         )
@@ -3293,6 +3300,37 @@ RSpec.describe Containers::Provision do
       result = service.send(:strip_codex_project_sections, toml)
 
       expect(result).to eq("model = \"gpt-5\"\n[features]\nmulti_agent = true\n")
+    end
+  end
+
+  describe "#sanitize_codex_host_config" do
+    let(:service) { described_class.new(agent_run: agent_run, project: project) }
+
+    it "replaces host model settings with an escaped Paid-selected Codex model" do
+      allow(service).to receive(:codex_container_model_id).and_return('gpt-"quoted"')
+
+      result = service.send(:sanitize_codex_host_config, <<~TOML)
+          model = "gpt-5.5"
+          model_reasoning_effort = "medium"
+        [features]
+        multi_agent = true
+      TOML
+
+      expect(result).to eq(<<~TOML)
+        model = "gpt-\\"quoted\\""
+        [features]
+        multi_agent = true
+      TOML
+    end
+
+    it "falls back to the active mid-tier Codex model when the run tier has no Codex default" do
+      create(:llm_model, :openai, model_id: "gpt-5.1", tier: "mid", capability_score: 9.0)
+      high_model = create(:llm_model, model_id: "claude-opus-test", provider: "anthropic", tier: "high")
+      create(:model_selection, agent_run: agent_run, llm_model: high_model, tier: "high")
+
+      result = service.send(:sanitize_codex_host_config, "model = \"gpt-5.5\"\n")
+
+      expect(result).to eq("model = \"gpt-5.1\"\n")
     end
   end
 end


### PR DESCRIPTION
## Summary

Codex subscription-auth agent runs no longer inherit workstation model defaults that may be unsupported by the pinned agent-image CLI. Container provisioning now removes host-level Codex model settings and writes Paid's active Codex-compatible model for the run tier, falling back to a known active Codex default instead of letting the CLI choose its own model.

This prevents fallback attempts from failing before work starts when a local `~/.codex/config.toml` points at a newer model than the installed Paid agent image supports.

## Architecture Note

Adds `RDR-040: Runner Model Compatibility Contracts`, which recommends a two-layer long-term design: `agent-harness` owns runner/model execution compatibility, while Paid keeps ownership of tier policy and model routing.

## Test Plan

- `bin/rspec spec/services/containers/provision_spec.rb`
- `bin/rspec spec/services/models/detect_broken_runner_models_spec.rb`
- `bin/rubocop app/services/containers/provision.rb spec/services/containers/provision_spec.rb`
- `bin/lint --changed`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)