### PR TITLE
fix(runners): recover agent runs from outage (codex model pin + container-death infra classification + back-off reset)

### DIFF
--- a/app/services/containers.rb
+++ b/app/services/containers.rb
@@ -3,6 +3,7 @@
 module Containers
   LOCAL_BACKEND_KEY = :local
   REMOTE_BACKEND_KEY = :remote
+  CONTAINER_NOT_RUNNING_PATTERN = /is not running|No such container/i
 
   class << self
     def backend

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -851,7 +851,7 @@ module Containers
 
     def container_died_error?(error)
       message = error.respond_to?(:message) ? error.message : error.to_s
-      message.to_s.match?(/is not running|No such container/i)
+      message.to_s.match?(Containers::CONTAINER_NOT_RUNNING_PATTERN)
     end
 
     # Best-effort cleanup that never raises, for use in ensure blocks when

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -811,6 +811,19 @@ module Containers
     end
 
     def cleanup_execution_preparation(cleanup_steps, env:)
+      # A stopped or removed container has no live filesystem to restore — its
+      # writable layer is ephemeral and about to be torn down. Restoring into a
+      # dead container only fails with "container is not running", masking the
+      # real cause of the container's death behind a misleading "Failed to
+      # restore prepared runtime state" terminal error. Skip the restore and
+      # invalidate so the run's real outcome (the exec result, or the
+      # container-death error from the exec path) stands.
+      unless container_running?
+        log_system("container.execute.preparation_cleanup_skipped_container_not_running", container_id: container&.id)
+        invalidate_container_after_preparation_cleanup_failure!
+        return
+      end
+
       cleanup_error = nil
 
       Array(cleanup_steps).reverse_each do |step_env|
@@ -821,8 +834,24 @@ module Containers
 
       return unless cleanup_error
 
+      # Capture whether the container died mid-restore before invalidating
+      # (invalidate stops the container, which would make a later liveness
+      # check always read false).
+      container_died = container_died_error?(cleanup_error) || !container_running?
+
       invalidate_container_after_preparation_cleanup_failure!
+
+      # Don't surface a terminal restore error for a container that died — that
+      # is infrastructure failure handled by the orchestration, not a genuine
+      # inability to restore real state.
+      return if container_died
+
       raise cleanup_execution_error(cleanup_error)
+    end
+
+    def container_died_error?(error)
+      message = error.respond_to?(:message) ? error.message : error.to_s
+      message.to_s.match?(/is not running|No such container/i)
     end
 
     # Best-effort cleanup that never raises, for use in ensure blocks when
@@ -1030,12 +1059,28 @@ module Containers
         env_key: "OPENAI_API_KEY",
         wire_api: "responses"
       )
-      content = "#{codex_notify_line}\n\n#{config_toml}"
+      # Pin a Paid-selected top-level model so the Codex CLI does not fall back
+      # to its built-in default (currently gpt-5.5), which the pinned CLI in the
+      # agent image rejects ("requires a newer version of Codex"). The proxy
+      # config has no model of its own, so without this the proxy auth path
+      # mirrors the host-config leak that seed_sanitized_codex_config! guards
+      # against on the subscription path. The model key must precede the
+      # [chatgpt] table to remain a top-level TOML key.
+      content = [ codex_notify_line, codex_model_config_line, config_toml ].compact.join("\n\n")
 
       write_container_file("/home/agent/.codex/config.toml", content)
       log_system("container.codex_config_seeded")
     rescue Docker::Error::DockerError => e
       log_system("container.codex_config_seed_failed", error: e.message)
+    end
+
+    # Returns a top-level `model = "..."` TOML line for the Paid-selected Codex
+    # model, or nil when no model id resolves (leaving the CLI default in place).
+    def codex_model_config_line
+      model_id = codex_container_model_id
+      return nil if model_id.blank?
+
+      %(model = "#{toml_string_escape(model_id)}")
     end
 
     def seed_codex_credentials!
@@ -1075,9 +1120,9 @@ module Containers
     def sanitize_codex_host_config(toml)
       sanitized = strip_codex_project_sections(toml)
       sanitized = strip_codex_top_level_model_settings(sanitized)
-      model_id = codex_container_model_id
+      model_line = codex_model_config_line
 
-      model_id.present? ? %(model = "#{toml_string_escape(model_id)}"\n#{sanitized}) : sanitized
+      model_line ? "#{model_line}\n#{sanitized}" : sanitized
     end
 
     def strip_codex_project_sections(toml)

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -133,6 +133,9 @@ module Activities
     PREFLIGHT_TIMEOUT_SECONDS = 10
     DIRECT_OUTBOUND_PREFLIGHT_TIMEOUT_SECONDS = 30
     PREFLIGHT_TIMEOUT_CIRCUIT_BREAKER_THRESHOLD = 3
+    # Matches Docker errors raised when a container has died, stopped, or been
+    # removed mid-run. These are infrastructure failures, not runner faults.
+    CONTAINER_NOT_RUNNING_PATTERN = /is not running|No such container/i
     # Backoff applied to a runner whose credit/quota is exhausted. Long
     # enough that we don't re-attempt every minute, short enough that a
     # top-up takes effect within the hour. Notification fires at the
@@ -531,6 +534,20 @@ module Activities
               error: e.message,
               duration_seconds: attempt_duration
             )
+
+            # A dead/unavailable container would poison the next runner too.
+            # Re-provision fresh infra before falling through; break when no
+            # fallback remains so the run fails cleanly without burning the
+            # remaining runners against a container that no longer exists.
+            if container_unavailable_for_fallback?(agent_run)
+              break unless recover_container_for_fallback!(
+                agent_run: agent_run,
+                runner: runner,
+                error_type: "error",
+                error_message: e.message,
+                fallback_remaining: runners[(index + 1)..].to_a
+              )
+            end
           rescue RunnerExecutionError => e
             last_error = "error"
             attempt_duration = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - attempt_started_at).round(1)
@@ -1436,7 +1453,15 @@ module Activities
         reset_at: reset_at
       )
     rescue Containers::Provision::ExecutionError => e
-      raise RunnerExecutionError, "Docker exec error: #{e.message}"
+      message = "Docker exec error: #{e.message}"
+      # A container that died mid-execution is infrastructure failure, not a
+      # runner fault. Classify it as infra so it does not trip the per-runner
+      # circuit breaker (which otherwise cascades into every later run skipping
+      # this runner as "unavailable") and so the loop re-provisions a fresh
+      # container for the next runner.
+      raise RunnerInfraExecutionError, message if container_not_running_error?(e.message)
+
+      raise RunnerExecutionError, message
     end
 
     def run_runner_preflight!(agent_run:, container_service:, command_context:, runner:, execution_env:)
@@ -1538,11 +1563,14 @@ module Activities
         reset_at: reset_at
       )
     rescue Containers::Provision::ExecutionError => e
-      raise_preflight_failure!(
-        agent_run: agent_run,
-        runner: runner,
-        reason: "Docker exec error: #{e.message}"
-      )
+      reason = "Docker exec error: #{e.message}"
+      # A container that died during preflight is infrastructure failure — keep
+      # it off the per-runner circuit breaker and let the loop re-provision.
+      if container_not_running_error?(e.message)
+        raise_preflight_infra_failure!(agent_run: agent_run, runner: runner, reason: reason)
+      end
+
+      raise_preflight_failure!(agent_run: agent_run, runner: runner, reason: reason)
     end
 
     def run_harness_preflight!(agent_run:, harness_provider:, runner:, execution_env:)
@@ -1979,6 +2007,17 @@ module Activities
     def raise_preflight_timeout!(agent_run:, runner:, reason:)
       log_preflight_failure(agent_run: agent_run, runner: runner, reason: reason)
       raise PreflightTimeoutError, "Preflight check failed: #{reason}"
+    end
+
+    def raise_preflight_infra_failure!(agent_run:, runner:, reason:)
+      log_preflight_failure(agent_run: agent_run, runner: runner, reason: reason)
+      raise RunnerInfraExecutionError, "Preflight check failed: #{reason}"
+    end
+
+    # True when an error message indicates the container is gone (died, stopped,
+    # or was removed). Such failures are infrastructure, not runner faults.
+    def container_not_running_error?(message)
+      message.to_s.match?(CONTAINER_NOT_RUNNING_PATTERN)
     end
 
     # Treat credit/quota exhaustion as a rate-limit-equivalent: mark the
@@ -2793,7 +2832,7 @@ module Activities
     end
 
     def container_dead_after_exec_error?(agent_run, error)
-      return false unless error.message.match?(/container.*is not running/i)
+      return false unless container_not_running_error?(error.message)
       return false if agent_run.container_id.blank?
 
       container_service = reconnect_container(agent_run) rescue nil

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -133,9 +133,6 @@ module Activities
     PREFLIGHT_TIMEOUT_SECONDS = 10
     DIRECT_OUTBOUND_PREFLIGHT_TIMEOUT_SECONDS = 30
     PREFLIGHT_TIMEOUT_CIRCUIT_BREAKER_THRESHOLD = 3
-    # Matches Docker errors raised when a container has died, stopped, or been
-    # removed mid-run. These are infrastructure failures, not runner faults.
-    CONTAINER_NOT_RUNNING_PATTERN = /is not running|No such container/i
     # Backoff applied to a runner whose credit/quota is exhausted. Long
     # enough that we don't re-attempt every minute, short enough that a
     # top-up takes effect within the hour. Notification fires at the
@@ -2018,7 +2015,7 @@ module Activities
     # True when an error message indicates the container is gone (died, stopped,
     # or was removed). Such failures are infrastructure, not runner faults.
     def container_not_running_error?(message)
-      message.to_s.match?(CONTAINER_NOT_RUNNING_PATTERN)
+      message.to_s.match?(Containers::CONTAINER_NOT_RUNNING_PATTERN)
     end
 
     # Treat credit/quota exhaustion as a rate-limit-equivalent: mark the

--- a/lib/tasks/runners.rake
+++ b/lib/tasks/runners.rake
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+namespace :runners do
+  desc <<~DESC
+    Reset accumulated back-off after a runner outage so failed/parked work
+    becomes eligible again immediately. Resets three things:
+      1. Open/half-open runner circuit breakers (and lingering rate limits).
+      2. rate_limited agent runs — makes them due now and clears the requeue/skip
+         counters so StaleRunDetectorJob re-queues them on its next tick.
+      3. Parked Issues::ReenqueueEligibleJob jobs whose exponential
+         (n**4) auto-pick delay has pushed them far into the future.
+    Idempotent. Defaults to a dry run; set DRY_RUN=false to apply.
+  DESC
+  task reset_backoff: :environment do
+    dry_run = ENV.fetch("DRY_RUN", "true") != "false"
+    now = Time.current
+
+    TenantContext.with_system_access do
+      # 1. Runner circuit breakers --------------------------------------------
+      circuits = RunnerState.where(circuit_state: %w[open half_open])
+        .or(RunnerState.where.not(rate_limited_until: nil))
+      circuit_count = circuits.count
+
+      # 2. Rate-limited agent runs --------------------------------------------
+      rate_limited = AgentRun.rate_limited
+      rate_limited_count = rate_limited.count
+
+      # 3. Parked auto-pick re-enqueue jobs -----------------------------------
+      parked_jobs = GoodJob::Job
+        .where(finished_at: nil, job_class: "Issues::ReenqueueEligibleJob")
+        .where(scheduled_at: now..)
+      parked_count = parked_jobs.count
+
+      puts "runners:reset_backoff (#{dry_run ? 'DRY RUN' : 'APPLYING'})"
+      puts "  runner circuits open/rate-limited : #{circuit_count}"
+      puts "  rate_limited agent runs           : #{rate_limited_count}"
+      puts "  parked re-enqueue jobs            : #{parked_count}"
+
+      if dry_run
+        puts "No changes written. Re-run with DRY_RUN=false to apply."
+        next
+      end
+
+      circuits.find_each { |state| state.record_success!(force_close: true) }
+
+      # Make parked rate-limited runs due now without exhausting their budget.
+      rate_limited.update_all(
+        rate_limited_until: 1.minute.ago,
+        stale_requeue_count: 0,
+        stale_skip_count: 0,
+        updated_at: now
+      )
+
+      # Release the exponential auto-pick delay so GoodJob runs them now.
+      parked_jobs.update_all(scheduled_at: now)
+
+      Rails.logger.info(
+        message: "runners.reset_backoff",
+        circuits_reset: circuit_count,
+        rate_limited_runs_reset: rate_limited_count,
+        reenqueue_jobs_released: parked_count
+      )
+
+      puts "Done. Reset #{circuit_count} circuits, #{rate_limited_count} rate-limited runs, " \
+        "released #{parked_count} re-enqueue jobs."
+    end
+  end
+end

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -443,6 +443,27 @@ RSpec.describe Containers::Provision do
         )
       end
 
+      it "pins a Paid-selected top-level model so Codex does not default to an unsupported model" do
+        create(:llm_model, :openai, model_id: "gpt-5.1", tier: "mid", capability_score: 9.0)
+
+        service.provision
+
+        expect(mock_container).to have_received(:exec).with(
+          [
+            "sh",
+            "-lc",
+            satisfy { |cmd|
+              decoded = decoded_base64_content(cmd)
+              cmd.include?("/home/agent/.codex/config.toml") &&
+                decoded.include?('model = "gpt-5.1"') &&
+                decoded.include?("[chatgpt]") &&
+                decoded.index('model = "gpt-5.1"') < decoded.index("[chatgpt]")
+            }
+          ],
+          user: "agent"
+        )
+      end
+
       it "seeds Codex config with the current notify command shape" do
         service.provision
         notify_line = described_class.codex_notify_line
@@ -3331,6 +3352,64 @@ RSpec.describe Containers::Provision do
       result = service.send(:sanitize_codex_host_config, "model = \"gpt-5.5\"\n")
 
       expect(result).to eq("model = \"gpt-5.1\"\n")
+    end
+  end
+
+  describe "#codex_model_config_line" do
+    let(:service) { described_class.new(agent_run: agent_run, project: project) }
+
+    it "returns a top-level model line for the Paid-selected Codex model" do
+      create(:llm_model, :openai, model_id: "gpt-5.1", tier: "mid", capability_score: 9.0)
+
+      expect(service.send(:codex_model_config_line)).to eq('model = "gpt-5.1"')
+    end
+
+    it "escapes quotes in the model id" do
+      allow(service).to receive(:codex_container_model_id).and_return('gpt-"x"')
+
+      expect(service.send(:codex_model_config_line)).to eq('model = "gpt-\\"x\\""')
+    end
+
+    it "returns nil when no Codex model resolves so the CLI default is left in place" do
+      allow(service).to receive(:codex_container_model_id).and_return(nil)
+
+      expect(service.send(:codex_model_config_line)).to be_nil
+    end
+  end
+
+  describe "#cleanup_execution_preparation" do
+    let(:service) { described_class.new(agent_run: agent_run, project: project) }
+    let(:cleanup_steps) { [ { "PAID_PREPARATION_TARGET" => "/x", "PAID_PREPARATION_STATE_DIR" => "/x.state" } ] }
+
+    it "skips the restore and invalidates when the container is not running" do
+      allow(service).to receive(:container_running?).and_return(false)
+      allow(service).to receive(:invalidate_container_after_preparation_cleanup_failure!)
+
+      expect(service).not_to receive(:run_preparation_cleanup_step)
+
+      expect {
+        service.send(:cleanup_execution_preparation, cleanup_steps, env: {})
+      }.not_to raise_error
+      expect(service).to have_received(:invalidate_container_after_preparation_cleanup_failure!)
+    end
+
+    it "does not raise a terminal restore error when the container dies mid-restore" do
+      allow(service).to receive(:invalidate_container_after_preparation_cleanup_failure!)
+      allow(service).to receive_messages(container_running?: true, run_preparation_cleanup_step: Containers::Provision::ExecutionError.new("container abc is not running"))
+
+      expect {
+        service.send(:cleanup_execution_preparation, cleanup_steps, env: {})
+      }.not_to raise_error
+      expect(service).to have_received(:invalidate_container_after_preparation_cleanup_failure!)
+    end
+
+    it "raises for a genuine restore failure while the container is still running" do
+      allow(service).to receive(:invalidate_container_after_preparation_cleanup_failure!)
+      allow(service).to receive_messages(container_running?: true, run_preparation_cleanup_step: Containers::Provision::ExecutionError.new("missing runtime preparation backup"))
+
+      expect {
+        service.send(:cleanup_execution_preparation, cleanup_steps, env: {})
+      }.to raise_error(Containers::Provision::ExecutionError, /Failed to restore prepared runtime state/)
     end
   end
 end

--- a/spec/tasks/runners_rake_spec.rb
+++ b/spec/tasks/runners_rake_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "rake"
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe "runners:reset_backoff" do
+  let(:task) { Rake::Task["runners:reset_backoff"] }
+  let(:project) { create(:project) }
+  let!(:open_circuit) { create(:runner_state, :circuit_open) }
+  let!(:rate_limited_run) { create(:agent_run, :rate_limited, project: project, stale_requeue_count: 4, stale_skip_count: 2) }
+  let!(:parked_job) do
+    GoodJob::Job.create!(
+      job_class: "Issues::ReenqueueEligibleJob",
+      queue_name: "default",
+      scheduled_at: 3.days.from_now,
+      serialized_params: {}
+    )
+  end
+
+  before do
+    Rails.application.load_tasks unless Rake::Task.task_defined?("runners:reset_backoff")
+    task.reenable
+  end
+
+  after { ENV.delete("DRY_RUN") }
+
+
+  context "with DRY_RUN (default)" do
+    it "reports counts without writing changes" do
+      expect { task.invoke }.to output(/DRY RUN/).to_stdout
+
+      expect(open_circuit.reload.circuit_state).to eq("open")
+      expect(rate_limited_run.reload.stale_requeue_count).to eq(4)
+      expect(parked_job.reload.scheduled_at).to be > 1.day.from_now
+    end
+  end
+
+  context "with DRY_RUN=false" do
+    before { ENV["DRY_RUN"] = "false" }
+
+    it "closes open runner circuits" do
+      task.invoke
+      expect(open_circuit.reload.circuit_state).to eq("closed")
+      expect(open_circuit.failure_count).to eq(0)
+    end
+
+    it "makes rate-limited runs due now and clears their requeue/skip counters" do
+      task.invoke
+      rate_limited_run.reload
+      expect(rate_limited_run.rate_limited_until).to be < Time.current
+      expect(rate_limited_run.stale_requeue_count).to eq(0)
+      expect(rate_limited_run.stale_skip_count).to eq(0)
+    end
+
+    it "releases parked auto-pick re-enqueue jobs to run now" do
+      task.invoke
+      expect(parked_job.reload.scheduled_at).to be <= Time.current
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/tasks/runners_rake_spec.rb
+++ b/spec/tasks/runners_rake_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe "runners:reset_backoff" do
 
   after { ENV.delete("DRY_RUN") }
 
-
   context "with DRY_RUN (default)" do
     it "reports counts without writing changes" do
       expect { task.invoke }.to output(/DRY RUN/).to_stdout

--- a/spec/temporal/activities/run_agent_activity_no_db_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_no_db_spec.rb
@@ -356,4 +356,19 @@ RSpec.describe Activities::RunAgentActivity, :no_db do
       expect(activity.send(:rate_limit_error?, redacted, runner_key: "codex")).to be(true)
     end
   end
+
+  describe "#container_not_running_error?" do
+    let(:activity) { described_class.new }
+
+    it "matches Docker container-death messages" do
+      expect(activity.send(:container_not_running_error?, "container abc123 is not running")).to be(true)
+      expect(activity.send(:container_not_running_error?, "Docker exec error: Failed to restore prepared runtime state: container abc is not running")).to be(true)
+      expect(activity.send(:container_not_running_error?, "No such container: abc")).to be(true)
+    end
+
+    it "does not match unrelated runner errors" do
+      expect(activity.send(:container_not_running_error?, "Agent exited with code 1: invalid model")).to be(false)
+      expect(activity.send(:container_not_running_error?, nil)).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
## Why

Agent runs were failing fleet-wide — **168 failed in 24h**, project 19 at 42/50 — all surfacing as `All runners exhausted`. Investigation of run 26918 (and the broader pattern) found every runner in the fallback chain broke independently, and a circuit-breaker cascade amplified it: once a runner tripped its circuit, all later runs skipped it as "unavailable".

This PR ships the two highest-impact root-cause fixes plus recovery tooling. Remaining failure modes are filed as follow-up issues.

## What

### 1. Pin the Codex model on the proxy-auth path
`seed_codex_config!` emitted a `[chatgpt]` block with **no model**, so the Codex CLI fell back to its built-in default (`gpt-5.5`), which the pinned CLI in the agent image rejects (`requires a newer version of Codex`). #2588 fixed only the **subscription** path; this closes the same leak on the **proxy** path via a shared `codex_model_config_line` helper. (~90 failures/day)

### 2. Treat container death as infrastructure failure, not a runner fault
A dead/removed container surfaced as a generic `RunnerExecutionError` (`Failed to restore prepared runtime state: container is not running`), which **tripped the per-runner circuit breaker** and cascaded — the dominant amplifier, especially for Claude (the last-resort fallback).
- `provision.rb`: skip the prepared-state restore when the container isn't running (a dead container has no live filesystem to restore) instead of raising a misleading terminal error.
- `run_agent_activity.rb`: classify `container is not running` exec/preflight errors as `RunnerInfraExecutionError` (no circuit trip) and re-provision a fresh container for the next runner.

### 3. `runners:reset_backoff` rake task
Resets accumulated back-off after the fix deploys so parked work becomes eligible immediately:
- closes open/half-open runner circuits,
- makes `rate_limited` runs due now (clearing requeue/skip counters),
- releases parked `Issues::ReenqueueEligibleJob` jobs whose exponential `(n**4)` auto-pick delay parked them far in the future.

Idempotent; **dry-run by default** (`DRY_RUN=false` to apply).

## Recovery after merge/deploy

```bash
bin/rails runners:reset_backoff               # dry run — preview counts
DRY_RUN=false bin/rails runners:reset_backoff # apply
```

## Testing

- `provision_spec.rb` — codex proxy model pin, `codex_model_config_line`, `cleanup_execution_preparation` dead-container skip vs genuine-failure raise (215 ex, green)
- `run_agent_activity_no_db_spec.rb` — `container_not_running_error?` classification (22 ex, green)
- `run_agent_activity_spec.rb` — full runner-loop suite (250 ex, green)
- `runners_rake_spec.rb` — dry-run + apply behavior (4 ex, green)

## Follow-up issues

- #2592 — Opencode MiniMax non-existent model id (`model_not_found`)
- #2593 — Claude container instability root cause (mid-run death + silent startup timeouts)
- #2594 — direct-outbound smoke preflight 30s timeout trips circuit
- #2595 — deterministic model/config errors shouldn't trip the per-runner circuit breaker

Related existing issues: #2566 (model-health drift), #2515 (system-wide dispatch halt), #2563 (runner-agnostic late-binding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
