### PR TITLE
fix(github-app): refresh installation repository caches

### DIFF
--- a/app/controllers/github_installations_controller.rb
+++ b/app/controllers/github_installations_controller.rb
@@ -29,7 +29,7 @@ class GithubInstallationsController < ApplicationController
     authorize @github_installation, :show?
 
     @projects_using_installation = @github_installation.projects.includes(:created_by).order(created_at: :desc)
-    @accessible_repos = Array(@github_installation.accessible_repositories).map(&:with_indifferent_access)
+    @accessible_repos = Array(@github_installation.cached_repositories).map(&:with_indifferent_access)
     @accessible_repos_count = @accessible_repos.size
   end
 
@@ -119,7 +119,7 @@ class GithubInstallationsController < ApplicationController
   end
 
   def normalized_repositories
-    Array(@github_installation.accessible_repositories).filter_map do |repo|
+    Array(@github_installation.cached_repositories).filter_map do |repo|
       data = repo.with_indifferent_access
       full_name = data[:full_name].presence
       next if full_name.blank?

--- a/app/models/github_installation.rb
+++ b/app/models/github_installation.rb
@@ -3,6 +3,9 @@
 class GithubInstallation < ApplicationRecord
   include TenantScoped
 
+  REPOSITORIES_CACHE_MAX_AGE = 1.hour
+  REPOSITORIES_SYNC_FAILURE_BACKOFF = 5.minutes
+
   belongs_to :account
   has_many :projects, dependent: :restrict_with_error
 
@@ -33,5 +36,38 @@ class GithubInstallation < ApplicationRecord
     Array(accessible_repositories).any? do |repository|
       repository.fetch("full_name", "").casecmp?(repo_full_name)
     end
+  end
+
+  def cached_repositories(max_age: REPOSITORIES_CACHE_MAX_AGE)
+    return accessible_repositories unless should_sync_repositories?(max_age)
+
+    sync_repositories!
+  rescue Github::InstallationRepositories::Error => e
+    Rails.logger.warn(
+      message: "github_installation.repositories_sync_failed",
+      github_installation_id: id,
+      error: e.message
+    )
+    Rails.cache.write(repositories_sync_failure_cache_key, true, expires_in: REPOSITORIES_SYNC_FAILURE_BACKOFF)
+    accessible_repositories
+  end
+
+  def sync_repositories!
+    repositories = Github::InstallationRepositories.fetch(installation_id: github_installation_id)
+    update!(accessible_repositories: repositories, repositories_synced_at: Time.current)
+    repositories
+  end
+
+  private
+
+  def should_sync_repositories?(max_age)
+    active? &&
+      (repositories_synced_at.nil? || repositories_synced_at < max_age.ago) &&
+      !Rails.cache.exist?(repositories_sync_failure_cache_key) &&
+      Github::AppRegistry.configured?
+  end
+
+  def repositories_sync_failure_cache_key
+    "github_installation:#{id || github_installation_id}:repositories_sync_failed"
   end
 end

--- a/app/services/github/installation_repositories.rb
+++ b/app/services/github/installation_repositories.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "faraday"
+
+module Github
+  class InstallationRepositories
+    API_BASE_URL = "https://api.github.com"
+    PER_PAGE = 100
+
+    class Error < StandardError; end
+    class ConfigurationError < Error; end
+
+    def self.fetch(installation_id:)
+      new(installation_id: installation_id).fetch
+    end
+
+    def initialize(installation_id:)
+      @installation_id = installation_id
+    end
+
+    def fetch
+      raise ConfigurationError, "Paid Agents GitHub App is not configured" unless AppRegistry.configured?
+
+      repositories = []
+      page = 1
+
+      loop do
+        body = get_repositories_page(page)
+        page_repositories = Array(body["repositories"])
+        repositories.concat(page_repositories)
+
+        total_count = body["total_count"].to_i
+        break if page_repositories.size < PER_PAGE || repositories.size >= total_count
+
+        page += 1
+      end
+
+      repositories.map { |repo| serialize_repository(repo) }
+    end
+
+    private
+
+    attr_reader :installation_id
+
+    def get_repositories_page(page)
+      response = connection.get("/installation/repositories", per_page: PER_PAGE, page: page) do |request|
+        request.headers["Accept"] = "application/vnd.github+json"
+        request.headers["Authorization"] = "Bearer #{installation_token}"
+      end
+
+      parse_response(response)
+    rescue Faraday::Error => e
+      raise Error, "GitHub App installation repositories request failed: #{e.message}"
+    end
+
+    def installation_token
+      @installation_token ||= begin
+        jwt = AppJwt.sign(app_id: AppRegistry.app_id, private_key: AppRegistry.private_key)
+        response = connection.post("/app/installations/#{installation_id}/access_tokens") do |request|
+          request.headers["Accept"] = "application/vnd.github+json"
+          request.headers["Authorization"] = "Bearer #{jwt}"
+          request.headers["Content-Type"] = "application/json"
+        end
+
+        parse_response(response).fetch("token")
+      end
+    rescue KeyError => e
+      raise Error, "GitHub App installation token response missing #{e.key}"
+    rescue Faraday::Error => e
+      raise Error, "GitHub App installation token request failed: #{e.message}"
+    end
+
+    def connection
+      @connection ||= Faraday.new(url: API_BASE_URL) do |faraday|
+        faraday.options.timeout = 30
+        faraday.options.open_timeout = 10
+      end
+    end
+
+    def parse_response(response)
+      body = JSON.parse(response.body)
+      return body if response.success?
+
+      message = body.is_a?(Hash) ? body["message"] : response.body
+      raise Error, "GitHub App installation repositories request failed (status #{response.status}): #{message}"
+    rescue JSON::ParserError
+      raise Error, "GitHub App installation repositories returned invalid JSON (status #{response.status})"
+    end
+
+    def serialize_repository(repo)
+      {
+        "id" => repo["id"],
+        "full_name" => repo["full_name"],
+        "name" => repo["name"],
+        "owner" => repo.dig("owner", "login") || repo["full_name"].to_s.split("/").first,
+        "default_branch" => repo["default_branch"],
+        "private" => repo["private"] || false
+      }
+    end
+  end
+end

--- a/db/migrate/20260616050244_add_repositories_synced_at_to_github_installations.rb
+++ b/db/migrate/20260616050244_add_repositories_synced_at_to_github_installations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddRepositoriesSyncedAtToGithubInstallations < ActiveRecord::Migration[8.1]
+  def change
+    add_column :github_installations, :repositories_synced_at, :datetime,
+      comment: "When accessible_repositories was last refreshed from the GitHub App installation API"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -971,6 +971,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_19_140623) do
     t.string "account_login", comment: "GitHub org or user login that installed the App"
     t.datetime "created_at", null: false
     t.bigint "github_installation_id", null: false, comment: "GitHub installation ID from App install event"
+    t.datetime "repositories_synced_at", comment: "When accessible_repositories was last refreshed from the GitHub App installation API"
     t.string "repository_selection", comment: "all or selected"
     t.datetime "revoked_at", comment: "When the installation was uninstalled/deleted"
     t.datetime "suspended_at", comment: "When the installation was suspended by GitHub"

--- a/spec/models/github_installation_spec.rb
+++ b/spec/models/github_installation_spec.rb
@@ -80,4 +80,62 @@ RSpec.describe GithubInstallation do
       expect(installation.covers_repository?("acme/widgets")).to be(false)
     end
   end
+
+  describe "#cached_repositories" do
+    it "returns fresh cached repositories without checking app credentials" do
+      installation = build(:github_installation, repositories_synced_at: 5.minutes.ago)
+
+      expect(Github::AppRegistry).not_to receive(:configured?)
+
+      expect(installation.cached_repositories).to eq(installation.accessible_repositories)
+    end
+
+    it "syncs stale repositories when app credentials are configured" do
+      installation = create(:github_installation, repositories_synced_at: nil)
+      repositories = [ { "id" => 456, "full_name" => "acme/refreshed" } ]
+
+      allow(Github::AppRegistry).to receive(:configured?).and_return(true)
+      allow(Github::InstallationRepositories).to receive(:fetch)
+        .with(installation_id: installation.github_installation_id)
+        .and_return(repositories)
+
+      expect(installation.cached_repositories).to eq(repositories)
+      expect(installation.reload.accessible_repositories).to eq(repositories)
+      expect(installation.repositories_synced_at).to be_present
+    end
+
+    it "falls back to cached repositories when a stale sync fails" do
+      installation = create(:github_installation, repositories_synced_at: nil)
+
+      allow(Github::AppRegistry).to receive(:configured?).and_return(true)
+      allow(Github::InstallationRepositories).to receive(:fetch)
+        .and_raise(Github::InstallationRepositories::Error, "timeout")
+
+      expect(installation.cached_repositories).to eq(installation.accessible_repositories)
+      expect(installation.reload.repositories_synced_at).to be_nil
+    end
+
+    it "does not retry a failed sync until the failure backoff expires" do
+      installation = create(:github_installation, repositories_synced_at: nil)
+
+      allow(Github::AppRegistry).to receive(:configured?).and_return(true)
+      allow(Github::InstallationRepositories).to receive(:fetch)
+        .and_raise(Github::InstallationRepositories::Error, "timeout")
+
+      with_memory_cache do
+        installation.cached_repositories
+        installation.cached_repositories
+      end
+
+      expect(Github::InstallationRepositories).to have_received(:fetch).once
+    end
+  end
+
+  def with_memory_cache
+    original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    yield
+  ensure
+    Rails.cache = original_cache
+  end
 end

--- a/spec/requests/github_installations_spec.rb
+++ b/spec/requests/github_installations_spec.rb
@@ -26,6 +26,22 @@ RSpec.describe "GithubInstallations" do
 
       expect(response).to have_http_status(:ok)
     end
+
+    it "refreshes stale repository caches for the visible repository count" do
+      installation = create(
+        :github_installation,
+        account: account,
+        accessible_repositories: [ repository_cache_entry(123, "acme/first-page") ],
+        repositories_synced_at: nil
+      )
+      stub_installation_repository_sync(installation)
+
+      get github_installation_path(installation)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("acme/second-page")
+      expect(installation.reload.accessible_repositories.size).to eq(2)
+    end
   end
 
   describe "GET /github_installations/:id/repositories" do
@@ -69,6 +85,65 @@ RSpec.describe "GithubInstallations" do
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body.map { |repo| repo.fetch("id") }).to eq([ 456 ])
     end
+
+    it "refreshes stale installation repository caches before rendering options" do
+      installation = create(
+        :github_installation,
+        account: account,
+        accessible_repositories: [ repository_cache_entry(123, "acme/first-page") ],
+        repositories_synced_at: nil
+      )
+
+      stub_installation_repository_sync(installation)
+
+      get repositories_github_installation_path(installation)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.map { |repo| repo.fetch("full_name") }).to eq([
+        "acme/first-page",
+        "acme/second-page"
+      ])
+      expect(installation.reload.accessible_repositories.size).to eq(2)
+      expect(installation.repositories_synced_at).to be_present
+    end
+
+    it "falls back to cached repositories when GitHub refresh fails" do
+      installation = create(
+        :github_installation,
+        account: account,
+        accessible_repositories: [ repository_cache_entry(123, "acme/cached") ],
+        repositories_synced_at: nil
+      )
+
+      stub_failed_installation_repository_sync(installation)
+
+      get repositories_github_installation_path(installation)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.map { |repo| repo.fetch("full_name") }).to eq([ "acme/cached" ])
+      expect(installation.reload.repositories_synced_at).to be_nil
+    end
+  end
+
+  def repository_cache_entry(id, full_name, default_branch: "main")
+    { "id" => id, "full_name" => full_name, "default_branch" => default_branch }
+  end
+
+  def stub_installation_repository_sync(installation)
+    allow(Github::AppRegistry).to receive(:configured?).and_return(true)
+    allow(Github::InstallationRepositories).to receive(:fetch)
+      .with(installation_id: installation.github_installation_id)
+      .and_return([
+        repository_cache_entry(123, "acme/first-page"),
+        repository_cache_entry(456, "acme/second-page", default_branch: "trunk")
+      ])
+  end
+
+  def stub_failed_installation_repository_sync(installation)
+    allow(Github::AppRegistry).to receive(:configured?).and_return(true)
+    allow(Github::InstallationRepositories).to receive(:fetch)
+      .with(installation_id: installation.github_installation_id)
+      .and_raise(Github::InstallationRepositories::Error, "timeout")
   end
 
   describe "GET /github_installations/:id/migrate" do

--- a/spec/services/github/installation_repositories_spec.rb
+++ b/spec/services/github/installation_repositories_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Github::InstallationRepositories do
+  let(:installation_id) { 42 }
+  let(:app_id) { "123456" }
+  let(:private_key) { OpenSSL::PKey::RSA.new(2048).to_pem }
+  let(:fake_token) { "ghs_test_token_abc123" }
+
+  around do |example|
+    original_id = ENV.delete("PAID_AGENT_APP_ID")
+    original_key = ENV.delete("PAID_AGENT_APP_PRIVATE_KEY")
+    example.run
+  ensure
+    ENV["PAID_AGENT_APP_ID"] = original_id
+    ENV["PAID_AGENT_APP_PRIVATE_KEY"] = original_key
+  end
+
+  before do
+    ENV["PAID_AGENT_APP_ID"] = app_id
+    ENV["PAID_AGENT_APP_PRIVATE_KEY"] = private_key
+  end
+
+  describe ".fetch" do
+    before do
+      stub_request(:post, "https://api.github.com/app/installations/#{installation_id}/access_tokens")
+        .to_return(
+          status: 201,
+          body: { token: fake_token, expires_at: 1.hour.from_now.iso8601 }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+    end
+
+    it "paginates every installation repository page" do
+      stub_repository_page(1, repositories: repositories_for_range(1..100), total_count: 102)
+      stub_repository_page(2, repositories: repositories_for_range(101..102), total_count: 102)
+
+      repositories = described_class.fetch(installation_id: installation_id)
+
+      expect(repositories.size).to eq(102)
+      expect(repositories.first).to include(first_serialized_repository)
+      expect(repositories.last.fetch("full_name")).to eq("acme/repo-102")
+    end
+
+    it "raises a helpful error when GitHub rejects the request" do
+      stub_request(:get, "https://api.github.com/installation/repositories")
+        .with(query: { "per_page" => "100", "page" => "1" })
+        .to_return(status: 403, body: { message: "Resource not accessible" }.to_json)
+
+      expect {
+        described_class.fetch(installation_id: installation_id)
+      }.to raise_error(described_class::Error, /403.*Resource not accessible/)
+    end
+
+    it "wraps transport failures in the service error type" do
+      stub_request(:get, "https://api.github.com/installation/repositories")
+        .with(query: { "per_page" => "100", "page" => "1" })
+        .to_timeout
+
+      expect {
+        described_class.fetch(installation_id: installation_id)
+      }.to raise_error(described_class::Error, /request failed/)
+    end
+  end
+
+  def repositories_for_range(range)
+    range.map { |index| repository_payload(index, "acme/repo-#{index}") }
+  end
+
+  def stub_repository_page(page, repositories:, total_count:)
+    stub_request(:get, "https://api.github.com/installation/repositories")
+      .with(query: { "per_page" => "100", "page" => page.to_s })
+      .to_return(
+        status: 200,
+        body: { total_count: total_count, repositories: repositories }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+  end
+
+  def first_serialized_repository
+    {
+      "id" => 1,
+      "full_name" => "acme/repo-1",
+      "name" => "repo-1",
+      "owner" => "acme",
+      "default_branch" => "main",
+      "private" => false
+    }
+  end
+
+  def repository_payload(id, full_name)
+    owner, name = full_name.split("/", 2)
+
+    {
+      id: id,
+      full_name: full_name,
+      name: name,
+      owner: { login: owner },
+      default_branch: "main",
+      private: false
+    }
+  end
+end


### PR DESCRIPTION
## Summary

GitHub App-backed project creation no longer gets stuck on the first 30 repositories from a stale installation cache. When the project form or installation detail page needs repository data, Paid now refreshes stale installation caches through the paginated GitHub App API and falls back to the last cached list if GitHub is unavailable.

This fixes the visible failure mode where an all-repositories installation, such as `viamin`, had access to more than 100 repositories in GitHub but only exposed 30 in Paid. The refresh path also backs off briefly after sync failures so users are not forced through repeated slow GitHub retries during an outage.

## Testing

- `bin/rspec spec/models/github_installation_spec.rb spec/requests/github_installations_spec.rb spec/services/github/installation_repositories_spec.rb`
- `bin/rubocop app/services/github/installation_repositories.rb app/models/github_installation.rb app/controllers/github_installations_controller.rb spec/models/github_installation_spec.rb spec/requests/github_installations_spec.rb spec/services/github/installation_repositories_spec.rb db/migrate/20260616050244_add_repositories_synced_at_to_github_installations.rb`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)