### PR TITLE
fix(runners): recover dead container after RunnerExecutionError so fallbacks can run

### DIFF
--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -578,14 +578,25 @@ module Activities
               **resolved_run_info
             )
 
-            if container_dead_after_exec_error?(agent_run, e)
-              logger.error(
-                message: "agent_execution.container_dead_breaking_runner_loop",
-                agent_run_id: agent_run.id,
-                container_id: agent_run.container_id,
-                error: e.message
+            # A dead/missing container would poison every remaining runner with
+            # "No container provisioned". This happens when the failure killed the
+            # container outright — e.g. an OOM kill during preflight, which Docker
+            # surfaces as exit code 137 (SIGKILL) rather than a "not running" exec
+            # error, so the message-based dead-container heuristic does not catch
+            # it. Re-provision fresh infra before falling through; break when the
+            # reprovision fails so the run fails cleanly instead of burning the
+            # remaining runners against a container that no longer exists. Only
+            # bother when a fallback actually remains — otherwise the loop is
+            # about to end and the live container is left for normal cleanup.
+            fallback_remaining = runners[(index + 1)..].to_a
+            if fallback_remaining.any? && container_unavailable_for_fallback?(agent_run)
+              break unless recover_container_for_fallback!(
+                agent_run: agent_run,
+                runner: runner,
+                error_type: "error",
+                error_message: e.message,
+                fallback_remaining: fallback_remaining
               )
-              break
             end
           end
 
@@ -2889,16 +2900,6 @@ module Activities
         reprovision_error: e.message
       )
       false
-    end
-
-    def container_dead_after_exec_error?(agent_run, error)
-      return false unless container_not_running_error?(error.message)
-      return false if agent_run.container_id.blank?
-
-      container_service = reconnect_container(agent_run) rescue nil
-      return false unless container_service
-
-      !container_service.container_running?
     end
 
     def container_unavailable_for_fallback?(agent_run)

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -3137,6 +3137,65 @@ expect(container_service).to receive(:execute).with(
       end
     end
 
+    context "when a runner execution failure kills the container before fallback (OOM / exit 137)" do
+      before do
+        user.runners.find_or_create_by!(runner_key: "cursor")
+        user.settings.update!(fallback_enabled: true, fallback_runners: [ "cursor" ])
+        allow(git_ops).to receive_messages(
+          head_sha: "pre_agent_sha_abc123",
+          commit_uncommitted_changes: false,
+          has_changes_since?: false
+        )
+        execute_calls = 0
+        allow(container_service).to receive(:execute) do
+          execute_calls += 1
+          if execute_calls == 1
+            # Simulate an OOM kill: Docker reports exit code 137 (SIGKILL) and
+            # the container is gone, so container_id is cleared. This surfaces as
+            # a RunnerExecutionError whose message does NOT match the docker
+            # "not running" pattern, so the dead container is only detectable via
+            # the blank container_id.
+            AgentRun.where(id: agent_run.id).update_all(container_id: nil)
+            Containers::Provision::Result.failure(
+              error: "exit 137",
+              stdout: "",
+              stderr: "> build · MiniMax-M3",
+              exit_code: 137
+            )
+          else
+            exec_success
+          end
+        end
+        allow(agent_run).to receive(:provision_container) { agent_run.update!(container_id: "reprovisioned-123") }
+        allow(Containers::Provision).to receive(:reconnect) do |agent_run:, container_id:|
+          raise "unexpected container id #{container_id}" unless [ "abc123", "reprovisioned-123" ].include?(container_id)
+
+          container_service
+        end
+      end
+
+      it "reprovisions the container and continues with the fallback runner instead of failing every runner" do
+        result = activity.execute(agent_run_id: agent_run.id)
+
+        agent_run.reload
+        expect(result).to include(success: true, final_runner: "cursor")
+        expect(agent_run.runners_attempted).to contain_exactly(
+          hash_including("runner" => "claude_code", "success" => false, "error_type" => "error"),
+          hash_including("runner" => "cursor", "success" => true)
+        )
+        expect(agent_run.runners_attempted).not_to include(
+          hash_including("error_message" => a_string_matching(/No container provisioned/))
+        )
+        expect(agent_run.runner_switches).to eq(1)
+        expect(agent_run.container_id).to eq("reprovisioned-123")
+        expect(git_ops).to have_received(:clone_and_restore_branch).with(
+          branch_name: agent_run.branch_name,
+          base_commit_sha: agent_run.base_commit_sha,
+          pull_request_number: agent_run.source_pull_request_number
+        )
+      end
+    end
+
     context "when a timeout leaves a stale container id before fallback" do
       before do
         user.runners.find_or_create_by!(runner_key: "cursor")


### PR DESCRIPTION
## Problem

Agent run [27706](http://localhost:3000/projects/19/agent_runs/27706) failed with `All runners exhausted: Opencode MiniMax, Codex, Claude` without ever executing an agent turn.

The first runner (Opencode MiniMax) died during preflight with exit 137, which destroyed the container and cleared `container_id`. The two healthy fallback runners (Codex, Claude) then failed instantly with `No container provisioned` — the run failed even though good fallbacks were available.

| # | Runner | Duration | Error |
|---|--------|----------|-------|
| 0 | Opencode MiniMax | 70.7s | `Preflight check failed: Agent exited with code 137` |
| 1 | Codex | 0.0s | `No container provisioned` |
| 2 | Claude | 0.0s | `No container provisioned` |

## Root cause

The `RunnerExecutionError` handler — unlike the timeout and infra handlers — never re-provisioned a dead container. Its only guard, `container_dead_after_exec_error?`, required the error message to match the docker `/is not running|No such container/` pattern **and** bailed early on a blank `container_id`. An exit-137 kill matches neither, so the loop fell through to the fallbacks against a container that no longer existed.

## Fix

Make the `RunnerExecutionError` handler mirror the timeout/infra handlers: when a fallback runner remains **and** the container is unavailable (`container_unavailable_for_fallback?`, which correctly treats a blank `container_id` as dead), re-provision fresh infra before continuing; break only if the reprovision fails. Guarded on a remaining fallback so single-runner runs don't pay an extra reconnect. Removes the now-unused `container_dead_after_exec_error?` helper.

The live-container-reuse path (normal runner error, container still alive) is preserved — `container_unavailable_for_fallback?` returns false, so no reprovision and no lost work.

## Tests

- New regression test: OOM/exit-137 with a dead container reprovisions and continues to the fallback runner instead of failing every runner (verified it fails without the fix).
- Existing live-container-reuse and single-runner deterministic-config tests stay green.

> [!NOTE]
> This addresses the *recovery* facet of incident 27706. A companion PR (P2) adds OOM detection/diagnostics so a bare exit 137 is identifiable in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)