### PR TITLE
fix(containers): default bundler paths in agent env

### DIFF
--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -1887,9 +1887,9 @@ module Containers
       tmpfs = {}
       tmpfs[HEARTBEAT_MOUNT_POINT] = "size=#{1024 * 1024},mode=0777" unless heartbeat_dir_host
 
-      # /tmp must be `exec` because every coding/review/rebase prompt has the
-      # agent run `bundle install` as step 1, and review-goal runs additionally
-      # set BUNDLE_PATH=/tmp/bundle. Bundler builds native gem extensions in
+      # /tmp must be `exec` because agent containers default Bundler to
+      # /tmp/bundle and the coding/review/rebase flows all run `bundle install`
+      # early in execution. Bundler builds native gem extensions in
       # the gem path; mkmf's try_link verifies the produced binary with
       # File.executable?, which returns false on a noexec mount — producing
       # a misleading "compiler failed to generate an executable file" error
@@ -2082,7 +2082,9 @@ module Containers
         "GITHUB_API_URL=#{proxy_base}/api/proxy/github",
         "KNOWLEDGE_SEARCH_URL=#{proxy_base}/api/proxy/knowledge/search",
         "PROJECT_ID=#{project.id}",
-        "HOME=/home/agent"
+        "HOME=/home/agent",
+        "BUNDLE_PATH=/tmp/bundle",
+        "BUNDLE_APP_CONFIG=/tmp/bundle-config"
       ]
 
       env.concat(run_scoped_environment(proxy_base)) if agent_run.present?

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -3237,10 +3237,9 @@ module Activities
 
       You may run targeted validation when it is useful for review confidence.
       Before running Ruby/Rails commands such as `bin/rspec`, run
-      `BUNDLE_PATH=/tmp/bundle BUNDLE_APP_CONFIG=/tmp/bundle-config BUNDLE_FROZEN=true bundle check || BUNDLE_PATH=/tmp/bundle BUNDLE_APP_CONFIG=/tmp/bundle-config BUNDLE_FROZEN=true bundle install --jobs 4 --retry 3`
-      so the fresh review checkout has the bundled gems it needs in a writable
-      path outside the repository without changing the lockfile. If dependency
-      installation or test execution still
+      `bundle check || BUNDLE_FROZEN=true bundle install --jobs 4 --retry 3`
+      so the fresh review checkout has the bundled gems it needs without
+      changing the lockfile. If dependency installation or test execution still
       fails because of missing network access, services, or environment
       constraints, mention that specific blocker in the review body.
 

--- a/db/seeds/prompts.rb
+++ b/db/seeds/prompts.rb
@@ -713,10 +713,9 @@ upsert_global_prompt.call(
 
     You may run targeted validation when it is useful for review confidence.
     Before running Ruby/Rails commands such as `bin/rspec`, run
-    `BUNDLE_PATH=/tmp/bundle BUNDLE_APP_CONFIG=/tmp/bundle-config BUNDLE_FROZEN=true bundle check || BUNDLE_PATH=/tmp/bundle BUNDLE_APP_CONFIG=/tmp/bundle-config BUNDLE_FROZEN=true bundle install --jobs 4 --retry 3`
-    so the fresh review checkout has the bundled gems it needs in a writable
-    path outside the repository without changing the lockfile. If dependency
-    installation or test execution still
+    `bundle check || BUNDLE_FROZEN=true bundle install --jobs 4 --retry 3`
+    so the fresh review checkout has the bundled gems it needs without
+    changing the lockfile. If dependency installation or test execution still
     fails because of missing network access, services, or environment
     constraints, mention that specific blocker in the review body.
 

--- a/spec/db/prompt_seeds_spec.rb
+++ b/spec/db/prompt_seeds_spec.rb
@@ -140,24 +140,22 @@ RSpec.describe Prompt, type: :model do
     it "seeded template tells reviewers to install bundled gems before Ruby validation" do
       template = described_class.global.find_by(slug: "goal.review_pull_request").current_version.template
       expect(template).to include(
-        "BUNDLE_PATH=/tmp/bundle BUNDLE_APP_CONFIG=/tmp/bundle-config BUNDLE_FROZEN=true bundle check || " \
-          "BUNDLE_PATH=/tmp/bundle BUNDLE_APP_CONFIG=/tmp/bundle-config BUNDLE_FROZEN=true bundle install --jobs 4 --retry 3"
+        "bundle check || BUNDLE_FROZEN=true bundle install --jobs 4 --retry 3"
       )
       expect(template).to include("Before running Ruby/Rails commands")
-      expect(template).to match(/writable\s+path outside the repository without changing the lockfile/)
+      expect(template).to match(/bundled gems it needs without\s+changing the lockfile/)
       expect(template).to include("missing network access")
     end
 
     it "FALLBACK_REVIEW_GOAL_PROMPT tells reviewers to install bundled gems before Ruby validation" do
       expect(Activities::RunAgentActivity::FALLBACK_REVIEW_GOAL_PROMPT)
         .to include(
-          "BUNDLE_PATH=/tmp/bundle BUNDLE_APP_CONFIG=/tmp/bundle-config BUNDLE_FROZEN=true bundle check || " \
-            "BUNDLE_PATH=/tmp/bundle BUNDLE_APP_CONFIG=/tmp/bundle-config BUNDLE_FROZEN=true bundle install --jobs 4 --retry 3"
+          "bundle check || BUNDLE_FROZEN=true bundle install --jobs 4 --retry 3"
         )
       expect(Activities::RunAgentActivity::FALLBACK_REVIEW_GOAL_PROMPT)
         .to include("Before running Ruby/Rails commands")
       expect(Activities::RunAgentActivity::FALLBACK_REVIEW_GOAL_PROMPT)
-        .to match(/writable\s+path outside the repository without changing the lockfile/)
+        .to match(/bundled gems it needs without\s+changing the lockfile/)
       expect(Activities::RunAgentActivity::FALLBACK_REVIEW_GOAL_PROMPT)
         .to include("missing network access")
     end

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -410,8 +410,8 @@ RSpec.describe Containers::Provision do
       # mkmf's File.executable? check fail when bundle install builds native
       # gem extensions in /tmp — surfacing as a misleading "compiler failed
       # to generate an executable file" error (e.g. bigdecimal extconf).
-      # Coding/review/rebase prompts all run bundle install as step 1, and
-      # review-goal runs additionally set BUNDLE_PATH=/tmp/bundle.
+      # Agent containers default Bundler to /tmp/bundle and the
+      # coding/review/rebase flows all run bundle install early.
       it "mounts /tmp tmpfs with exec so bundle install can build native gems" do
         expect(Docker::Container).to receive(:create) do |config|
           tmp_options = config.dig("HostConfig", "Tmpfs", "/tmp")
@@ -627,6 +627,17 @@ RSpec.describe Containers::Provision do
             "PAID_CLAUDE_SUBSCRIPTION_AUTH=0", "PAID_CODEX_SUBSCRIPTION_AUTH=0",
             "PAID_GEMINI_SUBSCRIPTION_AUTH=0", "PAID_COPILOT_SUBSCRIPTION_AUTH=0"
           )
+          mock_container
+        end
+
+        service.provision
+      end
+
+      it "sets writable Bundler paths for all agent containers" do
+        expect(Docker::Container).to receive(:create) do |config|
+          env = config["Env"]
+          expect(env).to include("BUNDLE_PATH=/tmp/bundle")
+          expect(env).to include("BUNDLE_APP_CONFIG=/tmp/bundle-config")
           mock_container
         end
 


### PR DESCRIPTION
## Summary
- default Bundler to writable `/tmp` paths in agent containers instead of relying on prompt instructions
- simplify the review prompt guidance so it no longer hardcodes runtime env vars
- add regression coverage for container env injection and updated prompt contracts

## Verification
- `bin/rubocop app/services/containers/provision.rb app/temporal/activities/run_agent_activity.rb db/seeds/prompts.rb spec/services/containers/provision_spec.rb spec/db/prompt_seeds_spec.rb`
- `bin/rspec spec/services/containers/provision_spec.rb spec/db/prompt_seeds_spec.rb`

## Notes
- I did not include the unrelated `db/schema.rb` reorder from the original workspace.
- Re-running the targeted specs inside the fresh worktree hit a missing branch-specific test database, but the same targeted specs had already passed before branching.