### PR TITLE
[codex] Surface empty chat model responses

### DIFF
--- a/app/services/chat_sessions/agent_loop.rb
+++ b/app/services/chat_sessions/agent_loop.rb
@@ -14,6 +14,7 @@ module ChatSessions
 
     MAX_TOOL_ITERATIONS = 8
     MAX_CONVERSATION_MESSAGES = 200
+    EMPTY_RESPONSE_MESSAGE = "I couldn't complete that turn because the model returned an empty response. Please try again."
     TOOL_ITERATION_LIMIT_MESSAGE = "I hit the maximum number of tool iterations for this turn. Please try again with a narrower request."
 
     attr_reader :chat_session, :llm_client, :on_chunk, :on_message_persisted, :stream_message_id
@@ -49,7 +50,13 @@ module ChatSessions
         last_response_model = response[:model]
 
         final_assistant_message = create_assistant_message(response) if response[:content].present?
-        break if response[:tool_calls].blank?
+        if response[:tool_calls].blank?
+          final_assistant_message ||= create_empty_response_message(
+            model: last_response_model,
+            aggregate_tokens: aggregate_tokens
+          )
+          break
+        end
 
         conversation << {
           role: "assistant",
@@ -238,6 +245,29 @@ module ChatSessions
 
       on_message_persisted&.call(message, stream_message_id: stream_message_id)
       message
+    end
+
+    def create_empty_response_message(model:, aggregate_tokens:)
+      log_empty_response(model:, aggregate_tokens:)
+
+      create_assistant_message(
+        content: EMPTY_RESPONSE_MESSAGE,
+        model: model,
+        tokens_input: aggregate_tokens[:input],
+        tokens_output: aggregate_tokens[:output]
+      )
+    end
+
+    def log_empty_response(model:, aggregate_tokens:)
+      Rails.logger.warn(
+        message: "chat_agent_loop.empty_response",
+        chat_session_id: chat_session.id,
+        project_id: chat_session.project_id,
+        runner_id: chat_session.runner_id,
+        model: model,
+        tokens_input: aggregate_tokens[:input],
+        tokens_output: aggregate_tokens[:output]
+      )
     end
 
     def persist_tool_call_message(tool_call, status: nil)

--- a/spec/services/chat_sessions/agent_loop_spec.rb
+++ b/spec/services/chat_sessions/agent_loop_spec.rb
@@ -170,6 +170,35 @@ RSpec.describe ChatSessions::AgentLoop do
         expect(chat_session.messages.where.not(tool_status: nil).count).to eq(0)
       end
     end
+
+    context "when the model returns no content or tool calls" do
+      let(:llm_client) do
+        Class.new do
+          def call(_conversation, tools: nil)
+            { content: nil, tool_calls: [], tokens_input: 12, tokens_output: 0, model: "glm-5.1" }
+          end
+        end.new
+      end
+
+      it "persists a visible assistant message instead of silently completing" do
+        allow(Rails.logger).to receive(:warn)
+
+        result = described_class.new(chat_session: chat_session, llm_client: llm_client).run
+
+        expect(result).to be_a(ChatMessage)
+        expect(result.content).to eq(described_class::EMPTY_RESPONSE_MESSAGE)
+        expect(result).to have_attributes(tokens_input: 12, tokens_output: 0, model: "glm-5.1")
+        expect(chat_session.messages.where(role: "assistant").last).to eq(result)
+        expect(Rails.logger).to have_received(:warn).with(hash_including(
+          message: "chat_agent_loop.empty_response",
+          chat_session_id: chat_session.id,
+          runner_id: chat_session.runner_id,
+          model: "glm-5.1",
+          tokens_input: 12,
+          tokens_output: 0
+        ))
+      end
+    end
   end
 
   describe "#build_conversation" do


### PR DESCRIPTION
## Summary
- Persist a visible assistant fallback when a chat model returns no content and no tool calls.
- Record the real aggregate token counts on that fallback message.
- Log `chat_agent_loop.empty_response` with session, project, runner, model, and token metadata for future diagnosis.

## Root Cause
`ChatSessions::AgentLoop` treated blank-content/no-tool responses as a successful turn and broke out of the loop without creating an assistant message, so the UI looked like the restarted chat had swallowed the user message.

## Validation
- `bin/rspec spec/services/chat_sessions/agent_loop_spec.rb spec/services/chat_sessions/send_message_spec.rb spec/jobs/chat_sessions/process_message_job_spec.rb`
- `bin/rubocop app/services/chat_sessions/agent_loop.rb spec/services/chat_sessions/agent_loop_spec.rb`
- Pre-commit hook passed on commit.
