### PR TITLE
feat(containers): detect and surface container OOM kills on exit 137

### DIFF
--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -556,11 +556,30 @@ module Containers
         if exit_code == 0
           Result.success(stdout: stdout, stderr: stderr, exit_code: exit_code)
         else
+          # Exit 137 (128 + SIGKILL) on a clean completion almost always means
+          # the cgroup OOM killer fired — the container's memory limit (swap is
+          # disabled) was exceeded. Inspect the container state so an OOM is
+          # recorded distinctly instead of being indistinguishable from an
+          # ordinary non-zero exit. Scoped to 137 so routine non-zero probe
+          # exits (git rev-parse -> 128, test -f -> 1) do not pay for an extra
+          # Docker inspect.
+          oom = exit_code == 137 ? oom_exit_diagnostics : {}
+          if oom[:oom_killed]
+            log_system("container.execute.oom_killed",
+              exit_code: exit_code, duration_ms: elapsed_ms,
+              memory_limit_bytes: oom[:memory_limit_bytes], container_running: oom[:container_running])
+          elsif exit_code == 137
+            log_system("container.execute.sigkill",
+              exit_code: exit_code, duration_ms: elapsed_ms,
+              memory_limit_bytes: oom[:memory_limit_bytes], container_running: oom[:container_running])
+          end
           Result.failure(
             error: "Command exited with code #{exit_code}",
             stdout: stdout,
             stderr: stderr,
-            exit_code: exit_code
+            exit_code: exit_code,
+            oom_killed: oom[:oom_killed] || false,
+            memory_limit_bytes: oom[:memory_limit_bytes]
           )
         end
       rescue OutputAbortError
@@ -725,6 +744,27 @@ module Containers
       container.info["State"]["Running"] == true
     rescue Docker::Error::DockerError
       false
+    end
+
+    # Inspects the container's post-exec state after an exit-137 (SIGKILL) to
+    # determine whether the cgroup OOM killer fired. Docker only sets
+    # State.OOMKilled when the kernel OOM killer killed the container, so it is
+    # the authoritative signal; a bare 137 is otherwise ambiguous. Best-effort —
+    # returns {} when the container is already gone.
+    def oom_exit_diagnostics
+      return {} unless container
+
+      container.refresh!
+      info = container.info || {}
+      state = info["State"] || {}
+      {
+        oom_killed: state["OOMKilled"] == true,
+        container_running: state["Running"],
+        memory_limit_bytes: info.dig("HostConfig", "Memory")
+      }
+    rescue Docker::Error::DockerError => e
+      log_system("container.execute.exit_state_unavailable", error: e.message)
+      {}
     end
 
     def heartbeat_host_path

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -1414,7 +1414,7 @@ module Activities
       end
 
       # Other execution error
-      raise RunnerExecutionError, "Agent exited with code #{result[:exit_code]}: #{output.truncate(500)}"
+      raise RunnerExecutionError, "Agent exited with code #{result[:exit_code]}#{oom_annotation(result)}: #{output.truncate(500)}"
     rescue Containers::Provision::TimeoutError => e
       # execution_started_at is nil if the timeout fires before execution
       # begins (e.g. during start!/callbacks); recent_timeout_output
@@ -1578,9 +1578,9 @@ module Activities
       end
 
       reason = if sanitized_output.present?
-        "Agent exited with code #{result[:exit_code]}: #{sanitized_output.truncate(500)}"
+        "Agent exited with code #{result[:exit_code]}#{oom_annotation(result)}: #{sanitized_output.truncate(500)}"
       else
-        "No output before exit code #{result[:exit_code]}. Check proxy configuration, auth, and network policy."
+        "No output before exit code #{result[:exit_code]}#{oom_annotation(result)}. Check proxy configuration, auth, and network policy."
       end
       raise_preflight_failure!(agent_run: agent_run, runner: runner, reason: reason)
     rescue Containers::Provision::OutputAbortError => e
@@ -2041,6 +2041,20 @@ module Activities
         agent_run_id: agent_run.id,
         reason: reason
       )
+    end
+
+    # Surfaces a container OOM kill inline in the runner error so the run's
+    # error_message explains a bare exit 137 (cgroup memory limit exceeded)
+    # instead of leaving it cryptic. Returns "" for non-OOM results.
+    def oom_annotation(result)
+      return "" unless result.respond_to?(:[]) && result[:oom_killed]
+
+      limit = result[:memory_limit_bytes].to_i
+      if limit.positive?
+        " (container OOM-killed; memory limit #{(limit / 1024.0**3).round(1)} GB)"
+      else
+        " (container OOM-killed)"
+      end
     end
 
     def raise_preflight_failure!(agent_run:, runner:, reason:)

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -1580,7 +1580,9 @@ module Activities
       reason = if sanitized_output.present?
         "Agent exited with code #{result[:exit_code]}#{oom_annotation(result)}: #{sanitized_output.truncate(500)}"
       else
-        "No output before exit code #{result[:exit_code]}#{oom_annotation(result)}. Check proxy configuration, auth, and network policy."
+        base = "No output before exit code #{result[:exit_code]}."
+        oom = oom_annotation(result)
+        oom.present? ? "#{base}#{oom}" : "#{base} Check proxy configuration, auth, and network policy."
       end
       raise_preflight_failure!(agent_run: agent_run, runner: runner, reason: reason)
     rescue Containers::Provision::OutputAbortError => e

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -2076,6 +2076,30 @@ RSpec.describe Containers::Provision do
       end
     end
 
+    context "when exit 137 occurs but the container is already gone" do
+      before do
+        allow(mock_container).to receive(:exec) do |_cmd, **_opts, &block|
+          block.call(:stderr, "Killed\n") if block
+          [ [], [ "Killed\n" ], 137 ]
+        end
+        allow(mock_container).to receive(:refresh!).and_raise(Docker::Error::NotFoundError, "No such container")
+      end
+
+      it "degrades gracefully without claiming OOM when state cannot be read" do
+        allow(agent_run).to receive(:log!)
+
+        result = service.execute("opencode run 'Reply with exactly OK.'")
+
+        expect(result).to be_failure
+        expect(result[:oom_killed]).to be false
+        expect(result[:memory_limit_bytes]).to be_nil
+        expect(agent_run).to have_received(:log!).with("system", "container.execute.exit_state_unavailable",
+          metadata: hash_including(error: /No such container/))
+        expect(agent_run).to have_received(:log!).with("system", "container.execute.sigkill",
+          metadata: hash_including(exit_code: 137))
+      end
+    end
+
     context "when command output contains invalid UTF-8 bytes" do
       let(:invalid_chunk) { "bad \xFF output\n".b }
 

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -2009,6 +2009,71 @@ RSpec.describe Containers::Provision do
         expect(result[:exit_code]).to eq(1)
         expect(result.error).to include("exited with code 1")
       end
+
+      it "does not inspect container state for ordinary non-zero exits" do
+        expect(mock_container).not_to receive(:refresh!)
+
+        result = service.execute("false")
+
+        expect(result[:oom_killed]).to be false
+      end
+    end
+
+    context "when the command is OOM-killed (exit 137)" do
+      before do
+        allow(mock_container).to receive(:exec) do |_cmd, **_opts, &block|
+          block.call(:stderr, "Killed\n") if block
+          [ [], [ "Killed\n" ], 137 ]
+        end
+        allow(mock_container).to receive(:info).and_return(
+          "State" => { "Running" => false, "ExitCode" => 137, "OOMKilled" => true },
+          "HostConfig" => { "Memory" => 4 * 1024 * 1024 * 1024 }
+        )
+      end
+
+      it "detects the OOM kill and flags the result" do
+        result = service.execute("opencode run 'Reply with exactly OK.'")
+
+        expect(result).to be_failure
+        expect(result[:exit_code]).to eq(137)
+        expect(result[:oom_killed]).to be true
+        expect(result[:memory_limit_bytes]).to eq(4 * 1024 * 1024 * 1024)
+      end
+
+      it "logs the OOM kill distinctly with the memory limit" do
+        allow(agent_run).to receive(:log!)
+
+        service.execute("opencode run 'Reply with exactly OK.'")
+
+        expect(agent_run).to have_received(:log!).with("system", "container.execute.oom_killed",
+          metadata: hash_including(
+            exit_code: 137,
+            memory_limit_bytes: 4 * 1024 * 1024 * 1024,
+            container_running: false
+          ))
+      end
+    end
+
+    context "when exit 137 occurs but the container is not OOM-killed" do
+      before do
+        allow(mock_container).to receive(:exec) do |_cmd, **_opts, &block|
+          block.call(:stderr, "Killed\n") if block
+          [ [], [ "Killed\n" ], 137 ]
+        end
+        allow(mock_container).to receive(:info).and_return(
+          "State" => { "Running" => true, "ExitCode" => 137, "OOMKilled" => false }
+        )
+      end
+
+      it "records a plain SIGKILL without claiming OOM" do
+        allow(agent_run).to receive(:log!)
+
+        result = service.execute("opencode run 'Reply with exactly OK.'")
+
+        expect(result[:oom_killed]).to be false
+        expect(agent_run).to have_received(:log!).with("system", "container.execute.sigkill",
+          metadata: hash_including(exit_code: 137))
+      end
     end
 
     context "when command output contains invalid UTF-8 bytes" do

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -3717,6 +3717,7 @@ expect(container_service).to receive(:execute).with(
         )
       end
 
+
       before do
         allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor aider])
         user.runners.find_or_create_by!(runner_key: "cursor")
@@ -3761,6 +3762,28 @@ expect(container_service).to receive(:execute).with(
           hash_including("runner" => "claude_code", "success" => false, "error_type" => "error",
             "error_message" => include("Docker exec error")),
           hash_including("runner" => "cursor", "success" => true)
+        )
+      end
+
+      it "annotates the runner error with the container OOM kill and memory limit" do
+        oom_failure = Containers::Provision::Result.failure(
+          error: "exit 137", stdout: "", stderr: "Killed",
+          exit_code: 137, oom_killed: true, memory_limit_bytes: 4 * 1024 * 1024 * 1024
+        )
+        call_count = 0
+        allow(container_service).to receive(:execute) do |_cmd, **_opts|
+          call_count += 1
+          call_count == 1 ? oom_failure : exec_success
+        end
+
+        result = activity.execute(agent_run_id: agent_run.id)
+
+        expect(result[:success]).to be true
+        expect(agent_run.reload.runners_attempted).to include(
+          hash_including(
+            "runner" => "claude_code", "success" => false,
+            "error_message" => include("container OOM-killed; memory limit 4.0 GB")
+          )
         )
       end
 

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -3717,7 +3717,6 @@ expect(container_service).to receive(:execute).with(
         )
       end
 
-
       before do
         allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor aider])
         user.runners.find_or_create_by!(runner_key: "cursor")


### PR DESCRIPTION
## Problem

A cgroup OOM kill (container memory limit exceeded; swap is disabled) surfaces only as a bare exit `137` (128 + SIGKILL). Paid recorded that **indistinguishably** from any other non-zero exit: the `oom_killed` flag was captured only on the docker `ExecutionError` branch, which a *clean* exec completion never hits.

In incident [27706](http://localhost:3000/projects/19/agent_runs/27706) the Opencode/MiniMax preflight died with exit 137 and the container was gone immediately after — but nothing in the run record said "OOM", so it looked like a generic runner fault and could not be diagnosed after the fact.

## Fix

On a clean exec completion with exit `137`, inspect the container state and:

- log `container.execute.oom_killed` (with the memory limit) when Docker reports `State.OOMKilled`, else `container.execute.sigkill`;
- carry `oom_killed` / `memory_limit_bytes` on the failure `Result`;
- annotate the runner error message — e.g. `Agent exited with code 137 (container OOM-killed; memory limit 4.0 GB)` — so the OOM is visible in the run's `error_message` and runner attempt history.

Scoped to exit `137` so routine non-zero probe exits (git `rev-parse` → 128, `test -f` → 1) don't pay for an extra Docker inspect. Classification stays on the normal `RunnerExecutionError` path so the per-runner circuit breaker still backs off a runner that keeps OOMing.

## Tests

- `provision_spec`: OOM detected + logged with memory limit; plain SIGKILL (no OOM) not mislabeled; ordinary non-zero exits skip the inspect. (Verified they fail without the fix.)
- `run_agent_activity_spec`: the OOM annotation surfaces in the runner attempt's `error_message`.

> [!NOTE]
> This is the *diagnostics* facet of incident 27706. The companion PR (P1) handles *recovery* — re-provisioning the dead container so fallback runners still run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)