### PR TITLE
fix(validations): accept provider-qualified model IDs and seed catalog for Pi runners

### DIFF
--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -1059,9 +1059,15 @@ class Runner < ApplicationRecord
         # overwrite tier_model_ids during save.
         next if will_save_change_to_config?
         configured = direct_outbound_model_id
-        if configured.present? && model_id != configured
-          errors.add(:tier_model_ids, "must match the configured direct-outbound model #{configured}")
-          return
+        if configured.present?
+          # The configured model may be provider-qualified (e.g.
+          # "minimax/MiniMax-M3") while the tier_model_ids value comes from the
+          # LlmModel catalog as the bare id ("MiniMax-M3"). Accept either form.
+          candidates = direct_outbound_catalog_model_id_candidates(configured)
+          unless candidates.include?(model_id)
+            errors.add(:tier_model_ids, "must match the configured direct-outbound model #{configured}")
+            return
+          end
         end
       elsif runner_key == OPENROUTER_FREE_RUNNER_KEY
         unless model.free? && model.provider == OPENROUTER_FREE_MODEL_PROVIDER

--- a/app/services/agent_runs/provider_resolver.rb
+++ b/app/services/agent_runs/provider_resolver.rb
@@ -85,7 +85,13 @@ module AgentRuns
       return unless credential.present?
       return if credential.provider_api_key? && !credential.provider_api_key.compatible_with?(base_provider.provider_key)
 
+      # Ensure the configured model exists in the LlmModel table before
+      # validation runs on the new provider record. Direct-outbound validations
+      # (direct_outbound_config_models_must_exist_in_catalog) reject model IDs
+      # not present in the catalog.
       provider_config = account_managed_provider_config(base_provider, credential)
+      seed_account_managed_model(base_provider, credential)
+
       owner.providers.kept_only.find_or_create_by!(
         provider_key: base_provider.provider_key,
         auth_type: "api_key",

--- a/app/services/agent_runs/runner_resolver.rb
+++ b/app/services/agent_runs/runner_resolver.rb
@@ -135,6 +135,12 @@ module AgentRuns
       return unless credential.present?
       return if credential.provider_api_key? && !credential.provider_api_key.compatible_with?(base_runner.runner_key)
 
+      # Ensure the configured model exists in the LlmModel table before
+      # validation runs on the new runner record. Direct-outbound validations
+      # (direct_outbound_config_models_must_exist_in_catalog) reject model IDs
+      # not present in the catalog.
+      seed_account_managed_model(base_runner, credential)
+
       owner.runners.kept_only.find_or_create_by!(
         runner_key: base_runner.runner_key,
         auth_type: "api_key",
@@ -172,6 +178,27 @@ module AgentRuns
       return static if static.present?
 
       nil
+    end
+
+    def seed_account_managed_model(base_runner, credential)
+      return unless base_runner.runner_key == "pi"
+
+      config = account_managed_runner_config(base_runner, credential)
+      model_id = config.dig("pi", "model")
+      api_provider = config.dig("pi", "api_provider")
+      return if model_id.blank? || api_provider.blank?
+      return if LlmModel.exists?(model_id: model_id)
+
+      LlmModel.create!(
+        model_id: model_id,
+        display_name: model_id.to_s.tr("_-", " ").split.map(&:capitalize).join(" "),
+        provider: api_provider,
+        category: "coding",
+        tier: "mid",
+        active: true,
+        catalog_source: "manual",
+        pricing_tier: "paid"
+      )
     end
 
     def account_managed_runner_config(base_runner, credential)


### PR DESCRIPTION
Two validation regressions from the direct-outbound model PR (#2617) broke CI on `main`.

**`tier_model_ids_must_be_valid`** compared tier_model_ids against the configured model with exact string equality, but the configured model can be provider-qualified (`minimax/MiniMax-M3`) while the catalog stores the bare ID (`MiniMax-M3`). Now uses `direct_outbound_catalog_model_id_candidates` to accept either form.

**`direct_outbound_config_models_must_exist_in_catalog`** rejects model IDs not present in the LlmModel table, but the `account_managed_runner` code path creates Pi providers dynamically without seeding the model. Added `seed_account_managed_model` to both `RunnerResolver` and `ProviderResolver` to create the entry before validation.
