### PR TITLE
fix(runners): skip free-model snapshot clearing on runner creation

### DIFF
--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -793,7 +793,10 @@ class Runner < ApplicationRecord
   # The snapshot lives on the RunnerState row keyed by the bare runner_key
   # (matching FreeModels::Rotation and Knowledge::RunnerExecutor), NOT the
   # routing-key state_key, so the lookup uses the same key that wrote it.
+  # Only relevant when editing an existing runner — creating a runner must
+  # not wipe a pre-existing recovery snapshot.
   def clear_free_model_rotation_snapshot
+    return if new_record?
     return unless runner_key == OPENROUTER_FREE_RUNNER_KEY
     return unless will_save_change_to_tier_model_ids?
     return unless user


### PR DESCRIPTION
## Problem

CI on `main` is red. The test `Runner free-model rotation snapshot clearing does not clear the snapshot during a system rotation` ([spec/models/runner_spec.rb:1653](spec/models/runner_spec.rb#L1653)) fails:

```
expected: {"high" => "free-orig"}
     got: nil
```

This was introduced by #2630 (Phase 3b: Free model rotation) and fails consistently on `main`.

## Root cause

`before_save :clear_free_model_rotation_snapshot` ran during **record creation**, not just updates. In the failing spec, `runner` is a lazy `let`, so the `create(:runner, ...)` first fires at the line that sets `rotating_tier_models = true` — but the save callback runs *before* that flag takes effect on a persisted change. Creating the runner therefore wiped the pre-existing `RunnerState` recovery snapshot before the rotation update happened.

Beyond the test, this was incorrect behavior: creating a runner should never erase another row's recovery point.

## Fix

Guard the callback with `return if new_record?` so it only fires when a user edits an existing runner's `tier_model_ids`.

## Verification

- `spec/models/runner_spec.rb` + `spec/models/runner_state_spec.rb`: **221 examples, 0 failures**
- RuboCop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)