### PR TITLE
fix(dev-update): harden auto-update restart recovery

### DIFF
--- a/app/temporal/activities/trigger_dev_environment_update_activity.rb
+++ b/app/temporal/activities/trigger_dev_environment_update_activity.rb
@@ -114,12 +114,19 @@ module Activities
       # is not the parent — setsid creates a new session.
       pid = Process.spawn(
         {
+          "BUNDLE_BIN_PATH" => nil,
+          "BUNDLE_GEMFILE" => nil,
+          "BUNDLER_SETUP" => nil,
+          "BUNDLER_VERSION" => nil,
           "DEV_UPDATE_TRIGGER_SOURCE" => self.class.name,
           "DEV_UPDATE_TRIGGER_MODE" => mode,
           "DEV_UPDATE_PROJECT_ID" => project_id.to_s,
           "DEV_UPDATE_PR_NUMBER" => pr_number.to_s,
           "DEV_UPDATE_CHANGED_FILES" => changed_files.join("\n"),
-          "DEV_UPDATE_RESTART_TRIGGER_FILES" => restart_trigger_files.join("\n")
+          "DEV_UPDATE_RESTART_TRIGGER_FILES" => restart_trigger_files.join("\n"),
+          "RUBYGEMS_GEMDEPS" => nil,
+          "RUBYLIB" => nil,
+          "RUBYOPT" => nil
         },
         "setsid", script, flag,
         out: [ log_path.to_s, "a" ],

--- a/bin/dev-update
+++ b/bin/dev-update
@@ -41,6 +41,7 @@ STOPPED_OVERMIND=0
 OVERMIND_STOP_POLL_COUNT="${DEV_UPDATE_OVERMIND_STOP_POLL_COUNT:-10}"
 OVERMIND_START_POLL_COUNT="${DEV_UPDATE_OVERMIND_START_POLL_COUNT:-15}"
 OVERMIND_POLL_INTERVAL="${DEV_UPDATE_OVERMIND_POLL_INTERVAL:-1}"
+OVERMIND_HEALTHY_CONFIRM_COUNT="${DEV_UPDATE_OVERMIND_HEALTHY_CONFIRM_COUNT:-2}"
 STARTUP_CLEANUP_KILL_ALL="${DEV_UPDATE_STARTUP_CLEANUP_KILL_ALL:-}"
 STASHED_CHANGES=0
 FAILURE_LOCK_FILE="${APP_ROOT}/tmp/dev-update-failure.lock"
@@ -240,6 +241,25 @@ overmind_running() {
   overmind_available && dev_supervisor_run_overmind overmind status &>/dev/null
 }
 
+overmind_healthy() {
+  overmind_available || return 1
+
+  local status_output
+  if ! status_output="$(dev_supervisor_overmind_status_output)"; then
+    return 1
+  fi
+
+  if dev_supervisor_overmind_has_dead_processes "$status_output"; then
+    return 1
+  fi
+
+  if dev_supervisor_tmux_has_dead_panes; then
+    return 1
+  fi
+
+  return 0
+}
+
 remove_stale_overmind_socket() {
   if [ -S "$OVERMIND_SOCKET" ] && ! overmind_running; then
     log "Removing stale Overmind socket..."
@@ -373,39 +393,24 @@ prune_worktree_databases() {
 run_setup() {
   log "Running bin/setup --skip-server..."
   local status=0
-  STARTUP_CLEANUP_KILL_ALL="$STARTUP_CLEANUP_KILL_ALL" bin/setup --skip-server || status=$?
+  STARTUP_CLEANUP_KILL_ALL="$STARTUP_CLEANUP_KILL_ALL" \
+    dev_supervisor_run_clean bin/setup --skip-server || status=$?
   # Mirror bin/setup's worktree-database creation by reaping orphans, but only
   # after a clean setup — the DB is in a known-good state and Ruby is available.
   [ "$status" -eq 0 ] && prune_worktree_databases
   return "$status"
 }
 
-start_dev() {
-  mkdir -p "$(dirname "$START_DEV_LOG")"
-  remove_stale_overmind_socket
-  dev_supervisor_cleanup_stale_tmux_sockets
-
-  if overmind_running; then
-    log "Overmind is already running, restarting processes."
-    local restart_output
-    restart_output="$(dev_supervisor_run_overmind overmind restart 2>&1)"
-    log_command_output "overmind restart" "$restart_output"
-    log "Overmind process restart requested."
-    return 0
-  fi
-
-  log "Starting dev environment..."
-  log "Streaming detached bin/dev output to $START_DEV_LOG"
-  dev_supervisor_snapshot_state "dev-update-before-start"
-  # Start bin/dev detached so this script can exit cleanly.
-  # Unset PORT so bin/dev applies its own default (3000) instead of
-  # inheriting a per-process port assigned by the previous Overmind session.
-  env -u PORT STARTUP_CLEANUP_KILL_ALL="$STARTUP_CLEANUP_KILL_ALL" nohup bin/dev >>"$START_DEV_LOG" 2>&1 &
-  disown
-  log "Dev environment start command launched (PID $!)."
-
+wait_for_overmind_health() {
+  local healthy_polls=0
   for ((i = 0; i < OVERMIND_START_POLL_COUNT; i += 1)); do
-    if overmind_running; then
+    if overmind_healthy; then
+      healthy_polls=$((healthy_polls + 1))
+    else
+      healthy_polls=0
+    fi
+
+    if [ "$healthy_polls" -ge "$OVERMIND_HEALTHY_CONFIRM_COUNT" ]; then
       log "Overmind is healthy after restart."
       return 0
     fi
@@ -424,8 +429,38 @@ start_dev() {
   return 1
 }
 
+start_dev() {
+  mkdir -p "$(dirname "$START_DEV_LOG")"
+  remove_stale_overmind_socket
+  dev_supervisor_cleanup_stale_tmux_sockets
+
+  if overmind_running; then
+    log "Overmind is already running, restarting processes."
+    local restart_output
+    restart_output="$(dev_supervisor_run_overmind overmind restart 2>&1)"
+    log_command_output "overmind restart" "$restart_output"
+    log "Overmind process restart requested."
+    wait_for_overmind_health
+    return $?
+  fi
+
+  log "Starting dev environment..."
+  log "Streaming detached bin/dev output to $START_DEV_LOG"
+  dev_supervisor_snapshot_state "dev-update-before-start"
+  # Start bin/dev detached so this script can exit cleanly.
+  # Unset PORT so bin/dev applies its own default (3000) instead of
+  # inheriting a per-process port assigned by the previous Overmind session.
+  dev_supervisor_run_clean env -u PORT -u TMUX \
+    STARTUP_CLEANUP_KILL_ALL="$STARTUP_CLEANUP_KILL_ALL" \
+    nohup bin/dev >>"$START_DEV_LOG" 2>&1 &
+  disown
+  log "Dev environment start command launched (PID $!)."
+
+  wait_for_overmind_health
+}
+
 recover_dev_if_needed() {
-  if [ "$STOPPED_OVERMIND" -eq 1 ] && ! overmind_running; then
+  if [ "$STOPPED_OVERMIND" -eq 1 ] && ! overmind_healthy; then
     log "Attempting recovery start because Overmind was stopped during this update."
     if start_dev; then
       log "Recovery start succeeded."

--- a/bin/lib/dev_supervisor.sh
+++ b/bin/lib/dev_supervisor.sh
@@ -33,7 +33,7 @@ dev_supervisor_prepare_logging() {
   touch "$(dev_supervisor_tmux_log)" "$(dev_supervisor_overmind_log)"
 }
 
-dev_supervisor_run_overmind() {
+dev_supervisor_run_clean() {
   env \
     -u BUNDLE_BIN_PATH \
     -u BUNDLE_GEMFILE \
@@ -43,6 +43,10 @@ dev_supervisor_run_overmind() {
     -u RUBYOPT \
     -u RUBYGEMS_GEMDEPS \
     "$@"
+}
+
+dev_supervisor_run_overmind() {
+  dev_supervisor_run_clean "$@"
 }
 
 dev_supervisor_overmind_status_output() {

--- a/spec/lib/dev_update_spec.rb
+++ b/spec/lib/dev_update_spec.rb
@@ -334,6 +334,73 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
     end
   end
 
+  it "clears bundler env before calling bin/setup" do
+    Dir.mktmpdir("dev-update-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir, capture_bundler_env_in_setup: true)
+      env = poll_env.merge(bundler_contaminated_env(dir))
+
+      stdout, stderr, status = Open3.capture3(env, script_path, "--full", chdir: dir)
+
+      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      setup_env_log = File.read(File.join(dir, "setup-bundler-env.log"))
+      expect(setup_env_log).not_to include("BUNDLE_GEMFILE=")
+      expect(setup_env_log).not_to include("RUBYOPT=")
+    end
+  end
+
+  it "clears bundler env before launching detached bin/dev" do
+    Dir.mktmpdir("dev-update-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir, capture_bundler_env_in_dev: true)
+      env = poll_env.merge(bundler_contaminated_env(dir))
+
+      stdout, stderr, status = Open3.capture3(env, script_path, "--full", chdir: dir)
+
+      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      dev_env_log = File.read(File.join(dir, "dev-bundler-env.log"))
+      expect(dev_env_log).not_to include("BUNDLE_GEMFILE=")
+      expect(dev_env_log).not_to include("RUBYOPT=")
+      expect(dev_env_log).not_to include("TMUX=")
+    end
+  end
+
+  it "requires consecutive healthy overmind polls before declaring restart success" do
+    Dir.mktmpdir("dev-update-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir, status_successes_after_start: 1)
+      env = poll_env.merge(
+        "PATH" => "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}",
+        "OVERMIND_SOCKET" => ".overmind.sock",
+        "DEV_UPDATE_OVERMIND_HEALTHY_CONFIRM_COUNT" => "2"
+      )
+
+      stdout, stderr, status = Open3.capture3(env, script_path, "--full", chdir: dir)
+      updater_log = read_updater_log(dir)
+
+      expect(status.success?).to be(false), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(updater_log).to include("Inspect log/dev-update/dev-start.log for detached bin/dev output.")
+      expect(updater_log).to include("ERROR: Full restart completed setup but failed to restore a healthy Overmind session.")
+    end
+  end
+
+  it "does not treat overmind restart as success unless health persists" do
+    Dir.mktmpdir("dev-update-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir, start_overmind_running: true, status_successes_after_start: 1)
+      env = poll_env.merge(
+        "PATH" => "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}",
+        "OVERMIND_SOCKET" => ".overmind.sock",
+        "DEV_UPDATE_OVERMIND_HEALTHY_CONFIRM_COUNT" => "2"
+      )
+
+      stdout, stderr, status = Open3.capture3(env, script_path, "--full", chdir: dir)
+      updater_log = read_updater_log(dir)
+
+      expect(status.success?).to be(false), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(File.exist?(File.join(dir, "overmind-restart-ran"))).to be(true)
+      expect(updater_log).to include("Overmind is already running, restarting processes.")
+      expect(updater_log).to include("Inspect log/dev-update/dev-start.log for detached bin/dev output.")
+      expect(updater_log).to include("ERROR: Full restart completed setup but failed to restore a healthy Overmind session.")
+    end
+  end
+
   it "auto-stashes dirty working tree before pulling" do
     Dir.mktmpdir("dev-update-spec", exec_tmpdir) do |dir|
       script_path = prepare_script_fixture(dir, dirty_tree: true)
@@ -504,13 +571,16 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
     setup_exit_status: 0,
     start_overmind_running: false,
     dev_starts_overmind: true,
+    capture_bundler_env_in_setup: false,
+    capture_bundler_env_in_dev: false,
     capture_port_in_dev: false,
     capture_kill_all_in_dev: false,
     dirty_tree: false,
     pull_exit_status: 0,
     stash_pop_exit_status: 0,
     stash_pop_output: "Applied stash",
-    pull_diff_files: []
+    pull_diff_files: [],
+    status_successes_after_start: nil
   )
     FileUtils.mkdir_p(File.join(dir, "bin"))
     FileUtils.mkdir_p(File.join(dir, "bin", "lib"))
@@ -528,6 +598,10 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
     capture_port_line = capture_port_in_dev ? %(printf '%s\n' "${PORT:-}" > "#{dir}/dev-port.log") : ""
     capture_kill_all_line =
       capture_kill_all_in_dev ? %(printf '%s\n' "${STARTUP_CLEANUP_KILL_ALL:-}" > "#{dir}/dev-env.log") : ""
+    capture_setup_bundler_line =
+      capture_bundler_env_in_setup ? %((env | sort | grep -E '^(BUNDLE_GEMFILE|BUNDLE_BIN_PATH|BUNDLER_SETUP|BUNDLER_VERSION|RUBYLIB|RUBYOPT|RUBYGEMS_GEMDEPS|TMUX)=' || true) > "#{dir}/setup-bundler-env.log") : ""
+    capture_dev_bundler_line =
+      capture_bundler_env_in_dev ? %((env | sort | grep -E '^(BUNDLE_GEMFILE|BUNDLE_BIN_PATH|BUNDLER_SETUP|BUNDLER_VERSION|RUBYLIB|RUBYOPT|RUBYGEMS_GEMDEPS|TMUX)=' || true) > "#{dir}/dev-bundler-env.log") : ""
 
     write_executable(
       File.join(dir, "bin", "setup"),
@@ -535,6 +609,7 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
         #!/usr/bin/env bash
         touch "#{dir}/setup-ran"
         printf '%s\n' "${STARTUP_CLEANUP_KILL_ALL:-}" > "#{dir}/setup-env.log"
+        #{capture_setup_bundler_line}
         exit #{setup_exit_status}
       BASH
     )
@@ -546,6 +621,7 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
         touch "#{dir}/dev-ran"
         #{capture_port_line}
         #{capture_kill_all_line}
+        #{capture_dev_bundler_line}
         #{dev_start_line}
         echo "bin/dev booted"
       BASH
@@ -617,7 +693,26 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
         case "$1" in
           status)
             [ -e "#{dir}/overmind-running" ]
-            exit $?
+            running=$?
+            if [ "$running" -ne 0 ]; then
+              exit "$running"
+            fi
+
+            count_file="#{dir}/overmind-status-count"
+            count=0
+            if [ -f "$count_file" ]; then
+              count="$(cat "$count_file")"
+            fi
+            count=$((count + 1))
+            printf '%s' "$count" > "$count_file"
+
+            if [ "#{status_successes_after_start.nil? ? '' : status_successes_after_start}" != "" ] && [ "$count" -gt #{status_successes_after_start || 0} ]; then
+              rm -f "#{dir}/overmind-running"
+              exit 1
+            fi
+            echo "PROCESS   PID       STATUS"
+            echo "web       12345     running"
+            exit 0
             ;;
           quit)
             touch "#{dir}/overmind-quit-ran"

--- a/spec/temporal/activities/trigger_dev_environment_update_activity_spec.rb
+++ b/spec/temporal/activities/trigger_dev_environment_update_activity_spec.rb
@@ -67,18 +67,15 @@ RSpec.describe Activities::TriggerDevEnvironmentUpdateActivity do
         it "spawns the dev-update script with --lightweight" do
           activity.execute(project_id: project.id, pr_number: 42)
 
-          log_path = Rails.root.join("log", "dev-update", "dev-update.log").to_s
           expect(Process).to have_received(:spawn).with(
-            hash_including(
-              "DEV_UPDATE_TRIGGER_SOURCE" => "Activities::TriggerDevEnvironmentUpdateActivity",
-              "DEV_UPDATE_TRIGGER_MODE" => "lightweight",
-              "DEV_UPDATE_PROJECT_ID" => project.id.to_s,
-              "DEV_UPDATE_PR_NUMBER" => "42",
-              "DEV_UPDATE_CHANGED_FILES" => "app/models/user.rb\napp/controllers/projects_controller.rb",
-              "DEV_UPDATE_RESTART_TRIGGER_FILES" => ""
+            expected_spawn_env(
+              mode: "lightweight",
+              changed_files: "app/models/user.rb\napp/controllers/projects_controller.rb",
+              restart_trigger_files: "",
+              project_id: project.id
             ),
             "setsid", /bin\/dev-update/, "--lightweight",
-            hash_including(out: [ log_path, "a" ], err: [ log_path, "a" ])
+            hash_including(out: [ dev_update_log_path, "a" ], err: [ dev_update_log_path, "a" ])
           )
           expect(Process).to have_received(:detach).with(12345)
         end
@@ -100,18 +97,15 @@ RSpec.describe Activities::TriggerDevEnvironmentUpdateActivity do
         it "spawns the dev-update script with --full" do
           activity.execute(project_id: project.id, pr_number: 42)
 
-          log_path = Rails.root.join("log", "dev-update", "dev-update.log").to_s
           expect(Process).to have_received(:spawn).with(
-            hash_including(
-              "DEV_UPDATE_TRIGGER_SOURCE" => "Activities::TriggerDevEnvironmentUpdateActivity",
-              "DEV_UPDATE_TRIGGER_MODE" => "full",
-              "DEV_UPDATE_PROJECT_ID" => project.id.to_s,
-              "DEV_UPDATE_PR_NUMBER" => "42",
-              "DEV_UPDATE_CHANGED_FILES" => "app/temporal/activities/new_activity.rb\napp/models/user.rb",
-              "DEV_UPDATE_RESTART_TRIGGER_FILES" => "app/temporal/activities/new_activity.rb"
+            expected_spawn_env(
+              mode: "full",
+              changed_files: "app/temporal/activities/new_activity.rb\napp/models/user.rb",
+              restart_trigger_files: "app/temporal/activities/new_activity.rb",
+              project_id: project.id
             ),
             "setsid", /bin\/dev-update/, "--full",
-            hash_including(out: [ log_path, "a" ], err: [ log_path, "a" ])
+            hash_including(out: [ dev_update_log_path, "a" ], err: [ dev_update_log_path, "a" ])
           )
         end
       end
@@ -291,5 +285,27 @@ RSpec.describe Activities::TriggerDevEnvironmentUpdateActivity do
         end
       end
     end
+  end
+
+  def dev_update_log_path
+    Rails.root.join("log", "dev-update", "dev-update.log").to_s
+  end
+
+  def expected_spawn_env(mode:, changed_files:, restart_trigger_files:, project_id:)
+    hash_including(
+      "BUNDLE_BIN_PATH" => nil,
+      "BUNDLE_GEMFILE" => nil,
+      "BUNDLER_SETUP" => nil,
+      "BUNDLER_VERSION" => nil,
+      "DEV_UPDATE_TRIGGER_SOURCE" => "Activities::TriggerDevEnvironmentUpdateActivity",
+      "DEV_UPDATE_TRIGGER_MODE" => mode,
+      "DEV_UPDATE_PROJECT_ID" => project_id.to_s,
+      "DEV_UPDATE_PR_NUMBER" => "42",
+      "DEV_UPDATE_CHANGED_FILES" => changed_files,
+      "DEV_UPDATE_RESTART_TRIGGER_FILES" => restart_trigger_files,
+      "RUBYGEMS_GEMDEPS" => nil,
+      "RUBYLIB" => nil,
+      "RUBYOPT" => nil
+    )
   end
 end


### PR DESCRIPTION
## Summary
- scrub inherited Bundler environment from the dev-update spawn and restart path
- require sustained healthy Overmind status before reporting restart success
- add regression coverage for Bundler contamination and false-positive restart recovery

## Testing
- `shellcheck -x bin/dev-update bin/lib/dev_supervisor.sh`
- `bundle exec rspec spec/lib/dev_update_spec.rb spec/temporal/activities/trigger_dev_environment_update_activity_spec.rb spec/lib/dev_script_spec.rb spec/lib/setup_script_spec.rb`