### PR TITLE
fix(agent-runs): raise default execution budgets

### DIFF
--- a/app/services/orchestration_strategies/defaults.rb
+++ b/app/services/orchestration_strategies/defaults.rb
@@ -96,7 +96,7 @@ module OrchestrationStrategies
     #   - Workflows::FeatureOrchestrationWorkflow::DEFAULT_TIMEOUT_SECONDS (line 24)
     def execution_timeouts
       {
-        "agent_timeout_default_seconds" => 3600,
+        "agent_timeout_default_seconds" => 5400,
         "issue_goal_timeout_seconds" => 600,
         "issue_goal_idle_timeout_seconds" => 120,
         "review_goal_idle_timeout_seconds" => 300,

--- a/config/initializers/agent_harness.rb
+++ b/config/initializers/agent_harness.rb
@@ -342,7 +342,7 @@ end
 # fallback when per-user settings are unavailable. Runtime code should
 # prefer UserSetting#agent_timeout_seconds resolved via
 # AgentRuns::UserSettingsResolver.
-AGENT_TIMEOUT_DEFAULT = 3600
+AGENT_TIMEOUT_DEFAULT = 5400
 Rails.application.config.x.agent_timeout = AGENT_TIMEOUT_DEFAULT
 
 AgentHarness.configure do |config|

--- a/db/migrate/20260625062207_adjust_default_agent_run_timeouts.rb
+++ b/db/migrate/20260625062207_adjust_default_agent_run_timeouts.rb
@@ -20,6 +20,7 @@ class AdjustDefaultAgentRunTimeouts < ActiveRecord::Migration[8.1]
       .where("updated_at = created_at")
       .update_all(agent_timeout_seconds: NEW_AGENT_TIMEOUT_SECONDS) # rubocop:disable Rails/SkipsModelValidations
     MigrationProject.where(max_execution_seconds: 3600)
+      .where("updated_at = created_at")
       .update_all(max_execution_seconds: NEW_MAX_EXECUTION_SECONDS) # rubocop:disable Rails/SkipsModelValidations
   end
 
@@ -28,6 +29,7 @@ class AdjustDefaultAgentRunTimeouts < ActiveRecord::Migration[8.1]
       .where("updated_at = created_at")
       .update_all(agent_timeout_seconds: 3600) # rubocop:disable Rails/SkipsModelValidations
     MigrationProject.where(max_execution_seconds: NEW_MAX_EXECUTION_SECONDS)
+      .where("updated_at = created_at")
       .update_all(max_execution_seconds: 3600) # rubocop:disable Rails/SkipsModelValidations
 
     change_column_default :user_settings, :agent_timeout_seconds, from: NEW_AGENT_TIMEOUT_SECONDS, to: 3600

--- a/db/migrate/20260625062207_adjust_default_agent_run_timeouts.rb
+++ b/db/migrate/20260625062207_adjust_default_agent_run_timeouts.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class AdjustDefaultAgentRunTimeouts < ActiveRecord::Migration[8.1]
+  NEW_AGENT_TIMEOUT_SECONDS = 5400
+  NEW_MAX_EXECUTION_SECONDS = 7200
+
+  class MigrationProject < ApplicationRecord
+    self.table_name = "projects"
+  end
+
+  class MigrationUserSetting < ApplicationRecord
+    self.table_name = "user_settings"
+  end
+
+  def up
+    change_column_default :user_settings, :agent_timeout_seconds, from: 3600, to: NEW_AGENT_TIMEOUT_SECONDS
+    change_column_default :projects, :max_execution_seconds, from: 3600, to: NEW_MAX_EXECUTION_SECONDS
+
+    MigrationUserSetting.where(agent_timeout_seconds: 3600)
+      .where("updated_at = created_at")
+      .update_all(agent_timeout_seconds: NEW_AGENT_TIMEOUT_SECONDS) # rubocop:disable Rails/SkipsModelValidations
+    MigrationProject.where(max_execution_seconds: 3600)
+      .update_all(max_execution_seconds: NEW_MAX_EXECUTION_SECONDS) # rubocop:disable Rails/SkipsModelValidations
+  end
+
+  def down
+    MigrationUserSetting.where(agent_timeout_seconds: NEW_AGENT_TIMEOUT_SECONDS)
+      .where("updated_at = created_at")
+      .update_all(agent_timeout_seconds: 3600) # rubocop:disable Rails/SkipsModelValidations
+    MigrationProject.where(max_execution_seconds: NEW_MAX_EXECUTION_SECONDS)
+      .update_all(max_execution_seconds: 3600) # rubocop:disable Rails/SkipsModelValidations
+
+    change_column_default :user_settings, :agent_timeout_seconds, from: NEW_AGENT_TIMEOUT_SECONDS, to: 3600
+    change_column_default :projects, :max_execution_seconds, from: NEW_MAX_EXECUTION_SECONDS, to: 3600
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -931,6 +931,27 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_062207) do
     t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
+  create_table "github_app_installations", comment: "GitHub App installations for org/repo access without PATs", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.string "app_id", null: false, comment: "GitHub App ID used for this installation"
+    t.string "app_slug", null: false, comment: "GitHub App slug for display and bot identity"
+    t.datetime "created_at", null: false
+    t.bigint "installation_id", null: false, comment: "GitHub installation ID from the App installation event"
+    t.bigint "installed_by_id"
+    t.jsonb "metadata", default: {}, null: false, comment: "Additional installation metadata from GitHub"
+    t.jsonb "repositories", default: [], null: false, comment: "Cached list of installed repository metadata"
+    t.datetime "repositories_synced_at", comment: "Last time the repository list was synced from GitHub"
+    t.string "repository_selection", default: "selected", null: false, comment: "GitHub installation repository_selection: all or selected"
+    t.datetime "revoked_at", comment: "When the installation was revoked or uninstalled"
+    t.string "status", default: "active", null: false, comment: "Installation status: active, suspended, uninstalled"
+    t.datetime "updated_at", null: false
+    t.index ["account_id", "installation_id"], name: "idx_on_account_id_installation_id_effaccd2e5", unique: true
+    t.index ["account_id"], name: "index_github_app_installations_on_account_id"
+    t.index ["installation_id"], name: "index_github_app_installations_on_installation_id", unique: true
+    t.index ["installed_by_id"], name: "index_github_app_installations_on_installed_by_id"
+    t.index ["status"], name: "index_github_app_installations_on_status"
+  end
+
   create_table "github_health_states", force: :cascade do |t|
     t.datetime "circuit_opened_at"
     t.string "circuit_state", limit: 20, default: "closed", null: false
@@ -938,7 +959,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_062207) do
     t.string "endpoint", limit: 50, default: "api", null: false
     t.integer "failure_count", default: 0, null: false
     t.text "last_error_message"
-    t.integer "rate_limit_limit", comment: "Total hourly request cap reported by GitHub for this credential (5,000 for PATs, 15,000 for App installations)."
+    t.integer "rate_limit_limit"
     t.datetime "rate_limit_observed_at", comment: "When the remaining/limit rate-limit figures were last sampled from the GitHub API for this credential endpoint."
     t.integer "rate_limit_remaining"
     t.datetime "rate_limit_reset_at"
@@ -2416,6 +2437,20 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_062207) do
     t.index ["uuid"], name: "index_tracker_configurations_on_uuid", unique: true
   end
 
+  create_table "user_identities", comment: "Links users to external identity providers (SSO/OIDC/SAML)", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.jsonb "auth_data", default: {}, null: false, comment: "Raw auth data from provider (serialized for audit trail)"
+    t.datetime "created_at", null: false
+    t.string "provider", null: false, comment: "Identity provider name: saml, oidc, github, etc."
+    t.string "uid", null: false, comment: "External user identifier from the IdP"
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["account_id"], name: "index_user_identities_on_account_id"
+    t.index ["provider", "uid"], name: "index_user_identities_on_provider_and_uid", unique: true
+    t.index ["user_id", "provider"], name: "index_user_identities_on_user_id_and_provider", unique: true
+    t.index ["user_id"], name: "index_user_identities_on_user_id"
+  end
+
   create_table "user_settings", force: :cascade do |t|
     t.integer "agent_timeout_seconds", default: 5400, null: false
     t.jsonb "allowed_service_images", default: ["postgres:16.13", "redis:7-alpine", "selenium/standalone-chromium:latest"]
@@ -2745,26 +2780,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_062207) do
   add_foreign_key "workflow_states", "projects"
   add_foreign_key "worktrees", "agent_runs", on_delete: :nullify
   add_foreign_key "worktrees", "projects", on_delete: :cascade
-
-  create_function :paid_current_account_id, sql_definition: <<-'SQL'
-      CREATE OR REPLACE FUNCTION public.paid_current_account_id()
-       RETURNS bigint
-       LANGUAGE sql
-       STABLE
-      AS $function$
-        SELECT NULLIF(current_setting('paid.current_account_id', true), '')::bigint
-      $function$
-  SQL
-
-  create_function :paid_tenant_bypass, sql_definition: <<-'SQL'
-      CREATE OR REPLACE FUNCTION public.paid_tenant_bypass()
-       RETURNS boolean
-       LANGUAGE sql
-       STABLE
-      AS $function$
-        SELECT current_setting('paid.bypass_tenant_rls', true) = 'true'
-      $function$
-  SQL
 
   create_function :logidze_capture_exception, sql_definition: <<-'SQL'
       CREATE OR REPLACE FUNCTION public.logidze_capture_exception(error_data jsonb)
@@ -3501,6 +3516,26 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_062207) do
       $function$
   SQL
 
+  create_function :paid_current_account_id, sql_definition: <<-'SQL'
+      CREATE OR REPLACE FUNCTION public.paid_current_account_id()
+       RETURNS bigint
+       LANGUAGE sql
+       STABLE
+      AS $function$
+        SELECT NULLIF(current_setting('paid.current_account_id', true), '')::bigint
+      $function$
+  SQL
+
+  create_function :paid_tenant_bypass, sql_definition: <<-'SQL'
+      CREATE OR REPLACE FUNCTION public.paid_tenant_bypass()
+       RETURNS boolean
+       LANGUAGE sql
+       STABLE
+      AS $function$
+        SELECT current_setting('paid.bypass_tenant_rls', true) = 'true'
+      $function$
+  SQL
+
   create_function :validate_orchestration_decision_strategy_version_scope, sql_definition: <<-'SQL'
       CREATE OR REPLACE FUNCTION public.validate_orchestration_decision_strategy_version_scope()
        RETURNS trigger
@@ -3617,16 +3652,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_062207) do
       CREATE TRIGGER logidze_on_provider_api_keys BEFORE INSERT OR UPDATE ON public.provider_api_keys FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{api_key}')
   SQL
 
-  create_trigger :logidze_on_providers, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_providers BEFORE INSERT OR UPDATE ON public.runners FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
-  SQL
-
   create_trigger :logidze_on_quality_gate_thresholds, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_quality_gate_thresholds BEFORE INSERT OR UPDATE ON public.quality_gate_thresholds FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
 
   create_trigger :logidze_on_quality_thresholds, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_quality_thresholds BEFORE INSERT OR UPDATE ON public.quality_thresholds FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  SQL
+
+  create_trigger :logidze_on_providers, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_providers BEFORE INSERT OR UPDATE ON public.runners FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
 
   create_trigger :logidze_on_service_containers, sql_definition: <<-SQL

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_23_131744) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_25_062207) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -931,27 +931,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_23_131744) do
     t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
-  create_table "github_app_installations", comment: "GitHub App installations for org/repo access without PATs", force: :cascade do |t|
-    t.bigint "account_id", null: false
-    t.string "app_id", null: false, comment: "GitHub App ID used for this installation"
-    t.string "app_slug", null: false, comment: "GitHub App slug for display and bot identity"
-    t.datetime "created_at", null: false
-    t.bigint "installation_id", null: false, comment: "GitHub installation ID from the App installation event"
-    t.bigint "installed_by_id"
-    t.jsonb "metadata", default: {}, null: false, comment: "Additional installation metadata from GitHub"
-    t.jsonb "repositories", default: [], null: false, comment: "Cached list of installed repository metadata"
-    t.datetime "repositories_synced_at", comment: "Last time the repository list was synced from GitHub"
-    t.string "repository_selection", default: "selected", null: false, comment: "GitHub installation repository_selection: all or selected"
-    t.datetime "revoked_at", comment: "When the installation was revoked or uninstalled"
-    t.string "status", default: "active", null: false, comment: "Installation status: active, suspended, uninstalled"
-    t.datetime "updated_at", null: false
-    t.index ["account_id", "installation_id"], name: "idx_on_account_id_installation_id_effaccd2e5", unique: true
-    t.index ["account_id"], name: "index_github_app_installations_on_account_id"
-    t.index ["installation_id"], name: "index_github_app_installations_on_installation_id", unique: true
-    t.index ["installed_by_id"], name: "index_github_app_installations_on_installed_by_id"
-    t.index ["status"], name: "index_github_app_installations_on_status"
-  end
-
   create_table "github_health_states", force: :cascade do |t|
     t.datetime "circuit_opened_at"
     t.string "circuit_state", limit: 20, default: "closed", null: false
@@ -959,7 +938,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_23_131744) do
     t.string "endpoint", limit: 50, default: "api", null: false
     t.integer "failure_count", default: 0, null: false
     t.text "last_error_message"
-    t.integer "rate_limit_limit"
+    t.integer "rate_limit_limit", comment: "Total hourly request cap reported by GitHub for this credential (5,000 for PATs, 15,000 for App installations)."
     t.datetime "rate_limit_observed_at", comment: "When the remaining/limit rate-limit figures were last sampled from the GitHub API for this credential endpoint."
     t.integer "rate_limit_remaining"
     t.datetime "rate_limit_reset_at"
@@ -1809,7 +1788,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_23_131744) do
     t.jsonb "log_data"
     t.integer "max_draft_review_rounds", default: 10, null: false
     t.integer "max_enhance_issue_reevaluation_rounds", default: 3, null: false
-    t.integer "max_execution_seconds", default: 3600, null: false
+    t.integer "max_execution_seconds", default: 7200, null: false
     t.integer "max_issue_runner_failures", comment: "Per-project override for the per-issue per-provider retry cap. When nil, the account-level agent setting (default 10) applies. After a provider fails this many times for a single issue it is excluded from scheduling for that issue."
     t.integer "max_pr_followup_runs", default: 8, null: false
     t.integer "max_tokens_per_run"
@@ -2437,22 +2416,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_23_131744) do
     t.index ["uuid"], name: "index_tracker_configurations_on_uuid", unique: true
   end
 
-  create_table "user_identities", comment: "Links users to external identity providers (SSO/OIDC/SAML)", force: :cascade do |t|
-    t.bigint "account_id", null: false
-    t.jsonb "auth_data", default: {}, null: false, comment: "Raw auth data from provider (serialized for audit trail)"
-    t.datetime "created_at", null: false
-    t.string "provider", null: false, comment: "Identity provider name: saml, oidc, github, etc."
-    t.string "uid", null: false, comment: "External user identifier from the IdP"
-    t.datetime "updated_at", null: false
-    t.bigint "user_id", null: false
-    t.index ["account_id"], name: "index_user_identities_on_account_id"
-    t.index ["provider", "uid"], name: "index_user_identities_on_provider_and_uid", unique: true
-    t.index ["user_id", "provider"], name: "index_user_identities_on_user_id_and_provider", unique: true
-    t.index ["user_id"], name: "index_user_identities_on_user_id"
-  end
-
   create_table "user_settings", force: :cascade do |t|
-    t.integer "agent_timeout_seconds", default: 3600, null: false
+    t.integer "agent_timeout_seconds", default: 5400, null: false
     t.jsonb "allowed_service_images", default: ["postgres:16.13", "redis:7-alpine", "selenium/standalone-chromium:latest"]
     t.jsonb "auto_pick_skip_labels", comment: "Optional user-level override for labels that make auto-pick skip an issue. Null means inherit tenant or built-in defaults."
     t.integer "circuit_breaker_failure_threshold", default: 5, null: false
@@ -2780,6 +2745,26 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_23_131744) do
   add_foreign_key "workflow_states", "projects"
   add_foreign_key "worktrees", "agent_runs", on_delete: :nullify
   add_foreign_key "worktrees", "projects", on_delete: :cascade
+
+  create_function :paid_current_account_id, sql_definition: <<-'SQL'
+      CREATE OR REPLACE FUNCTION public.paid_current_account_id()
+       RETURNS bigint
+       LANGUAGE sql
+       STABLE
+      AS $function$
+        SELECT NULLIF(current_setting('paid.current_account_id', true), '')::bigint
+      $function$
+  SQL
+
+  create_function :paid_tenant_bypass, sql_definition: <<-'SQL'
+      CREATE OR REPLACE FUNCTION public.paid_tenant_bypass()
+       RETURNS boolean
+       LANGUAGE sql
+       STABLE
+      AS $function$
+        SELECT current_setting('paid.bypass_tenant_rls', true) = 'true'
+      $function$
+  SQL
 
   create_function :logidze_capture_exception, sql_definition: <<-'SQL'
       CREATE OR REPLACE FUNCTION public.logidze_capture_exception(error_data jsonb)
@@ -3516,26 +3501,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_23_131744) do
       $function$
   SQL
 
-  create_function :paid_current_account_id, sql_definition: <<-'SQL'
-      CREATE OR REPLACE FUNCTION public.paid_current_account_id()
-       RETURNS bigint
-       LANGUAGE sql
-       STABLE
-      AS $function$
-        SELECT NULLIF(current_setting('paid.current_account_id', true), '')::bigint
-      $function$
-  SQL
-
-  create_function :paid_tenant_bypass, sql_definition: <<-'SQL'
-      CREATE OR REPLACE FUNCTION public.paid_tenant_bypass()
-       RETURNS boolean
-       LANGUAGE sql
-       STABLE
-      AS $function$
-        SELECT current_setting('paid.bypass_tenant_rls', true) = 'true'
-      $function$
-  SQL
-
   create_function :validate_orchestration_decision_strategy_version_scope, sql_definition: <<-'SQL'
       CREATE OR REPLACE FUNCTION public.validate_orchestration_decision_strategy_version_scope()
        RETURNS trigger
@@ -3652,16 +3617,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_23_131744) do
       CREATE TRIGGER logidze_on_provider_api_keys BEFORE INSERT OR UPDATE ON public.provider_api_keys FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{api_key}')
   SQL
 
+  create_trigger :logidze_on_providers, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_providers BEFORE INSERT OR UPDATE ON public.runners FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  SQL
+
   create_trigger :logidze_on_quality_gate_thresholds, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_quality_gate_thresholds BEFORE INSERT OR UPDATE ON public.quality_gate_thresholds FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
 
   create_trigger :logidze_on_quality_thresholds, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_quality_thresholds BEFORE INSERT OR UPDATE ON public.quality_thresholds FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
-  SQL
-
-  create_trigger :logidze_on_providers, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_providers BEFORE INSERT OR UPDATE ON public.runners FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
 
   create_trigger :logidze_on_service_containers, sql_definition: <<-SQL

--- a/spec/factories/user_settings.rb
+++ b/spec/factories/user_settings.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     default_poll_interval_seconds { 60 }
     github_token_cache_ttl_minutes { 60 }
     token_validation_stale_minutes { 2 }
-    agent_timeout_seconds { 3600 }
+    agent_timeout_seconds { 5400 }
     marketplace_auto_attach_enabled { false }
     default_agent_runner { "claude" }
     container_memory_bytes { 4 * 1024 * 1024 * 1024 }

--- a/spec/migrations/adjust_default_agent_run_timeouts_spec.rb
+++ b/spec/migrations/adjust_default_agent_run_timeouts_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe AdjustDefaultAgentRunTimeouts, :aggregate_failures do
     truncate_migration_test_data
   end
 
-  it "updates untouched defaults without clobbering explicit 3600-second user preferences" do
+  it "updates untouched defaults without clobbering explicit 3600-second user or project preferences" do
     migration.migrate(:down)
     UserSetting.reset_column_information
     Project.reset_column_information
@@ -30,6 +30,8 @@ RSpec.describe AdjustDefaultAgentRunTimeouts, :aggregate_failures do
     explicit_3600_setting = create(:user_setting, agent_timeout_seconds: 3600)
     explicit_3600_setting.update!(default_poll_interval_seconds: 120)
     project_default = create(:project, max_execution_seconds: 3600)
+    explicit_3600_project = create(:project, max_execution_seconds: 3600)
+    explicit_3600_project.update!(poll_interval_seconds: 120)
 
     migration.migrate(:up)
     UserSetting.reset_column_information
@@ -38,6 +40,7 @@ RSpec.describe AdjustDefaultAgentRunTimeouts, :aggregate_failures do
     expect(untouched_setting.reload.agent_timeout_seconds).to eq(5400)
     expect(explicit_3600_setting.reload.agent_timeout_seconds).to eq(3600)
     expect(project_default.reload.max_execution_seconds).to eq(7200)
+    expect(explicit_3600_project.reload.max_execution_seconds).to eq(3600)
     expect(default_for(:user_settings, :agent_timeout_seconds)).to eq(5400)
     expect(default_for(:projects, :max_execution_seconds)).to eq(7200)
   end

--- a/spec/migrations/adjust_default_agent_run_timeouts_spec.rb
+++ b/spec/migrations/adjust_default_agent_run_timeouts_spec.rb
@@ -45,6 +45,26 @@ RSpec.describe AdjustDefaultAgentRunTimeouts, :aggregate_failures do
     expect(default_for(:projects, :max_execution_seconds)).to eq(7200)
   end
 
+  it "reverts untouched backfilled rows and restores legacy defaults on down without clobbering explicit values" do
+    untouched_setting = create(:user_setting, agent_timeout_seconds: 5400)
+    explicit_5400_setting = create(:user_setting, agent_timeout_seconds: 5400)
+    explicit_5400_setting.update!(default_poll_interval_seconds: 120)
+    untouched_project = create(:project, max_execution_seconds: 7200)
+    explicit_7200_project = create(:project, max_execution_seconds: 7200)
+    explicit_7200_project.update!(poll_interval_seconds: 120)
+
+    migration.migrate(:down)
+    UserSetting.reset_column_information
+    Project.reset_column_information
+
+    expect(untouched_setting.reload.agent_timeout_seconds).to eq(3600)
+    expect(explicit_5400_setting.reload.agent_timeout_seconds).to eq(5400)
+    expect(untouched_project.reload.max_execution_seconds).to eq(3600)
+    expect(explicit_7200_project.reload.max_execution_seconds).to eq(7200)
+    expect(default_for(:user_settings, :agent_timeout_seconds)).to eq(3600)
+    expect(default_for(:projects, :max_execution_seconds)).to eq(3600)
+  end
+
   private
 
   def default_for(table_name, column_name)

--- a/spec/migrations/adjust_default_agent_run_timeouts_spec.rb
+++ b/spec/migrations/adjust_default_agent_run_timeouts_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require Rails.root.join("db/migrate/20260625062207_adjust_default_agent_run_timeouts")
+
+RSpec.describe AdjustDefaultAgentRunTimeouts, :aggregate_failures do
+  self.use_transactional_tests = false
+
+  let(:migration) { described_class.new }
+  let(:connection) { ActiveRecord::Base.connection }
+
+  include MigrationSpecHelpers
+
+  around do |example|
+    truncate_migration_test_data
+    example.run
+  ensure
+    migration.migrate(:up)
+    UserSetting.reset_column_information
+    Project.reset_column_information
+    truncate_migration_test_data
+  end
+
+  it "updates untouched defaults without clobbering explicit 3600-second user preferences" do
+    migration.migrate(:down)
+    UserSetting.reset_column_information
+    Project.reset_column_information
+
+    untouched_setting = create(:user_setting, agent_timeout_seconds: 3600)
+    explicit_3600_setting = create(:user_setting, agent_timeout_seconds: 3600)
+    explicit_3600_setting.update!(default_poll_interval_seconds: 120)
+    project_default = create(:project, max_execution_seconds: 3600)
+
+    migration.migrate(:up)
+    UserSetting.reset_column_information
+    Project.reset_column_information
+
+    expect(untouched_setting.reload.agent_timeout_seconds).to eq(5400)
+    expect(explicit_3600_setting.reload.agent_timeout_seconds).to eq(3600)
+    expect(project_default.reload.max_execution_seconds).to eq(7200)
+    expect(default_for(:user_settings, :agent_timeout_seconds)).to eq(5400)
+    expect(default_for(:projects, :max_execution_seconds)).to eq(7200)
+  end
+
+  private
+
+  def default_for(table_name, column_name)
+    connection.columns(table_name).find { |column| column.name == column_name.to_s }&.default
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -35,9 +35,9 @@ RSpec.describe Project do
     it { is_expected.to validate_numericality_of(:max_execution_seconds).only_integer.is_greater_than_or_equal_to(60).is_less_than_or_equal_to(86_400) }
     it { is_expected.to validate_inclusion_of(:data_classification).in_array(described_class::DATA_CLASSIFICATIONS) }
 
-    it "defaults max_execution_seconds to 3600" do
+    it "defaults max_execution_seconds to 7200" do
       project = build(:project)
-      expect(project.max_execution_seconds).to eq(3600)
+      expect(project.max_execution_seconds).to eq(7200)
     end
 
     it "defaults data_classification to internal" do

--- a/spec/models/user_setting_spec.rb
+++ b/spec/models/user_setting_spec.rb
@@ -427,7 +427,7 @@ RSpec.describe UserSetting do
     end
 
     it "sets default agent execution values" do
-      expect(setting.agent_timeout_seconds).to eq(3600)
+      expect(setting.agent_timeout_seconds).to eq(5400)
       expect(setting.default_agent_runner).to eq(user.runners.find_by!(runner_key: "claude").routing_key)
     end
 

--- a/spec/services/orchestration_strategies/defaults_spec.rb
+++ b/spec/services/orchestration_strategies/defaults_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe OrchestrationStrategies::Defaults do
     subject(:config) { described_class.execution_timeouts }
 
     it "preserves the agent timeout default" do
-      expect(config["agent_timeout_default_seconds"]).to eq(3600)
+      expect(config["agent_timeout_default_seconds"]).to eq(5400)
     end
 
     it "preserves issue goal timeout" do

--- a/spec/temporal/activities/create_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/create_agent_run_activity_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Activities::CreateAgentRunActivity do
     it "returns default max_execution_seconds when not customized" do
       result = activity.execute(project_id: project.id, issue_id: issue.id)
 
-      expect(result[:max_execution_seconds]).to eq(3600)
+      expect(result[:max_execution_seconds]).to eq(7200)
     end
 
     it "returns the user override for max_execution_seconds when set" do

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -1550,7 +1550,7 @@ RSpec.describe Activities::RunAgentActivity do
         "diagnostics" => hash_including(
           "timeout_type" => "wall_clock",
           "elapsed_seconds" => 901.2,
-          "effective_timeout_seconds" => 3600
+          "effective_timeout_seconds" => AGENT_TIMEOUT_DEFAULT
         )
       ),
       hash_including("runner" => "cursor", "success" => true)
@@ -3032,7 +3032,7 @@ expect(container_service).to receive(:execute).with(
         expect(agent_run.error_message).to include("idle_timeout")
         expect(agent_run.runners_attempted.first["diagnostics"]).to include(
           "timeout_type" => "idle",
-          "effective_timeout_seconds" => 3600,
+          "effective_timeout_seconds" => AGENT_TIMEOUT_DEFAULT,
           "startup_timeout_seconds" => described_class::CREATE_PR_RUNNER_STARTUP_TIMEOUTS["claude"],
           "idle_timeout_seconds" => described_class::CREATE_PR_RUNNER_IDLE_TIMEOUTS["claude_code"],
           "heartbeat_supported" => true

--- a/spec/temporal/workflows/agent_execution_workflow_spec.rb
+++ b/spec/temporal/workflows/agent_execution_workflow_spec.rb
@@ -518,7 +518,7 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
     let(:input) { { project_id: 1, issue_id: 1, goal: "create_pr" } }
 
     before do
-      allow(Rails.application.config.x).to receive(:agent_timeout).and_return(3600)
+      allow(Rails.application.config.x).to receive(:agent_timeout).and_return(AGENT_TIMEOUT_DEFAULT)
       allow(Temporalio::Workflow).to receive_messages(logger: Rails.logger, patched: true)
     end
 
@@ -527,7 +527,7 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
         case activity_class.name
         when "Activities::CreateAgentRunActivity" then { agent_run_id: 42, runner_attempt_count: 3 }
         when "Activities::RunAgentActivity"
-          expect(opts[:start_to_close_timeout]).to eq(11_100) # (3600 * 3 attempts) + 300
+          expect(opts[:start_to_close_timeout]).to eq(16_500) # (5400 * 3 attempts) + 300
           { success: true, has_changes: false }
         when "Activities::MarkAgentRunCompleteActivity" then {}
         else {}
@@ -543,7 +543,7 @@ RSpec.describe Workflows::AgentExecutionWorkflow do
         when "Activities::CreateAgentRunActivity"
           { agent_run_id: 42, runner_attempt_count: 2 }
         when "Activities::RunAgentActivity"
-          expect(opts[:start_to_close_timeout]).to eq(7500) # (3600 * 2 attempts) + 300
+          expect(opts[:start_to_close_timeout]).to eq(11_100) # (5400 * 2 attempts) + 300
           { success: true, has_changes: false }
         when "Activities::MarkAgentRunCompleteActivity" then {}
         else {}


### PR DESCRIPTION
## Summary
- raise the default agent execution timeout to 5400 seconds
- raise the default project execution cap to 7200 seconds
- backfill legacy defaults without clobbering explicit 3600-second user settings
- update timeout-related specs and add migration coverage

## Why
Recent `claude_code` and `codex` `create_pr` runs were timing out disproportionately at the legacy one-hour defaults. Successful runs were already clustering close to that ceiling, so the default budgets were too tight for current behavior.

## Testing
- `bundle exec rspec spec/migrations/adjust_default_agent_run_timeouts_spec.rb spec/models/project_spec.rb spec/models/user_setting_spec.rb spec/services/orchestration_strategies/defaults_spec.rb spec/temporal/activities/create_agent_run_activity_spec.rb spec/temporal/activities/run_agent_activity_spec.rb spec/temporal/workflows/agent_execution_workflow_spec.rb`
