### PR TITLE
feat(dashboard): add retry-limited issues/PRs table under upcoming queue

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -29,6 +29,11 @@ class DashboardController < ApplicationController
       .where.not(quality_paused_at: nil)
       .order(quality_paused_at: :desc)
       .limit(10)
+    @retry_limited_issues = Issue.where.not(runner_retry_abandoned_at: nil)
+      .where(project_id: current_account.projects.select(:id))
+      .includes(:project)
+      .order(runner_retry_abandoned_at: :desc)
+      .limit(20)
     @recent_activity = Dashboard::RecentActivity.call(account: current_account)
   end
 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -29,11 +29,13 @@ class DashboardController < ApplicationController
       .where.not(quality_paused_at: nil)
       .order(quality_paused_at: :desc)
       .limit(10)
-    @retry_limited_issues = Issue.where.not(runner_retry_abandoned_at: nil)
-      .where(project_id: current_account.projects.select(:id))
+    @retry_limited_issues = Issue.joins(:project)
+      .where(projects: { account_id: current_account.id })
+      .where.not(runner_retry_abandoned_at: nil)
       .includes(:project)
       .order(runner_retry_abandoned_at: :desc)
       .limit(20)
+      .to_a
     @recent_activity = Dashboard::RecentActivity.call(account: current_account)
   end
 

--- a/app/views/dashboard/_retry_limited_issues.html.erb
+++ b/app/views/dashboard/_retry_limited_issues.html.erb
@@ -1,0 +1,61 @@
+<div class="rounded-lg border border-orange-200 bg-orange-50 p-6 shadow-sm">
+  <div class="flex items-start justify-between gap-4">
+    <div>
+      <h3 class="text-base font-semibold text-orange-900">Retry-limited issues</h3>
+      <p class="mt-1 text-sm text-orange-700">These issues/PRs reached their runner retry cap. Clear the flag to retry, or run them manually.</p>
+    </div>
+    <% if retry_limited_issues.any? %>
+      <span class="inline-flex items-center rounded-md bg-orange-100 px-2 py-1 text-xs font-medium text-orange-800">
+        <%= pluralize(retry_limited_issues.size, "item") %>
+      </span>
+    <% end %>
+  </div>
+
+  <% if retry_limited_issues.any? %>
+    <div class="mt-4 flow-root">
+      <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+        <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
+          <table class="min-w-full divide-y divide-orange-200">
+            <thead>
+              <tr>
+                <th scope="col" class="py-2 pl-4 pr-3 text-left text-xs font-medium uppercase tracking-wide text-orange-700 sm:pl-0">Project</th>
+                <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-orange-700">Issue</th>
+                <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-orange-700">Type</th>
+                <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-orange-700">Reason</th>
+                <th scope="col" class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wide text-orange-700">Abandoned</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-orange-200 bg-orange-50">
+              <% retry_limited_issues.each do |issue| %>
+                <tr>
+                  <td class="whitespace-nowrap py-3 pl-4 pr-3 text-sm font-medium text-orange-900 sm:pl-0">
+                    <%= link_to issue.project.full_name, project_path(issue.project), class: "hover:text-indigo-600" %>
+                  </td>
+                  <td class="whitespace-nowrap px-3 py-3 text-sm text-orange-900">
+                    <%= link_to "##{issue.github_number}", issue.github_url, target: "_blank", rel: "noopener noreferrer", class: "text-indigo-600 hover:text-indigo-900" %>
+                    <span class="ml-1 text-orange-700"><%= truncate(issue.title, length: 60) %></span>
+                  </td>
+                  <td class="whitespace-nowrap px-3 py-3 text-sm">
+                    <% if issue.push_permission_abandoned? %>
+                      <span class="inline-flex items-center rounded-md bg-orange-100 px-2 py-0.5 text-xs font-medium text-orange-700 ring-1 ring-inset ring-orange-600/20">Push Blocked</span>
+                    <% else %>
+                      <span class="inline-flex items-center rounded-md bg-red-50 px-2 py-0.5 text-xs font-medium text-red-700 ring-1 ring-inset ring-red-600/20">Retry Cap</span>
+                    <% end %>
+                  </td>
+                  <td class="px-3 py-3 text-sm text-orange-700 max-w-xs truncate" title="<%= issue.runner_retry_abandon_reason.to_s %>">
+                    <%= issue.runner_retry_abandon_reason.to_s %>
+                  </td>
+                  <td class="whitespace-nowrap px-3 py-3 text-sm text-orange-700">
+                    <%= local_time(issue.runner_retry_abandoned_at, format: :relative) %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  <% else %>
+    <p class="mt-4 text-sm text-orange-700">No retry-limited issues or PRs at the moment.</p>
+  <% end %>
+</div>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -56,6 +56,10 @@
         <%= render "dashboard/queue_preview", queue_preview: @queue_preview %>
       </div>
 
+      <div class="mt-6">
+        <%= render "dashboard/retry_limited_issues", retry_limited_issues: @retry_limited_issues %>
+      </div>
+
       <turbo-frame id="dashboard-runner-health"
         data-dashboard-frames-target="frame"
         data-dashboard-frames-src="<%= dashboard_runner_health_path %>"


### PR DESCRIPTION
Issues/PRs that reach their runner retry cap or hit a terminal push-permission rejection are excluded from auto-pick, but there was no dashboard-level visibility — operators had to notice individual badges on the issue list or check the Rails console.

Adds a **Retry-limited issues** section below the Upcoming Queue that surfaces these blocked items. The section header is always visible so users know the feature exists, with a zero-state message when empty.

![HARNESS](https://img.shields.io/badge/OPENCODE-not_available-6b7280?logo=opencollective&logoColor=white)
