### PR TITLE
fix(ci): include paid-agents[bot] in trusted CI allowlist

### DIFF
--- a/.github/workflows/agent-image.yml
+++ b/.github/workflows/agent-image.yml
@@ -41,7 +41,7 @@ jobs:
     if: >-
       github.event_name != 'pull_request'
       || contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
-      || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]"]'), github.event.pull_request.user.login)
+      || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]","paid-agents[bot]"]'), github.event.pull_request.user.login)
     runs-on: ubuntu-latest
     timeout-minutes: 25
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     if: >-
       github.event_name != 'pull_request'
       || contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
-      || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]"]'), github.event.pull_request.user.login)
+      || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]","paid-agents[bot]"]'), github.event.pull_request.user.login)
     runs-on: ubuntu-latest
     env:
       BUNDLE_FROZEN: "true"
@@ -150,7 +150,7 @@ jobs:
     if: >-
       github.event_name != 'pull_request'
       || contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
-      || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]"]'), github.event.pull_request.user.login)
+      || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]","paid-agents[bot]"]'), github.event.pull_request.user.login)
     runs-on: ubuntu-24.04
     timeout-minutes: 45
 
@@ -264,7 +264,7 @@ jobs:
     if: >-
       github.event_name != 'pull_request'
       || contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
-      || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]"]'), github.event.pull_request.user.login)
+      || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]","paid-agents[bot]"]'), github.event.pull_request.user.login)
     runs-on: ubuntu-latest
     env:
       BUNDLE_FROZEN: "true"
@@ -285,7 +285,7 @@ jobs:
     if: >-
       github.event_name != 'pull_request'
       || contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
-      || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]"]'), github.event.pull_request.user.login)
+      || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]","paid-agents[bot]"]'), github.event.pull_request.user.login)
     runs-on: ubuntu-24.04
     timeout-minutes: 45
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -79,7 +79,7 @@ jobs:
               ;;
             *)
               case "${AUTHOR_LOGIN}" in
-                "dependabot[bot]"|"renovate[bot]"|"github-actions[bot]")
+                "dependabot[bot]"|"renovate[bot]"|"github-actions[bot]"|"paid-agents[bot]")
                   echo "allowed=true" >> "$GITHUB_OUTPUT"
                   ;;
                 *)
@@ -150,7 +150,7 @@ jobs:
           # The action runs in a Docker container, so the Rails test database
           # must be addressed by the service hostname rather than localhost.
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.client_payload.pr_number }}'
-          allowed_bots: 'dependabot[bot]'
+          allowed_bots: "dependabot[bot],paid-agents[bot]"
 
       - name: Complete PR head check run
         if: always() && steps.pr.outputs.head_repo_fork != 'true' && steps.trust.outputs.allowed == 'true'

--- a/.github/workflows/ephemeral_tests.yml
+++ b/.github/workflows/ephemeral_tests.yml
@@ -30,7 +30,7 @@ jobs:
     name: Detect ephemeral tests
     if: >-
       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
-      || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]"]'), github.event.pull_request.user.login)
+      || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]","paid-agents[bot]"]'), github.event.pull_request.user.login)
     runs-on: ubuntu-latest
     outputs:
       has_tests: ${{ steps.check.outputs.has_tests }}
@@ -185,7 +185,7 @@ jobs:
       always()
       && (
         contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
-        || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]"]'), github.event.pull_request.user.login)
+        || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]","paid-agents[bot]"]'), github.event.pull_request.user.login)
       )
       && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-artifact-check.yml
+++ b/.github/workflows/pr-artifact-check.yml
@@ -15,7 +15,7 @@ jobs:
   check-artifacts:
     if: >-
       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
-      || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]"]'), github.event.pull_request.user.login)
+      || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]","paid-agents[bot]"]'), github.event.pull_request.user.login)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/pr-screenshots-publish.yml
+++ b/.github/workflows/pr-screenshots-publish.yml
@@ -14,7 +14,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
       && (
         contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
-        || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]"]'), github.event.pull_request.user.login)
+        || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]","paid-agents[bot]"]'), github.event.pull_request.user.login)
       )
     runs-on: ubuntu-24.04
     services:

--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -28,7 +28,7 @@ jobs:
       && (
         (github.event_name != 'pull_request' && github.event_name != 'pull_request_target')
         || contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
-        || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]"]'), github.event.pull_request.user.login)
+        || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]","paid-agents[bot]"]'), github.event.pull_request.user.login)
       )
     runs-on: ubuntu-latest
     permissions:
@@ -84,7 +84,7 @@ jobs:
       && (
         (github.event_name != 'pull_request' && github.event_name != 'pull_request_target')
         || contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
-        || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]"]'), github.event.pull_request.user.login)
+        || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]","paid-agents[bot]"]'), github.event.pull_request.user.login)
       )
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -250,7 +250,7 @@ jobs:
       github.event.action == 'closed'
       && (
         contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
-        || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]"]'), github.event.pull_request.user.login)
+        || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]","paid-agents[bot]"]'), github.event.pull_request.user.login)
       )
       && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,7 @@ jobs:
     if: >-
       github.event_name != 'pull_request'
       || contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
-      || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]"]'), github.event.pull_request.user.login)
+      || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]","paid-agents[bot]"]'), github.event.pull_request.user.login)
     runs-on: ubuntu-latest
     env:
       BUNDLE_FROZEN: "true"

--- a/.github/workflows/system_tests.yml
+++ b/.github/workflows/system_tests.yml
@@ -19,7 +19,7 @@ jobs:
     if: >-
       github.event_name != 'pull_request'
       || contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
-      || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]"]'), github.event.pull_request.user.login)
+      || contains(fromJson('["dependabot[bot]","renovate[bot]","github-actions[bot]","paid-agents[bot]"]'), github.event.pull_request.user.login)
     runs-on: ubuntu-24.04
     timeout-minutes: 20
 


### PR DESCRIPTION
PRs opened by the system's own agent bot (`paid-agents[bot]`) were silently skipping all CI jobs because the `author_association` guard matches only `OWNER`/`MEMBER`/`COLLABORATOR`, and GitHub Apps receive `NONE` association. Add `paid-agents[bot]` to the bot-login allowlist across all 9 workflow files so CI runs for agent-opened PRs, preventing regressions from reaching main.
