### PR TITLE
feat(projects): show PR review-phase badge instead of paid_state

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -177,6 +177,28 @@ module ApplicationHelper
     )
   end
 
+  # Badge for a PR's position in the review -> merge gate. Driven by
+  # Issue#pr_review_phase, the same field that drives the paid-ready /
+  # paid-escalated / paid-auto-merged GitHub labels, so the project page badge
+  # tracks GitHub readiness rather than "the agent finished a run" (paid_state).
+  PR_REVIEW_PHASE_STYLES = {
+    "draft" => { bg: "bg-blue-100", text: "text-blue-700", label: "In Review" },
+    "restarted" => { bg: "bg-blue-100", text: "text-blue-700", label: "In Review" },
+    "ready" => { bg: "bg-green-100", text: "text-green-700", label: "Ready" },
+    "escalated" => { bg: "bg-orange-100", text: "text-orange-700", label: "Escalated" },
+    "merged" => { bg: "bg-purple-100", text: "text-purple-700", label: "Merged" }
+  }.freeze
+
+  def pr_review_phase_badge(phase, review_count: nil)
+    styles = PR_REVIEW_PHASE_STYLES[phase] || PR_REVIEW_PHASE_STYLES["draft"]
+    title = review_count.to_i.positive? ? pluralize(review_count, "review round") : nil
+    tag.span(
+      styles[:label],
+      title: title,
+      class: "inline-flex items-center rounded-md #{styles[:bg]} px-2 py-1 text-xs font-medium #{styles[:text]}"
+    )
+  end
+
   ISSUE_LIFECYCLE_DISPLAY = {
     blocked: { emoji: "\u{1F550}", label: "Blocked" },
     in_progress: { emoji: "\u{1F9E0}", label: "In Progress" },

--- a/app/views/projects/_pull_request.html.erb
+++ b/app/views/projects/_pull_request.html.erb
@@ -26,7 +26,7 @@
     <% end %>
   </div>
   <div class="ml-4 flex flex-shrink-0 items-center space-x-2">
-    <%= paid_state_badge(pull_request.paid_state) %>
+    <%= pr_review_phase_badge(pull_request.pr_review_phase, review_count: pull_request.draft_review_count) %>
     <%= render "projects/issue_pause_toggle", issue: pull_request, project: project %>
     <% subscription_locals = { issue: pull_request, project: project } %>
     <% if local_assigns.key?(:merge_notification_issue_ids) %>

--- a/spec/helpers/application_helper_pr_review_phase_spec.rb
+++ b/spec/helpers/application_helper_pr_review_phase_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationHelper, :no_db do
+  describe "#pr_review_phase_badge" do
+    it "renders 'In Review' for draft and restarted phases" do
+      expect(helper.pr_review_phase_badge("draft")).to include("In Review", "bg-blue-100")
+      expect(helper.pr_review_phase_badge("restarted")).to include("In Review", "bg-blue-100")
+    end
+
+    it "renders 'Ready' (matching the paid-ready label) when the review gate passes" do
+      badge = helper.pr_review_phase_badge("ready")
+
+      expect(badge).to include("Ready")
+      expect(badge).to include("bg-green-100")
+    end
+
+    it "renders 'Escalated' (matching the paid-escalated label)" do
+      badge = helper.pr_review_phase_badge("escalated")
+
+      expect(badge).to include("Escalated")
+      expect(badge).to include("bg-orange-100")
+    end
+
+    it "renders 'Merged' (matching the paid-auto-merged label)" do
+      badge = helper.pr_review_phase_badge("merged")
+
+      expect(badge).to include("Merged")
+      expect(badge).to include("bg-purple-100")
+    end
+
+    it "falls back to 'In Review' for nil or unknown phases" do
+      expect(helper.pr_review_phase_badge(nil)).to include("In Review")
+      expect(helper.pr_review_phase_badge("bogus")).to include("In Review")
+    end
+
+    it "adds a pluralized review-round tooltip when review_count is positive" do
+      expect(helper.pr_review_phase_badge("draft", review_count: 1)).to include('title="1 review round"')
+      expect(helper.pr_review_phase_badge("draft", review_count: 3)).to include('title="3 review rounds"')
+    end
+
+    it "omits the tooltip when there have been no review rounds" do
+      expect(helper.pr_review_phase_badge("draft", review_count: 0)).not_to include("title=")
+    end
+  end
+end


### PR DESCRIPTION
## Why

The project page rendered PR rows with the coarse `paid_state` badge, which flips to **Completed** the moment the `create_pr` agent run finishes — even while the PR is still in draft review and unmerged. "Completed" meant *"the agent finished a run"*, not *"the PR is ready"*, which was confusing (e.g. PR #2698 read "Completed" while still in draft review).

## What

Drive the PR badge from `Issue#pr_review_phase` instead — the same field that already drives the `paid-ready` / `paid-escalated` / `paid-auto-merged` GitHub labels — so the badge tracks GitHub readiness:

| `pr_review_phase` | Badge | Matching GitHub label |
|---|---|---|
| `draft` / `restarted` | **In Review** (blue) | — |
| `ready` | **Ready** (green) | `paid-ready` |
| `escalated` | **Escalated** (orange) | `paid-escalated` |
| `merged` | **Merged** (purple) | `paid-auto-merged` |

A PR needing human attention surfaces as **Escalated**. A hover tooltip shows the review-round count. Scope is **PR rows only** — issue badges are unchanged (an issue still flips to "Completed" when its PR opens; a clean follow-up if we want it).

## Implementation

- `pr_review_phase_badge` helper + `PR_REVIEW_PHASE_STYLES` map in `application_helper.rb`
- `_pull_request.html.erb` calls the new helper instead of `paid_state_badge`
- New helper spec

## Testing

- New helper spec: 7 examples
- Full project request spec: 213 examples, 0 failures
- RuboCop + Herb (ERB) lint: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)