### PR TITLE
fix(runners): harden Codex test-agent auth handling

### DIFF
--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -361,6 +361,7 @@ module Containers
     private def execute_unlocked(command, timeout: nil, startup_timeout: nil, idle_timeout: nil, stream: true, env: {}, preparation: nil, heartbeat_path: nil, abort_patterns: nil)
       timeout ||= options[:timeout_seconds]
       cmd_array = command.is_a?(Array) ? command : [ "sh", "-c", command ]
+      cmd_array = close_stdin_for_codex_exec(cmd_array)
       exec_options = { wait: timeout, Env: exec_environment(env) }
       cleanup_steps = apply_execution_preparation(preparation, env: env)
 
@@ -704,6 +705,13 @@ module Containers
           end
         end
       end
+    end
+
+    def close_stdin_for_codex_exec(command)
+      return command unless codex_exec_command?(command)
+
+      escaped = command.map { |part| Shellwords.escape(part.to_s) }.join(" ")
+      [ "sh", "-lc", "exec #{escaped} < /dev/null" ]
     end
 
     # Stops and removes the container, cleaning up resources.
@@ -1142,6 +1150,18 @@ module Containers
 
       mount = codex_subscription_auth_mount
       log_system("container.codex_credentials_shared", source_path: mount.host_path)
+      seed_local_credentials!(
+        source_path: mount.config_path,
+        target_path: "/home/agent/.codex",
+        files: [ "auth.json" ],
+        success_log_key: "container.codex_credentials_seeded",
+        failure_log_key: "container.codex_credentials_seed_failed"
+      )
+      verify_container_file_present!(
+        path: "/home/agent/.codex/auth.json",
+        failure_log_key: "container.codex_credentials_seed_failed",
+        error_message: "Codex subscription auth.json was not copied into the container"
+      )
       seed_sanitized_codex_config!(source_path: mount.config_path)
 
       seed_codex_notify_hook!
@@ -1283,11 +1303,14 @@ module Containers
 
         if acquired
           log_system("container.codex_auth_lock.acquired", lockfile: lockfile)
-          yield
+          result = yield
+          sync_codex_auth_file_to_source!
+          result
         else
           log_system("container.codex_auth_lock.timeout",
             lockfile: lockfile,
             lock_timeout_seconds: lock_timeout)
+          log_system("container.codex_auth_sync_skipped_without_lock", source_path: codex_subscription_auth_source_path)
           yield
         end
       ensure
@@ -1484,6 +1507,21 @@ module Containers
       end
     rescue Docker::Error::DockerError, SystemCallError => e
       log_system(failure_log_key, error: e.message)
+    end
+
+    def verify_container_file_present!(path:, failure_log_key:, error_message:)
+      _stdout, stderr, status = backend.exec_in_container(
+        container,
+        [ "sh", "-lc", "test -s #{Shellwords.escape(path)}" ],
+        user: "agent"
+      )
+      return if status.to_i.zero?
+
+      log_system(failure_log_key, error: [ error_message, Array(stderr).join.presence ].compact.join(": "), path: path)
+      raise ProvisionError, error_message
+    rescue Docker::Error::DockerError => e
+      log_system(failure_log_key, error: e.message, path: path)
+      raise ProvisionError, error_message
     end
 
     # Batches all ownership fixes into a single container exec call.
@@ -1856,10 +1894,6 @@ module Containers
          File.directory?(claude_config_host_path) &&
          File.file?(File.join(claude_config_host_path, ".credentials.json"))
         binds << "#{claude_config_host_path}:/home/agent/.claude-host:ro"
-      end
-
-      if backend.supports_host_paths? && codex_subscription_auth_host_mount_path.present?
-        binds.concat(codex_subscription_auth_file_binds)
       end
 
       if backend.supports_host_paths? &&
@@ -2350,22 +2384,34 @@ module Containers
       (codex_config_candidate_paths + [ codex_local_config_path ]).compact.uniq
     end
 
-    def codex_subscription_auth_file_binds
-      base = codex_subscription_auth_host_mount_path
-      return [] unless base.present?
-
-      [ "#{File.join(base, 'auth.json')}:/home/agent/.codex/auth.json:rw" ]
-    end
-
     def codex_auth_lock_required?(command)
-      codex_subscription_auth_host_mount_path.present? && codex_exec_command?(command)
+      codex_subscription_auth? && codex_exec_command?(command)
     end
 
     def codex_exec_command?(command)
-      parts = command.is_a?(Array) ? command : Shellwords.split(command.to_s)
+      parts = normalized_command_parts(command)
+      return false if parts.empty?
+
+      if parts.first == "env"
+        index = 1
+        while index < parts.length
+          case parts[index]
+          when "-u"
+            index += 2
+          else
+            break
+          end
+        end
+        parts = parts[index..] || []
+      end
+
       parts.first(2) == %w[codex exec]
     rescue ArgumentError
       false
+    end
+
+    def normalized_command_parts(command)
+      command.is_a?(Array) ? command.map(&:to_s) : Shellwords.split(command.to_s)
     end
 
     def codex_auth_lockfile_path
@@ -2374,12 +2420,37 @@ module Containers
       base_path = lock_config&.dig(:path)&.sub(/\.lock\z/, "")
       raise TypeError, "no lock path configured" unless base_path
 
-      host_mount = codex_subscription_auth_host_mount_path
-      digest = Digest::SHA256.hexdigest(host_mount)[0, 16]
+      source_path = codex_subscription_auth_source_path
+      digest = Digest::SHA256.hexdigest(source_path)[0, 16]
       "#{base_path}-#{digest}.lock"
     rescue TypeError
       base = lock_config&.dig(:path)&.sub(/\.lock\z/, "") || "/tmp/codex-auth"
       "#{base}-missing.lock"
+    end
+
+    def codex_subscription_auth_source_path
+      codex_subscription_auth_mount&.config_path
+    end
+
+    def sync_codex_auth_file_to_source!
+      source_path = codex_subscription_auth_source_path
+      return if source_path.blank?
+
+      source_file = File.join(source_path, "auth.json")
+      stdout, stderr, status = backend.exec_in_container(
+        container,
+        [ "sh", "-lc", "base64 -w0 /home/agent/.codex/auth.json" ],
+        user: "agent"
+      )
+      raise Docker::Error::DockerError, Array(stderr).join if status.to_i != 0
+
+      encoded = Array(stdout).join
+      return if encoded.blank?
+
+      File.binwrite(source_file, Base64.strict_decode64(encoded))
+      log_system("container.codex_auth_synced", source_path: source_path)
+    rescue Docker::Error::DockerError, SystemCallError, ArgumentError => e
+      log_system("container.codex_auth_sync_failed", error: e.message, source_path: source_path)
     end
 
     def codex_harness_provider

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -360,8 +360,8 @@ module Containers
 
     private def execute_unlocked(command, timeout: nil, startup_timeout: nil, idle_timeout: nil, stream: true, env: {}, preparation: nil, heartbeat_path: nil, abort_patterns: nil)
       timeout ||= options[:timeout_seconds]
-      cmd_array = command.is_a?(Array) ? command : [ "sh", "-c", command ]
-      cmd_array = close_stdin_for_codex_exec(cmd_array)
+      cmd_array = close_stdin_for_codex_exec(command)
+      cmd_array = cmd_array.is_a?(Array) ? cmd_array : [ "sh", "-c", cmd_array ]
       exec_options = { wait: timeout, Env: exec_environment(env) }
       cleanup_steps = apply_execution_preparation(preparation, env: env)
 
@@ -710,7 +710,8 @@ module Containers
     def close_stdin_for_codex_exec(command)
       return command unless codex_exec_command?(command)
 
-      escaped = command.map { |part| Shellwords.escape(part.to_s) }.join(" ")
+      parts = command.is_a?(Array) ? command : Shellwords.split(command.to_s)
+      escaped = parts.map { |part| Shellwords.escape(part.to_s) }.join(" ")
       [ "sh", "-lc", "exec #{escaped} < /dev/null" ]
     end
 

--- a/app/services/providers/test_agent.rb
+++ b/app/services/providers/test_agent.rb
@@ -155,7 +155,7 @@ module Providers
           # behaviour match real agent runs.
           execute_container_diagnostic
         elsif harness_health_check_supported?
-          process_harness_result(execute_harness_health_check)
+          execute_harness_health_check_with_fallback
         else
           execute_container_smoke_test
         end
@@ -259,28 +259,47 @@ module Providers
       AgentHarness.check_provider(harness_provider_name, timeout: TIMEOUT)
     end
 
-    # Runs the agent-harness smoke_test contract inside a provisioned container.
-    #
-    # Instead of building provider-specific CLI commands locally, this delegates
-    # to the harness provider's smoke_test method with a container-backed executor.
-    def execute_container_smoke_test
+    def execute_harness_health_check_with_fallback
+      process_harness_result(maybe_fallback_harness_result(execute_harness_health_check))
+    rescue StandardError => e
+      raise unless fallback_to_container_smoke_test?(e.message)
+
+      log_harness_fallback(error_message: e.message, error_class: e.class.name)
+      execute_container_smoke_test
+    end
+
+    def maybe_fallback_harness_result(result)
+      return result unless fallback_to_container_smoke_test?(result[:message], result[:output])
+
+      log_harness_fallback(error_message: [ result[:message], result[:output] ].compact.join("\n"))
+      execute_container_smoke_test_raw
+    end
+
+    def execute_container_smoke_test_raw
       test_run = build_test_run
 
       begin
         test_run.with_container do |run|
           executor = Containers::HarnessExecutor.new(run)
           prepare_kilocode_config!(run) if kilocode_direct_outbound?
-          harness_result = AgentHarness.check_provider(
+          AgentHarness.check_provider(
             harness_provider_name,
             timeout: TIMEOUT,
             executor: executor,
             provider_runtime: container_provider_runtime
           )
-          process_harness_result(harness_result)
         end
       ensure
         test_run.destroy! if test_run&.persisted?
       end
+    end
+
+    # Runs the agent-harness smoke_test contract inside a provisioned container.
+    #
+    # Instead of building provider-specific CLI commands locally, this delegates
+    # to the harness provider's smoke_test method with a container-backed executor.
+    def execute_container_smoke_test
+      process_harness_result(execute_container_smoke_test_raw)
     end
 
     def process_harness_result(result)
@@ -472,6 +491,26 @@ module Providers
       return false if effective_provider.subscription?
       api_key_name = ProviderSupport.proxy_health_check_api_key_for(effective_provider.provider_key)
       !!(api_key_name && proxy_api_key_configured?(api_key_name))
+    end
+
+    def fallback_to_container_smoke_test?(*messages)
+      return false unless test_project
+
+      combined = messages.compact.map { |message| normalize_output_text(message) }.join("\n")
+      return false if combined.blank?
+
+      combined.match?(/permission denied \(os error 13\)/i) ||
+        combined.match?(/sandbox failure detected/i) ||
+        combined.match?(/bwrap:.*permission denied/i)
+    end
+
+    def log_harness_fallback(error_message:, error_class: nil)
+      Rails.logger.warn(
+        message: "providers.test_agent.host_health_check_fallback",
+        provider_key: effective_provider.provider_key,
+        error_class: error_class,
+        error_message: normalize_output_text(error_message)
+      )
     end
 
     def harness_provider_name

--- a/app/services/providers/test_agent.rb
+++ b/app/services/providers/test_agent.rb
@@ -255,51 +255,22 @@ module Providers
       Result.new(success: true, error_type: nil, message: "Diagnostic passed (#{summary})")
     end
 
+    include TestAgentHealthCheckFallback
+
+    def harness_health_check_key
+      harness_provider_name
+    end
+
+    def harness_fallback_log_prefix
+      "providers.test_agent"
+    end
+
+    def harness_fallback_log_context
+      { provider_key: effective_provider.provider_key }
+    end
+
     def execute_harness_health_check
       AgentHarness.check_provider(harness_provider_name, timeout: TIMEOUT)
-    end
-
-    def execute_harness_health_check_with_fallback
-      process_harness_result(maybe_fallback_harness_result(execute_harness_health_check))
-    rescue StandardError => e
-      raise unless fallback_to_container_smoke_test?(e.message)
-
-      log_harness_fallback(error_message: e.message, error_class: e.class.name)
-      execute_container_smoke_test
-    end
-
-    def maybe_fallback_harness_result(result)
-      return result unless fallback_to_container_smoke_test?(result[:message], result[:output])
-
-      log_harness_fallback(error_message: [ result[:message], result[:output] ].compact.join("\n"))
-      execute_container_smoke_test_raw
-    end
-
-    def execute_container_smoke_test_raw
-      test_run = build_test_run
-
-      begin
-        test_run.with_container do |run|
-          executor = Containers::HarnessExecutor.new(run)
-          prepare_kilocode_config!(run) if kilocode_direct_outbound?
-          AgentHarness.check_provider(
-            harness_provider_name,
-            timeout: TIMEOUT,
-            executor: executor,
-            provider_runtime: container_provider_runtime
-          )
-        end
-      ensure
-        test_run.destroy! if test_run&.persisted?
-      end
-    end
-
-    # Runs the agent-harness smoke_test contract inside a provisioned container.
-    #
-    # Instead of building provider-specific CLI commands locally, this delegates
-    # to the harness provider's smoke_test method with a container-backed executor.
-    def execute_container_smoke_test
-      process_harness_result(execute_container_smoke_test_raw)
     end
 
     def process_harness_result(result)
@@ -491,26 +462,6 @@ module Providers
       return false if effective_provider.subscription?
       api_key_name = ProviderSupport.proxy_health_check_api_key_for(effective_provider.provider_key)
       !!(api_key_name && proxy_api_key_configured?(api_key_name))
-    end
-
-    def fallback_to_container_smoke_test?(*messages)
-      return false unless test_project
-
-      combined = messages.compact.map { |message| normalize_output_text(message) }.join("\n")
-      return false if combined.blank?
-
-      combined.match?(/permission denied \(os error 13\)/i) ||
-        combined.match?(/sandbox failure detected/i) ||
-        combined.match?(/bwrap:.*permission denied/i)
-    end
-
-    def log_harness_fallback(error_message:, error_class: nil)
-      Rails.logger.warn(
-        message: "providers.test_agent.host_health_check_fallback",
-        provider_key: effective_provider.provider_key,
-        error_class: error_class,
-        error_message: normalize_output_text(error_message)
-      )
     end
 
     def harness_provider_name

--- a/app/services/runners/test_agent.rb
+++ b/app/services/runners/test_agent.rb
@@ -255,51 +255,22 @@ module Runners
       Result.new(success: true, error_type: nil, message: "Diagnostic passed (#{summary})")
     end
 
+    include TestAgentHealthCheckFallback
+
+    def harness_health_check_key
+      harness_runner_key
+    end
+
+    def harness_fallback_log_prefix
+      "runners.test_agent"
+    end
+
+    def harness_fallback_log_context
+      { runner_key: runner.runner_key }
+    end
+
     def execute_harness_health_check
       AgentHarness.check_provider(harness_runner_key, timeout: TIMEOUT)
-    end
-
-    def execute_harness_health_check_with_fallback
-      process_harness_result(maybe_fallback_harness_result(execute_harness_health_check))
-    rescue StandardError => e
-      raise unless fallback_to_container_smoke_test?(e.message)
-
-      log_harness_fallback(error_message: e.message, error_class: e.class.name)
-      execute_container_smoke_test
-    end
-
-    def maybe_fallback_harness_result(result)
-      return result unless fallback_to_container_smoke_test?(result[:message], result[:output])
-
-      log_harness_fallback(error_message: [ result[:message], result[:output] ].compact.join("\n"))
-      execute_container_smoke_test_raw
-    end
-
-    def execute_container_smoke_test_raw
-      test_run = build_test_run
-
-      begin
-        test_run.with_container do |run|
-          executor = Containers::HarnessExecutor.new(run)
-          prepare_kilocode_config!(run) if kilocode_direct_outbound?
-          AgentHarness.check_provider(
-            harness_runner_key,
-            timeout: TIMEOUT,
-            executor: executor,
-            provider_runtime: container_provider_runtime
-          )
-        end
-      ensure
-        test_run.destroy! if test_run&.persisted?
-      end
-    end
-
-    # Runs the agent-harness smoke_test contract inside a provisioned container.
-    #
-    # Instead of building provider-specific CLI commands locally, this delegates
-    # to the harness provider's smoke_test method with a container-backed executor.
-    def execute_container_smoke_test
-      process_harness_result(execute_container_smoke_test_raw)
     end
 
     def process_harness_result(result)
@@ -530,26 +501,6 @@ module Runners
       return false if runner.subscription?
       api_key_name = RunnerSupport.proxy_health_check_api_key_for(runner.runner_key)
       !!(api_key_name && proxy_api_key_configured?(api_key_name))
-    end
-
-    def fallback_to_container_smoke_test?(*messages)
-      return false unless test_project
-
-      combined = messages.compact.map { |message| normalize_output_text(message) }.join("\n")
-      return false if combined.blank?
-
-      combined.match?(/permission denied \(os error 13\)/i) ||
-        combined.match?(/sandbox failure detected/i) ||
-        combined.match?(/bwrap:.*permission denied/i)
-    end
-
-    def log_harness_fallback(error_message:, error_class: nil)
-      Rails.logger.warn(
-        message: "runners.test_agent.host_health_check_fallback",
-        runner_key: runner.runner_key,
-        error_class: error_class,
-        error_message: normalize_output_text(error_message)
-      )
     end
 
     def harness_runner_key

--- a/app/services/runners/test_agent.rb
+++ b/app/services/runners/test_agent.rb
@@ -155,7 +155,7 @@ module Runners
           # behaviour match real agent runs.
           execute_container_diagnostic
         elsif harness_health_check_supported?
-          process_harness_result(execute_harness_health_check)
+          execute_harness_health_check_with_fallback
         else
           execute_container_smoke_test
         end
@@ -259,28 +259,47 @@ module Runners
       AgentHarness.check_provider(harness_runner_key, timeout: TIMEOUT)
     end
 
-    # Runs the agent-harness smoke_test contract inside a provisioned container.
-    #
-    # Instead of building provider-specific CLI commands locally, this delegates
-    # to the harness provider's smoke_test method with a container-backed executor.
-    def execute_container_smoke_test
+    def execute_harness_health_check_with_fallback
+      process_harness_result(maybe_fallback_harness_result(execute_harness_health_check))
+    rescue StandardError => e
+      raise unless fallback_to_container_smoke_test?(e.message)
+
+      log_harness_fallback(error_message: e.message, error_class: e.class.name)
+      execute_container_smoke_test
+    end
+
+    def maybe_fallback_harness_result(result)
+      return result unless fallback_to_container_smoke_test?(result[:message], result[:output])
+
+      log_harness_fallback(error_message: [ result[:message], result[:output] ].compact.join("\n"))
+      execute_container_smoke_test_raw
+    end
+
+    def execute_container_smoke_test_raw
       test_run = build_test_run
 
       begin
         test_run.with_container do |run|
           executor = Containers::HarnessExecutor.new(run)
           prepare_kilocode_config!(run) if kilocode_direct_outbound?
-          harness_result = AgentHarness.check_provider(
+          AgentHarness.check_provider(
             harness_runner_key,
             timeout: TIMEOUT,
             executor: executor,
             provider_runtime: container_provider_runtime
           )
-          process_harness_result(harness_result)
         end
       ensure
         test_run.destroy! if test_run&.persisted?
       end
+    end
+
+    # Runs the agent-harness smoke_test contract inside a provisioned container.
+    #
+    # Instead of building provider-specific CLI commands locally, this delegates
+    # to the harness provider's smoke_test method with a container-backed executor.
+    def execute_container_smoke_test
+      process_harness_result(execute_container_smoke_test_raw)
     end
 
     def process_harness_result(result)
@@ -511,6 +530,26 @@ module Runners
       return false if runner.subscription?
       api_key_name = RunnerSupport.proxy_health_check_api_key_for(runner.runner_key)
       !!(api_key_name && proxy_api_key_configured?(api_key_name))
+    end
+
+    def fallback_to_container_smoke_test?(*messages)
+      return false unless test_project
+
+      combined = messages.compact.map { |message| normalize_output_text(message) }.join("\n")
+      return false if combined.blank?
+
+      combined.match?(/permission denied \(os error 13\)/i) ||
+        combined.match?(/sandbox failure detected/i) ||
+        combined.match?(/bwrap:.*permission denied/i)
+    end
+
+    def log_harness_fallback(error_message:, error_class: nil)
+      Rails.logger.warn(
+        message: "runners.test_agent.host_health_check_fallback",
+        runner_key: runner.runner_key,
+        error_class: error_class,
+        error_message: normalize_output_text(error_message)
+      )
     end
 
     def harness_runner_key

--- a/app/services/test_agent_health_check_fallback.rb
+++ b/app/services/test_agent_health_check_fallback.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# Shared host-health-check-with-container-fallback logic for Runners::TestAgent
+# and Providers::TestAgent.
+#
+# Including classes must implement:
+#   - #harness_health_check_key  — the harness provider/runner key Symbol to
+#       pass to AgentHarness.check_provider
+#   - #harness_fallback_log_prefix — log message prefix (e.g. "runners.test_agent")
+#   - #harness_fallback_log_context — Hash of extra log attributes (e.g. { runner_key: "codex" })
+#
+# Including classes must also define:
+#   - TIMEOUT constant
+#   - #test_project, #build_test_run, #execute_harness_health_check, #process_harness_result
+#   - #kilocode_direct_outbound?, #prepare_kilocode_config!, #container_provider_runtime
+#   - #normalize_output_text (via OutputSanitizer)
+module TestAgentHealthCheckFallback
+  private
+
+  def execute_harness_health_check_with_fallback
+    process_harness_result(maybe_fallback_harness_result(execute_harness_health_check))
+  rescue StandardError => e
+    raise unless fallback_to_container_smoke_test?(e.message)
+
+    log_harness_fallback(error_message: e.message, error_class: e.class.name)
+    execute_container_smoke_test
+  end
+
+  def maybe_fallback_harness_result(result)
+    return result unless fallback_to_container_smoke_test?(result[:message], result[:output])
+
+    log_harness_fallback(error_message: [ result[:message], result[:output] ].compact.join("\n"))
+    execute_container_smoke_test_raw
+  end
+
+  def execute_container_smoke_test_raw
+    test_run = build_test_run
+
+    begin
+      test_run.with_container do |run|
+        executor = Containers::HarnessExecutor.new(run)
+        prepare_kilocode_config!(run) if kilocode_direct_outbound?
+        AgentHarness.check_provider(
+          harness_health_check_key,
+          timeout: self.class::TIMEOUT,
+          executor: executor,
+          provider_runtime: container_provider_runtime
+        )
+      end
+    ensure
+      test_run.destroy! if test_run&.persisted?
+    end
+  end
+
+  # Runs the agent-harness smoke_test contract inside a provisioned container.
+  #
+  # Instead of building provider-specific CLI commands locally, this delegates
+  # to the harness provider's smoke_test method with a container-backed executor.
+  def execute_container_smoke_test
+    process_harness_result(execute_container_smoke_test_raw)
+  end
+
+  def fallback_to_container_smoke_test?(*messages)
+    return false unless test_project
+
+    combined = messages.compact.map { |message| normalize_output_text(message) }.join("\n")
+    return false if combined.blank?
+
+    combined.match?(/permission denied \(os error 13\)/i) ||
+      combined.match?(/sandbox failure detected/i) ||
+      combined.match?(/bwrap:.*permission denied/i)
+  end
+
+  def log_harness_fallback(error_message:, error_class: nil)
+    Rails.logger.warn(
+      message: "#{harness_fallback_log_prefix}.host_health_check_fallback",
+      **harness_fallback_log_context,
+      error_class: error_class,
+      error_message: normalize_output_text(error_message)
+    )
+  end
+end

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -1411,10 +1411,10 @@ RSpec.describe Containers::Provision do
         FileUtils.rm_rf(codex_config_dir)
       end
 
-      it "bind-mounts only Codex auth and sets the subscription marker" do
+      it "keeps Codex auth in tmpfs and sets the subscription marker" do
         expect(Docker::Container).to receive(:create) do |config|
           binds = config["HostConfig"]["Binds"]
-          expect(binds).to include("#{File.join(codex_config_dir, 'auth.json')}:/home/agent/.codex/auth.json:rw")
+          expect(binds.none? { |bind| bind.include?("/home/agent/.codex/auth.json") }).to be true
           expect(binds.none? { |bind| bind.include?("/home/agent/.codex/config.toml") }).to be true
           env = config["Env"]
           expect(env).to include("PAID_CODEX_SUBSCRIPTION_AUTH=1")
@@ -1426,19 +1426,40 @@ RSpec.describe Containers::Provision do
         service.provision
       end
 
-      it "uses a shared writable Codex auth mount instead of copying credentials" do
+      it "copies Codex auth into tmpfs and records the shared source path" do
         allow(agent_run).to receive(:log!).and_call_original
 
         service.provision
 
-        expect(mock_container).not_to have_received(:exec).with(
-          [ "sh", "-lc", include("/home/agent/.codex/config.toml").and(include('model_provider = "paid"')) ],
+        expect(mock_container).to have_received(:exec).with(
+          [ "sh", "-lc", satisfy { |cmd|
+            cmd.include?("/home/agent/.codex/auth.json") &&
+              decoded_base64_content(cmd).include?("{")
+          } ],
           user: "agent"
         )
         expect(agent_run).to have_received(:log!).with(
           "system",
           "container.codex_credentials_shared",
           metadata: hash_including(source_path: codex_config_dir)
+        )
+      end
+
+      it "fails clearly when Codex auth is not actually copied into tmpfs" do
+        allow(mock_container).to receive(:exec) do |cmd, **_opts|
+          shell = cmd.last.to_s
+          if cmd.first(2) == [ "sh", "-lc" ] && shell.include?("/home/agent/.codex/auth.json")
+            [ [], [ "write failed\n" ], 1 ]
+          else
+            [ [], [], 0 ]
+          end
+        end
+
+        expect {
+          service.provision
+        }.to raise_error(
+          Containers::Provision::ProvisionError,
+          /Codex subscription auth\.json was not copied into the container/
         )
       end
 
@@ -1522,10 +1543,10 @@ RSpec.describe Containers::Provision do
         FileUtils.rm_rf(codex_local_dir)
       end
 
-      it "bind-mounts local Codex auth as the shared writable auth source" do
+      it "does not bind-mount local Codex auth directly" do
         expect(Docker::Container).to receive(:create) do |config|
           binds = config["HostConfig"]["Binds"]
-          expect(binds).to include("#{File.join(codex_local_dir, 'auth.json')}:/home/agent/.codex/auth.json:rw")
+          expect(binds.none? { |bind| bind.include?("/home/agent/.codex/auth.json") }).to be true
           expect(binds.none? { |bind| bind.include?(":/home/agent/.codex:rw") }).to be true
           expect(config["Env"]).to include("PAID_CODEX_SUBSCRIPTION_AUTH=1")
 
@@ -1537,13 +1558,13 @@ RSpec.describe Containers::Provision do
         service.provision
       end
 
-      it "uses shared Codex auth and writes sanitized config into the writable tmpfs" do
+      it "copies shared Codex auth and writes sanitized config into the writable tmpfs" do
         service.provision
 
-        expect(mock_container).not_to have_received(:exec).with(
+        expect(mock_container).to have_received(:exec).with(
           [ "sh", "-lc", satisfy { |cmd|
             cmd.include?("/home/agent/.codex/auth.json") &&
-              !cmd.include?("/home/agent/.codex/config.toml")
+              decoded_base64_content(cmd).include?("\"refresh_token\":\"test-token\"")
           } ],
           user: "agent"
         )
@@ -1558,7 +1579,7 @@ RSpec.describe Containers::Provision do
         )
       end
 
-      it "translates a mounted local Codex path to the Docker host bind source" do
+      it "uses the mounted local Codex path as the shared source without binding auth directly" do
         mount_source = Dir.mktmpdir("codex-host")
         mount_destination = File.dirname(codex_local_dir)
         current_container = instance_double(
@@ -1569,8 +1590,7 @@ RSpec.describe Containers::Provision do
 
         expect(Docker::Container).to receive(:create) do |config|
           binds = config["HostConfig"]["Binds"]
-          expected_source = File.join(mount_source, File.basename(codex_local_dir), "auth.json")
-          expect(binds).to include("#{expected_source}:/home/agent/.codex/auth.json:rw")
+          expect(binds.none? { |bind| bind.include?("/home/agent/.codex/auth.json") }).to be true
           mock_container
         end
 
@@ -2541,6 +2561,29 @@ RSpec.describe Containers::Provision do
 
         expect(agent_run).to have_received(:log!).with(
           "system", "container.codex_auth_lock.acquired", metadata: hash_including(:lockfile)
+        )
+      end
+
+      it "treats env-wrapped Codex execution as a Codex command" do
+        allow(agent_run).to receive(:log!)
+
+        service.execute([ "env", "-u", "OPENAI_API_KEY", "codex", "exec", "--dangerously-bypass-approvals-and-sandbox", "--", "prompt" ])
+
+        expect(agent_run).to have_received(:log!).with(
+          "system", "container.codex_auth_lock.acquired", metadata: hash_including(:lockfile)
+        )
+      end
+
+      it "does not sync shared auth back after timing out on the lock" do
+        allow(service).to receive(:acquire_lock_with_timeout).and_return(false)
+        allow(service).to receive(:sync_codex_auth_file_to_source!)
+        allow(agent_run).to receive(:log!)
+
+        service.execute([ "codex", "exec", "--dangerously-bypass-approvals-and-sandbox", "--", "prompt" ])
+
+        expect(service).not_to have_received(:sync_codex_auth_file_to_source!)
+        expect(agent_run).to have_received(:log!).with(
+          "system", "container.codex_auth_sync_skipped_without_lock", metadata: hash_including(:source_path)
         )
       end
 

--- a/spec/services/runners/test_agent_spec.rb
+++ b/spec/services/runners/test_agent_spec.rb
@@ -259,6 +259,54 @@ RSpec.describe Runners::TestAgent do
       end
     end
 
+    context "when the codex host health check hits a permission error" do
+      let(:api_key_record) { create(:runner_api_key, user: user, api_service_type: "openai") }
+      let(:runner_record) { create(:runner, :api_key, user: user, runner_key: "codex", enabled_for_agent_runs: false, enabled_for_fallback: false, provider_api_key: api_key_record) }
+      let(:host_health_result) do
+        {
+          name: :codex,
+          status: "error",
+          message: "Permission denied (os error 13)",
+          error_category: :unknown,
+          latency_ms: 12
+        }
+      end
+      let(:container_health_result) do
+        {
+          name: :codex,
+          status: "ok",
+          message: "All checks passed",
+          output: "OK",
+          error_category: nil,
+          latency_ms: 18
+        }
+      end
+
+      before do
+        allow(RunnerSupport).to receive_messages(supported_runner_key?: true,
+          container_executable_runner_key?: true, harness_runner_key_for: "codex")
+        stub_proxy_api_key(:openai, "sk-test-key")
+        stub_insert_all
+        allow(test_run).to receive(:with_container).and_yield(test_run)
+        allow(AgentHarness).to receive(:check_provider).and_return(host_health_result, container_health_result)
+      end
+
+      it "falls back to the container smoke test" do
+        result = described_class.call(runner: provider)
+
+        expect(result).to be_success
+        expect(result.message).to eq("Agent is healthy")
+        expect(AgentHarness).to have_received(:check_provider).with(:codex, timeout: 60).once
+        expect(AgentHarness).to have_received(:check_provider).with(
+          :codex,
+          hash_including(
+            timeout: 60,
+            executor: an_instance_of(Containers::HarnessExecutor)
+          )
+        ).once
+      end
+    end
+
     context "when agent-harness returns a binary-encoded failure message" do
       let(:api_key_record) { create(:runner_api_key, user: user, api_service_type: "openai") }
       let(:runner_record) { create(:runner, :api_key, user: user, runner_key: "codex", enabled_for_agent_runs: false, enabled_for_fallback: false, provider_api_key: api_key_record) }


### PR DESCRIPTION
## Summary
- fall back from host Codex health checks to the container smoke path on host-side permission and sandbox failures
- copy Codex subscription auth into container tmpfs, close stdin for Codex exec, and sync refreshed auth back only when the shared auth lock is actually held
- add regression coverage for the Codex host fallback and container auth seeding/lock behavior

## Verification
- `bundle exec rspec spec/services/containers/provision_spec.rb`
- `bundle exec rspec spec/services/runners/test_agent_spec.rb`
- `bundle exec rubocop app/services/containers/provision.rb spec/services/containers/provision_spec.rb app/services/runners/test_agent.rb app/services/providers/test_agent.rb spec/services/runners/test_agent_spec.rb`