### PR TITLE
feat(runners): add bin/provider-smoke for ad-hoc provider/model smoke tests

### DIFF
--- a/bin/provider-smoke
+++ b/bin/provider-smoke
@@ -43,13 +43,16 @@ def usage
 
     Credentials:
       Export the provider's API key env var first (or have a matching
-      provider/api key in the development DB). Per-provider env vars:
+      provider/api key in the development DB). Supported providers by runner:
   USAGE
 
-  Runner::DIRECT_OUTBOUND_API_PROVIDERS.each do |provider, config|
-    service_type = config[:service_type]
-    env_var = RunnerSmokeHelpers::SERVICE_TYPE_ENV_VARS[service_type]
-    puts "      #{provider.ljust(16)} #{env_var || '(no env var mapping)'}"
+  DIRECT_OUTBOUND_RUNNER_KEYS.each do |runner_key|
+    puts "      #{runner_key}:"
+
+    RunnerSmokeHelpers.provider_configs_for_runner(runner_key).each_key do |provider|
+      env_var = RunnerSmokeHelpers.api_key_env_var_for(runner_key: runner_key, api_provider: provider)
+      puts "        #{provider.ljust(14)} #{env_var || '(no env var mapping)'}"
+    end
   end
 end
 
@@ -82,14 +85,14 @@ unless DIRECT_OUTBOUND_RUNNER_KEYS.include?(runner_key)
   exit 1
 end
 
-provider_config = Runner::DIRECT_OUTBOUND_API_PROVIDERS[provider]
+provider_config = RunnerSmokeHelpers.provider_config_for(runner_key: runner_key, api_provider: provider)
 if provider_config.nil?
-  warn "Unknown provider #{provider.inspect}. Run `bin/provider-smoke list` for valid providers."
+  valid_providers = RunnerSmokeHelpers.provider_configs_for_runner(runner_key).keys.join(", ")
+  warn "Unsupported provider #{provider.inspect} for #{runner_key}. Supported: #{valid_providers}."
   exit 1
 end
 
-service_type = provider_config[:service_type]
-env_var = RunnerSmokeHelpers::SERVICE_TYPE_ENV_VARS[service_type]
+env_var = RunnerSmokeHelpers.api_key_env_var_for(runner_key: runner_key, api_provider: provider)
 if env_var && ENV[env_var].to_s.strip.empty?
   warn "Note: #{env_var} is not set; the test will be skipped unless a matching " \
        "provider/api key exists in the development DB."

--- a/bin/provider-smoke
+++ b/bin/provider-smoke
@@ -1,0 +1,120 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "shellwords"
+
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+
+require "bundler/setup"
+require_relative "../config/environment"
+require_relative "../spec/support/runner_smoke_helpers"
+
+# Runners that authenticate per-request with an api_provider + model pair (the
+# shape this tool builds). Mirrors Runner#requires_direct_outbound?, minus
+# openrouter_free, which resolves its model by tier rather than from an
+# explicit api_provider/model config and so cannot be smoke-tested this way.
+DIRECT_OUTBOUND_RUNNER_KEYS = %w[opencode kilocode pi].freeze
+
+# Smoke-tests an arbitrary direct-outbound provider/model pair through the real
+# agent-harness smoke contract (in a container), so an unresolvable model id
+# (e.g. a brand-new z.ai model not yet in the bundled opencode catalog) fails
+# here with "Model not found" / ProviderModelNotFoundError instead of at live
+# agent-run time. Reuses Runners::TestAgent via the :provider_smoke spec.
+def usage
+  puts <<~USAGE
+    Usage:
+      bin/provider-smoke [-v|--diagnostic] <provider> <model> [runner_key]
+      bin/provider-smoke list
+
+    Examples:
+      bin/provider-smoke zai_coding glm-5.2
+      bin/provider-smoke -v zai_coding glm-5.2          # show actual model output
+      bin/provider-smoke minimax MiniMax-M2.7 opencode
+
+    Options:
+      -v, --diagnostic  Run a real prompt and echo the model's actual
+                        output/error. Passes on any clean response, so it
+                        distinguishes "model resolved but chatty" from
+                        "model not found". The default mode requires the
+                        model to reply with exactly "OK".
+
+    Defaults:
+      runner_key defaults to `opencode`. Supported: #{DIRECT_OUTBOUND_RUNNER_KEYS.join(", ")}.
+
+    Credentials:
+      Export the provider's API key env var first (or have a matching
+      provider/api key in the development DB). Per-provider env vars:
+  USAGE
+
+  Runner::DIRECT_OUTBOUND_API_PROVIDERS.each do |provider, config|
+    service_type = config[:service_type]
+    env_var = RunnerSmokeHelpers::SERVICE_TYPE_ENV_VARS[service_type]
+    puts "      #{provider.ljust(16)} #{env_var || '(no env var mapping)'}"
+  end
+end
+
+diagnostic = !(ARGV.delete("-v") || ARGV.delete("--diagnostic")).nil?
+
+command = ARGV.first
+
+if command.nil? || %w[--help -h help].include?(command)
+  usage
+  exit(command.nil? ? 1 : 0)
+end
+
+if command == "list"
+  usage
+  exit 0
+end
+
+provider, model, runner_key = ARGV
+runner_key ||= "opencode"
+
+if provider.nil? || model.nil?
+  warn "Both <provider> and <model> are required."
+  usage
+  exit 1
+end
+
+unless DIRECT_OUTBOUND_RUNNER_KEYS.include?(runner_key)
+  warn "Unsupported runner_key #{runner_key.inspect}. " \
+       "Supported: #{DIRECT_OUTBOUND_RUNNER_KEYS.join(', ')}."
+  exit 1
+end
+
+provider_config = Runner::DIRECT_OUTBOUND_API_PROVIDERS[provider]
+if provider_config.nil?
+  warn "Unknown provider #{provider.inspect}. Run `bin/provider-smoke list` for valid providers."
+  exit 1
+end
+
+service_type = provider_config[:service_type]
+env_var = RunnerSmokeHelpers::SERVICE_TYPE_ENV_VARS[service_type]
+if env_var && ENV[env_var].to_s.strip.empty?
+  warn "Note: #{env_var} is not set; the test will be skipped unless a matching " \
+       "provider/api key exists in the development DB."
+end
+
+env = {
+  "RUN_PROVIDER_SMOKE" => "true",
+  "RUN_RUNNER_SMOKE" => "true",
+  "COVERAGE" => "false",
+  "PAID_SMOKE_ADHOC_RUNNER" => runner_key,
+  "PAID_SMOKE_ADHOC_PROVIDER" => provider,
+  "PAID_SMOKE_ADHOC_DIAGNOSTIC" => diagnostic.to_s,
+  RunnerSmokeHelpers::ADHOC_MODEL_ENV => model
+}
+spec_command = [
+  "bundle", "exec", "rspec",
+  "--options", "/dev/null",
+  "--require", "spec_helper",
+  "--color",
+  "--format", "documentation",
+  "spec/services/runners/test_agent_adhoc_smoke_spec.rb"
+]
+
+puts "Smoke-testing #{runner_key} / #{provider} / #{model}"
+puts "Running #{Shellwords.join(spec_command)}"
+
+success = system(env, *spec_command)
+exit($CHILD_STATUS.exitstatus || 1) unless success

--- a/bin/provider-smoke
+++ b/bin/provider-smoke
@@ -97,7 +97,6 @@ end
 
 env = {
   "RUN_PROVIDER_SMOKE" => "true",
-  "RUN_RUNNER_SMOKE" => "true",
   "COVERAGE" => "false",
   "PAID_SMOKE_ADHOC_RUNNER" => runner_key,
   "PAID_SMOKE_ADHOC_PROVIDER" => provider,
@@ -117,4 +116,4 @@ puts "Smoke-testing #{runner_key} / #{provider} / #{model}"
 puts "Running #{Shellwords.join(spec_command)}"
 
 success = system(env, *spec_command)
-exit($CHILD_STATUS.exitstatus || 1) unless success
+exit($CHILD_STATUS&.exitstatus || 1) unless success

--- a/bin/provider-smoke
+++ b/bin/provider-smoke
@@ -10,8 +10,8 @@ require_relative "../config/environment"
 require_relative "../spec/support/runner_smoke_helpers"
 
 # Runners that authenticate per-request with an api_provider + model pair (the
-# shape this tool builds). Mirrors Runner#requires_direct_outbound?, minus
-# openrouter_free, which resolves its model by tier rather than from an
+# shape this tool builds). Mirrors Runner#direct_outbound_capable_runner?,
+# minus openrouter_free, which resolves its model by tier rather than from an
 # explicit api_provider/model config and so cannot be smoke-tested this way.
 DIRECT_OUTBOUND_RUNNER_KEYS = %w[opencode kilocode pi].freeze
 

--- a/bin/provider-smoke
+++ b/bin/provider-smoke
@@ -9,10 +9,13 @@ require "bundler/setup"
 require_relative "../config/environment"
 require_relative "../spec/support/runner_smoke_helpers"
 
-# Runners that authenticate per-request with an api_provider + model pair (the
-# shape this tool builds). Mirrors Runner#direct_outbound_capable_runner?,
-# minus openrouter_free, which resolves its model by tier rather than from an
-# explicit api_provider/model config and so cannot be smoke-tested this way.
+# Runners for which Runners::TestAgent#container_provider_runtime has
+# direct-outbound smoke plumbing (i.e. an api_provider + model pair resolves
+# to a real container call, not subscription auth or tier-based routing).
+# `aider` is excluded because TestAgent has no aider_direct_outbound? branch
+# despite having aider config plumbing; `openrouter_free` is excluded because
+# its model resolves by tier rather than from an explicit api_provider/model
+# config and so cannot be smoke-tested with an explicit provider/model pair.
 DIRECT_OUTBOUND_RUNNER_KEYS = %w[opencode kilocode pi].freeze
 
 # Smoke-tests an arbitrary direct-outbound provider/model pair through the real

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,16 @@ require "action_cable/engine"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+# Opt into RubyLLM's new acts_as mode before ActiveRecord loads. The gem's
+# railtie reads this flag from an `on_load :active_record` hook that fires
+# during the railtie phase (before config/initializers), and emits a per-boot
+# deprecation warning when it is false. We use RubyLLM only for model-catalog
+# data (app/services/models/*), never its acts_as ActiveRecord API, so enabling
+# the new mode is inert beyond silencing that warning across every CLI/process.
+RubyLLM.configure do |config|
+  config.use_new_acts_as = true
+end
+
 # Loaded via require_relative because the middleware must be registered before
 # Zeitwerk autoloading is available. The middleware is stateless so the pinned
 # constant is a low-risk trade-off; use to_prepare for install! re-subscription.

--- a/spec/lib/runner_smoke_helpers_spec.rb
+++ b/spec/lib/runner_smoke_helpers_spec.rb
@@ -99,6 +99,58 @@ RSpec.describe RunnerSmokeHelpers do
       expect(runner.opencode_model_id).to eq("MiniMax-M2.7")
       expect(runner.provider_api_key.api_service_type).to eq("minimax")
     end
+
+    it "builds Pi Google runners with the Pi-specific provider config" do
+      pi_scenario = described_class::Scenario.new(
+        name: "pi-google",
+        runner_key: "pi",
+        auth_type: "api_key",
+        api_provider: "google",
+        model_env: "PAID_SMOKE_PI_GOOGLE_MODEL",
+        default_model: "gemini-2.5-pro",
+        label: "Pi with Google API key"
+      )
+      allow(described_class).to receive(:development_runner_info_for).with(pi_scenario).and_return(
+        { "api_key" => "sk-gemini-test" }
+      )
+
+      runner = described_class.build_direct_outbound_runner!(user: user, scenario: pi_scenario)
+
+      expect(runner.runner_key).to eq("pi")
+      expect(runner.pi_api_provider).to eq("google")
+      expect(runner.pi_model_id).to eq("gemini-2.5-pro")
+      expect(runner.provider_api_key.api_service_type).to eq("google")
+    end
+
+    it "rejects providers that are unsupported for the selected runner" do
+      pi_scenario = described_class::Scenario.new(
+        name: "pi-zai-coding",
+        runner_key: "pi",
+        auth_type: "api_key",
+        api_provider: "zai_coding",
+        model_env: "PAID_SMOKE_PI_ZAI_CODING_MODEL",
+        default_model: "glm-5.2",
+        label: "Pi with z.ai coding API key"
+      )
+
+      expect { described_class.build_direct_outbound_runner!(user: user, scenario: pi_scenario) }
+        .to raise_error(
+          RunnerSmokeHelpers::ScenarioUnavailableError,
+          /Unsupported pi api provider "zai_coding"/
+        )
+    end
+  end
+
+  describe ".api_key_env_var_for" do
+    it "uses the Pi provider override for Google Gemini" do
+      expect(described_class.api_key_env_var_for(runner_key: "pi", api_provider: "google"))
+        .to eq("GEMINI_API_KEY")
+    end
+
+    it "uses the direct-outbound provider override for MiniMax" do
+      expect(described_class.api_key_env_var_for(runner_key: "opencode", api_provider: "minimax"))
+        .to eq("ANTHROPIC_API_KEY")
+    end
   end
 
   describe ".current_enabled_scenario_names" do

--- a/spec/paid/provider_smoke_script_spec.rb
+++ b/spec/paid/provider_smoke_script_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "open3"
+
+class ProviderSmokeScript < Pathname
+end
+
+RSpec.describe ProviderSmokeScript, :no_db do
+  def run_script(*args)
+    Open3.capture3(
+      {
+        "RAILS_ENV" => "test",
+        "SECRET_KEY_BASE" => "test-secret-key-base"
+      },
+      "bundle", "exec", "ruby", "bin/provider-smoke", *args,
+      chdir: Rails.root.to_s
+    )
+  end
+
+  it "lists Pi-specific providers with their configured API key env vars" do
+    stdout, stderr, status = run_script("list")
+
+    expect(status.success?).to be(true), stderr
+    expect(stdout).to include("pi:")
+    expect(stdout).to include("google         GEMINI_API_KEY")
+  end
+
+  it "rejects providers that are unsupported for the selected runner" do
+    _stdout, stderr, status = run_script("zai_coding", "glm-5.2", "pi")
+
+    expect(status.success?).to be(false)
+    expect(stderr).to include('Unsupported provider "zai_coding" for pi.')
+    expect(stderr).to include("Supported: anthropic, openai, deepseek, google, mistral, minimax, xai, zai, openrouter")
+  end
+end

--- a/spec/services/runners/test_agent_adhoc_smoke_spec.rb
+++ b/spec/services/runners/test_agent_adhoc_smoke_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "securerandom"
+
+# Drives an ad-hoc provider/model smoke test for bin/provider-smoke. Builds a
+# direct-outbound runner for the PAID_SMOKE_ADHOC_* provider/model and runs the
+# real agent-harness smoke contract in a container, so an unresolvable model id
+# surfaces as a "Model not found" / ProviderModelNotFoundError failure here
+# rather than at live agent-run time.
+#
+# Set PAID_SMOKE_ADHOC_DIAGNOSTIC=true (bin/provider-smoke -v) to run a
+# diagnostic prompt instead of the fixed "OK" smoke contract: it passes on any
+# clean model response and echoes the actual output/error, which is what you
+# need to tell "model resolved but was chatty" apart from "model not found".
+RSpec.describe Runners::TestAgent, :provider_smoke do
+  scenarios = [ RunnerSmokeHelpers.adhoc_scenario_from_env ].compact
+
+  if scenarios.empty?
+    it "needs an ad-hoc provider/model" do
+      skip "Set PAID_SMOKE_ADHOC_PROVIDER and PAID_SMOKE_ADHOC_MODEL (use bin/provider-smoke)"
+    end
+  end
+
+  scenarios.each do |scenario|
+    it "resolves and smoke-tests #{scenario.label}" do
+      runner = build_adhoc_runner(scenario)
+      result = run_adhoc_smoke(runner)
+      report(scenario, result)
+
+      expect(result).to be_success,
+        "#{scenario.name} smoke test failed: #{result.error_type} - #{result.message}"
+    rescue RunnerSmokeHelpers::ScenarioUnavailableError => e
+      skip e.message
+    end
+  end
+
+  def build_adhoc_runner(scenario)
+    suffix = SecureRandom.hex(6)
+    account = create(:account, slug: "provider-smoke-adhoc-#{suffix}")
+    user = create(:user, :owner, account: account, email: "provider-smoke-adhoc-#{suffix}@example.com")
+    RunnerSmokeHelpers.create_smoke_project!(user: user)
+    RunnerSmokeHelpers.build_runner!(user: user, scenario: scenario)
+  end
+
+  def run_adhoc_smoke(runner)
+    return Runners::TestAgent.call(runner: runner) unless ENV["PAID_SMOKE_ADHOC_DIAGNOSTIC"] == "true"
+
+    # Pattern /\S/ ("any non-whitespace") passes on any real model response but
+    # fails on empty output, so a model that resolves and answers is
+    # distinguished from one that exits cleanly with nothing (a silent failure).
+    # The Result message carries the real output/error for inspection.
+    Runners::TestAgent.call(
+      runner: runner,
+      diagnostic_prompt: "Reply with exactly OK.",
+      diagnostic_timeout: 60,
+      diagnostic_success_pattern: /\S/
+    )
+  end
+
+  def report(scenario, result)
+    RSpec.configuration.reporter.message(
+      "\n[provider-smoke] #{scenario.name}: success=#{result.success?} " \
+      "error_type=#{result.error_type.inspect}\n[provider-smoke] message: #{result.message}\n"
+    )
+  end
+end

--- a/spec/support/runner_smoke_helpers.rb
+++ b/spec/support/runner_smoke_helpers.rb
@@ -211,6 +211,32 @@ module RunnerSmokeHelpers
     (configured.presence || [ "current-enabled" ]).flat_map { |name| expand_name(name) }
   end
 
+  def provider_configs_for_runner(runner_key)
+    case runner_key.to_s
+    when "opencode", "kilocode"
+      Runner::DIRECT_OUTBOUND_API_PROVIDERS
+    when "pi"
+      Runner::PI_API_PROVIDERS
+    else
+      {}
+    end
+  end
+
+  def provider_config_for(runner_key:, api_provider:)
+    provider_configs_for_runner(runner_key)[api_provider.to_s]
+  end
+
+  def api_service_type_for(runner_key:, api_provider:)
+    provider_config_for(runner_key: runner_key, api_provider: api_provider)&.fetch(:service_type)
+  end
+
+  def api_key_env_var_for(runner_key:, api_provider:)
+    config = provider_config_for(runner_key: runner_key, api_provider: api_provider)
+    return if config.blank?
+
+    config[:env_var].presence || SERVICE_TYPE_ENV_VARS[config.fetch(:service_type)]
+  end
+
   def scenarios_from_env
     scenario_names_from_env.map { |name| scenario_for(name) }
   end
@@ -254,7 +280,7 @@ module RunnerSmokeHelpers
   end
 
   def build_direct_outbound_runner!(user:, scenario:)
-    service_type = Runner::DIRECT_OUTBOUND_API_PROVIDERS.dig(scenario.api_provider, :service_type)
+    service_type = api_service_type_for(runner_key: scenario.runner_key, api_provider: scenario.api_provider)
     if service_type.blank?
       raise ScenarioUnavailableError,
         "Unsupported #{scenario.runner_key} api provider #{scenario.api_provider.inspect} for #{scenario.label}"
@@ -268,10 +294,11 @@ module RunnerSmokeHelpers
       raise ScenarioUnavailableError, "Set #{scenario.model_env} to run #{scenario.label}"
     end
 
-    api_key = api_key_for_service_type(service_type, scenario: scenario, development_runner: dev_runner)
+    api_key_env_var = api_key_env_var_for(runner_key: scenario.runner_key, api_provider: scenario.api_provider)
+    api_key = api_key_for_env_var(api_key_env_var, development_runner: dev_runner)
     if api_key.blank?
       raise ScenarioUnavailableError,
-        "Set #{SERVICE_TYPE_ENV_VARS.fetch(service_type)} or create a matching provider/api key in the development DB to run #{scenario.label}"
+        "Set #{api_key_env_var} or create a matching provider/api key in the development DB to run #{scenario.label}"
     end
 
     provider_api_key = FactoryBot.create(
@@ -301,8 +328,9 @@ module RunnerSmokeHelpers
     runner
   end
 
-  def api_key_for_service_type(service_type, scenario:, development_runner: nil)
-    env_var = SERVICE_TYPE_ENV_VARS.fetch(service_type)
+  def api_key_for_env_var(env_var, development_runner: nil)
+    return development_runner&.fetch("api_key", nil).to_s.strip.presence if env_var.blank?
+
     ENV[env_var].to_s.strip.presence ||
       development_runner&.fetch("api_key", nil).to_s.strip.presence
   end
@@ -317,7 +345,7 @@ module RunnerSmokeHelpers
     @development_runner_info_cache ||= {}
     return @development_runner_info_cache[scenario.name] if @development_runner_info_cache.key?(scenario.name)
 
-    service_type = Runner::DIRECT_OUTBOUND_API_PROVIDERS.dig(scenario.api_provider, :service_type)
+    service_type = api_service_type_for(runner_key: scenario.runner_key, api_provider: scenario.api_provider)
     desired_model = ENV[scenario.model_env].to_s.strip.presence || scenario.default_model
     payload = {
       runner_key: scenario.runner_key,
@@ -441,7 +469,7 @@ module RunnerSmokeHelpers
       next false unless scenario.auth_type == config["auth_type"].to_s
       next true if scenario.subscription?
 
-      service_type = Runner::DIRECT_OUTBOUND_API_PROVIDERS.dig(scenario.api_provider, :service_type)
+      service_type = api_service_type_for(runner_key: scenario.runner_key, api_provider: scenario.api_provider)
       service_type == config["service_type"].to_s &&
         scenario.api_provider == config["api_provider"].to_s
     end&.name

--- a/spec/support/runner_smoke_helpers.rb
+++ b/spec/support/runner_smoke_helpers.rb
@@ -180,7 +180,31 @@ module RunnerSmokeHelpers
     "claude-diagnostics" => CLAUDE_DIAGNOSTIC_SCENARIO_NAMES
   }.freeze
 
+  # Env var carrying the model id for an ad-hoc (bin/provider-smoke) run.
+  ADHOC_MODEL_ENV = "PAID_SMOKE_ADHOC_MODEL"
+
   module_function
+
+  # Builds a one-off direct-outbound Scenario from env vars instead of the
+  # fixed SCENARIOS matrix, so bin/provider-smoke can smoke-test an arbitrary
+  # provider/model pair (e.g. zai_coding / glm-5.2) before it is added to the
+  # model catalog. Returns nil when the required env vars are absent.
+  def adhoc_scenario_from_env
+    provider = ENV["PAID_SMOKE_ADHOC_PROVIDER"].to_s.strip.presence
+    model = ENV[ADHOC_MODEL_ENV].to_s.strip.presence
+    return nil if provider.blank? || model.blank?
+
+    runner_key = ENV["PAID_SMOKE_ADHOC_RUNNER"].to_s.strip.presence || "opencode"
+    Scenario.new(
+      name: "adhoc-#{runner_key}-#{provider}-#{model}",
+      runner_key: runner_key,
+      auth_type: "api_key",
+      api_provider: provider,
+      model_env: ADHOC_MODEL_ENV,
+      default_model: model,
+      label: "#{runner_key} with #{provider} model #{model} (ad-hoc)"
+    )
+  end
 
   def scenario_names_from_env
     configured = ENV["PAID_SMOKE_SCENARIOS"].to_s.split(",").map(&:strip).reject(&:blank?)


### PR DESCRIPTION
## What

Adds `bin/provider-smoke`, a CLI to smoke-test an arbitrary direct-outbound provider/model pair (e.g. `zai_coding` / `glm-5.2`) through the real agent-harness smoke contract in a container — *before* the model is added to the catalog or used in a live agent run.

```bash
bin/provider-smoke zai_coding glm-5.2            # strict: model must reply "OK"
bin/provider-smoke -v zai_coding glm-5.2         # diagnostic: echo actual output/error
bin/provider-smoke list                          # providers + required API-key env vars
```

An unresolvable model id surfaces here as a `Model not found` / `ProviderModelNotFoundError` failure instead of failing at live agent-run time.

## Why

We needed to answer "does z.ai's new GLM-5.2 work via opencode, or do we need an agent-harness bump?" without shipping it blind. There was no way to probe a single provider/model pair quickly — `bin/runner-smoke` only runs a fixed scenario matrix.

## How

- Reuses `Runners::TestAgent` + `RunnerSmokeHelpers.build_runner!` via a new `:provider_smoke` spec (`spec/services/runners/test_agent_adhoc_smoke_spec.rb`), driven by an ad-hoc scenario built from `PAID_SMOKE_ADHOC_*` env vars (`RunnerSmokeHelpers.adhoc_scenario_from_env`). No container/credential plumbing reinvented.
- Validates `runner_key` against the direct-outbound-capable set (`opencode`/`kilocode`/`pi`) and the provider against `Runner::DIRECT_OUTBOUND_API_PROVIDERS`, with clear errors instead of deep failures.
- `-v/--diagnostic` mode echoes the model's real output/error and treats **empty output as failure** (`/\S/`), distinguishing "resolved but chatty" from a silent failure that the bare smoke contract reports only as the opaque `exit code 0`.

Also includes an unrelated boot-noise fix (separate commit): opt into RubyLLM's new `acts_as` mode in `config/application.rb` so the per-boot legacy-API deprecation warning stops printing on every CLI/process. The app uses RubyLLM only for model-catalog data, never its `acts_as` ActiveRecord API.

## Test plan / status

- Gated by `RUN_PROVIDER_SMOKE=true` (set by the wrapper) and makes real network calls — won't run in normal CI.
- Local runs against `zai_coding` returned **empty output for both `glm-5.2` and the known-good `glm-5.1` control** — i.e. inconclusive due to local credential/egress, not model resolution. **Verdict deferred to CI** with a valid `ZAI_CODING_API_KEY` and egress to `api.z.ai`:
  - glm-5.1 passes, glm-5.2 → not-found ⇒ needs agent-harness bump.
  - both pass ⇒ GLM-5.2 works; just add the `LlmModel` record.
  - glm-5.1 still empty ⇒ run in the real agent environment, not the dev shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)