### PR TITLE
chore(devcontainer): disable remote.autoForwardPorts

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -181,7 +181,7 @@
         },
         "terminal.integrated.scrollback": 10000,
         // Remote ports
-        "remote.autoForwardPorts": true,
+        "remote.autoForwardPorts": false,
         "remote.portsAttributes": {
           "3000": {
             "onAutoForward": "ignore"


### PR DESCRIPTION
## What

Sets `remote.autoForwardPorts` to `false` in `.devcontainer/devcontainer.json`.

## Why

With auto-forwarding on, VS Code forwarded every loopback socket opened by the AI agent CLIs (`claude`, `codex`, `kilo`) and the extension host as they run. This produced a stream of phantom entries in the Ports tab — e.g. a "port 30" mapped to `localhost:59098`, then `59099`, etc. — that read like unexpected open ports.

Audit confirmed they are all `127.0.0.1`-bound editor/agent IPC sockets with **no external surface**; the only externally-bound listener remains `0.0.0.0:3000` (Rails). The auto-forward churn was alarming noise with no benefit.

## Impact

- Ports tab stays quiet; no phantom forwards.
- **Port 3000 is unaffected** — it's published directly by `compose.yaml`, not via VS Code forwarding, so the Rails app stays reachable.
- Any other port can still be forwarded manually via the Ports tab when needed.
- Takes effect on container rebuild / window reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)