### PR TITLE
fix(chat): safely resume closed API sessions

### DIFF
--- a/app/services/chat_sessions/resume.rb
+++ b/app/services/chat_sessions/resume.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module ChatSessions
+  # Reopens a closed API chat session so the same thread can continue later.
+  # Workspace sessions remain non-resumable because close tears down resources.
+  class Resume
+    CLOSE_SNAPSHOT_KEYS = %w[
+      total_tokens_input
+      total_tokens_output
+      total_cost_cents
+      total_messages
+      closed_at
+    ].freeze
+
+    attr_reader :chat_session
+
+    def initialize(chat_session:)
+      @chat_session = chat_session
+    end
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def call
+      chat_session.with_lock do
+        chat_session.reload
+        validate!
+        resume! if chat_session.status == "closed"
+      end
+
+      chat_session
+    end
+
+    private
+
+    def validate!
+      raise ArgumentError, "workspace chat sessions cannot be resumed" if chat_session.mode == "workspace"
+      return if %w[active closed].include?(chat_session.status)
+
+      raise ArgumentError, "chat session must be active or closed to resume"
+    end
+
+    def resume!
+      chat_session.update!(
+        status: "active",
+        idle_timeout_at: ChatSession::IDLE_TIMEOUT_DURATION.from_now,
+        metadata: resumed_metadata
+      )
+    end
+
+    def resumed_metadata
+      metadata = (chat_session.metadata || {}).deep_dup
+      CLOSE_SNAPSHOT_KEYS.each { |key| metadata.delete(key) }
+      metadata["last_resumed_at"] = Time.current.iso8601
+      metadata["resume_count"] = metadata.fetch("resume_count", 0).to_i + 1
+      metadata
+    end
+  end
+end

--- a/app/services/chat_sessions/send_message.rb
+++ b/app/services/chat_sessions/send_message.rb
@@ -31,8 +31,10 @@ module ChatSessions
     end
 
     def call
-      validate!
+      validate_content!
+      validate_session_state!
       check_token_limit!
+      resume_session_if_needed!
 
       persist_user_message
       assistant_message = ChatSessions::AgentLoop.new(**loop_kwargs).run
@@ -42,10 +44,31 @@ module ChatSessions
 
     private
 
-    def validate!
-      raise ArgumentError, "chat session must be active" unless chat_session.status == "active"
+    def resume_session_if_needed!
+      return unless chat_session.status == "closed"
+
+      ChatSessions::Resume.call(chat_session: chat_session)
+    end
+
+    def validate_content!
       raise ArgumentError, "content cannot be blank" if content.blank?
       raise ArgumentError, "content exceeds maximum length of #{MAX_CONTENT_LENGTH} characters" if content.length > MAX_CONTENT_LENGTH
+    end
+
+    def validate_session_state!
+      return if chat_session.status == "active"
+      return if resumable_closed_session?
+      raise ArgumentError, "workspace chat sessions cannot be resumed" if closed_workspace_session?
+
+      raise ArgumentError, "chat session must be active"
+    end
+
+    def resumable_closed_session?
+      chat_session.status == "closed" && chat_session.mode != "workspace"
+    end
+
+    def closed_workspace_session?
+      chat_session.status == "closed" && chat_session.mode == "workspace"
     end
 
     def check_token_limit!

--- a/spec/requests/chat_messages_spec.rb
+++ b/spec/requests/chat_messages_spec.rb
@@ -77,6 +77,21 @@ RSpec.describe "ChatMessages" do
         expect(response.parsed_body["content"]).to eq("Hello back!")
       end
 
+      it "reopens a closed API session when sending a new message" do
+        chat_session.update!(status: "closed", idle_timeout_at: 1.day.ago)
+
+        llm_client = instance_double(Proc)
+        allow(ChatSessions::BuildLlmClient).to receive(:call).with(chat_session: chat_session).and_return(llm_client)
+        allow(ChatSessions::SendMessage).to receive(:call).and_call_original
+        allow(llm_client).to receive(:call).and_return(llm_response)
+
+        post chat_session_chat_messages_path(chat_session), params: { content: "Hello again" }
+
+        expect(response).to have_http_status(:created)
+        expect(chat_session.reload.status).to eq("active")
+        expect(chat_session.messages.where(role: "user", content: "Hello again")).to exist
+      end
+
       it "returns error when content is blank" do
         post chat_session_chat_messages_path(chat_session), params: { content: "" }
         expect(response).to have_http_status(:unprocessable_content)

--- a/spec/services/chat_sessions/resume_spec.rb
+++ b/spec/services/chat_sessions/resume_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ChatSessions::Resume do
+  let(:account) { create(:account) }
+  let(:user) { create(:user, account: account) }
+
+  describe ".call" do
+    it "reopens a closed API session" do
+      session = create(:chat_session, :closed, account: account, created_by: user, idle_timeout_at: 1.day.ago)
+
+      freeze_time do
+        described_class.call(chat_session: session)
+
+        expect(session.reload.status).to eq("active")
+        expect(session.idle_timeout_at).to be_within(5.seconds).of(30.minutes.from_now)
+        expect(session.metadata).to include(
+          "resume_count" => 1,
+          "last_resumed_at" => Time.current.iso8601
+        )
+      end
+    end
+
+    it "increments resume metadata" do
+      session = create(:chat_session, :closed, account: account, created_by: user,
+        metadata: { "resume_count" => 2, "last_resumed_at" => 1.day.ago.iso8601 })
+
+      described_class.call(chat_session: session)
+
+      expect(session.reload.metadata["resume_count"]).to eq(3)
+    end
+
+    it "clears close snapshot metadata when reopening" do
+      session = create(:chat_session, :closed, account: account, created_by: user,
+        metadata: {
+          "closed_at" => 1.day.ago.iso8601,
+          "total_messages" => 9,
+          "total_tokens_input" => 100,
+          "total_tokens_output" => 50,
+          "total_cost_cents" => 12
+        })
+
+      described_class.call(chat_session: session)
+
+      expect(session.reload.metadata).not_to include(
+        "closed_at",
+        "total_messages",
+        "total_tokens_input",
+        "total_tokens_output",
+        "total_cost_cents"
+      )
+    end
+
+    it "treats already-active API sessions as a no-op" do
+      session = create(:chat_session, account: account, created_by: user)
+
+      expect {
+        described_class.call(chat_session: session)
+      }.not_to change { session.reload.attributes.slice("status", "metadata") }
+    end
+
+    it "rejects workspace sessions" do
+      session = create(:chat_session, :closed, :workspace, account: account, created_by: user)
+
+      expect {
+        described_class.call(chat_session: session)
+      }.to raise_error(ArgumentError, /cannot be resumed/)
+    end
+
+    it "rejects idle sessions" do
+      session = create(:chat_session, :idle, account: account, created_by: user)
+
+      expect {
+        described_class.call(chat_session: session)
+      }.to raise_error(ArgumentError, /active or closed/)
+    end
+  end
+end

--- a/spec/services/chat_sessions/send_message_spec.rb
+++ b/spec/services/chat_sessions/send_message_spec.rb
@@ -91,12 +91,47 @@ RSpec.describe ChatSessions::SendMessage do
       expect(chat_session.idle_timeout_at).to be_within(5.seconds).of(30.minutes.from_now)
     end
 
-    it "raises when session is not active" do
+    it "resumes a closed API session before sending the next message" do
+      closed_session = create(:chat_session, :closed, account: account, created_by: user)
+
+      described_class.call(chat_session: closed_session, content: "Hello", llm_client: llm_client)
+
+      expect(closed_session.reload.status).to eq("active")
+      expect(closed_session.metadata).to include("resume_count" => 1)
+      expect(closed_session.metadata["last_resumed_at"]).to be_present
+    end
+
+    it "does not reopen a closed session for blank content" do
       closed_session = create(:chat_session, :closed, account: account, created_by: user)
 
       expect {
+        described_class.call(chat_session: closed_session, content: "", llm_client: llm_client)
+      }.to raise_error(ArgumentError, /blank/)
+
+      expect(closed_session.reload.status).to eq("closed")
+      expect(closed_session.metadata).not_to include("resume_count")
+    end
+
+    it "does not reopen a closed session when the token limit is already exceeded" do
+      closed_session = create(:chat_session, :closed, account: account, created_by: user)
+      create(:tenant_setting, account: account,
+        features: { "chat_settings" => { "chat_session_token_limit" => 100 } })
+      create(:token_usage, :chat, chat_session: closed_session, input_tokens: 80, output_tokens: 30)
+
+      expect {
         described_class.call(chat_session: closed_session, content: "Hello", llm_client: llm_client)
-      }.to raise_error(ArgumentError, /active/)
+      }.to raise_error(ChatSessions::TokenLimitExceededError)
+
+      expect(closed_session.reload.status).to eq("closed")
+      expect(closed_session.metadata).not_to include("resume_count")
+    end
+
+    it "raises when a closed workspace session is resumed" do
+      closed_session = create(:chat_session, :closed, :workspace, account: account, created_by: user)
+
+      expect {
+        described_class.call(chat_session: closed_session, content: "Hello", llm_client: llm_client)
+      }.to raise_error(ArgumentError, /cannot be resumed/)
     end
 
     it "raises when content is blank" do


### PR DESCRIPTION
## Summary
- add a dedicated chat-session resume service for closed API sessions
- only reopen a session after content and token-limit checks pass
- preserve correct UX and state by rejecting closed workspace resumes and clearing stale close snapshot metadata on reopen

## Testing
- `bundle exec rspec spec/services/chat_sessions/resume_spec.rb spec/services/chat_sessions/send_message_spec.rb spec/requests/chat_messages_spec.rb spec/jobs/chat_sessions/process_message_job_spec.rb spec/channels/chat_channel_spec.rb`
- pre-commit lint checks passed during commit