### PR TITLE
fix(github-app): default github_installation factory to fresh sync timestamp

### DIFF
--- a/spec/factories/github_installations.rb
+++ b/spec/factories/github_installations.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     target_type { "Organization" }
     repository_selection { "selected" }
     accessible_repositories { [ { "full_name" => "test-org/repo", "id" => 123 } ] }
+    repositories_synced_at { Time.current }
 
     trait :suspended do
       suspended_at { Time.current }


### PR DESCRIPTION
## Problem

CI on `main` is red. The `test` job fails with 3 failures in `spec/requests/github_installations_spec.rb` (the `show` and `repositories` actions):

```
WebMock::NetConnectNotAllowedError:
  Real HTTP connections are disabled. Unregistered request:
  POST https://api.github.com/app/installations/.../access_tokens
```

## Root cause

Commit #2619 ("refresh installation repository caches") made `GithubInstallation#cached_repositories` trigger a real installation-repository sync when `repositories_synced_at` is `nil` **and** the GitHub App registry is configured. The `github_installation` factory left `repositories_synced_at` `nil` by default, so the three controller request specs that don't stub the sync attempt a live GitHub access-token request in CI (where the app registry *is* configured) and fail under WebMock.

These specs passed in the PR's own CI run only because credential availability differed; on `main` the app registry is configured, exposing the latent gap.

## Fix

Default the factory to a fresh `repositories_synced_at { Time.current }` so created installations are treated as up-to-date unless a spec explicitly opts into the stale path. The specs that test the sync/refresh behavior already set `repositories_synced_at: nil` explicitly (both here and in `spec/models/github_installation_spec.rb`), so this only closes the unintended network-call path.

## Verification

```
bin/rspec spec/requests/github_installations_spec.rb spec/models/github_installation_spec.rb
34 examples, 0 failures
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)