### PR TITLE
[codex] Update RDR adoption and implementation statuses

### DIFF
--- a/.github/workflows/ephemeral_tests.yml
+++ b/.github/workflows/ephemeral_tests.yml
@@ -232,5 +232,8 @@ jobs:
               --method PATCH \
               --field body="$body"
           else
-            gh pr comment "${{ github.event.pull_request.number }}" --body "$body"
+            gh api \
+              "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+              --method POST \
+              --field body="$body"
           fi

--- a/docs/rdrs/RDR-001-web-framework-selection.md
+++ b/docs/rdrs/RDR-001-web-framework-selection.md
@@ -5,11 +5,15 @@
 ## Metadata
 
 - **Date**: 2025-01-23
-- **Status**: Final
+- **Status**: Implemented
 - **Type**: Architecture
 - **Priority**: High
 - **Related Issues**: N/A (foundational decision)
 - **Related Tests**: Integration tests for Rails controllers, Hotwire functionality
+
+## Implementation Status
+
+Implemented in Paid as a Rails 8.1 application using Hotwire, Action Cable/Solid Cable, GoodJob, Pundit, PostgreSQL, and the Temporal Ruby SDK. The original Phlex component-layer dependency was deferred; current project guidance treats ERB as the active view stack until a future Phlex adoption effort lands.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-002-workflow-orchestration.md
+++ b/docs/rdrs/RDR-002-workflow-orchestration.md
@@ -5,11 +5,15 @@
 ## Metadata
 
 - **Date**: 2025-01-23
-- **Status**: Final
+- **Status**: Implemented
 - **Type**: Architecture
 - **Priority**: High
 - **Related Issues**: N/A (foundational decision)
 - **Related Tests**: Workflow integration tests, activity unit tests
+
+## Implementation Status
+
+Implemented in Paid with the `temporalio` gem, Temporal services in Docker Compose, workflow/activity code under `app/temporal`, split poll and agent task queues, and GoodJob retained for lightweight background jobs. The implementation uses `app/temporal/workflows` and `app/temporal/activities` rather than the earlier illustrative `app/workflows` and `app/activities` paths.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-003-database-selection.md
+++ b/docs/rdrs/RDR-003-database-selection.md
@@ -5,11 +5,15 @@
 ## Metadata
 
 - **Date**: 2025-01-23
-- **Status**: Final
+- **Status**: Implemented
 - **Type**: Architecture
 - **Priority**: High
 - **Related Issues**: N/A (foundational decision)
 - **Related Tests**: Database migration tests, model specs
+
+## Implementation Status
+
+Implemented in Paid with PostgreSQL for Rails data, GoodJob, Solid Cache, Solid Cable, and Temporal persistence in the local Compose stack. The schema uses PostgreSQL features including JSONB, GIN indexes, full-text search, fx-managed functions/triggers, Logidze, and tenant RLS. Operational follow-ups such as large-table partitioning, retention policies, read-replica criteria, and `pg_stat_statements` monitoring remain scale-triggered work rather than blockers for the core database decision.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-004-container-isolation.md
+++ b/docs/rdrs/RDR-004-container-isolation.md
@@ -5,11 +5,15 @@
 ## Metadata
 
 - **Date**: 2025-01-23
-- **Status**: Final
+- **Status**: Implemented
 - **Type**: Architecture
 - **Priority**: High
 - **Related Issues**: N/A (foundational decision)
 - **Related Tests**: Container security tests, integration tests for agent execution
+
+## Implementation Status
+
+Implemented with Docker agent containers, non-root execution, read-only root filesystems, dropped capabilities, tmpfs writable areas, resource limits, and per-run workspace isolation. The network contract evolved after this RDR: proxy-mode API-key runs use restricted/firewalled networking and the secrets proxy, while subscription-auth and direct-outbound runners intentionally use `paid_internal`; service containers are intentional same-network peers as described by RDR-020.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-005-git-worktree-management.md
+++ b/docs/rdrs/RDR-005-git-worktree-management.md
@@ -5,11 +5,15 @@
 ## Metadata
 
 - **Date**: 2025-01-23
-- **Status**: Final
+- **Status**: Superseded
 - **Type**: Architecture
 - **Priority**: High
 - **Related Issues**: N/A (foundational decision)
 - **Related Tests**: Worktree service tests, cleanup job tests
+
+## Implementation Status
+
+Partially superseded by RDR-019 for normal agent execution. Paid still uses `Worktree` records and host-side worktrees for branch ownership metadata and maintenance flows, but ordinary agent runs now use Docker named volumes with an in-container clone instead of host-created git worktrees bind-mounted into containers. See RDR-019 for the current remote/container execution workspace model.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-006-secrets-proxy.md
+++ b/docs/rdrs/RDR-006-secrets-proxy.md
@@ -5,11 +5,15 @@
 ## Metadata
 
 - **Date**: 2025-01-23
-- **Status**: Final
+- **Status**: Implemented
 - **Type**: Architecture
 - **Priority**: High
 - **Related Issues**: N/A (foundational decision)
 - **Related Tests**: Proxy unit tests, integration tests for API key injection
+
+## Implementation Status
+
+Implemented as Rails API proxy endpoints (`Api::SecretsProxyController`) authenticated by run-scoped container credentials (`Api::ContainerAuthentication`), not as a separate Rack middleware or proxy service. Proxy-mode runners receive provider base URLs and placeholder credentials while Paid injects real provider credentials server-side; subscription-auth and direct-outbound modes are intentional exceptions documented in the current security model.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-007-agent-cli-abstraction.md
+++ b/docs/rdrs/RDR-007-agent-cli-abstraction.md
@@ -5,11 +5,15 @@
 ## Metadata
 
 - **Date**: 2025-01-23
-- **Status**: Final
+- **Status**: Implemented
 - **Type**: Architecture
 - **Priority**: High
 - **Related Issues**: N/A (foundational decision)
 - **Related Tests**: Provider unit tests, integration tests for each agent type
+
+## Implementation Status
+
+Implemented with the `agent-harness` gem as Paid's agent and LLM abstraction. Paid configures providers in `config/initializers/agent_harness.rb`, delegates runner support through `RunnerSupport`, builds execution plans through `Runners::HarnessExecutionPlan`, executes containers through `Containers::HarnessExecutor`, and records usage from `AgentHarness::Response`. The original scope boundary that left API-only planning/evaluation to direct RubyLLM calls is stale; current Paid guidance routes LLM calls through `AgentHarness`, with the secrets proxy remaining the infrastructure exception for container traffic.
 
 ## Decision
 

--- a/docs/rdrs/RDR-008-model-selection.md
+++ b/docs/rdrs/RDR-008-model-selection.md
@@ -5,11 +5,15 @@
 ## Metadata
 
 - **Date**: 2025-01-23
-- **Status**: Final
+- **Status**: Implemented
 - **Type**: Architecture
 - **Priority**: Medium
 - **Related Issues**: N/A (foundational decision)
 - **Related Tests**: Meta-agent tests, fallback logic tests
+
+## Implementation Status
+
+Implemented through `Models::Select`, `Models::MetaAgentSelector`, `Models::RulesBasedSelector`, the `LlmModel` catalog, and persistent `ModelSelection` audit records. The implementation uses `AgentHarness` for LLM calls, not the older raw RubyLLM examples in this RDR. Budget data informs prompts and runtime cost enforcement; explicit selection-time affordability filtering remains a possible refinement rather than a blocker for the core decision.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-009-prompt-evolution.md
+++ b/docs/rdrs/RDR-009-prompt-evolution.md
@@ -5,11 +5,15 @@
 ## Metadata
 
 - **Date**: 2025-01-23
-- **Status**: Final
+- **Status**: Implemented
 - **Type**: Architecture
 - **Priority**: High
 - **Related Issues**: N/A (foundational decision)
 - **Related Tests**: Evolution workflow tests, A/B test analysis tests
+
+## Implementation Status
+
+Implemented with prompt/version models, prompt review states, A/B test models and services, the prompt evolution workflow/job, evolution activities, quality metric collection, and GoodJob cron scheduling. Live A/B assignment is wired for goal wrapper prompts in `Activities::RunAgentActivity`; some direct prompt-building paths still resolve the current prompt version directly.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-010-multi-tenancy-rbac.md
+++ b/docs/rdrs/RDR-010-multi-tenancy-rbac.md
@@ -5,11 +5,15 @@
 ## Metadata
 
 - **Date**: 2025-01-23
-- **Status**: Final
+- **Status**: Implemented
 - **Type**: Architecture
 - **Priority**: Medium
 - **Related Issues**: N/A (foundational decision)
 - **Related Tests**: Authorization policy tests, account scoping tests
+
+## Implementation Status
+
+Implemented with explicit account and project memberships, Pundit policies, request-level tenant context, database session tenant context, and forced PostgreSQL row-level security on tenant-scoped tables. RDR-024 and RDR-029 extend and harden this foundation rather than superseding it.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-011-observability.md
+++ b/docs/rdrs/RDR-011-observability.md
@@ -5,11 +5,15 @@
 ## Metadata
 
 - **Date**: 2025-01-23
-- **Status**: Final
+- **Status**: Partially Implemented
 - **Type**: Architecture
 - **Priority**: Medium
 - **Related Issues**: N/A (foundational decision)
 - **Related Tests**: Metrics endpoint tests, alert rule tests
+
+## Implementation Status
+
+Partially implemented. Paid exposes Prometheus-compatible metrics at `/api/metrics`, collects application metrics through `Metrics::PrometheusCollector`, and includes in-app queue monitoring/alerts. The full stack described here is not yet checked in: Prometheus configuration/rules, Grafana dashboards/provisioning, AlertManager routing, exporter configuration, and Compose observability services remain follow-up work.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-012-github-integration.md
+++ b/docs/rdrs/RDR-012-github-integration.md
@@ -5,11 +5,15 @@
 ## Metadata
 
 - **Date**: 2025-01-23
-- **Status**: Final
+- **Status**: Partially Implemented
 - **Type**: Architecture
 - **Priority**: High
 - **Related Issues**: N/A (foundational decision)
 - **Related Tests**: GitHub client tests, polling workflow tests
+
+## Implementation Status
+
+Mostly implemented for polling-first GitHub sync, local issue/PR caching, Octokit-backed API access, rate-limit/circuit state, webhooks, PAT credentials, and GitHub App credentials. The original PAT-only assumption was superseded by RDR-030. GitHub Projects V2 field/item synchronization from this RDR has not been implemented and remains follow-up work unless intentionally abandoned.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-013-code-quality-backpressure.md
+++ b/docs/rdrs/RDR-013-code-quality-backpressure.md
@@ -5,11 +5,15 @@
 ## Metadata
 
 - **Date**: 2025-01-23
-- **Status**: Implemented
+- **Status**: Superseded
 - **Type**: Architecture
 - **Priority**: High
 - **Related Issues**: N/A (foundational decision)
 - **Related Tests**: Hook execution tests, CI pipeline tests, linter integration tests
+
+## Implementation Status
+
+Superseded by later concrete quality systems rather than implemented exactly as written. Paid now enforces quality through repository CI/security workflows, `.githooks/pre-commit`, container pre-commit hooks, `PreCommitRequirement` evaluation, project convention guardrails, quality gates/recovery, and mutation backpressure from RDR-036. The original Lefthook/pre-push/SARIF-oriented shape and broad `QualityConfiguratorService` / `RunQualityChecksActivity` design were not adopted as-is.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-014-learned-orchestration.md
+++ b/docs/rdrs/RDR-014-learned-orchestration.md
@@ -11,6 +11,10 @@
 - **Related Issues**: N/A (future enhancement)
 - **Related RDRs**: RDR-002 (Workflow Orchestration), RDR-009 (Prompt Evolution)
 
+## Implementation Status
+
+Implemented with follow-up gaps. Paid has strategy/version models, orchestration decision logging, strategy selection services, baseline extraction, strategy evolution workflows, experiments, human review gates, and coordination policy paths. The generic `Strategies::Select` path is not yet fully wired into every active orchestration decision point, and the promotion loop remains intentionally guarded by review workflows.
+
 ## Problem Statement
 
 Paid's current orchestration layer uses hand-designed workflows: poll issues → plan → execute → create PR. While functional, this approach:

--- a/docs/rdrs/RDR-015-end-to-end-optimization.md
+++ b/docs/rdrs/RDR-015-end-to-end-optimization.md
@@ -11,6 +11,10 @@
 - **Related Issues**: N/A (future enhancement)
 - **Related RDRs**: RDR-009 (Prompt Evolution), RDR-014 (Learned Orchestration)
 
+## Implementation Status
+
+Implemented with one accepted design drift to review. Paid has configuration bundles, bundle outcomes, objective scoring, runtime bundle assignment, outcome recording, exploration/exploitation, optimization services, and dashboard stats. The production surrogate is `ConfigurationBundles::SurrogateOutcomeModel`, a weighted similarity/prior model with uncertainty, not the Gaussian Process surrogate originally specified here.
+
 ## Problem Statement
 
 Paid currently optimizes individual components:

--- a/docs/rdrs/RDR-016-self-improving-coordination.md
+++ b/docs/rdrs/RDR-016-self-improving-coordination.md
@@ -11,6 +11,10 @@
 - **Related Issues**: N/A (future enhancement)
 - **Related RDRs**: RDR-007 (Agent Abstraction), RDR-014 (Learned Orchestration), RDR-015 (End-to-End Optimization)
 
+## Implementation Status
+
+Implemented with follow-up gaps. Paid has coordination policy/version models, orchestration decision logging, decomposition and recovery policy services, coordination policy evolution workflows, coordination experiments, runtime parallelism policy hooks, and decision metrics. Scheduled coordination policy evolution and experiment-to-policy promotion are not yet wired as production automation.
+
 ## Problem Statement
 
 Current multi-agent coordination in Paid follows fixed patterns:

--- a/docs/rdrs/RDR-017-orchestration-scaling-laws.md
+++ b/docs/rdrs/RDR-017-orchestration-scaling-laws.md
@@ -11,6 +11,10 @@
 - **Related Issues**: N/A (foundational research)
 - **Related RDRs**: RDR-014 (Learned Orchestration), RDR-015 (End-to-End Optimization)
 
+## Implementation Status
+
+Implemented with follow-up gaps. Paid records scaling observations, assigns scaling experiments, analyzes scaling behavior, integrates learned allocation into feature orchestration, and uses `Scaling::ResourceAllocator` for dynamic allocation. Confidence interval reporting, a dedicated scaling experiment dashboard, and stronger statistical sample thresholds remain follow-up work.
+
 ## Problem Statement
 
 The Bitter Lesson's core insight is that methods which **scale with computation** ultimately win. For LLM training, this manifests as scaling laws: larger models trained on more data perform predictably better.

--- a/docs/rdrs/RDR-018-semantic-code-search.md
+++ b/docs/rdrs/RDR-018-semantic-code-search.md
@@ -11,6 +11,10 @@
 - **Related Issues**: #66 (Look into using arcaneum for semantic data)
 - **Related Tests**: N/A (investigation phase)
 
+## Implementation Status
+
+Implemented through the later RDR-021 knowledge-base architecture. Paid uses Qdrant for semantic vector search and PostgreSQL `tsvector`/trigram indexes for exact and full-text search; the original MeiliSearch portion of this RDR was not adopted.
+
 ## Problem Statement
 
 Paid agents operate on codebases they have no prior understanding of. Each agent run starts from scratch—reading issue descriptions, exploring the repository, and building mental models before writing any code. This is wasteful:

--- a/docs/rdrs/RDR-021-knowledge-base.md
+++ b/docs/rdrs/RDR-021-knowledge-base.md
@@ -5,13 +5,17 @@
 ## Metadata
 
 - **Date**: 2026-03-28
-- **Status**: Final
+- **Status**: Implemented
 - **Type**: Architecture
 - **Priority**: High
 - **Related Issues**: #267 (Knowledge Base Architecture Docs), #66 (Semantic data investigation)
 - **Related RDRs**: [RDR-018](RDR-018-semantic-code-search.md) (Semantic Code Search)
 - **Note**: The #267 implementation plan originally referenced this as RDR-019. It was renumbered to RDR-021 because RDR-019 was already assigned to Remote Container Execution.
 - **Related Tests**: `spec/services/knowledge/`, `spec/models/knowledge_*.rb`
+
+## Implementation Status
+
+Implemented with PostgreSQL as the canonical store, Qdrant as a derived vector index, collector runs, project versions, knowledge artifacts/chunks/links, hybrid search, redaction before embedding, audit events, prompt integration, proxy search, and MCP search tooling. Retroactive physical scrubbing/rebuild workflows for already-indexed PostgreSQL and Qdrant data remain follow-up work beyond the logical redaction flags and pre-embedding redaction pipeline.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-022-auto-merge-pr-strategy.md
+++ b/docs/rdrs/RDR-022-auto-merge-pr-strategy.md
@@ -5,11 +5,15 @@
 ## Metadata
 
 - **Date**: 2026-04-11
-- **Status**: Final
+- **Status**: Implemented
 - **Type**: Process
 - **Priority**: Medium
 - **Related Issues**: #1003 (Merge strategy decision), #948 (Umbrella auto-merge issue)
 - **Related PRs**: #950 (umbrella), #927 (trigger routing), #1000 (max review rounds), #993 (bot wiring, merged), #921 (clean signal, merged)
+
+## Implementation Status
+
+Implemented as a process decision. PR #950 was closed rather than merged wholesale, and the auto-merge work landed through incremental PRs and follow-up issues. The current implementation includes `Automation::Strategies::AutoMerge`, project auto-merge settings, scanner delegation, merge execution, and Dependabot-specific auto-merge paths.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-023-automation-modularization-architecture.md
+++ b/docs/rdrs/RDR-023-automation-modularization-architecture.md
@@ -5,12 +5,16 @@
 ## Metadata
 
 - **Date**: 2026-04-15
-- **Status**: Implemented
+- **Status**: Partially Implemented
 - **Type**: Architecture
 - **Priority**: High
 - **Related Issues**: #1114, #1116
 - **Related Tests**: N/A
 - **Related RDRs**: [RDR-012](RDR-012-github-integration.md) (GitHub Integration), [RDR-022](RDR-022-auto-merge-pr-strategy.md) (Auto-Merge Strategy), [RDR-002](RDR-002-workflow-orchestration.md) (Workflow Orchestration)
+
+## Implementation Status
+
+Partially implemented. Paid has provider capability interfaces, provider data objects, GitHub provider adapters, strategy classes, provider resolver wiring, and some merge/review paths using the modular automation layer. Remaining work includes extracting signal collection from `ScanPaidPrsActivity`, adding the strategy coordinator described here, removing remaining direct scanner provider calls, and shrinking `ScanPaidPrsActivity` into orchestration glue.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-024-multi-tenancy-isolation-strategy.md
+++ b/docs/rdrs/RDR-024-multi-tenancy-isolation-strategy.md
@@ -5,11 +5,15 @@
 ## Metadata
 
 - **Date**: 2026-04-17
-- **Status**: Final
+- **Status**: Implemented
 - **Type**: Architecture
 - **Priority**: High
 - **Related Issues**: #729 (Multi-tenancy design), RDR-010 (Multi-Tenancy and RBAC)
 - **Related Tests**: `spec/models/account_spec.rb`, `spec/models/tenant_setting_spec.rb`, `spec/models/concerns/tenant_scoped_spec.rb`
+
+## Implementation Status
+
+Implemented with material hardening beyond the original recommendation. Paid uses account lifecycle states, tenant settings, request-level tenant enforcement, explicit tenant scopes, database session tenant context, and broad forced PostgreSQL RLS. The implementation intentionally evolved from "application-level primary, RLS later" to a hybrid model with database-enforced tenant isolation.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-025-provider-quota-tracking.md
+++ b/docs/rdrs/RDR-025-provider-quota-tracking.md
@@ -5,11 +5,15 @@
 ## Metadata
 
 - **Date**: 2026-04-19
-- **Status**: Implemented
+- **Status**: Superseded
 - **Type**: Architecture
 - **Priority**: Medium
 - **Related Issues**: TBD
 - **Related RDRs**: [RDR-007](RDR-007-agent-cli-abstraction.md) (agent-harness), [RDR-008](RDR-008-model-selection.md) (model selection), [RDR-006](RDR-006-secrets-proxy.md) (secrets proxy)
+
+## Implementation Status
+
+Superseded by [RDR-025: Runner Quota Tracking and Quota-Aware Routing](RDR-025-runner-quota-tracking.md), which uses the current runner terminology. The active runner quota RDR is partially implemented: Paid has internal usage and reactive rate-limit state, but not proactive upstream quota polling, snapshots, refresh, display, or quota-aware routing.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-025-runner-quota-tracking.md
+++ b/docs/rdrs/RDR-025-runner-quota-tracking.md
@@ -5,11 +5,15 @@
 ## Metadata
 
 - **Date**: 2026-04-19
-- **Status**: Implemented
+- **Status**: Partially Implemented
 - **Type**: Architecture
 - **Priority**: Medium
 - **Related Issues**: TBD
 - **Related RDRs**: [RDR-007](RDR-007-agent-cli-abstraction.md) (agent-harness), [RDR-008](RDR-008-model-selection.md) (model selection), [RDR-006](RDR-006-secrets-proxy.md) (secrets proxy)
+
+## Implementation Status
+
+Partially implemented. Paid shows recent runner usage from internal run/token data, records reactive runner rate-limit/circuit state, skips currently limited runners, and surfaces reactive quota notifications. Proactive upstream quota polling, quota credentials/snapshots, scheduled refresh, upstream quota display, and quota-aware routing scores are not implemented yet.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-026-admin-interface-strategy.md
+++ b/docs/rdrs/RDR-026-admin-interface-strategy.md
@@ -5,11 +5,15 @@
 ## Metadata
 
 - **Date**: 2026-04-22
-- **Status**: Draft
+- **Status**: Implemented
 - **Type**: Architecture
 - **Priority**: Medium
 - **Related Issues**: #2011 (Avo Operator Console), #2012 (User-Facing Account Administration)
 - **Related RDRs**: [RDR-010](RDR-010-multi-tenancy-rbac.md) (Multi-Tenancy and RBAC), [RDR-024](RDR-024-multi-tenancy-isolation-strategy.md) (Multi-Tenancy Isolation Strategy), [RDR-018](RDR-018-billing-aggregation.md) (Billing Aggregation)
+
+## Implementation Status
+
+Implemented with an Avo-powered operator console mounted at `/admin`, fail-closed operator access checks, Pundit-backed operator policies, core account/user/membership/tenant setting resources, account lifecycle actions, and separate customer-facing account administration. Related Phase 5.1 and 5.2 issues are closed.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-027-auto-enhance-knowledge-evolution.md
+++ b/docs/rdrs/RDR-027-auto-enhance-knowledge-evolution.md
@@ -5,11 +5,15 @@
 ## Metadata
 
 - **Date**: 2026-04-23
-- **Status**: Implemented
+- **Status**: Partially Implemented
 - **Type**: Architecture
 - **Priority**: High
 - **Related RDRs**: [RDR-009](RDR-009-prompt-evolution.md) (Prompt Evolution), [RDR-021](RDR-021-knowledge-base.md) (Knowledge Base), [RDR-023](RDR-023-automation-modularization-architecture.md) (Automation Modularization)
 - **Related Tests**: `spec/temporal/activities/analyze_issue_activity_spec.rb`, `spec/services/knowledge/usage_stats_spec.rb`, `spec/temporal/workflows/knowledge_evolution_workflow_spec.rb`
+
+## Implementation Status
+
+Partially implemented. Paid implements auto-enhance analysis runs, readiness routing, knowledge usage stats, knowledge evolution workflows, and recommendation UI. The remaining gap is usage attribution coverage: `EnhanceIssueActivity` passes `agent_run_id` into knowledge search/bundles, but `AnalyzeIssueActivity` and `Prompts::BuildForIssue` still have knowledge calls that do not provide an `agent_run_id`, so those paths do not fully feed knowledge usage tracking.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-028-interactive-chat.md
+++ b/docs/rdrs/RDR-028-interactive-chat.md
@@ -11,6 +11,10 @@
 - **Related Issues**: TBD
 - **Related RDRs**: [RDR-007](RDR-007-agent-cli-abstraction.md) (agent-harness), [RDR-004](RDR-004-container-isolation.md) (containers), [RDR-006](RDR-006-secrets-proxy.md) (secrets proxy), [RDR-025](RDR-025-runner-quota-tracking.md) (quota tracking)
 
+## Implementation Status
+
+Implemented for API-mode interactive chat: sessions, messages, UI/API routes, streaming, tool calls, MCP tools, token tracking, and write-tool confirmation are present. The workspace/container chat mode described here is superseded by RDR-037, which tracks containerized multi-repo chat and workspace mutation tools.
+
 ## Problem Statement
 
 Paid orchestrates AI agents to build software through a batch-oriented workflow: label an issue, queue an agent run, wait for the PR. This workflow is powerful but cannot handle four increasingly important use cases:

--- a/docs/rdrs/RDR-029-multi-tenancy-preparation.md
+++ b/docs/rdrs/RDR-029-multi-tenancy-preparation.md
@@ -5,12 +5,16 @@
 ## Metadata
 
 - **Date**: 2026-05-06
-- **Status**: Final
+- **Status**: Implemented
 - **Type**: Architecture
 - **Priority**: High
 - **Related Issues**: #740 (Multi-Tenancy Phase 3.7), #729, #730, #731, #732, #733
 - **Related RDRs**: RDR-010 (Multi-Tenancy and RBAC), RDR-024 (Isolation Strategy), RDR-018 (Billing Aggregation)
 - **Related Tests**: `spec/services/accounts/provision_spec.rb`, `spec/models/concerns/tenant_enforcement_spec.rb`
+
+## Implementation Status
+
+Implemented for the preparation scope. Paid provisions accounts with tenant settings, billing plans, and onboarding steps; enforces tenant lifecycle state; installs `TenantContext` in requests; applies forced RLS; and exposes account lifecycle UI/actions. Future commercial lifecycle work such as automated billing suspension, tenant limit usage alerts, self-service plan upgrades, and deactivated-account data export remains separate follow-up scope.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-030-github-app-bot-account.md
+++ b/docs/rdrs/RDR-030-github-app-bot-account.md
@@ -5,12 +5,16 @@
 ## Metadata
 
 - **Date**: 2026-05-09
-- **Status**: Implemented
+- **Status**: Partially Implemented
 - **Type**: Architecture
 - **Priority**: High
-- **Related Issues**: TBD
+- **Related Issues**: #2181, #2218, #2408, #2413, #2645
 - **Related RDRs**: [RDR-012](RDR-012-github-integration.md) (extends auth model), [RDR-022](RDR-022-auto-merge-pr-strategy.md) (consumes bot identity for PR authorship)
 - **Related Tests**: `spec/services/github/`, `spec/models/github_installation_*`, `spec/requests/github_app/installations_spec.rb`
+
+## Implementation Status
+
+Partially implemented. Paid has GitHub App registry/configuration, installation token minting and caching, `GithubInstallation` records, project credential resolution, App/PAT switching, git credential and GitHub API proxies, migration UI/services, bot author identity, and health/rate-limit separation. Remaining work includes self-hosted/admin GitHub App manifest setup, an install/callback lifecycle, and automatic persistence/update of installation records from GitHub installation events.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-031-focused-agent-runs.md
+++ b/docs/rdrs/RDR-031-focused-agent-runs.md
@@ -11,6 +11,10 @@
 - **Related Issues**: #1987 (foundation), #1988 (prompt scoping), #1989 (quality scoring)
 - **Related RDRs**: RDR-013 (Code Quality & Backpressure), RDR-014 (Learned Orchestration), RDR-023 (Automation Modularization)
 
+## Implementation Status
+
+Implemented. Focus is now first-class on `AgentRun`, scanner focus resolution, workflow/create paths, prompt scoping, quality metrics, and focus-resolution attribution. The rollout feature flag described in this RDR has been removed because focused runs are now default behavior.
+
 ## Problem Statement
 
 When an agent run encounters multiple classes of problems on a PR (failing CI workflows, code review comments, merge conflicts, linter errors, security findings), the current system bundles all of them into a single agent run and instructs the agent to fix everything in one pass. This causes:

--- a/docs/rdrs/RDR-032-eager-queue-seeding.md
+++ b/docs/rdrs/RDR-032-eager-queue-seeding.md
@@ -5,11 +5,15 @@
 ## Metadata
 
 - **Date**: 2026-05-15
-- **Status**: Draft
+- **Status**: Implemented
 - **Type**: Architecture
 - **Priority**: P1
 - **Related Issues**: #2019 (foundation), #2020 (sync hooks), #2021 (remove throttling), #2022 (dependency resolution)
 - **Related RDRs**: RDR-023 (Automation Modularization), RDR-031 (Focused Agent Runs)
+
+## Implementation Status
+
+Implemented with follow-up hardening. Paid eagerly enqueues eligible issues through single and bulk enqueue services, issue sync hooks, auto-pick enablement hooks, and dependency-unblock hooks; the queue processor is now dequeue-oriented and dashboard preview reads already queued work. A remaining hardening gap is a general dequeue-time eligibility recheck for queued runs whose issues become ineligible after seeding.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-033-worker-pool-scaling-algorithm.md
+++ b/docs/rdrs/RDR-033-worker-pool-scaling-algorithm.md
@@ -6,6 +6,10 @@
 
 > Originally numbered RDR-024. Renumbered to RDR-033 to resolve collision with RDR-024 (Multi-Tenancy Isolation Strategy).
 
+## Implementation Status
+
+Implemented for the advisory algorithm and simulator. Paid has `Scaling::WorkerPoolAdvisor`, `Scaling::Configuration`, `Scaling::MetricsSnapshot`, and `Scaling::Simulator`; wiring advisor recommendations into live infrastructure autoscaling remains outside this RDR's pure-function scope unless a separate operational rollout is planned.
+
 ## Context
 
 Paid's worker pools (GoodJob threads, Temporal activity slots, Docker containers) are currently statically sized. As workload grows and varies throughout the day, fixed pools either waste resources during quiet periods or bottleneck during bursts. We need an algorithm that recommends when to add or remove workers based on observable metrics, while respecting cost constraints and avoiding thrashing.

--- a/docs/rdrs/RDR-034-tier-based-runner-fallback.md
+++ b/docs/rdrs/RDR-034-tier-based-runner-fallback.md
@@ -5,11 +5,15 @@
 ## Metadata
 
 - **Date**: 2026-05-23
-- **Status**: Draft
+- **Status**: Implemented
 - **Type**: Architecture
 - **Priority**: P1
-- **Related Issues**: TBD (file alongside merging this RDR)
+- **Related Issues**: #2235, #2236, #2237, #2238, #2239, #2240
 - **Related RDRs**: RDR-007 (Agent CLI Abstraction), RDR-008 (Model Selection Strategy), RDR-025 (Runner Quota Tracking)
+
+## Implementation Status
+
+Implemented with minor accepted divergences. Paid filters fallback runners by tier support, resolves concrete models per runner attempt, records resolved attempt metadata, supports runner tier model maps, and fingerprints bundles by tier/selector metadata. The optional `selector_type: tier_only` and `model_pin` escape hatch described here were not implemented; file follow-up work only if those remain desired.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-035-style-guide-evolution.md
+++ b/docs/rdrs/RDR-035-style-guide-evolution.md
@@ -5,12 +5,16 @@
 ## Metadata
 
 - **Date**: 2026-05-24
-- **Status**: Proposed
+- **Status**: Accepted
 - **Type**: Architecture
 - **Priority**: High
 - **Related Issues**: #2254, #2249
 - **Related RDRs**: [RDR-009](RDR-009-prompt-evolution.md) (Prompt Evolution)
 - **Related Tests**: (to be created during implementation)
+
+## Implementation Status
+
+Accepted but not implemented. Paid still has direct `StyleGuide` records with Logidze history and prompt injection through `StyleGuides::InjectIntoPrompt`; the versioning, style-guide A/B tests, exposure tracking, evolution workflow, and quality attribution pipeline described here have not been added.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-036-mutation-testing-for-ai-generated-tests.md
+++ b/docs/rdrs/RDR-036-mutation-testing-for-ai-generated-tests.md
@@ -5,7 +5,7 @@
 ## Metadata
 
 - **Date**: 2026-05-25
-- **Status**: Draft
+- **Status**: Partially Implemented
 - **Type**: Architecture
 - **Priority**: P1
 - **Related Issues**: viamin/paid#2371 (this amendment), viamin/paid#2367 (gem-source switch), viamin/paid#2368 (`--usage` cleanup), viamin/paid#2370 (customer UI)
@@ -15,6 +15,10 @@
   - [RDR-031](RDR-031-focused-agent-runs.md) (Focused Agent Runs)
   - [RDR-035](RDR-035-style-guide-evolution.md) (Style Guide Evolution)
 - **Related Tests**: (to be created during implementation)
+
+## Implementation Status
+
+Partially implemented. Paid has mutation CI, `bin/mutation`, managed-project mutation pre-commit requirements, container quality-hook support, Mutant feedback parsing, mutation quality metrics, scheduled sweeps, and dashboard reporting. Remaining work includes completing the sanctioned-source transition to `viamin/mutant` as the default, cleaning stale `--usage`/licensing artifacts, and finishing customer-facing configuration tracked by #2370.
 
 ## Amendment 1 (2026-05-29)
 

--- a/docs/rdrs/RDR-037-containerized-multi-repo-chat.md
+++ b/docs/rdrs/RDR-037-containerized-multi-repo-chat.md
@@ -5,11 +5,15 @@
 ## Metadata
 
 - **Date**: 2026-05-29
-- **Status**: Draft
+- **Status**: Final
 - **Type**: Architecture
 - **Priority**: High
 - **Related Issues**: #2349 (chat-auth invariant), #2350 (admin tools), #2351 (operator tools), #2352 (source-code tools), #2353 (dangerous_mode audit), #2354 (this RDR's tracking issue)
 - **Related RDRs**: [RDR-028](RDR-028-interactive-chat.md) (interactive chat — this RDR supersedes its workspace-mode design), [RDR-004](RDR-004-container-isolation.md) (container isolation), [RDR-005](RDR-005-git-worktree-management.md) (worktree management), [RDR-006](RDR-006-secrets-proxy.md) (secrets proxy)
+
+## Implementation Status
+
+Final and tracked, not implemented. API-mode chat prerequisites and source-code read tools exist, and #2354 plus child issues track the containerized multi-repo work. Core RDR-037 requirements such as capability state, background provisioning, multi-repo clone manifests, mutation tools, shell execution, and PR proposal tooling remain open.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-038-free-models-catalog-and-runner.md
+++ b/docs/rdrs/RDR-038-free-models-catalog-and-runner.md
@@ -5,11 +5,15 @@
 ## Metadata
 
 - **Date**: 2026-05-30
-- **Status**: Draft
+- **Status**: Partially Implemented
 - **Type**: Architecture
 - **Priority**: P1
 - **Related Issues**: #2378 (tracking), #2381 (phase 1), #2380 (phase 2), #2379 (phase 3a), #2383 (phase 3b), #2382 (phase 3c), #2384 (phase 4), #2385 (phase 5)
 - **Related RDRs**: [RDR-007](RDR-007-agent-cli-abstraction.md) (agent-harness), [RDR-008](RDR-008-model-selection.md) (model selection), [RDR-034](RDR-034-tier-based-runner-fallback.md) (tier-based fallback), [RDR-025](RDR-025-runner-quota-tracking.md) (runner quota tracking)
+
+## Implementation Status
+
+Partially implemented. Paid has free-model fields on `LlmModel`, project data classification, the `openrouter_free` runner, OpenRouter data-routing controls, free-model defaults, rotation for knowledge execution, catalog UI, exclusions, and runner wiring. OpenRouter model sync/classification/quality filtering is not implemented yet and remains tracked by #2380.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-039-exception-notification-custom-notifier.md
+++ b/docs/rdrs/RDR-039-exception-notification-custom-notifier.md
@@ -5,11 +5,15 @@
 ## Metadata
 
 - **Date**: 2026-05-30
-- **Status**: Draft
+- **Status**: Implemented
 - **Type**: Architecture
 - **Priority**: P2
-- **Related Issues**: TBD (umbrella issue filed alongside this RDR)
+- **Related Issues**: #2395 (umbrella), #2388, #2389, #2390, #2391, #2392, #2393, #2394
 - **Related RDRs**: [RDR-011](RDR-011-observability.md) (observability stack), [RDR-029](RDR-029-multi-tenancy-preparation.md) (tenant context propagation)
+
+## Implementation Status
+
+Implemented. Paid uses the `exception_notification` gem, a custom `Paid::ExceptionNotifier`, Rack middleware integration, ActiveJob terminal-failure notification, subsystem/project context for knowledge jobs, allowlisted issue filing, rate limits, and dashboard surfacing. The middleware placement intentionally differs from the draft text so production 500s are captured inside Rails exception handling.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-040-runner-model-compatibility-contracts.md
+++ b/docs/rdrs/RDR-040-runner-model-compatibility-contracts.md
@@ -4,10 +4,15 @@
 
 ## Metadata
 
-- **Status**: Draft
+- **Status**: Partially Implemented
 - **Date**: 2026-06-13
 - **Priority**: P1
+- **Related Issues**: #2600
 - **Related RDRs**: RDR-007 (Agent CLI Abstraction), RDR-008 (Model Selection Strategy), RDR-034 (Tier-Based Runner Fallback), RDR-038 (Free Models Catalog and Runner)
+
+## Implementation Status
+
+Partially implemented. Paid wraps `AgentHarness.model_compatibility`, filters default tier selection, validates runner tier model maps, rejects incompatible tier candidates during resolution, guards Codex host model leakage, and detects some model-health failures reactively. Remaining work includes applying compatibility in general `Models::Select` override paths, using full compatibility during fallback ordering, passing provider runtime into compatibility checks, and adding proactive drift reporting for active model rows versus runner contracts.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-041-subscription-runner-auth-lifecycle.md
+++ b/docs/rdrs/RDR-041-subscription-runner-auth-lifecycle.md
@@ -4,10 +4,15 @@
 
 ## Metadata
 
-- **Status**: Draft
+- **Status**: Accepted
 - **Date**: 2026-06-26
 - **Priority**: P1
+- **Related Issues**: #2690, #2683, #2685, #2684, #2686, #2687, #2688, #2689
 - **Related RDRs**: RDR-004 (Container Isolation), RDR-006 (Secrets Proxy Architecture), RDR-007 (Agent CLI Abstraction), RDR-010 (Multi-Tenancy and RBAC), RDR-025 (Runner Quota Tracking), RDR-040 (Runner Model Compatibility Contracts)
+
+## Implementation Status
+
+Accepted and tracked, not materially implemented yet. Existing pre-RDR plumbing includes the `auth_expired` run status and non-zero auth classification, but the exit-0/preflight auth gap, proactive auth health, managed runner credentials, Claude long-lived token injection, and self-heal flows remain open work tracked by the related phase issues.
 
 ## Problem Statement
 

--- a/docs/rdrs/RDR-042-change-intent-records.md
+++ b/docs/rdrs/RDR-042-change-intent-records.md
@@ -5,11 +5,15 @@
 ## Metadata
 
 - **Date**: 2026-06-27
-- **Status**: Draft
+- **Status**: Accepted
 - **Type**: Process + Architecture
 - **Priority**: Medium
-- **Related Issues**: N/A
+- **Related Issues**: #2695, #2696, #2697
 - **Related Tests**: Knowledge artifact integration tests, context bundle tests, decision record collector tests
+
+## Implementation Status
+
+Accepted and tracked, not implemented yet. Related phase issues cover the `ChangeIntent` model and knowledge pipeline, chat creation flow, issue detection, and external agent exposure. Existing `DecisionRecord` and knowledge collector plumbing are prerequisites only; no `change_intents` table/model, change-intent collector, or MCP tools exist yet.
 
 ## Problem Statement
 

--- a/docs/rdrs/README.md
+++ b/docs/rdrs/README.md
@@ -15,7 +15,9 @@ For more information, see the [RDR methodology](https://github.com/cwensel/rdr).
 | Status | Meaning |
 |--------|---------|
 | Draft | During planning/research phase |
+| Accepted | Recommendation accepted but implementation not started |
 | Final | Locked, ready for or during implementation |
+| Partially Implemented | Adopted and partly shipped, with remaining implementation work tracked |
 | Implemented | Implementation complete |
 | Abandoned | RDR not implemented |
 | Superseded | Replaced by another RDR |
@@ -26,50 +28,51 @@ For more information, see the [RDR methodology](https://github.com/cwensel/rdr).
 
 | RDR | Title | Status | Priority |
 |-----|-------|--------|----------|
-| [RDR-001](RDR-001-web-framework-selection.md) | Web Framework Selection (Rails) | Final | High |
-| [RDR-002](RDR-002-workflow-orchestration.md) | Workflow Orchestration (Temporal.io) | Final | High |
-| [RDR-003](RDR-003-database-selection.md) | Database Selection (PostgreSQL) | Final | High |
+| [RDR-001](RDR-001-web-framework-selection.md) | Web Framework Selection (Rails) | Implemented | High |
+| [RDR-002](RDR-002-workflow-orchestration.md) | Workflow Orchestration (Temporal.io) | Implemented | High |
+| [RDR-003](RDR-003-database-selection.md) | Database Selection (PostgreSQL) | Implemented | High |
 
 ### Security & Isolation
 
 | RDR | Title | Status | Priority |
 |-----|-------|--------|----------|
-| [RDR-004](RDR-004-container-isolation.md) | Container Isolation Strategy | Final | High |
-| [RDR-005](RDR-005-git-worktree-management.md) | Git Worktree Management | Final | High |
-| [RDR-006](RDR-006-secrets-proxy.md) | Secrets Proxy Architecture | Final | High |
-| [RDR-041](RDR-041-subscription-runner-auth-lifecycle.md) | Subscription Runner Auth Lifecycle (Detection, Long-Lived Tokens, Self-Heal) | Draft | P1 |
+| [RDR-004](RDR-004-container-isolation.md) | Container Isolation Strategy | Implemented | High |
+| [RDR-005](RDR-005-git-worktree-management.md) | Git Worktree Management | Superseded | High |
+| [RDR-006](RDR-006-secrets-proxy.md) | Secrets Proxy Architecture | Implemented | High |
+| [RDR-041](RDR-041-subscription-runner-auth-lifecycle.md) | Subscription Runner Auth Lifecycle (Detection, Long-Lived Tokens, Self-Heal) | Accepted | P1 |
 
 ### Agent System
 
 | RDR | Title | Status | Priority |
 |-----|-------|--------|----------|
-| [RDR-007](RDR-007-agent-cli-abstraction.md) | Agent CLI Abstraction (agent-harness gem) | Final | High |
-| [RDR-008](RDR-008-model-selection.md) | Model Selection Strategy | Final | Medium |
-| [RDR-034](RDR-034-tier-based-runner-fallback.md) | Tier-Based Runner Fallback | Draft | P1 |
+| [RDR-007](RDR-007-agent-cli-abstraction.md) | Agent CLI Abstraction (agent-harness gem) | Implemented | High |
+| [RDR-008](RDR-008-model-selection.md) | Model Selection Strategy | Implemented | Medium |
+| [RDR-034](RDR-034-tier-based-runner-fallback.md) | Tier-Based Runner Fallback | Implemented | P1 |
 
 ### Intelligence
 
 | RDR | Title | Status | Priority |
 |-----|-------|--------|----------|
-| [RDR-009](RDR-009-prompt-evolution.md) | Prompt Evolution System | Final | High |
+| [RDR-009](RDR-009-prompt-evolution.md) | Prompt Evolution System | Implemented | High |
 
 ### Operations & Access
 
 | RDR | Title | Status | Priority |
 |-----|-------|--------|----------|
-| [RDR-010](RDR-010-multi-tenancy-rbac.md) | Multi-Tenancy and RBAC | Final | Medium |
-| [RDR-011](RDR-011-observability.md) | Observability Stack | Final | Medium |
-| [RDR-039](RDR-039-exception-notification-custom-notifier.md) | Exception Reporting via `exception_notification` Custom Notifier | Draft | P2 |
-| [RDR-024](RDR-024-multi-tenancy-isolation-strategy.md) | Multi-Tenancy Isolation Strategy | Final | High |
-| [RDR-026](RDR-026-admin-interface-strategy.md) | Admin Interface Strategy | Draft | Medium |
-| [RDR-029](RDR-029-multi-tenancy-preparation.md) | Multi-Tenancy Preparation | Final | High |
+| [RDR-010](RDR-010-multi-tenancy-rbac.md) | Multi-Tenancy and RBAC | Implemented | Medium |
+| [RDR-011](RDR-011-observability.md) | Observability Stack | Partially Implemented | Medium |
+| [RDR-039](RDR-039-exception-notification-custom-notifier.md) | Exception Reporting via `exception_notification` Custom Notifier | Implemented | P2 |
+| [RDR-018](RDR-018-billing-aggregation.md) | Billing Aggregation System | Implemented | P2 |
+| [RDR-024](RDR-024-multi-tenancy-isolation-strategy.md) | Multi-Tenancy Isolation Strategy | Implemented | High |
+| [RDR-026](RDR-026-admin-interface-strategy.md) | Admin Interface Strategy | Implemented | Medium |
+| [RDR-029](RDR-029-multi-tenancy-preparation.md) | Multi-Tenancy Preparation | Implemented | High |
 
 ### External Integration
 
 | RDR | Title | Status | Priority |
 |-----|-------|--------|----------|
-| [RDR-012](RDR-012-github-integration.md) | GitHub Integration Strategy | Final | High |
-| [RDR-030](RDR-030-github-app-bot-account.md) | GitHub App Bot Account for Repository Actions | Implemented | High |
+| [RDR-012](RDR-012-github-integration.md) | GitHub Integration Strategy | Partially Implemented | High |
+| [RDR-030](RDR-030-github-app-bot-account.md) | GitHub App Bot Account for Repository Actions | Partially Implemented | High |
 
 ### Service Infrastructure
 
@@ -82,6 +85,7 @@ For more information, see the [RDR methodology](https://github.com/cwensel/rdr).
 | RDR | Title | Status | Priority |
 |-----|-------|--------|----------|
 | [RDR-028](RDR-028-interactive-chat.md) | Interactive Chat for Agent-Driven Development | Implemented | High |
+| [RDR-037](RDR-037-containerized-multi-repo-chat.md) | Containerized Multi-Repo Chat Sessions | Final | High |
 
 ### Scaling & Distribution
 
@@ -94,27 +98,31 @@ For more information, see the [RDR methodology](https://github.com/cwensel/rdr).
 
 | RDR | Title | Status | Priority |
 |-----|-------|--------|----------|
-| [RDR-013](RDR-013-code-quality-backpressure.md) | Code Quality and Backpressure System | Implemented | High |
-| [RDR-022](RDR-022-auto-merge-pr-strategy.md) | Auto-Merge PR Merge Strategy | Final | Medium |
-| [RDR-023](RDR-023-automation-modularization-architecture.md) | Automation Modularization Architecture | Implemented | High |
+| [RDR-013](RDR-013-code-quality-backpressure.md) | Code Quality and Backpressure System | Superseded | High |
+| [RDR-022](RDR-022-auto-merge-pr-strategy.md) | Auto-Merge PR Merge Strategy | Implemented | Medium |
+| [RDR-023](RDR-023-automation-modularization-architecture.md) | Automation Modularization Architecture | Partially Implemented | High |
 | [RDR-031](RDR-031-focused-agent-runs.md) | Focused Agent Runs — Single-Problem-Per-Run | Implemented | P1 |
-| [RDR-036](RDR-036-mutation-testing-for-ai-generated-tests.md) | Mutation Testing for AI-Generated Tests (Mutant) | Draft | P1 |
+| [RDR-032](RDR-032-eager-queue-seeding.md) | Eager Queue Seeding — Eliminate Auto-Pick Throttling | Implemented | P1 |
+| [RDR-035](RDR-035-style-guide-evolution.md) | Style Guide Evolution | Accepted | High |
+| [RDR-036](RDR-036-mutation-testing-for-ai-generated-tests.md) | Mutation Testing for AI-Generated Tests (Mutant) | Partially Implemented | P1 |
 
 ### Runner Intelligence
 
 | RDR | Title | Status | Priority |
 |-----|-------|--------|----------|
-| [RDR-025](RDR-025-runner-quota-tracking.md) | Runner Quota Tracking and Quota-Aware Routing | Implemented | Medium |
-| [RDR-040](RDR-040-runner-model-compatibility-contracts.md) | Runner Model Compatibility Contracts | Draft | P1 |
+| [RDR-025](RDR-025-runner-quota-tracking.md) | Runner Quota Tracking and Quota-Aware Routing | Partially Implemented | Medium |
+| [RDR-025](RDR-025-provider-quota-tracking.md) | Provider Quota Tracking and Quota-Aware Routing | Superseded | Medium |
+| [RDR-038](RDR-038-free-models-catalog-and-runner.md) | Free Models Catalog and Runner | Partially Implemented | P1 |
+| [RDR-040](RDR-040-runner-model-compatibility-contracts.md) | Runner Model Compatibility Contracts | Partially Implemented | P1 |
 
 ### Semantic Understanding
 
 | RDR | Title | Status | Priority |
 |-----|-------|--------|----------|
-| [RDR-018](RDR-018-semantic-code-search.md) | Semantic Code Search (Qdrant + MeiliSearch) | Implemented | Medium |
-| [RDR-021](RDR-021-knowledge-base.md) | Knowledge Base Architecture | Final | High |
-| [RDR-027](RDR-027-auto-enhance-knowledge-evolution.md) | Auto-Enhance and Knowledge Base Evolution | Implemented | High |
-| [RDR-042](RDR-042-change-intent-records.md) | Change Intent Records for the Knowledge Base | Draft | Medium |
+| [RDR-018](RDR-018-semantic-code-search.md) | Semantic Code Search (Qdrant + PostgreSQL full-text) | Implemented | Medium |
+| [RDR-021](RDR-021-knowledge-base.md) | Knowledge Base Architecture | Implemented | High |
+| [RDR-027](RDR-027-auto-enhance-knowledge-evolution.md) | Auto-Enhance and Knowledge Base Evolution | Partially Implemented | High |
+| [RDR-042](RDR-042-change-intent-records.md) | Change Intent Records for the Knowledge Base | Accepted | Medium |
 
 ### AI-Native Evolution (Phase 4)
 


### PR DESCRIPTION
## Summary

- Audit `docs/rdrs` for adoption state, implementation evidence, and remaining work.
- Update RDR markdown status fields and add implementation-status notes where needed.
- Sync the RDR README index, including duplicate-number RDRs and later records that were missing from the index.

## Tracking

Opened follow-up issues for remaining implementation/documentation work and labeled them by priority: #2702, #2703, #2704, #2705, #2706, #2707, #2708, #2709, #2710, #2711, #2712, #2713, #2714, #2715, #2716, #2717, #2718, and #2719.

Existing tracking remains in place for RDR-037, RDR-038, RDR-041, and RDR-042 workstreams. Low-priority follow-up work uses P3 labels rather than P4.

## Validation

- `bin/lint --changed`
- pre-commit lint suite from the commit hook
