### PR TITLE
feat(github): opt-in PAT fallback for git pushes the App can't make

### DIFF
--- a/app/controllers/api/git_credentials_controller.rb
+++ b/app/controllers/api/git_credentials_controller.rb
@@ -21,13 +21,27 @@ module Api
         return
       end
 
-      token = project.github_credential
+      # The App installation token is the default for every operation. The
+      # fallback PAT is served only while the run is flagged for a permission
+      # retry (set transiently by Containers::GitOperations around a push the
+      # App token was rejected for, e.g. one touching .github/workflows/).
+      token = fallback_credential_for(project)
+      if token
+        project.git_push_fallback_token.touch_last_used!
+        Rails.logger.info(
+          message: "git_credentials.app_installation_pat_fallback",
+          project_id: project.id,
+          git_push_fallback_token_id: project.git_push_fallback_token_id
+        )
+      else
+        token = project.github_credential
+        project.github_token&.touch_last_used!
+      end
+
       unless token
         render json: { error: github_credential_unavailable_message(project) }, status: :forbidden
         return
       end
-
-      project.github_token&.touch_last_used!
 
       render plain: credential_response(token), content_type: "text/plain"
     rescue Github::AppInstallation::ConfigurationError => e
@@ -39,6 +53,17 @@ module Api
     end
 
     private
+
+    # Returns the project's fallback PAT credential when the authenticated
+    # agent run is currently flagged for a permission-rejected push retry and
+    # the project has the fallback configured; otherwise nil.
+    def fallback_credential_for(project)
+      run = @authenticated_run
+      return unless run.respond_to?(:git_credential_fallback_active?)
+      return unless run.git_credential_fallback_active?
+
+      project.git_push_fallback_credential
+    end
 
     def credential_response(token)
       <<~CREDENTIALS

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -386,7 +386,8 @@ class ProjectsController < ApplicationController
   end
 
   def project_params
-    params.require(:project).permit(:github_auth_source, :github_token_id, :github_installation_id, :owner, :repo, :name, :active,
+    params.require(:project).permit(:github_auth_source, :github_token_id, :github_installation_id,
+      :git_push_pat_fallback_enabled, :git_push_fallback_token_id, :owner, :repo, :name, :active,
       :poll_interval_seconds, :max_execution_seconds, :github_id, :default_branch,
       :owner_reviewer_login, :merge_method, :max_draft_review_rounds, :auto_pick_enabled, :auto_merge_mode,
       :allow_bot_authored_pr_auto_merge, :auto_fix_merge_conflicts, :auto_scan_security,

--- a/app/models/github_token.rb
+++ b/app/models/github_token.rb
@@ -17,6 +17,13 @@ class GithubToken < ApplicationRecord
   belongs_to :created_by, class_name: "User", optional: true
 
   has_many :projects, dependent: :restrict_with_error
+  # Projects that reference this token only as their git-push fallback (not as
+  # their primary credential). Restrict destroy so a hard-delete fails with a
+  # model error instead of a raw foreign-key violation; the normal UI path
+  # revokes (soft-deletes), which a fallback's active? check already neutralizes.
+  has_many :git_push_fallback_projects, class_name: "Project",
+    foreign_key: :git_push_fallback_token_id, inverse_of: :git_push_fallback_token,
+    dependent: :restrict_with_error
 
   encrypts :token
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -154,6 +154,11 @@ class Project < ApplicationRecord
 
   belongs_to :github_token, counter_cache: true, optional: true
   belongs_to :github_installation, optional: true
+  # Optional PAT used as the git push/fetch credential for app-backed projects
+  # when the App installation can't perform the push (e.g. lacks the workflows
+  # permission). Distinct from +github_token+ — it is never the project's
+  # primary credential and is exempt from +exactly_one_github_credential+.
+  belongs_to :git_push_fallback_token, class_name: "GithubToken", optional: true
   belongs_to :created_by, class_name: "User", optional: true
 
   has_many :project_memberships, dependent: :destroy
@@ -211,6 +216,7 @@ class Project < ApplicationRecord
 
   before_validation :normalize_priority_labels
   before_validation :normalize_interop_settings
+  before_validation :reset_git_push_pat_fallback_unless_app_backed
   after_update_commit :invalidate_relationship_parsing_on_trust_change
 
   validates :name, presence: true
@@ -248,6 +254,8 @@ class Project < ApplicationRecord
   validate :github_token_is_active, if: -> { github_token.present? && github_token_id_changed? }
   validate :github_installation_belongs_to_same_account, if: -> { github_installation.present? }
   validate :github_installation_is_active, if: -> { github_installation.present? && github_installation_id_changed? }
+  validate :git_push_fallback_token_valid, if: -> { git_push_fallback_token_id.present? }
+  validate :git_push_pat_fallback_requires_token, if: -> { git_push_pat_fallback_enabled? }
   validate :created_by_belongs_to_same_account, if: -> { created_by.present? }
   validate :review_settings_valid
   validate :screenshot_settings_valid
@@ -969,6 +977,27 @@ class Project < ApplicationRecord
     end
   end
 
+  # True when this app-backed project is configured to retry a git push with
+  # its fallback PAT after the App installation token is rejected for a missing
+  # permission (e.g. a push touching .github/workflows/). This is the opt-in
+  # gate only — the App remains the default credential for every operation; the
+  # PAT is used solely for the failing retry (see Containers::GitOperations and
+  # WorktreeService). We trust the configured setting rather than inspecting the
+  # PAT's scopes, because fine-grained PATs do not report classic OAuth scopes.
+  def git_push_pat_fallback_configured?
+    return false unless github_installation_id.present? || github_installation.present?
+    return false unless git_push_pat_fallback_enabled?
+    return false unless git_push_fallback_token.present?
+
+    credential_active?(git_push_fallback_token)
+  end
+
+  # The fallback PAT credential string, or nil when fallback is not configured.
+  # Callers use this only on a permission-rejected push retry.
+  def git_push_fallback_credential
+    git_push_fallback_token.token if git_push_pat_fallback_configured?
+  end
+
   # Returns a GithubClient authenticated via the project's GitHub credential
   # (installation token for app-backed projects, PAT for token-backed projects).
   def client
@@ -1226,6 +1255,33 @@ class Project < ApplicationRecord
     return if github_installation.account_id == account_id
 
     errors.add(:github_installation, "must belong to the same account")
+  end
+
+  # Validates the selected fallback token exists and is in this account. Checking
+  # by id (not the loaded association) also rejects a non-existent id from a
+  # crafted request, which would otherwise pass to a raw foreign-key violation.
+  def git_push_fallback_token_valid
+    return if git_push_fallback_token&.account_id == account_id
+
+    errors.add(:git_push_fallback_token, "must belong to the same account")
+  end
+
+  # Enabling the fallback is meaningless without a PAT to fall back to.
+  def git_push_pat_fallback_requires_token
+    return if git_push_fallback_token_id.present?
+
+    errors.add(:git_push_fallback_token, "must be selected to enable PAT push fallback")
+  end
+
+  # The fallback PAT only makes sense for app-backed projects. Rather than
+  # rejecting a project that is switched to PAT auth while a fallback lingers
+  # (a dead-end the user can't escape from the PAT settings panel), drop the
+  # now-meaningless fallback so the switch saves cleanly.
+  def reset_git_push_pat_fallback_unless_app_backed
+    return if github_installation_id.present? || github_installation.present?
+
+    self.git_push_pat_fallback_enabled = false
+    self.git_push_fallback_token_id = nil
   end
 
   def github_installation_is_active

--- a/app/services/containers/git_operations.rb
+++ b/app/services/containers/git_operations.rb
@@ -327,12 +327,20 @@ module Containers
     def push_branch
       validate_branch_name!
 
-      result =
-        if agent_run.existing_pr?
-          push_existing_pr_branch
-        else
-          push_new_branch
-        end
+      # Defensive: a prior attempt hard-killed mid-retry could leave the flag
+      # set, which would route this first push to the PAT. Clear it so the App
+      # token is always tried first. Only writes when actually stale.
+      clear_stale_fallback_flag
+
+      result = push_to_origin
+
+      # The App installation token is the default. If GitHub rejected the push
+      # for a permission the App lacks (e.g. a change under .github/workflows/)
+      # and the project opted into PAT push fallback, retry that one push with
+      # the fallback PAT — scoped to the failing operation only.
+      if result.failure? && app_permission_rejection?(result) && pat_push_fallback_configured?
+        result = push_with_fallback_credential
+      end
 
       raise PushError, "Push failed: #{error_with_stderr(result)}" if result.failure?
 
@@ -676,6 +684,49 @@ module Containers
       execute_git("rebase", "--abort")
     rescue Error
       # Best effort — abort may fail if rebase state is already gone
+    end
+
+    def push_to_origin
+      if agent_run.existing_pr?
+        push_existing_pr_branch
+      else
+        push_new_branch
+      end
+    end
+
+    # Re-runs the push with the run flagged so the git-credentials proxy serves
+    # the project's fallback PAT (instead of the App installation token) for the
+    # duration of this retry. The push runs after the agent has exited, so the
+    # flag window covers only this system push. The flag is always cleared.
+    def push_with_fallback_credential
+      Rails.logger.info(
+        message: "container_git.pat_push_fallback_retry",
+        agent_run_id: agent_run.id,
+        project_id: agent_run.project_id
+      )
+      agent_run.update_columns(git_credential_fallback_active: true)
+      push_to_origin
+    ensure
+      agent_run.update_columns(git_credential_fallback_active: false)
+    end
+
+    def pat_push_fallback_configured?
+      agent_run.project.git_push_pat_fallback_configured?
+    end
+
+    def clear_stale_fallback_flag
+      return unless agent_run.git_credential_fallback_active?
+
+      agent_run.update_columns(git_credential_fallback_active: false)
+    end
+
+    # True when the push was rejected because the authenticating GitHub App
+    # installation token lacks a permission the operation needs (the PAT may
+    # have it). GitHub phrases this as "refusing to allow a GitHub App ...".
+    def app_permission_rejection?(result)
+      [ result[:stdout], result[:stderr] ].compact.any? do |output|
+        output.include?("refusing to allow a GitHub App")
+      end
     end
 
     def push_new_branch

--- a/app/services/worktree_service.rb
+++ b/app/services/worktree_service.rb
@@ -211,10 +211,7 @@ class WorktreeService
       raise WorktreeError, "Cannot push branch: worktree_path is blank for AgentRun##{agent_run.id}"
     end
 
-    run_git(
-      "push", "origin", agent_run.branch_name,
-      chdir: agent_run.worktree_path
-    )
+    push_branch_to_remote(agent_run)
 
     result_sha = run_git("rev-parse", "HEAD", chdir: agent_run.worktree_path).strip
     agent_run.update!(result_commit_sha: result_sha)
@@ -380,8 +377,37 @@ class WorktreeService
     true
   end
 
+  # Pushes via the App-authenticated origin by default. If the App installation
+  # token is rejected for a missing permission and the project opted into PAT
+  # push fallback, retries that one push against the fallback PAT URL.
+  def push_branch_to_remote(agent_run)
+    run_git("push", "origin", agent_run.branch_name, chdir: agent_run.worktree_path)
+  rescue Error => e
+    raise unless app_permission_rejection?(e.message) && project.git_push_pat_fallback_configured?
+
+    Rails.logger.info(
+      message: "worktree_service.pat_push_fallback_retry",
+      agent_run_id: agent_run.id,
+      project_id: project.id
+    )
+    run_git("push", fallback_push_url, agent_run.branch_name, chdir: agent_run.worktree_path)
+  end
+
   def authenticated_clone_url
     "https://x-access-token:#{project.github_credential}@github.com/#{project.full_name}.git"
+  end
+
+  # Push URL that authenticates with the project's fallback PAT instead of the
+  # App installation token. Used only to retry a push the App token was rejected
+  # for (see #push_branch). The PAT is redacted from logs by #redact_credentials.
+  def fallback_push_url
+    "https://x-access-token:#{project.git_push_fallback_credential}@github.com/#{project.full_name}.git"
+  end
+
+  # True when a push failed because the GitHub App installation token lacks a
+  # permission the operation needs (e.g. a change under .github/workflows/).
+  def app_permission_rejection?(message)
+    message.to_s.include?("refusing to allow a GitHub App")
   end
 
   def run_git(*args, chdir: nil, raise_on_error: true)

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -221,6 +221,39 @@
                   </div>
                 </div>
               <% end %>
+
+              <div class="mt-4 rounded-md border border-gray-200 p-4">
+                <div class="flex items-start gap-3">
+                  <div class="flex h-6 items-center">
+                    <%= form.check_box :git_push_pat_fallback_enabled,
+                      class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" %>
+                  </div>
+                  <div class="text-sm leading-6">
+                    <%= form.label :git_push_pat_fallback_enabled, "Use a PAT fallback for git pushes",
+                      class: "font-medium text-gray-900" %>
+                    <p class="text-gray-500">
+                      The App is used for everything by default. If a push is rejected because the App
+                      lacks a permission it needs — for example a change under
+                      <code>.github/workflows/</code>, which requires the <code>workflows</code> permission —
+                      that single push is retried with the selected token instead. The token must have the
+                      needed permission; fine-grained tokens don't report their scopes, so this is trusted
+                      rather than verified.
+                    </p>
+                  </div>
+                </div>
+
+                <div class="mt-3">
+                  <%= form.label :git_push_fallback_token_id, "Fallback token",
+                    class: "block text-sm font-medium leading-6 text-gray-900" %>
+                  <div class="mt-2">
+                    <%= form.select :git_push_fallback_token_id,
+                        options_from_collection_for_select(@github_tokens, :id, :name, @project.git_push_fallback_token_id),
+                        { include_blank: true },
+                        class: "block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
+                  </div>
+                  <p class="mt-1 text-xs text-gray-500">Required when the fallback is enabled. Must have access to this repository and the permissions the App is missing.</p>
+                </div>
+              </div>
             </div>
 
             <div class="<%= [ "mt-4", ("hidden" unless @github_auth_source == "pat") ].compact.join(" ") %>" data-project-settings-form-target="patPanel">

--- a/db/migrate/20260623041248_add_git_push_fallback_token_to_projects.rb
+++ b/db/migrate/20260623041248_add_git_push_fallback_token_to_projects.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class AddGitPushFallbackTokenToProjects < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :projects, :git_push_fallback_token,
+      null: true,
+      index: { algorithm: :concurrently },
+      comment: "Optional PAT (selected in project settings) used as the git push " \
+               "credential when git_push_pat_fallback_enabled is set and the GitHub App " \
+               "installation token is rejected for a missing permission (e.g. a push " \
+               "under .github/workflows/). The App stays the default for all other operations."
+    safety_assured do
+      add_foreign_key :projects, :github_tokens, column: :git_push_fallback_token_id, validate: false
+    end
+  end
+end

--- a/db/migrate/20260623054014_add_git_push_pat_fallback_enabled_to_projects.rb
+++ b/db/migrate/20260623054014_add_git_push_pat_fallback_enabled_to_projects.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddGitPushPatFallbackEnabledToProjects < ActiveRecord::Migration[8.1]
+  def change
+    add_column :projects, :git_push_pat_fallback_enabled, :boolean, default: false, null: false,
+      comment: "When true, an app-backed project retries a git push with its " \
+               "git_push_fallback_token PAT if the GitHub App installation token is " \
+               "rejected for a missing permission (e.g. a push touching .github/workflows/). " \
+               "Opt-in; the App remains the default credential for every other operation."
+  end
+end

--- a/db/migrate/20260623054016_add_git_credential_fallback_active_to_agent_runs.rb
+++ b/db/migrate/20260623054016_add_git_credential_fallback_active_to_agent_runs.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddGitCredentialFallbackActiveToAgentRuns < ActiveRecord::Migration[8.1]
+  def change
+    add_column :agent_runs, :git_credential_fallback_active, :boolean, default: false, null: false,
+      comment: "Transient flag set by Containers::GitOperations only while retrying a " \
+               "push with the project's git_push_fallback_token PAT. The git-credentials " \
+               "proxy serves the fallback PAT (instead of the App installation token) while " \
+               "this is true, then it is cleared. Not part of run history/state."
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_21_003413) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_23_054016) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -232,6 +232,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_003413) do
     t.string "external_source_key", comment: "External system that executed the run, such as github_copilot, cursor, devin, factory, or internal_agent_workflows."
     t.string "final_runner", limit: 50
     t.string "focus", limit: 50, default: "general", null: false, comment: "Focused run intent derived from the highest-priority PR trigger or assigned workflow context."
+    t.boolean "git_credential_fallback_active", default: false, null: false, comment: "Transient flag set by Containers::GitOperations only while retrying a push with the project's git_push_fallback_token PAT. The git-credentials proxy serves the fallback PAT (instead of the App installation token) while this is true, then it is cleared. Not part of run history/state."
     t.string "goal", limit: 50, default: "create_pr", null: false
     t.jsonb "guardrail_context"
     t.string "guardrail_violation_type", limit: 50
@@ -1785,6 +1786,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_003413) do
     t.string "enhance_issue_needs_input_label_name", default: "paid-needs-input", null: false
     t.jsonb "fitness_settings", default: {}, null: false
     t.string "generated_label_name", default: "paid-generated", null: false
+    t.bigint "git_push_fallback_token_id", comment: "Optional PAT (selected in project settings) used as the git push credential when git_push_pat_fallback_enabled is set and the GitHub App installation token is rejected for a missing permission (e.g. a push under .github/workflows/). The App stays the default for all other operations."
+    t.boolean "git_push_pat_fallback_enabled", default: false, null: false, comment: "When true, an app-backed project retries a git push with its git_push_fallback_token PAT if the GitHub App installation token is rejected for a missing permission (e.g. a push touching .github/workflows/). Opt-in; the App remains the default credential for every other operation."
     t.bigint "github_id", null: false
     t.bigint "github_installation_id", comment: "GitHub App installation for repo auth; mutually exclusive with github_token_id"
     t.bigint "github_token_id"
@@ -1839,6 +1842,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_003413) do
     t.index ["account_id", "last_github_activity_at"], name: "index_projects_on_account_id_and_last_github_activity_at"
     t.index ["account_id"], name: "index_projects_on_account_id"
     t.index ["created_by_id"], name: "index_projects_on_created_by_id"
+    t.index ["git_push_fallback_token_id"], name: "index_projects_on_git_push_fallback_token_id"
     t.index ["github_installation_id"], name: "index_projects_on_github_installation_id"
     t.index ["github_token_id"], name: "index_projects_on_github_token_id"
     t.index ["owner", "repo"], name: "index_projects_on_owner_and_repo"
@@ -2705,6 +2709,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_21_003413) do
   add_foreign_key "projects", "accounts"
   add_foreign_key "projects", "github_installations", validate: false
   add_foreign_key "projects", "github_tokens"
+  add_foreign_key "projects", "github_tokens", column: "git_push_fallback_token_id", validate: false
   add_foreign_key "projects", "users", column: "created_by_id"
   add_foreign_key "prompt_versions", "prompt_versions", column: "parent_version_id", on_delete: :nullify
   add_foreign_key "prompt_versions", "prompts", on_delete: :cascade

--- a/spec/factories/github_tokens.rb
+++ b/spec/factories/github_tokens.rb
@@ -22,6 +22,10 @@ FactoryBot.define do
       validation_error { "Token is invalid or has been revoked" }
     end
 
+    trait :with_workflow_scope do
+      scopes { [ "repo", "read:org", "workflow" ] }
+    end
+
     trait :fine_grained do
       token { "github_pat_#{SecureRandom.alphanumeric(22)}_#{SecureRandom.alphanumeric(40)}" }
     end

--- a/spec/models/github_token_spec.rb
+++ b/spec/models/github_token_spec.rb
@@ -6,6 +6,18 @@ RSpec.describe GithubToken do
   describe "associations" do
     it { is_expected.to belong_to(:account) }
     it { is_expected.to belong_to(:created_by).class_name("User").optional }
+    it { is_expected.to have_many(:projects).dependent(:restrict_with_error) }
+
+    it "blocks a hard destroy while referenced as a project's git-push fallback" do
+      account = create(:account)
+      token = create(:github_token, account: account)
+      create(:project, :with_github_installation, account: account, git_push_pat_fallback_enabled: true,
+        git_push_fallback_token: token)
+
+      expect(token.destroy).to be(false)
+      expect(token.errors[:base]).to be_present
+      expect(described_class.exists?(token.id)).to be(true)
+    end
   end
 
   describe "validations" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Project do
     it { is_expected.to belong_to(:account) }
     it { is_expected.to belong_to(:github_token).optional }
     it { is_expected.to belong_to(:github_installation).optional }
+    it { is_expected.to belong_to(:git_push_fallback_token).class_name("GithubToken").optional }
     it { is_expected.to belong_to(:created_by).class_name("User").optional }
     it { is_expected.to have_many(:project_memberships).dependent(:destroy) }
     it { is_expected.to have_many(:members).through(:project_memberships).source(:user) }
@@ -74,6 +75,61 @@ RSpec.describe Project do
 
         expect(project).not_to be_valid
         expect(project.errors[:github_token]).to include("must belong to the same account")
+      end
+    end
+
+    describe "git_push_fallback_token validation" do
+      it "allows a fallback token from the same account on an app-backed project" do
+        account = create(:account)
+        fallback = create(:github_token, :with_workflow_scope, account: account)
+        project = build(:project, :with_github_installation, account: account, git_push_fallback_token: fallback)
+
+        expect(project).to be_valid
+      end
+
+      it "rejects a fallback token from a different account" do
+        account = create(:account)
+        fallback = create(:github_token, account: create(:account))
+        project = build(:project, :with_github_installation, account: account, git_push_fallback_token: fallback)
+
+        expect(project).not_to be_valid
+        expect(project.errors[:git_push_fallback_token]).to include("must belong to the same account")
+      end
+
+      it "clears the fallback config when the project is not app-backed (no dead-end on auth switch)" do
+        account = create(:account)
+        fallback = create(:github_token, account: account)
+        project = build(:project, account: account, git_push_pat_fallback_enabled: true, git_push_fallback_token: fallback)
+
+        expect(project).to be_valid
+        expect(project.git_push_fallback_token_id).to be_nil
+        expect(project.git_push_pat_fallback_enabled).to be(false)
+      end
+
+      it "rejects a non-existent fallback token id on an app-backed project" do
+        account = create(:account)
+        project = build(:project, :with_github_installation, account: account)
+        project.git_push_fallback_token_id = 0
+
+        expect(project).not_to be_valid
+        expect(project.errors[:git_push_fallback_token]).to include("must belong to the same account")
+      end
+
+      it "rejects enabling the fallback without selecting a token" do
+        account = create(:account)
+        project = build(:project, :with_github_installation, account: account, git_push_pat_fallback_enabled: true)
+
+        expect(project).not_to be_valid
+        expect(project.errors[:git_push_fallback_token]).to include("must be selected to enable PAT push fallback")
+      end
+
+      it "allows enabling the fallback with a same-account token on an app-backed project" do
+        account = create(:account)
+        fallback = create(:github_token, account: account)
+        project = build(:project, :with_github_installation, account: account,
+          git_push_pat_fallback_enabled: true, git_push_fallback_token: fallback)
+
+        expect(project).to be_valid
       end
     end
 
@@ -996,6 +1052,67 @@ RSpec.describe Project do
         install = build(:github_installation, github_installation_id: 42, revoked_at: Time.current)
         project = build(:project, :with_github_installation, github_installation: install)
         expect(project.github_credential).to be_nil
+      end
+    end
+
+    describe "#git_push_pat_fallback_configured? and #git_push_fallback_credential" do
+      def app_backed_project(account, **attrs)
+        build(:project, :with_github_installation, account: account, **attrs)
+      end
+
+      it "is configured when enabled with an active fallback token on an app-backed project" do
+        account = create(:account)
+        fallback = create(:github_token, account: account)
+        project = app_backed_project(account, git_push_pat_fallback_enabled: true, git_push_fallback_token: fallback)
+
+        expect(project.git_push_pat_fallback_configured?).to be(true)
+        expect(project.git_push_fallback_credential).to eq(fallback.token)
+      end
+
+      it "is not configured when the setting is disabled, even with a token attached" do
+        account = create(:account)
+        fallback = create(:github_token, account: account)
+        project = app_backed_project(account, git_push_pat_fallback_enabled: false, git_push_fallback_token: fallback)
+
+        expect(project.git_push_pat_fallback_configured?).to be(false)
+        expect(project.git_push_fallback_credential).to be_nil
+      end
+
+      it "is not configured when the fallback token is revoked" do
+        account = create(:account)
+        fallback = create(:github_token, :revoked, account: account)
+        project = app_backed_project(account, git_push_pat_fallback_enabled: true, git_push_fallback_token: fallback)
+
+        expect(project.git_push_pat_fallback_configured?).to be(false)
+        expect(project.git_push_fallback_credential).to be_nil
+      end
+
+      it "does not depend on the token's reported scopes (fine-grained tokens report none)" do
+        account = create(:account)
+        fallback = create(:github_token, account: account, scopes: [])
+        project = app_backed_project(account, git_push_pat_fallback_enabled: true, git_push_fallback_token: fallback)
+
+        expect(project.git_push_pat_fallback_configured?).to be(true)
+      end
+
+      it "is not configured for token-backed projects (no App installation)" do
+        account = create(:account)
+        fallback = create(:github_token, account: account)
+        project = build(:project, account: account, github_token: create(:github_token, account: account),
+          git_push_pat_fallback_enabled: true, git_push_fallback_token: fallback)
+
+        expect(project.git_push_pat_fallback_configured?).to be(false)
+      end
+
+      it "never mints an App installation token (it is a push-only fallback)" do
+        account = create(:account)
+        fallback = create(:github_token, account: account)
+        project = app_backed_project(account, git_push_pat_fallback_enabled: true, git_push_fallback_token: fallback)
+        allow(Github::AppInstallation).to receive(:token_for)
+
+        project.git_push_fallback_credential
+
+        expect(Github::AppInstallation).not_to have_received(:token_for)
       end
     end
 

--- a/spec/requests/api/git_credentials_spec.rb
+++ b/spec/requests/api/git_credentials_spec.rb
@@ -137,6 +137,48 @@ RSpec.describe "Api::GitCredentials" do
       end
     end
 
+    context "with git push PAT fallback configured (app-backed project)" do
+      let(:project) { create(:project, :with_github_installation) }
+      let(:fallback_token) { create(:github_token, :with_workflow_scope, account: project.account) }
+
+      before do
+        project.update!(git_push_pat_fallback_enabled: true, git_push_fallback_token: fallback_token)
+      end
+
+      context "when the run is flagged for a permission retry" do
+        let(:agent_run) { create(:agent_run, :running, project: project, git_credential_fallback_active: true) }
+
+        it "serves the fallback PAT without minting an App token" do
+          allow(Github::AppInstallation).to receive(:token_for)
+
+          get "/api/proxy/git-credentials", headers: valid_headers
+
+          expect(Github::AppInstallation).not_to have_received(:token_for)
+          expect(response).to have_http_status(:ok)
+          lines = response.body.strip.split("\n").map(&:strip)
+          expect(lines).to include("password=#{fallback_token.token}")
+        end
+
+        it "touches last_used_at on the fallback token" do
+          expect { get "/api/proxy/git-credentials", headers: valid_headers }
+            .to change { fallback_token.reload.last_used_at }
+        end
+      end
+
+      context "when the run is not flagged" do
+        before { allow(Github::AppInstallation).to receive(:token_for).and_return("ghs_app_token") }
+
+        it "serves the App installation token, not the fallback PAT" do
+          get "/api/proxy/git-credentials", headers: valid_headers
+
+          expect(response).to have_http_status(:ok)
+          lines = response.body.strip.split("\n").map(&:strip)
+          expect(lines).to include("password=ghs_app_token")
+          expect(lines).not_to include("password=#{fallback_token.token}")
+        end
+      end
+    end
+
     context "with a projectless chat session" do
       let(:chat_session) { create(:chat_session, account: project.account, project: nil) }
 

--- a/spec/services/containers/git_operations_spec.rb
+++ b/spec/services/containers/git_operations_spec.rb
@@ -511,6 +511,75 @@ RSpec.describe Containers::GitOperations do
       expect(agent_run.worktree.reload).to be_pushed
     end
 
+    context "when the App push is rejected for a missing permission" do
+      # Methods (not `let`s) to stay within RSpec/MultipleMemoizedHelpers.
+      def push_command
+        [ "git", "push", "--no-verify", "origin", "paid/test-branch" ]
+      end
+
+      def permission_rejection
+        Containers::Provision::Result.failure(
+          error: "Command exited with code 1",
+          stdout: "",
+          stderr: " ! [remote rejected] paid/test-branch -> paid/test-branch " \
+                  "(refusing to allow a GitHub App to create or update workflow " \
+                  "`.github/workflows/mutation.yml` without `workflows` permission)",
+          exit_code: 1
+        )
+      end
+
+      context "when PAT push fallback is configured" do
+        let(:project) { create(:project, :with_github_installation) }
+
+        before do
+          fallback_token = create(:github_token, :with_workflow_scope, account: project.account)
+          project.update!(git_push_pat_fallback_enabled: true, git_push_fallback_token: fallback_token)
+        end
+
+        it "retries the push once and returns the SHA, leaving the flag cleared" do
+          allow(container_service).to receive(:execute)
+            .with(push_command, timeout: 60, stream: false, env: described_class::NETWORK_GIT_ENV)
+            .and_return(permission_rejection, success_result)
+
+          expect(git_ops.push_branch).to eq(head_sha)
+          expect(agent_run.reload.git_credential_fallback_active).to be(false)
+        end
+
+        it "flags the run only while retrying, so the proxy serves the PAT for that push" do
+          flag_states = []
+          allow(container_service).to receive(:execute)
+            .with(push_command, timeout: 60, stream: false, env: described_class::NETWORK_GIT_ENV) do
+              flag_states << agent_run.reload.git_credential_fallback_active
+              flag_states.size == 1 ? permission_rejection : success_result
+            end
+
+          git_ops.push_branch
+
+          expect(flag_states).to eq([ false, true ])
+        end
+
+        it "raises PushError and clears the flag when the retry also fails" do
+          allow(container_service).to receive(:execute)
+            .with(push_command, timeout: 60, stream: false, env: described_class::NETWORK_GIT_ENV)
+            .and_return(permission_rejection, permission_rejection)
+
+          expect { git_ops.push_branch }.to raise_error(described_class::PushError)
+          expect(agent_run.reload.git_credential_fallback_active).to be(false)
+        end
+      end
+
+      context "when PAT push fallback is not configured" do
+        it "does not retry and raises PushError" do
+          expect(container_service).to receive(:execute)
+            .with(push_command, timeout: 60, stream: false, env: described_class::NETWORK_GIT_ENV)
+            .once
+            .and_return(permission_rejection)
+
+          expect { git_ops.push_branch }.to raise_error(described_class::PushError)
+        end
+      end
+    end
+
     it "uses --force-with-lease for existing PR branches" do
       agent_run.update!(source_pull_request_number: 42)
 

--- a/spec/services/worktree_service_spec.rb
+++ b/spec/services/worktree_service_spec.rb
@@ -503,6 +503,51 @@ RSpec.describe WorktreeService do
 
       expect(service.push_branch(agent_run)).to eq(result_sha)
     end
+
+    context "when the App push is rejected for a missing permission" do
+      # Method (not a `let`) to stay within RSpec/MultipleMemoizedHelpers.
+      def permission_error
+        described_class::Error.new(
+          "Git command failed: git push origin paid/test-branch\n " \
+          "! [remote rejected] paid/test-branch (refusing to allow a GitHub App to create " \
+          "or update workflow `.github/workflows/mutation.yml` without `workflows` permission)"
+        )
+      end
+
+      context "when PAT push fallback is configured" do
+        let(:project) { create(:project, :with_github_installation) }
+
+        before do
+          fallback_token = create(:github_token, :with_workflow_scope, account: project.account)
+          project.update!(git_push_pat_fallback_enabled: true, git_push_fallback_token: fallback_token)
+        end
+
+        it "retries the push against the fallback PAT URL and returns the SHA" do
+          fallback_url = "https://x-access-token:#{project.git_push_fallback_token.token}@github.com/#{project.full_name}.git"
+          allow(service).to receive(:run_git)
+            .with("push", "origin", "paid/test-branch", chdir: worktree_dir)
+            .and_raise(permission_error)
+          expect(service).to receive(:run_git)
+            .with("push", fallback_url, "paid/test-branch", chdir: worktree_dir)
+          allow(service).to receive(:run_git)
+            .with("rev-parse", "HEAD", chdir: worktree_dir)
+            .and_return("#{result_sha}\n")
+
+          expect(service.push_branch(agent_run)).to eq(result_sha)
+        end
+      end
+
+      context "when PAT push fallback is not configured" do
+        it "does not retry and re-raises the error" do
+          allow(service).to receive(:run_git)
+            .with("push", "origin", "paid/test-branch", chdir: worktree_dir)
+            .and_raise(permission_error)
+
+          expect { service.push_branch(agent_run) }
+            .to raise_error(described_class::Error, /refusing to allow a GitHub App/)
+        end
+      end
+    end
   end
 
   describe "#cleanup_stale_worktrees" do


### PR DESCRIPTION
## Summary

App-backed projects authenticate git operations as a **GitHub App installation token**. GitHub categorically rejects any push touching `.github/workflows/` from an App token that lacks the `workflows` permission:

```
! [remote rejected] … (refusing to allow a GitHub App to create or update workflow
  `.github/workflows/mutation.yml` without `workflows` permission)
```

This stalled real agent runs in a retry loop (one issue produced 267 runs). See **#2645** for the incident write-up.

This adds an **opt-in, per-project fallback**: the App stays the default credential for every operation, but when a push is rejected for a missing App permission and the project has configured a fallback PAT, **that single push** is retried with the PAT.

## How it works (reactive, scoped to the failing op)

| Path | Behavior |
|---|---|
| **Container push** (`Containers::GitOperations`) | On a permission rejection, set a transient `agent_runs.git_credential_fallback_active` flag, retry the push, clear it. The git-credentials **proxy** serves the PAT *only* while the flag is set (and the project is configured) — the token never enters the container env, and the window is post-agent (push runs in a separate Temporal activity after the agent CLI exits). |
| **Host push** (`WorktreeService`) | Retry against a PAT-authenticated, log-redacted remote URL. |

- **Gating is the explicit project setting + an active attached token.** Scopes are *not* inspected, because fine-grained PATs don't report classic OAuth scopes — we trust the operator's opt-in.
- **Settings UI**: enable checkbox + fallback-token selector in the project's GitHub App panel.

## Design decisions / edge cases handled

- App is always tried first; the PAT is used only for the rejected retry.
- Switching a project to PAT auth **auto-clears** the now-meaningless fallback config (`before_validation`) so the change saves cleanly instead of dead-ending on validation.
- A non-existent or cross-account fallback token id is rejected before it can hit a raw FK error.
- Deleting a token used only as a fallback is restricted with a model error (consistent with primary-token behavior); the normal revoke path is neutralized by the `active?` check.
- A stale fallback flag (e.g. from a hard-killed retry) is defensively cleared before each push, preserving "App first."

## Schema

- `projects.git_push_fallback_token_id` (FK → `github_tokens`)
- `projects.git_push_pat_fallback_enabled` (bool, default false)
- `agent_runs.git_credential_fallback_active` (transient bool, set only during a retry)

## Testing

- RuboCop + Herb (ERB) lint clean; full affected suite green (582 examples).
- Coverage: model config/validation/auto-clear, proxy reactive serving (flagged vs not), container retry (success / flag windowing / retry-failure / not-configured), host retry, and token-destroy restriction.

## Follow-ups (tracked in #2645)

- The infinite re-enqueue loop on permanent push rejections (terminal-error classification) is a separate robustness fix.
- Optionally gate on a *live* check of the App installation's granted permissions (the installation record doesn't store permissions today).

## Operator note

This does not change behavior until a project opts in **and** attaches a PAT carrying the needed permission. The immediate alternative remains granting the `paid-agents` App the `workflows` permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
