### PR TITLE
fix(containers): pre-seed Kilocode DB to prevent preflight timeout

### DIFF
--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -199,6 +199,7 @@ module Containers
       start_container
       fix_all_ownership!
       seed_opencode_database!
+      seed_kilo_database!
       seed_codex_credentials!
       seed_gemini_credentials!
       seed_copilot_credentials!
@@ -1368,6 +1369,43 @@ module Containers
       RunnerSupport.runner_key_for_agent_type(agent_run.agent_type) == "opencode"
     end
 
+    # Restores the pre-migrated Kilocode SQLite database into the runtime tmpfs.
+    # The Kilocode CLI runs a slow "one time database migration" on its first
+    # invocation in a fresh container; without this seed that migration runs
+    # inside the runner smoke preflight and exceeds the preflight wall-clock
+    # timeout, exhausting the runner. The build pre-migrates the DB into
+    # /opt/kilo-seed (see docker/agent/Dockerfile); the ~/.local/share/kilo
+    # tmpfs mount wipes the build-time copy, so it is restored after start.
+    # Mirrors seed_opencode_database!.
+    def seed_kilo_database!
+      return unless kilocode_runner_requested?
+
+      result = backend.exec_in_container(
+        container,
+        [ "sh", "-c",
+          "if [ -d /opt/kilo-seed ]; then " \
+          "cp -a /opt/kilo-seed/. /home/agent/.local/share/kilo/ && " \
+          "chown -R agent:agent /home/agent/.local/share/kilo; " \
+          "fi" ],
+        user: "root"
+      )
+      exit_code = result.is_a?(Array) ? result[2].to_i : 0
+      raise Docker::Error::DockerError, "kilo database seed exited with #{exit_code}" unless exit_code == 0
+
+      log_system("container.kilo_database_seeded")
+    rescue Docker::Error::DockerError => e
+      log_system("container.kilo_database_seed_failed", error: e.message)
+    end
+
+    def kilocode_runner_requested?
+      return false unless agent_run
+
+      runners = resolved_run_runner_candidates
+      return runners.any? { |runner| runner.runner_key == "kilocode" } if runners.any?
+
+      RunnerSupport.runner_key_for_agent_type(agent_run.agent_type) == "kilocode"
+    end
+
     def seed_gemini_credentials!
       source_files = %w[
         oauth_creds.json
@@ -2321,7 +2359,17 @@ module Containers
       RunnerSupport.runner_key_for_agent_type(agent_run.agent_type) == "codex"
     end
 
+    # Memoized: several provision-time guards (opencode/kilo/codex runner
+    # detection) resolve the candidate chain, and it is deterministic for a
+    # given run + settings. Caching avoids repeated Runner.for_identifier
+    # lookups on the provision path.
     def resolved_run_runner_candidates
+      return @resolved_run_runner_candidates if defined?(@resolved_run_runner_candidates)
+
+      @resolved_run_runner_candidates = compute_resolved_run_runner_candidates
+    end
+
+    def compute_resolved_run_runner_candidates
       return run_runner_candidates if agent_run.runner
 
       settings = resolved_user_settings

--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -238,6 +238,37 @@ RUN if [ -z "${KILOCODE_INSTALL_COMMAND}" ]; then \
     && echo "Installing Kilocode CLI via agent-harness contract: ${KILOCODE_INSTALL_COMMAND}" \
     && eval "${KILOCODE_INSTALL_COMMAND}"
 
+# Pre-seed the Kilocode SQLite database so the first container invocation does
+# not run "Performing one time database migration, may take a few minutes..."
+# inside the runner smoke preflight, where it exceeds the preflight wall-clock
+# timeout and exhausts the runner (the original symptom: exit 137 after a 60s
+# preflight timeout). The migration is a local SQLite operation that runs on
+# first `kilo run` regardless of model auth, so warming needs no credentials.
+#
+# `kilo run` opens an interactive session that never exits on its own, so we
+# cap it with `timeout`, which cleanly terminates kilo and its child binary
+# once the migration has had time to run (verified: no orphaned processes, DB
+# fully migrated). We deliberately do NOT pattern-kill "kilo": this RUN's own
+# shell argv contains "kilo", so `pkill -f kilo` would also kill the build
+# shell. The window is generous — the migration was ~60s on a heavily loaded
+# runtime host, and build hosts are far less contended — and `timeout` always
+# runs the full window because the session never exits. The next RUN fails
+# loudly if the migrated DB is absent, rather than shipping a regressed
+# (unwarmed) image. Mirrors the OpenCode pre-seed below.
+#
+# The pre-seeded DB is copied to /opt/kilo-seed so it survives the tmpfs mount
+# that Provision#host_config places at /home/agent/.local/share/kilo at
+# runtime. Containers::Provision#seed_kilo_database! restores it from /opt into
+# the tmpfs after the container starts.
+USER agent
+RUN mkdir -p /home/agent/.local/share/kilo \
+    && timeout -k 10s 120s kilo run "OK" > /dev/null 2>&1 || true
+USER root
+RUN test -f /home/agent/.local/share/kilo/kilo.db \
+    && mkdir -p /opt/kilo-seed \
+    && cp -a /home/agent/.local/share/kilo/. /opt/kilo-seed/ \
+    && chown -R agent:agent /opt/kilo-seed
+
 # OpenCode CLI: version is owned by agent-harness (installation_contract).
 # OPENCODE_PACKAGE is extracted from agent-harness at build time by
 # build-agent-image.sh / agent-image.yml — Paid no longer pins this version.

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe Containers::Provision do
     allow(provision).to receive(:ensure_network!)
     allow(provision).to receive(:fix_all_ownership!)
     allow(provision).to receive(:seed_opencode_database!)
+    allow(provision).to receive(:seed_kilo_database!)
     allow(provision).to receive(:seed_codex_credentials!)
     allow(provision).to receive(:seed_gemini_credentials!)
     allow(provision).to receive(:seed_copilot_credentials!)
@@ -1906,6 +1907,99 @@ RSpec.describe Containers::Provision do
 
         expect(agent_run).to have_received(:log!).with("system", "container.opencode_database_seed_failed",
           metadata: hash_including(error: "opencode database seed exited with 1"))
+      end
+    end
+  end
+
+  describe "#seed_kilo_database!" do
+    let(:api_key) { create(:provider_api_key, user: project.created_by, api_service_type: "anthropic") }
+    let!(:kilocode_provider) do
+      create(
+        :runner,
+        :api_key,
+        user: project.created_by,
+        runner_key: "kilocode",
+        provider_api_key: api_key,
+        config: { "kilocode" => { "api_provider" => "anthropic", "model" => "claude-sonnet-4-5" } }
+      )
+    end
+    let(:service) { described_class.new(agent_run: agent_run, worktree_path: worktree_path) }
+
+    before do
+      project.created_by.settings.update!(default_agent_runner: kilocode_provider.routing_key)
+      allow(Docker::Container).to receive(:create).and_return(mock_container)
+      allow(mock_container).to receive(:start)
+      allow(NetworkPolicy).to receive_messages(ensure_network!: mock_network, apply_firewall_rules: nil)
+      allow(Docker::Volume).to receive(:create).and_return(mock_volume)
+      allow(Docker::Volume).to receive(:get).and_raise(Docker::Error::NotFoundError)
+      allow(agent_run).to receive(:log!)
+    end
+
+    it "copies pre-seeded database from /opt/kilo-seed into the tmpfs" do
+      service.provision
+
+      expect(mock_container).to have_received(:exec).with(
+        [ "sh", "-c",
+          satisfy { |script|
+            script.include?("/opt/kilo-seed") &&
+              script.include?("/home/agent/.local/share/kilo")
+          } ],
+        user: "root"
+      )
+    end
+
+    it "logs the seeding success" do
+      service.provision
+
+      expect(agent_run).to have_received(:log!).with("system", "container.kilo_database_seeded",
+        metadata: {})
+    end
+
+    it "does not seed when the run resolves to a different runner" do
+      project.created_by.settings.update!(default_agent_runner: "claude")
+
+      service.provision
+
+      expect(mock_container).not_to have_received(:exec).with(
+        [ "sh", "-c", include("/opt/kilo-seed") ],
+        user: "root"
+      )
+    end
+
+    context "when Docker exec fails during kilo seed" do
+      before do
+        allow(mock_container).to receive(:exec) do |cmd, **opts|
+          if cmd.is_a?(Array) && cmd[0] == "sh" && cmd[1] == "-c" && cmd.last.include?("/opt/kilo-seed")
+            raise Docker::Error::DockerError, "copy failed"
+          end
+          nil
+        end
+      end
+
+      it "logs the failure but does not raise" do
+        expect { service.provision }.not_to raise_error
+
+        expect(agent_run).to have_received(:log!).with("system", "container.kilo_database_seed_failed",
+          metadata: hash_including(error: "copy failed"))
+      end
+    end
+
+    context "when the cp command exits non-zero" do
+      before do
+        allow(mock_container).to receive(:exec) do |cmd, **opts|
+          if cmd.is_a?(Array) && cmd[0] == "sh" && cmd[1] == "-c" && cmd.last.include?("/opt/kilo-seed")
+            [ [], [], 1 ]
+          else
+            nil
+          end
+        end
+      end
+
+      it "logs the failure with the exit code" do
+        expect { service.provision }.not_to raise_error
+
+        expect(agent_run).to have_received(:log!).with("system", "container.kilo_database_seed_failed",
+          metadata: hash_including(error: "kilo database seed exited with 1"))
       end
     end
   end


### PR DESCRIPTION
## Problem

Agent runs whose runner fallback chain includes **Kilocode** were failing with `All runners exhausted`. Tracing one failure ([project 19, run 28612](http://localhost:3000/projects/19/agent_runs/28612)) showed the recorded attempt died in the **runner smoke preflight** with:

> Preflight check failed: **No output before exit code 137.**

Root cause: the Kilocode CLI runs a slow `Performing one time database migration, may take a few minutes...` on its **first** `kilo run` in a fresh container. Because `~/.local/share/kilo` is a per-run tmpfs, that migration ran *inside* the preflight, exceeded the 60s wall-clock timeout (first attempt: 61.2s), and the retry was SIGKILLed (exit 137). The runner was discarded and the whole fallback chain exhausted.

OpenCode never hit this because it is **already** warmed at build time (`/opt/opencode-seed` → restored by `seed_opencode_database!`). Kilocode was simply missing the equivalent.

## Fix

Mirror the OpenCode pre-seed for Kilocode:

1. **Build** ([docker/agent/Dockerfile](docker/agent/Dockerfile)) — warm the Kilocode SQLite DB with `timeout -k 10s 120s kilo run "OK"`, then copy the migrated DB to `/opt/kilo-seed`. The follow-up `RUN` `test -f kilo.db` fails the build loudly if warming didn't produce a DB, so we never ship a regressed (unwarmed) image.
2. **Runtime** ([provision.rb](app/services/containers/provision.rb)) — `seed_kilo_database!` + `kilocode_runner_requested?` restore `/opt/kilo-seed` into the runtime tmpfs after the container starts (fires whenever kilocode is anywhere in the resolved runner candidate chain, including as a fallback — the production scenario).
3. Memoize `resolved_run_runner_candidates` — now resolved by three provision-time runner guards (opencode/kilo/codex), to avoid repeated `Runner.for_identifier` lookups on the provision path.

### Why `timeout` and not a pattern kill
`kilo run` opens an interactive session that never exits. An earlier draft backgrounded it and ran `pkill -f kilo` — but the `RUN` shell's own argv contains "kilo", so that would SIGKILL the build shell. `timeout` cleanly terminates kilo **and** its child platform binary (verified: no orphaned processes, DB fully migrated 118 KB).

## Scope decision
An offline (`--network none`) test confirmed the **DB migration is the only blocking step**: with just the DB seeded, kilo skips the migration entirely; the `~/.config/kilo` plugin install is non-blocking. So the seed covers only `~/.local/share/kilo`, exactly mirroring OpenCode.

## Testing
- `spec/services/containers/provision_spec.rb`: **229 examples, 0 failures** (incl. new `#seed_kilo_database!` specs mirroring the OpenCode coverage + the memoization change)
- `bin/rubocop` on changed Ruby: clean
- Warm + restore mechanics validated end-to-end against the live `paid-agent:latest` image (clean process teardown, migrated DB, `kilo run` skips migration after restore)

> [!NOTE]
> Takes effect once the agent image is **rebuilt** (the `/opt/kilo-seed` payload is created at build time). Until then, Kilocode runs still cold-migrate. The runtime seed no-ops gracefully on older images (`if [ -d /opt/kilo-seed ]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)