### PR TITLE
fix(navigation): clean up top nav and fix dropdown close behavior

### DIFF
--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -39,7 +39,6 @@ export default class extends Controller {
     }
 
     event.preventDefault()
-    event.stopPropagation()
 
     if (this.isOpen()) {
       this.close()

--- a/app/javascript/controllers/mobile_menu_controller.js
+++ b/app/javascript/controllers/mobile_menu_controller.js
@@ -5,7 +5,8 @@ export default class extends Controller {
   static targets = ["menu", "openIcon", "closeIcon", "button"]
 
   connect() {
-    this.mediaQuery = window.matchMedia("(min-width: 768px)")
+    // Matches the Tailwind `lg` breakpoint where the desktop nav takes over.
+    this.mediaQuery = window.matchMedia("(min-width: 1024px)")
     this.boundCloseOnDesktop = this.closeOnDesktop.bind(this)
     this.mediaQuery.addEventListener("change", this.boundCloseOnDesktop)
 

--- a/app/javascript/controllers/nav_badges_controller.js
+++ b/app/javascript/controllers/nav_badges_controller.js
@@ -1,7 +1,9 @@
 import { Controller } from "@hotwired/stimulus"
 
 // Reads badge counts from the notification_nav_badges element and injects
-// badge indicators into nav links that have a matching data-nav-section attribute.
+// badge indicators into nav elements. Single sections use data-nav-section;
+// dropdown triggers that collapse several sections use data-nav-badge-rollup
+// (a space-separated list) to show the combined count of their hidden items.
 export default class extends Controller {
   static values = { counts: Object }
 
@@ -15,18 +17,29 @@ export default class extends Controller {
 
   updateBadges() {
     const counts = this.countsValue
-    document.querySelectorAll("[data-nav-section]").forEach((link) => {
-      const section = link.dataset.navSection
-      const existing = link.querySelector(".nav-badge")
-      if (existing) existing.remove()
 
-      const count = counts[section]
-      if (count && count > 0) {
-        const badge = document.createElement("span")
-        badge.className = "nav-badge ml-1 inline-flex items-center justify-center rounded-full bg-red-500 px-1.5 py-0.5 text-[10px] font-bold text-white"
-        badge.textContent = count > 99 ? "99+" : count
-        link.appendChild(badge)
-      }
+    document.querySelectorAll("[data-nav-section]").forEach((link) => {
+      this.renderBadge(link, counts[link.dataset.navSection] || 0)
     })
+
+    document.querySelectorAll("[data-nav-badge-rollup]").forEach((trigger) => {
+      const total = trigger.dataset.navBadgeRollup
+        .split(/\s+/)
+        .filter(Boolean)
+        .reduce((sum, section) => sum + (counts[section] || 0), 0)
+      this.renderBadge(trigger, total)
+    })
+  }
+
+  renderBadge(element, count) {
+    const existing = element.querySelector(".nav-badge")
+    if (existing) existing.remove()
+
+    if (count > 0) {
+      const badge = document.createElement("span")
+      badge.className = "nav-badge ml-1 inline-flex items-center justify-center rounded-full bg-red-500 px-1.5 py-0.5 text-[10px] font-bold text-white"
+      badge.textContent = count > 99 ? "99+" : count
+      element.appendChild(badge)
+    }
   }
 }

--- a/app/javascript/controllers/notification_dropdown_controller.js
+++ b/app/javascript/controllers/notification_dropdown_controller.js
@@ -16,9 +16,7 @@ export default class extends Controller {
     document.removeEventListener("keydown", this.boundCloseOnEscape)
   }
 
-  toggle(event) {
-    event.stopPropagation()
-
+  toggle() {
     if (this.menuTarget.classList.contains("hidden")) {
       this.menuTarget.classList.remove("hidden")
     } else {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -61,12 +61,16 @@
           </div>
 
           <%# Desktop navigation %>
-          <div class="hidden md:flex md:items-center md:space-x-4">
+          <div class="hidden lg:flex lg:items-center lg:space-x-4">
             <% if user_signed_in? %>
-              <%= link_to "Dashboard", dashboard_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white", data: { nav_section: "dashboard" } %>
-              <%= link_to "Projects", projects_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white", data: { nav_section: "projects" } %>
-              <%= link_to "Agent Runs", agent_runs_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white", data: { nav_section: "agent_runs" } %>
-              <%= link_to "Chat", chat_sessions_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white", data: { nav_section: "chat" } %>
+              <% nav_link_class = "whitespace-nowrap text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white" %>
+              <% nav_trigger_class = "inline-flex items-center gap-1 whitespace-nowrap text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white" %>
+              <% nav_menu_class = "absolute left-0 top-full z-10 mt-2 hidden min-w-48 overflow-hidden rounded-md bg-white py-1 shadow-lg ring-1 ring-black/5 dark:bg-gray-800 dark:ring-white/10" %>
+              <% nav_menu_item_class = "block whitespace-nowrap px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-700" %>
+              <%= link_to "Dashboard", dashboard_path, class: nav_link_class, data: { nav_section: "dashboard" } %>
+              <%= link_to "Projects", projects_path, class: nav_link_class, data: { nav_section: "projects" } %>
+              <%= link_to "Agent Runs", agent_runs_path, class: nav_link_class, data: { nav_section: "agent_runs" } %>
+              <%= link_to "Chat", chat_sessions_path, class: nav_link_class, data: { nav_section: "chat" } %>
               <% if current_account&.scheduler_paused? %>
                 <%= link_to agent_runs_path,
                   class: "inline-flex items-center gap-x-1 rounded-full bg-yellow-100 px-2.5 py-1 text-xs font-semibold text-yellow-800 ring-1 ring-inset ring-yellow-400 hover:bg-yellow-200",
@@ -78,18 +82,64 @@
                   <span>Paused</span>
                 <% end %>
               <% end %>
-              <%= link_to "Prompts", prompts_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white" %>
 
-              <%= link_to "Quality", quality_dashboard_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white" %>
-              <% if policy(ExceptionIncident).index? %>
-                <%= link_to "Exception incidents", exception_incidents_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white", data: { nav_section: "exception_incidents" } %>
-              <% end %>
-              <%= link_to "Knowledge", knowledge_search_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white" %>
-              <%= link_to "Integrations", integrations_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white" %>
-              <%= link_to "Runners", runners_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white", data: { nav_section: "runners" } %>
-              <% if policy(ServiceContainer).index? %>
-                <%= link_to "Services", service_containers_path, class: "text-sm font-medium text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white" %>
-              <% end %>
+              <%# Insights dropdown: quality, prompting, and knowledge %>
+              <div class="relative" data-controller="dropdown">
+                <button type="button"
+                        id="insights-menu-button"
+                        class="<%= nav_trigger_class %>"
+                        aria-haspopup="menu"
+                        aria-expanded="false"
+                        aria-controls="insights-menu"
+                        data-action="dropdown#toggle"
+                        data-dropdown-target="button">
+                  <span>Insights</span>
+                  <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25 4.5a.75.75 0 0 1-1.08 0l-4.25-4.5a.75.75 0 0 1 .02-1.06Z" clip-rule="evenodd" />
+                  </svg>
+                </button>
+                <div id="insights-menu"
+                     class="<%= nav_menu_class %>"
+                     role="menu"
+                     aria-labelledby="insights-menu-button"
+                     data-dropdown-target="menu">
+                  <%= link_to "Quality", quality_dashboard_path, class: nav_menu_item_class, role: "menuitem", data: { action: "dropdown#close" } %>
+                  <%= link_to "Prompts", prompts_path, class: nav_menu_item_class, role: "menuitem", data: { action: "dropdown#close" } %>
+                  <%= link_to "Knowledge", knowledge_search_path, class: nav_menu_item_class, role: "menuitem", data: { action: "dropdown#close" } %>
+                </div>
+              </div>
+
+              <%# Operations dropdown: infrastructure, integrations, and incidents %>
+              <div class="relative" data-controller="dropdown">
+                <button type="button"
+                        id="operations-menu-button"
+                        class="<%= nav_trigger_class %>"
+                        aria-haspopup="menu"
+                        aria-expanded="false"
+                        aria-controls="operations-menu"
+                        data-action="dropdown#toggle"
+                        data-dropdown-target="button">
+                  <span data-nav-badge-rollup="runners exception_incidents">Operations</span>
+                  <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25 4.5a.75.75 0 0 1-1.08 0l-4.25-4.5a.75.75 0 0 1 .02-1.06Z" clip-rule="evenodd" />
+                  </svg>
+                </button>
+                <div id="operations-menu"
+                     class="<%= nav_menu_class %>"
+                     role="menu"
+                     aria-labelledby="operations-menu-button"
+                     data-dropdown-target="menu">
+                  <%= link_to "Runners", runners_path, class: nav_menu_item_class, role: "menuitem", data: { action: "dropdown#close", nav_section: "runners" } %>
+                  <% if policy(ServiceContainer).index? %>
+                    <%= link_to "Services", service_containers_path, class: nav_menu_item_class, role: "menuitem", data: { action: "dropdown#close" } %>
+                  <% end %>
+                  <%= link_to "Integrations", integrations_path, class: nav_menu_item_class, role: "menuitem", data: { action: "dropdown#close" } %>
+                  <% if policy(ExceptionIncident).index? %>
+                    <%= link_to "Exception incidents", exception_incidents_path, class: nav_menu_item_class, role: "menuitem", data: { action: "dropdown#close", nav_section: "exception_incidents" } %>
+                  <% end %>
+                </div>
+              </div>
+
               <%= render "notifications/bell", account: current_account %>
               <% user_menu_button_id = "user-menu-button" %>
               <% user_menu_id = "user-menu" %>
@@ -102,8 +152,8 @@
                         aria-controls="<%= user_menu_id %>"
                         data-action="dropdown#toggle"
                         data-dropdown-target="button">
-                  <span><%= current_user.email %></span>
-                  <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <span class="max-w-[12rem] truncate"><%= current_user.email %></span>
+                  <svg class="h-4 w-4 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                     <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25 4.5a.75.75 0 0 1-1.08 0l-4.25-4.5a.75.75 0 0 1 .02-1.06Z" clip-rule="evenodd" />
                   </svg>
                 </button>
@@ -145,7 +195,7 @@
           </div>
 
           <%# Mobile hamburger button %>
-          <div class="flex items-center md:hidden">
+          <div class="flex items-center lg:hidden">
             <button type="button" data-action="mobile-menu#toggle" data-mobile-menu-target="button" class="inline-flex items-center justify-center rounded-md p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-500 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" aria-expanded="false" aria-controls="mobile-menu">
               <span class="sr-only">Main menu</span>
               <%# Hamburger icon %>
@@ -162,13 +212,15 @@
       </div>
 
       <%# Mobile dropdown menu %>
-      <div id="mobile-menu" data-mobile-menu-target="menu" class="hidden md:hidden" aria-hidden="true">
+      <div id="mobile-menu" data-mobile-menu-target="menu" class="hidden lg:hidden" aria-hidden="true">
         <div class="space-y-1 px-4 pb-3 pt-2">
           <% if user_signed_in? %>
-            <%= link_to "Dashboard", dashboard_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
-            <%= link_to "Projects", projects_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
-            <%= link_to "Agent Runs", agent_runs_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
-            <%= link_to "Chat", chat_sessions_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
+            <% mobile_link_class = "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
+            <% mobile_heading_class = "px-3 pb-1 pt-3 text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500" %>
+            <%= link_to "Dashboard", dashboard_path, data: { action: "mobile-menu#close", nav_section: "dashboard" }, class: mobile_link_class %>
+            <%= link_to "Projects", projects_path, data: { action: "mobile-menu#close", nav_section: "projects" }, class: mobile_link_class %>
+            <%= link_to "Agent Runs", agent_runs_path, data: { action: "mobile-menu#close", nav_section: "agent_runs" }, class: mobile_link_class %>
+            <%= link_to "Chat", chat_sessions_path, data: { action: "mobile-menu#close", nav_section: "chat" }, class: mobile_link_class %>
             <% if current_account&.scheduler_paused? %>
               <%= link_to agent_runs_path,
                 data: { action: "mobile-menu#close", testid: "navbar-scheduler-paused-mobile" },
@@ -179,19 +231,22 @@
                 <span>Scheduler Paused</span>
               <% end %>
             <% end %>
-            <%= link_to "Prompts", prompts_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
 
-            <%= link_to "Quality", quality_dashboard_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
-            <% if policy(ExceptionIncident).index? %>
-              <%= link_to "Exception incidents", exception_incidents_path, data: { action: "mobile-menu#close", testid: "mobile-exception-incidents-link" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
-            <% end %>
-            <%= link_to "Knowledge", knowledge_search_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
-            <%= link_to "Integrations", integrations_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
-            <%= link_to "Runners", runners_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
+            <p class="<%= mobile_heading_class %>">Insights</p>
+            <%= link_to "Quality", quality_dashboard_path, data: { action: "mobile-menu#close" }, class: mobile_link_class %>
+            <%= link_to "Prompts", prompts_path, data: { action: "mobile-menu#close" }, class: mobile_link_class %>
+            <%= link_to "Knowledge", knowledge_search_path, data: { action: "mobile-menu#close" }, class: mobile_link_class %>
+
+            <p class="<%= mobile_heading_class %>">Operations</p>
+            <%= link_to "Runners", runners_path, data: { action: "mobile-menu#close", nav_section: "runners" }, class: mobile_link_class %>
             <% if policy(ServiceContainer).index? %>
-              <%= link_to "Services", service_containers_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
+              <%= link_to "Services", service_containers_path, data: { action: "mobile-menu#close" }, class: mobile_link_class %>
             <% end %>
-            <%= link_to "Notifications", notifications_path, data: { action: "mobile-menu#close" }, class: "block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>
+            <%= link_to "Integrations", integrations_path, data: { action: "mobile-menu#close" }, class: mobile_link_class %>
+            <% if policy(ExceptionIncident).index? %>
+              <%= link_to "Exception incidents", exception_incidents_path, data: { action: "mobile-menu#close", testid: "mobile-exception-incidents-link", nav_section: "exception_incidents" }, class: mobile_link_class %>
+            <% end %>
+            <%= link_to "Notifications", notifications_path, data: { action: "mobile-menu#close" }, class: mobile_link_class %>
             <div class="border-t border-gray-200 dark:border-gray-600 pt-3 mt-2">
               <p class="px-3 text-sm text-gray-700 dark:text-gray-300"><%= current_user.email %></p>
               <%= link_to "Settings", edit_user_settings_path, data: { action: "mobile-menu#close" }, class: "mt-1 block rounded-md px-3 py-2 text-base font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white" %>

--- a/spec/lib/dropdown_controller_node_harness_spec.rb
+++ b/spec/lib/dropdown_controller_node_harness_spec.rb
@@ -91,8 +91,12 @@ class DropdownControllerNodeHarness
 
       harness.controller.toggle(toggleEvent);
 
-      if (!toggleEvent.prevented || !toggleEvent.stopped) {
-        throw new Error("Expected toggle() to stop the triggering click event");
+      if (!toggleEvent.prevented) {
+        throw new Error("Expected toggle() to prevent the click's default action");
+      }
+
+      if (toggleEvent.stopped) {
+        throw new Error("Expected toggle() to let the click propagate so other open menus close");
       }
 
       if (harness.menu.classList.contains("hidden")) {

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "Dashboard" do
         get dashboard_path
 
         doc = Nokogiri::HTML(response.body)
-        desktop_nav = doc.at_xpath("//nav//div[contains(@class, 'hidden') and contains(@class, 'md:flex')]")
+        desktop_nav = doc.at_xpath("//nav//div[contains(@class, 'hidden') and contains(@class, 'lg:flex')]")
         top_level_labels = desktop_nav.xpath("./a|./form/button").map { |node| node.text.strip }
 
         expect(top_level_labels).not_to include("Settings")


### PR DESCRIPTION
## Problem

The desktop top nav had **12 top-level links** plus the notification bell and user menu, which overflowed the flex row:

- "Exception incidents" wrapped to two lines, leaving a large blank gap.
- Badge/link text spilled leftward onto the "Paid" brand.
- Opening one dropdown and then clicking another left the first dropdown **stuck open**.

## Changes

**Nav restructure (Insights + Operations grouping)**
- Top-level links kept flat: **Dashboard, Projects, Agent Runs, Chat** (each keeps its notification badge).
- **Insights ▾**: Quality, Prompts, Knowledge.
- **Operations ▾**: Runners, Services, Integrations, Exception incidents — its trigger shows a **rolled-up badge** summing the collapsed sections' counts.
- Reuses the existing `dropdown` Stimulus controller / account-menu markup (ARIA, outside-click, Escape).

**Layout hardening**
- `whitespace-nowrap` on links/triggers; user email truncated (`max-w-[12rem] truncate`).
- Desktop breakpoint raised `md` → `lg` so tablet widths (768–1023px) get the clean hamburger instead of a cramped row (`mobile_menu_controller` media query updated to match).
- Mobile menu reorganized with **INSIGHTS / OPERATIONS** section headings and badge parity.

**Dropdown close bug**
- Removed `event.stopPropagation()` from `dropdown#toggle` and `notification-dropdown#toggle`. The call prevented the click from reaching the `document`-level outside-click handlers, so sibling menus never closed. Each controller already guards its own menu via `element.contains(target)`, so removing it is safe and lets any open menu close when another trigger is clicked.

**Tests**
- Flipped the `dropdown_controller_node_harness` assertion to require `preventDefault()` **without** `stopPropagation()` — locking in the fix as a regression guard.
- Updated `dashboard_spec` desktop-nav selector `md:flex` → `lg:flex`.

## Verification

- `spec/lib/dropdown_controller_node_harness_spec.rb` + `spec/requests/dashboard_spec.rb`: **61 examples, 0 failures**.
- Browser-verified at 1280 / 1024 / 800px: single-line nav, dropdowns open/switch correctly, bell ↔ dropdown close in both directions, no horizontal overflow at the 1024px boundary, grouped mobile menu with working badges.
- ESLint, Herb, RuboCop all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)