### PR TITLE
feat(screenshots): scope and annotate PR screenshots to changed pages

### DIFF
--- a/app/services/screenshots/capture_targets.rb
+++ b/app/services/screenshots/capture_targets.rb
@@ -183,12 +183,13 @@ module Screenshots
       workflow_status: Target.new(slug: "workflow_status", path_builder: ->(seed_data) { "/projects/#{seed_data.fetch(:project).id}/workflow_status" }, requires_auth: true)
     }.freeze
 
-    def self.call(changed_files:)
-      new(changed_files: changed_files).call
+    def self.call(changed_files:, repo_path: nil)
+      new(changed_files: changed_files, repo_path: repo_path).call
     end
 
-    def initialize(changed_files:)
+    def initialize(changed_files:, repo_path: nil)
       @changed_files = Array(changed_files)
+      @repo_path = repo_path.presence&.chomp("/")
     end
 
     def call
@@ -305,8 +306,12 @@ module Screenshots
       return targets_for_javascript_registry if path == "app/javascript/controllers/index.js"
 
       if path.start_with?("app/javascript/controllers/")
-        explicit_targets = targets_for_javascript_controller(path.delete_prefix("app/javascript/controllers/"))
+        relative = path.delete_prefix("app/javascript/controllers/")
+        explicit_targets = targets_for_javascript_controller(relative)
         return explicit_targets if explicit_targets.any?
+
+        scanned = targets_for_stimulus_usage(relative)
+        return scanned if scanned&.any?
       end
 
       return SHARED_TARGET_KEYS if shared_ui_file?(path)
@@ -353,6 +358,109 @@ module Screenshots
         .uniq
 
       return explicit_targets if explicit_targets.any?
+
+      SHARED_TARGET_KEYS
+    end
+
+    # Globs scanned to discover which views statically reference a Stimulus
+    # controller via `data-controller`. Used to narrow a JS controller change to
+    # the pages that actually mount it, instead of fanning out to every page.
+    STIMULUS_SCAN_GLOBS = %w[app/views/**/*.erb app/components/**/*.erb app/components/**/*.rb].freeze
+
+    # Returns target keys for the pages that statically mount the given Stimulus
+    # controller, or nil to signal "cannot narrow" so the caller falls back to
+    # the conservative shared-target behavior. Requires a repo_path to scan.
+    def targets_for_stimulus_usage(relative_path)
+      return nil if @repo_path.blank?
+
+      identifier = stimulus_identifier(relative_path)
+      return nil if identifier.nil?
+
+      matches = stimulus_usage_index[identifier]
+      return nil if matches.empty? # not referenced statically — stay conservative
+
+      # Mounted on a globally rendered surface (layout, shared partial, component)
+      # — a change can affect any page, so we cannot safely narrow.
+      return SHARED_TARGET_KEYS if matches.any? { |file| global_surface?(file) }
+
+      matches.flat_map { |file| targets_for_static_view(file) }.uniq
+    end
+
+    # Derives the Stimulus identifier from a controller file path, mirroring
+    # Stimulus conventions: underscores become dashes and nested directories
+    # become `--`. e.g. "foo/bar_baz_controller.js" => "foo--bar-baz".
+    def stimulus_identifier(relative_path)
+      return nil unless relative_path.end_with?("_controller.js")
+
+      relative_path
+        .delete_suffix("_controller.js")
+        .split("/")
+        .map { |segment| segment.tr("_", "-") }
+        .join("--")
+    end
+
+    def stimulus_usage_index
+      @stimulus_usage_index ||= STIMULUS_SCAN_GLOBS.each_with_object(Hash.new { |h, k| h[k] = [] }) do |glob, index|
+        Dir.glob(File.join(@repo_path, glob)).each do |file|
+          relative = file.delete_prefix("#{@repo_path}/")
+          stimulus_identifiers_in(read_scrubbed(file)).each { |identifier| index[identifier] << relative }
+        rescue SystemCallError, ArgumentError
+          next # unreadable or undecodable file — skip
+        end
+      end
+    end
+
+    # Reads a file as scrubbed UTF-8 so a stray invalid byte sequence can never
+    # raise from the regex scan and abort the whole capture-targets resolution.
+    def read_scrubbed(file)
+      File.read(file).scrub
+    end
+
+    # Extracts the Stimulus identifiers referenced in the given markup, covering
+    # both the HTML attribute form (`data-controller="a b"`) and the Rails
+    # tag-helper hash form (`data: { controller: "a" }` / `controller: "a"`).
+    def stimulus_identifiers_in(content)
+      content
+        .scan(/(?:data-controller=|\bcontroller:\s*)("|')([^"']*)\1/)
+        .flat_map { |_quote, value| value.split(/\s+/) }
+        .uniq
+    end
+
+    def global_surface?(file)
+      file.start_with?("app/components/") ||
+        file.start_with?("app/views/layouts/") ||
+        file.start_with?("app/views/shared/") ||
+        layout_rendered_partials.include?(file)
+    end
+
+    LAYOUT_GLOB = "app/views/layouts/**/*.erb"
+
+    # Partials rendered directly from a layout are mounted on every page that
+    # uses that layout, so a Stimulus controller living in one cannot be narrowed
+    # to a single page (e.g. the notification bell rendered into the global nav).
+    # Over-matching here only widens capture, which is safe.
+    def layout_rendered_partials
+      @layout_rendered_partials ||= build_layout_rendered_partials
+    end
+
+    def build_layout_rendered_partials
+      return Set.new if @repo_path.blank?
+
+      Dir.glob(File.join(@repo_path, LAYOUT_GLOB)).each_with_object(Set.new) do |layout, set|
+        read_scrubbed(layout).scan(/render\b\s*\(?\s*(?:partial:\s*)?("|')([^"']+)\1/) do |_quote, partial|
+          dir, _, name = partial.rpartition("/")
+          next if name.empty?
+
+          set << "app/views/#{dir.empty? ? '' : "#{dir}/"}_#{name}.html.erb"
+        end
+      rescue SystemCallError, ArgumentError
+        next
+      end
+    end
+
+    def targets_for_static_view(file)
+      return SHARED_TARGET_KEYS if global_surface?(file)
+      return targets_for_view(file.delete_prefix("app/views/")) if file.start_with?("app/views/")
 
       SHARED_TARGET_KEYS
     end

--- a/app/services/screenshots/container_capture.rb
+++ b/app/services/screenshots/container_capture.rb
@@ -52,6 +52,7 @@ module Screenshots
       @config = nil
       @network = nil
       @published_url = nil
+      @hints = {}
     end
 
     def call
@@ -74,6 +75,15 @@ module Screenshots
         # Re-detect with full repo context (custom patterns/exclusions from config)
         ui_files = detect_ui_files(changed_files, repo_path)
         return finalize_skip("no_ui_changes", changed_files:, ui_files:) if ui_files.empty?
+
+        # Derive per-route hints (best-effort) to scope and annotate capture to the
+        # pages the agent actually changed. Empty hints fall back to all routes.
+        @hints = Screenshots::DeriveHints.call(
+          agent_run: agent_run,
+          routes: @config.routes,
+          changed_files: ui_files,
+          logger: logger
+        )
 
         provision_service_dependencies!
         start_chrome!
@@ -343,6 +353,7 @@ module Screenshots
         route_name = File.basename(path, ".png")
         {
           route_name: route_name,
+          summary: @hints.dig(route_name, "summary"),
           url: storage.upload(
             file_path: path,
             org: project.owner,
@@ -411,12 +422,40 @@ module Screenshots
           ]);
         }
 
+        async function annotate(annotation) {
+          if (!annotation) return;
+          await page.evaluate((hint) => {
+            if (hint.selector) {
+              try {
+                const el = document.querySelector(hint.selector);
+                if (el) {
+                  el.scrollIntoView({ block: "center", inline: "center" });
+                  el.style.outline = "3px solid #ff3b30";
+                  el.style.outlineOffset = "2px";
+                }
+              } catch (e) { /* invalid selector — skip highlight */ }
+            }
+            if (hint.summary) {
+              const banner = document.createElement("div");
+              banner.textContent = "Changed: " + hint.summary;
+              Object.assign(banner.style, {
+                position: "fixed", top: "0", left: "0", right: "0", zIndex: "2147483647",
+                background: "rgba(255,59,48,0.95)", color: "#fff",
+                font: "14px/1.4 system-ui, -apple-system, sans-serif",
+                padding: "8px 12px", boxSizing: "border-box",
+              });
+              document.body.appendChild(banner);
+            }
+          }, annotation);
+        }
+
         await fs.mkdir(outputDir, { recursive: true });
         await authenticate();
 
         for (const route of config.routes) {
           const target = new URL(route.path, config.base_url).toString();
           await page.goto(target, { waitUntil: "networkidle" });
+          await annotate(route.annotation);
           await page.screenshot({ path: `${outputDir}/${route.name}.png`, fullPage: true });
         }
 
@@ -424,11 +463,24 @@ module Screenshots
       JS
     end
 
+    # Scopes capture to the routes the agent's change affected, when hints are
+    # available. Falls back to every configured route when hints are empty or
+    # none of them match a configured route name (conservative — never captures
+    # less than the unscoped behavior would when hints are unusable).
+    def routes_for_capture
+      return config.routes if @hints.blank?
+
+      scoped = config.routes.select { |route| @hints.key?(route.name.to_s) }
+      scoped.presence || config.routes
+    end
+
     def screenshot_config_json
       {
         base_url: config.base_url,
         viewport: { width: config.viewport.width, height: config.viewport.height },
-        routes: config.routes.map { |route| { path: route.path, name: route.name } },
+        routes: routes_for_capture.map { |route|
+          { path: route.path, name: route.name, annotation: @hints[route.name.to_s] }.compact
+        },
         auth: {
           strategy: config.auth.strategy,
           login_path: config.auth.login_path,

--- a/app/services/screenshots/derive_hints.rb
+++ b/app/services/screenshots/derive_hints.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+module Screenshots
+  # Derives per-route screenshot hints from an agent run's change, using
+  # agent_harness. Given the project's configured screenshot routes, the agent's
+  # summary, and the changed files, it asks the LLM which rendered pages the
+  # change affects, a one-line summary of what changed on each, and an optional
+  # CSS selector to highlight.
+  #
+  # The result scopes screenshot capture to the affected pages and lets the
+  # capture runner annotate them. It is persisted to +agent_run.screenshot_hints+
+  # as a Hash keyed by route name:
+  #
+  #   { "dashboard" => { "summary" => "Added a weekly cost card", "selector" => "[data-testid='cost-card']" } }
+  #
+  # Best-effort: returns +{}+ (and leaves the column unchanged) on any failure,
+  # so callers fall back to capturing every configured route.
+  class DeriveHints
+    DEFAULT_MODEL = "claude-sonnet-4-6"
+    TIMEOUT = 30
+    MAX_SUMMARY_INPUT = 8_000
+    MAX_FILES = 100
+    MAX_HINT_SUMMARY = 200
+    MAX_SELECTOR_LENGTH = 200
+
+    PROMPT = <<~PROMPT
+      You are scoping UI screenshots for a code change. Below are the screenshot routes
+      configured for an application, the summary of an automated agent's change, and the
+      files it changed. Decide which routes render a page that this change could visibly
+      affect.
+
+      Respond with ONLY a JSON object (no preamble, no markdown fences) mapping each
+      affected route name to an object with:
+        - "summary": one short sentence describing what visibly changed on that page.
+        - "selector": OPTIONAL CSS selector for the single most relevant changed element,
+          or null if you cannot identify one confidently.
+
+      Rules:
+        - Bias toward inclusion. A page you omit will NOT be screenshotted, so the
+          reviewer never sees it — when in doubt whether a route is affected, include it.
+        - Only omit a route when you are confident the change cannot affect its page.
+        - If a change is global (shared layout, global stylesheet, navigation), include
+          every route.
+        - Use the exact route names provided. Do not invent routes.
+        - If the change genuinely cannot affect any listed page, respond with {}.
+
+      ## Routes (name — path)
+      {{routes}}
+
+      ## Agent change summary
+      {{agent_summary}}
+
+      ## Changed files
+      {{changed_files}}
+    PROMPT
+
+    def self.call(agent_run:, routes:, changed_files: [], logger: Rails.logger)
+      new(agent_run:, routes:, changed_files:, logger:).call
+    end
+
+    def initialize(agent_run:, routes:, changed_files:, logger:)
+      @agent_run = agent_run
+      @routes = Array(routes)
+      @changed_files = Array(changed_files)
+      @logger = logger
+    end
+
+    def call
+      return {} if @routes.empty?
+
+      hints = sanitize(request_hints)
+      persist(hints)
+      hints
+    rescue => e
+      @logger.warn(
+        message: "screenshots.derive_hints_failed",
+        agent_run_id: @agent_run.id,
+        error: e.message,
+        error_class: e.class.name
+      )
+      {}
+    end
+
+    private
+
+    def request_hints
+      response = AgentHarness.send_message(
+        prompt,
+        provider: :claude,
+        model: DEFAULT_MODEL,
+        timeout: TIMEOUT,
+        tools: :none,
+        **Llm::TextMode.options
+      )
+      return {} unless response.success?
+
+      parse_json(response.output)
+    end
+
+    # Keeps only known route names with well-formed summary/selector values, so a
+    # malformed or over-eager LLM response can never widen capture or inject bad
+    # selectors.
+    def sanitize(parsed)
+      return {} unless parsed.is_a?(Hash)
+
+      valid_names = @routes.map { |route| route.name.to_s }.to_set
+
+      parsed.each_with_object({}) do |(name, value), result|
+        name = name.to_s
+        next unless valid_names.include?(name)
+        next unless value.is_a?(Hash)
+
+        summary = value["summary"].to_s.strip
+        next if summary.empty?
+
+        result[name] = {
+          "summary" => summary.truncate(MAX_HINT_SUMMARY),
+          "selector" => clean_selector(value["selector"])
+        }.compact
+      end
+    end
+
+    # A selector is fed to document.querySelector in the browser; keep it bounded
+    # and single-line. querySelector cannot execute script, so this is bloat/DoS
+    # hygiene rather than an XSS fix.
+    def clean_selector(raw)
+      selector = raw.to_s.strip
+      return nil if selector.empty? || selector.length > MAX_SELECTOR_LENGTH || selector.match?(/[\r\n]/)
+
+      selector
+    end
+
+    def persist(hints)
+      @agent_run.update!(screenshot_hints: hints)
+    end
+
+    def parse_json(text)
+      cleaned = strip_fence(text.to_s.strip)
+      JSON.parse(cleaned)
+    rescue JSON::ParserError
+      {}
+    end
+
+    def strip_fence(text)
+      match = text.match(/\A```(?:json)?\s*\n(.*)\n```\z/m)
+      match ? match[1].strip : text
+    end
+
+    def prompt
+      route_lines = @routes.map { |route| "- #{route.name} — #{route.path}" }.join("\n")
+      file_lines = @changed_files.first(MAX_FILES).map { |file| "- #{file}" }.join("\n").presence || "(none reported)"
+
+      PROMPT
+        .sub("{{routes}}", route_lines)
+        .sub("{{agent_summary}}", @agent_run.agent_summary(limit: MAX_SUMMARY_INPUT).presence || "(no summary available)")
+        .sub("{{changed_files}}", file_lines)
+    end
+  end
+end

--- a/app/services/screenshots/derive_hints.rb
+++ b/app/services/screenshots/derive_hints.rb
@@ -18,7 +18,8 @@ module Screenshots
   class DeriveHints
     DEFAULT_MODEL = "claude-sonnet-4-6"
     TIMEOUT = 30
-    MAX_SUMMARY_INPUT = 8_000
+    MAX_SUMMARY_CHARS = 8_000
+    MAX_SUMMARY_ENTRIES = 500
     MAX_FILES = 100
     MAX_HINT_SUMMARY = 200
     MAX_SELECTOR_LENGTH = 200
@@ -152,7 +153,10 @@ module Screenshots
 
       PROMPT
         .sub("{{routes}}", route_lines)
-        .sub("{{agent_summary}}", @agent_run.agent_summary(limit: MAX_SUMMARY_INPUT).presence || "(no summary available)")
+        .sub(
+          "{{agent_summary}}",
+          @agent_run.agent_summary(limit: MAX_SUMMARY_ENTRIES).truncate(MAX_SUMMARY_CHARS, omission: "").presence || "(no summary available)"
+        )
         .sub("{{changed_files}}", file_lines)
     end
   end

--- a/app/services/screenshots/derive_hints.rb
+++ b/app/services/screenshots/derive_hints.rb
@@ -2,10 +2,10 @@
 
 module Screenshots
   # Derives per-route screenshot hints from an agent run's change, using
-  # agent_harness. Given the project's configured screenshot routes, the agent's
-  # summary, and the changed files, it asks the LLM which rendered pages the
-  # change affects, a one-line summary of what changed on each, and an optional
-  # CSS selector to highlight.
+  # agent_harness. Given the project's configured screenshot routes and the
+  # changed files, it asks the LLM which rendered pages the change affects, a
+  # one-line summary of what changed on each, and an optional CSS selector to
+  # highlight.
   #
   # The result scopes screenshot capture to the affected pages and lets the
   # capture runner annotate them. It is persisted to +agent_run.screenshot_hints+
@@ -18,17 +18,14 @@ module Screenshots
   class DeriveHints
     DEFAULT_MODEL = "claude-sonnet-4-6"
     TIMEOUT = 30
-    MAX_SUMMARY_CHARS = 8_000
-    MAX_SUMMARY_ENTRIES = 500
     MAX_FILES = 100
     MAX_HINT_SUMMARY = 200
     MAX_SELECTOR_LENGTH = 200
 
     PROMPT = <<~PROMPT
       You are scoping UI screenshots for a code change. Below are the screenshot routes
-      configured for an application, the summary of an automated agent's change, and the
-      files it changed. Decide which routes render a page that this change could visibly
-      affect.
+      configured for an application and the files changed in the repo. Decide
+      which routes render a page that this change could visibly affect.
 
       Respond with ONLY a JSON object (no preamble, no markdown fences) mapping each
       affected route name to an object with:
@@ -47,9 +44,6 @@ module Screenshots
 
       ## Routes (name — path)
       {{routes}}
-
-      ## Agent change summary
-      {{agent_summary}}
 
       ## Changed files
       {{changed_files}}
@@ -153,10 +147,6 @@ module Screenshots
 
       PROMPT
         .sub("{{routes}}", route_lines)
-        .sub(
-          "{{agent_summary}}",
-          @agent_run.agent_summary(limit: MAX_SUMMARY_ENTRIES).truncate(MAX_SUMMARY_CHARS, omission: "").presence || "(no summary available)"
-        )
         .sub("{{changed_files}}", file_lines)
     end
   end

--- a/app/services/screenshots/pr_comment.rb
+++ b/app/services/screenshots/pr_comment.rb
@@ -113,21 +113,30 @@ module Screenshots
         return "#{MARKER}\n## UI Screenshots\n\nNo screenshots captured for commit `#{short_sha}`.\n"
       end
 
+      grouped = group_by_category(@screenshots)
+
+      annotated = @screenshots.any? { |s| s[:summary].present? }
+
       lines = [ MARKER ]
       lines << "## UI Screenshots"
       lines << ""
       lines << "This PR includes **UI-facing changes**. Screenshots captured from commit `#{short_sha}`."
+      if annotated
+        lines << ""
+        lines << "> Pages were scoped by Paid to those this change appears to affect; " \
+                 "pages judged unrelated were skipped. Request a full capture if something looks missing."
+      end
       lines << ""
-
-      grouped = group_by_category(@screenshots)
 
       grouped.each do |category, category_screenshots|
         lines << "### #{category}"
         lines << ""
 
         if @previous_screenshots.any?
-          lines << "| Page | Before | After |"
-          lines << "|------|--------|-------|"
+          header = annotated ? "| Page | What changed | Before | After |" : "| Page | Before | After |"
+          divider = annotated ? "|------|--------------|--------|-------|" : "|------|--------|-------|"
+          lines << header
+          lines << divider
 
           category_screenshots.sort_by { |s| s[:route_name] }.each do |screenshot|
             name = screenshot[:route_name]
@@ -135,16 +144,24 @@ module Screenshots
             before_url = @previous_screenshots[name]
 
             before_cell = before_url ? "![before-#{name}](#{before_url})" : "_New page_"
-            lines << "| #{humanize_route(name)} | #{before_cell} | ![#{name}](#{after_url}) |"
+            cells = [ humanize_route(name) ]
+            cells << changed_cell(screenshot) if annotated
+            cells += [ before_cell, "![#{name}](#{after_url})" ]
+            lines << "| #{cells.join(' | ')} |"
           end
         else
-          lines << "| Page | Screenshot |"
-          lines << "|------|-----------|"
+          header = annotated ? "| Page | What changed | Screenshot |" : "| Page | Screenshot |"
+          divider = annotated ? "|------|--------------|-----------|" : "|------|-----------|"
+          lines << header
+          lines << divider
 
           category_screenshots.sort_by { |s| s[:route_name] }.each do |screenshot|
             name = screenshot[:route_name]
             url = screenshot[:url]
-            lines << "| #{humanize_route(name)} | ![#{name}](#{url}) |"
+            cells = [ humanize_route(name) ]
+            cells << changed_cell(screenshot) if annotated
+            cells << "![#{name}](#{url})"
+            lines << "| #{cells.join(' | ')} |"
           end
         end
 
@@ -166,6 +183,20 @@ module Screenshots
 
     def humanize_route(route_name)
       route_name.to_s.tr("_", " ").gsub(/\b\w/, &:upcase)
+    end
+
+    MAX_SUMMARY_LENGTH = 300
+
+    # Renders the agent-derived "what changed" summary for a table cell. The text
+    # is agent-influenced, so every markdown/HTML-significant character is
+    # backslash-escaped (neutralizing images, links, raw HTML, and table
+    # breakouts) and whitespace is collapsed to keep the row intact. GFM strips
+    # the backslashes on render, so the displayed text stays clean.
+    def changed_cell(screenshot)
+      summary = screenshot[:summary].to_s.gsub(/\s+/, " ").strip
+      return "—" if summary.empty?
+
+      summary.truncate(MAX_SUMMARY_LENGTH).gsub(/[\\`*_{}\[\]()#+\-!<>|~]/) { |char| "\\#{char}" }
     end
 
     def group_by_category(screenshots)

--- a/db/migrate/20260628041053_add_screenshot_hints_to_agent_runs.rb
+++ b/db/migrate/20260628041053_add_screenshot_hints_to_agent_runs.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddScreenshotHintsToAgentRuns < ActiveRecord::Migration[8.1]
+  def change
+    add_column :agent_runs, :screenshot_hints, :jsonb, default: {}, null: false,
+      comment: "Per-route screenshot hints derived from the agent's change (route name => {summary, selector}). " \
+               "Used to scope and annotate UI screenshots to what the agent actually changed."
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_26_174154) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_28_041053) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -259,6 +259,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_26_174154) do
     t.bigint "runner_id"
     t.integer "runner_switches", default: 0, null: false
     t.jsonb "runners_attempted", default: [], null: false
+    t.jsonb "screenshot_hints", default: {}, null: false, comment: "Per-route screenshot hints derived from the agent's change (route name => {summary, selector}). Used to scope and annotate UI screenshots to what the agent actually changed."
     t.jsonb "service_container_ids", default: []
     t.jsonb "service_environment", default: {}
     t.integer "source_pull_request_number"

--- a/lib/screenshots/capture.rb
+++ b/lib/screenshots/capture.rb
@@ -23,7 +23,7 @@ module Screenshots
         repo_path: @repo_path,
         project: @project,
         config: legacy_config,
-        targets: Screenshots::CaptureTargets.call(changed_files: @changed_files)
+        targets: Screenshots::CaptureTargets.call(changed_files: @changed_files, repo_path: @repo_path)
       )
 
       raise_capture_error!(result.failures) if result.failures.any?

--- a/spec/lib/screenshots/capture_spec.rb
+++ b/spec/lib/screenshots/capture_spec.rb
@@ -55,7 +55,8 @@ RSpec.describe Screenshots::Capture do
 
     expect(result).to eq([ "#{output_dir}/project_show.png" ])
     expect(Screenshots::CaptureTargets).to have_received(:call).with(
-      changed_files: [ "app/views/projects/show.html.erb" ]
+      changed_files: [ "app/views/projects/show.html.erb" ],
+      repo_path: Rails.root.to_s
     )
   end
 

--- a/spec/services/screenshots/capture_targets_spec.rb
+++ b/spec/services/screenshots/capture_targets_spec.rb
@@ -264,6 +264,126 @@ RSpec.describe Screenshots::CaptureTargets, :no_db do
       expect(slugs).to include("chat_sessions", "ab_tests", "style_guides", "knowledge_search")
     end
 
+    context "when scanning Stimulus controller usage with a repo_path" do
+      let(:repo_path) { Dir.mktmpdir }
+
+      after { FileUtils.remove_entry(repo_path) if File.directory?(repo_path) }
+
+      def write_view(repo_path, relative_path, controllers)
+        write_raw(repo_path, relative_path, %(<div data-controller="#{controllers}">content</div>\n))
+      end
+
+      def write_raw(repo_path, relative_path, content)
+        absolute = File.join(repo_path, relative_path)
+        FileUtils.mkdir_p(File.dirname(absolute))
+        File.write(absolute, content)
+      end
+
+      it "narrows an unmapped controller to the pages that mount it" do
+        write_view(repo_path, "app/views/prompts/show.html.erb", "widget")
+
+        targets = described_class.call(
+          changed_files: [ "app/javascript/controllers/widget_controller.js" ],
+          repo_path: repo_path
+        )
+
+        expect(targets.map(&:slug)).to eq([ "prompt_show" ])
+      end
+
+      it "derives nested and underscored identifiers per Stimulus conventions" do
+        write_view(repo_path, "app/views/projects/edit.html.erb", "forms--auto-save")
+
+        targets = described_class.call(
+          changed_files: [ "app/javascript/controllers/forms/auto_save_controller.js" ],
+          repo_path: repo_path
+        )
+
+        expect(targets.map(&:slug)).to eq([ "project_edit" ])
+      end
+
+      it "matches the controller as a whole token, not a substring" do
+        write_view(repo_path, "app/views/prompts/show.html.erb", "chat-stream")
+
+        targets = described_class.call(
+          changed_files: [ "app/javascript/controllers/chat_controller.js" ],
+          repo_path: repo_path
+        )
+
+        # `chat` must not match the `chat-stream` identifier, so it stays conservative.
+        expect(targets.map(&:slug)).to include("dashboard", "projects")
+      end
+
+      it "falls back to shared targets when the controller is mounted in a shared partial" do
+        write_view(repo_path, "app/views/shared/_header.html.erb", "widget")
+        write_view(repo_path, "app/views/prompts/show.html.erb", "widget")
+
+        targets = described_class.call(
+          changed_files: [ "app/javascript/controllers/widget_controller.js" ],
+          repo_path: repo_path
+        )
+
+        expect(targets.map(&:slug)).to include("dashboard", "projects", "prompts")
+      end
+
+      it "stays conservative when the controller is not referenced in any view" do
+        targets = described_class.call(
+          changed_files: [ "app/javascript/controllers/widget_controller.js" ],
+          repo_path: repo_path
+        )
+
+        expect(targets.map(&:slug)).to include("dashboard", "projects")
+      end
+
+      it "detects the Rails tag-helper hash form (data: { controller: ... })" do
+        write_raw(repo_path, "app/views/prompts/show.html.erb",
+          %(<%= form_with data: { controller: "widget", action: "x->widget#go" } do |f| %><% end %>\n))
+
+        targets = described_class.call(
+          changed_files: [ "app/javascript/controllers/widget_controller.js" ],
+          repo_path: repo_path
+        )
+
+        expect(targets.map(&:slug)).to eq([ "prompt_show" ])
+      end
+
+      it "treats a controller in a layout-rendered partial as global" do
+        write_view(repo_path, "app/views/notifications/_bell.html.erb", "widget")
+        write_raw(repo_path, "app/views/layouts/application.html.erb",
+          %(<body><%= render "notifications/bell" %></body>\n))
+
+        targets = described_class.call(
+          changed_files: [ "app/javascript/controllers/widget_controller.js" ],
+          repo_path: repo_path
+        )
+
+        # Mounted in the global nav via the layout — must not narrow to /notifications.
+        expect(targets.map(&:slug)).to include("dashboard", "projects", "prompts")
+      end
+
+      it "narrows even when repo_path has a trailing slash" do
+        write_view(repo_path, "app/views/prompts/show.html.erb", "widget")
+
+        targets = described_class.call(
+          changed_files: [ "app/javascript/controllers/widget_controller.js" ],
+          repo_path: "#{repo_path}/"
+        )
+
+        expect(targets.map(&:slug)).to eq([ "prompt_show" ])
+      end
+
+      it "does not crash when a scanned view contains invalid UTF-8 bytes" do
+        write_view(repo_path, "app/views/prompts/show.html.erb", "widget")
+        write_raw(repo_path, "app/views/prompts/_broken.html.erb", "data-controller=\"widget\" \xC3\x28 invalid")
+
+        expect {
+          described_class.call(
+            changed_files: [ "app/javascript/controllers/widget_controller.js" ],
+            repo_path: repo_path
+          )
+        }.not_to raise_error
+      end
+    end
+
     it "maps Devise registration views to sign_up target" do
       targets = described_class.call(changed_files: [ "app/views/devise/registrations/new.html.erb" ])
 

--- a/spec/services/screenshots/container_capture_spec.rb
+++ b/spec/services/screenshots/container_capture_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Screenshots::ContainerCapture do
     allow(service).to receive(:provision_capture_container) { service.instance_variable_set(:@network, "paid-test") }
     allow(service).to receive(:checkout_branch!)
     allow(Screenshots::PrComment).to receive(:call)
+    allow(Screenshots::DeriveHints).to receive(:call).and_return({})
     allow(Screenshots::ConfigParser).to receive_messages(from_repo_path: config, ui_detection_overrides: {})
     allow(service).to receive_messages(
       fetch_changed_files: [ "app/views/home/index.html.erb" ],
@@ -148,5 +149,47 @@ RSpec.describe Screenshots::ContainerCapture do
     expect(command).to include("SCREENSHOT_APP_PATH=/it\\'s-a-path")
     expect(command).to include('ENV.fetch("SCREENSHOT_APP_PATH")')
     expect(command).not_to include(%q(uri = URI("http://localhost:3000/it's-a-path")))
+  end
+
+  describe "#screenshot_config_json (capture scoping and annotation)" do
+    let(:multi_route_config) do
+      Screenshots::Configuration.from_hash(
+        "base_url" => "http://localhost:3000",
+        "routes" => [
+          { "path" => "/dashboard", "name" => "dashboard" },
+          { "path" => "/settings", "name" => "settings" }
+        ]
+      )
+    end
+
+    before { allow(service).to receive(:config).and_return(multi_route_config) }
+
+    it "captures every configured route when there are no hints" do
+      routes = JSON.parse(service.send(:screenshot_config_json)).fetch("routes")
+
+      expect(routes.map { |r| r["name"] }).to contain_exactly("dashboard", "settings")
+      expect(routes).to all(satisfy { |r| !r.key?("annotation") })
+    end
+
+    it "scopes capture to hinted routes and attaches their annotations" do
+      service.instance_variable_set(:@hints, {
+        "dashboard" => { "summary" => "New cost card", "selector" => "[data-testid='cost']" }
+      })
+
+      routes = JSON.parse(service.send(:screenshot_config_json)).fetch("routes")
+
+      expect(routes.map { |r| r["name"] }).to eq([ "dashboard" ])
+      expect(routes.first["annotation"]).to eq(
+        "summary" => "New cost card", "selector" => "[data-testid='cost']"
+      )
+    end
+
+    it "falls back to all routes when hints match no configured route" do
+      service.instance_variable_set(:@hints, { "nonexistent" => { "summary" => "x" } })
+
+      routes = JSON.parse(service.send(:screenshot_config_json)).fetch("routes")
+
+      expect(routes.map { |r| r["name"] }).to contain_exactly("dashboard", "settings")
+    end
   end
 end

--- a/spec/services/screenshots/derive_hints_spec.rb
+++ b/spec/services/screenshots/derive_hints_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Screenshots::DeriveHints, :no_db do
+  before { allow(Llm::TextMode).to receive(:options).and_return(mode: :text) }
+
+  let(:route_struct) { Struct.new(:name, :path) }
+  let(:routes) do
+    [
+      route_struct.new("dashboard", "/dashboard"),
+      route_struct.new("sign_in", "/users/sign_in")
+    ]
+  end
+  let(:agent_run) do
+    instance_double(
+      AgentRun,
+      id: 7,
+      agent_summary: "Redesigned the dashboard summary cards."
+    )
+  end
+
+  def stub_llm(output, success: true)
+    response = instance_double(AgentHarness::Response, success?: success, output: output)
+    allow(AgentHarness).to receive(:send_message).and_return(response)
+  end
+
+  describe ".call" do
+    it "returns and persists sanitized hints for known routes" do
+      stub_llm({ "dashboard" => { "summary" => "New weekly cost card", "selector" => "[data-testid='cost']" } }.to_json)
+      allow(agent_run).to receive(:update!)
+
+      result = described_class.call(agent_run: agent_run, routes: routes, changed_files: [ "app/views/dashboard/show.html.erb" ])
+
+      expect(result).to eq(
+        "dashboard" => { "summary" => "New weekly cost card", "selector" => "[data-testid='cost']" }
+      )
+      expect(agent_run).to have_received(:update!).with(screenshot_hints: result)
+    end
+
+    it "passes the route catalog, summary, and changed files to the LLM" do
+      stub_llm("{}")
+      allow(agent_run).to receive(:update!)
+
+      described_class.call(agent_run: agent_run, routes: routes, changed_files: [ "app/views/dashboard/show.html.erb" ])
+
+      expect(AgentHarness).to have_received(:send_message).with(
+        a_string_including("dashboard — /dashboard", "Redesigned the dashboard", "app/views/dashboard/show.html.erb"),
+        provider: :claude,
+        model: described_class::DEFAULT_MODEL,
+        timeout: described_class::TIMEOUT,
+        tools: :none,
+        mode: :text
+      )
+    end
+
+    it "drops routes that are not in the configured catalog" do
+      stub_llm({ "nonexistent" => { "summary" => "x" }, "dashboard" => { "summary" => "real" } }.to_json)
+      allow(agent_run).to receive(:update!)
+
+      result = described_class.call(agent_run: agent_run, routes: routes)
+
+      expect(result.keys).to eq([ "dashboard" ])
+    end
+
+    it "drops entries without a usable summary" do
+      stub_llm({ "dashboard" => { "summary" => "  " }, "sign_in" => { "selector" => ".x" } }.to_json)
+      allow(agent_run).to receive(:update!)
+
+      result = described_class.call(agent_run: agent_run, routes: routes)
+
+      expect(result).to be_empty
+    end
+
+    it "omits a blank selector" do
+      stub_llm({ "dashboard" => { "summary" => "changed", "selector" => "" } }.to_json)
+      allow(agent_run).to receive(:update!)
+
+      result = described_class.call(agent_run: agent_run, routes: routes)
+
+      expect(result["dashboard"]).to eq("summary" => "changed")
+    end
+
+    it "drops an over-long or multi-line selector but keeps the summary" do
+      stub_llm({
+        "dashboard" => { "summary" => "changed", "selector" => "a" * 250 },
+        "sign_in" => { "summary" => "also changed", "selector" => "div\nspan" }
+      }.to_json)
+      allow(agent_run).to receive(:update!)
+
+      result = described_class.call(agent_run: agent_run, routes: routes)
+
+      expect(result["dashboard"]).to eq("summary" => "changed")
+      expect(result["sign_in"]).to eq("summary" => "also changed")
+    end
+
+    it "tolerates a fenced JSON response" do
+      stub_llm("```json\n{\"dashboard\": {\"summary\": \"fenced\"}}\n```")
+      allow(agent_run).to receive(:update!)
+
+      result = described_class.call(agent_run: agent_run, routes: routes)
+
+      expect(result["dashboard"]).to eq("summary" => "fenced")
+    end
+
+    it "returns empty hints (without raising) on malformed JSON" do
+      stub_llm("not json at all")
+      allow(agent_run).to receive(:update!)
+
+      result = described_class.call(agent_run: agent_run, routes: routes)
+
+      expect(result).to eq({})
+    end
+
+    it "returns empty hints when the LLM call fails" do
+      stub_llm("", success: false)
+      allow(agent_run).to receive(:update!)
+
+      expect(described_class.call(agent_run: agent_run, routes: routes)).to eq({})
+    end
+
+    it "returns empty hints without calling the LLM when there are no routes" do
+      allow(AgentHarness).to receive(:send_message)
+
+      expect(described_class.call(agent_run: agent_run, routes: [])).to eq({})
+      expect(AgentHarness).not_to have_received(:send_message)
+    end
+
+    it "swallows persistence failures and returns empty hints" do
+      stub_llm({ "dashboard" => { "summary" => "x" } }.to_json)
+      allow(agent_run).to receive(:update!).and_raise(ActiveRecord::RecordInvalid.new(AgentRun.new))
+
+      expect(described_class.call(agent_run: agent_run, routes: routes)).to eq({})
+    end
+  end
+end

--- a/spec/services/screenshots/derive_hints_spec.rb
+++ b/spec/services/screenshots/derive_hints_spec.rb
@@ -54,6 +54,23 @@ RSpec.describe Screenshots::DeriveHints, :no_db do
       )
     end
 
+    it "limits summary input by entry count and character count" do
+      captured_prompt = nil
+      response = instance_double(AgentHarness::Response, success?: true, output: "{}")
+      allow(AgentHarness).to receive(:send_message) do |prompt, **|
+        captured_prompt = prompt
+        response
+      end
+      allow(agent_run).to receive(:update!)
+      allow(agent_run).to receive(:agent_summary).with(limit: described_class::MAX_SUMMARY_ENTRIES).and_return("a" * 9_000)
+
+      described_class.call(agent_run: agent_run, routes: routes)
+
+      expect(agent_run).to have_received(:agent_summary).with(limit: described_class::MAX_SUMMARY_ENTRIES)
+      expect(captured_prompt).to include("a" * described_class::MAX_SUMMARY_CHARS)
+      expect(captured_prompt).not_to include("a" * (described_class::MAX_SUMMARY_CHARS + 1))
+    end
+
     it "drops routes that are not in the configured catalog" do
       stub_llm({ "nonexistent" => { "summary" => "x" }, "dashboard" => { "summary" => "real" } }.to_json)
       allow(agent_run).to receive(:update!)

--- a/spec/services/screenshots/derive_hints_spec.rb
+++ b/spec/services/screenshots/derive_hints_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe Screenshots::DeriveHints, :no_db do
   let(:agent_run) do
     instance_double(
       AgentRun,
-      id: 7,
-      agent_summary: "Redesigned the dashboard summary cards."
+      id: 7
     )
   end
 
@@ -38,14 +37,14 @@ RSpec.describe Screenshots::DeriveHints, :no_db do
       expect(agent_run).to have_received(:update!).with(screenshot_hints: result)
     end
 
-    it "passes the route catalog, summary, and changed files to the LLM" do
+    it "passes the route catalog and changed files to the LLM" do
       stub_llm("{}")
       allow(agent_run).to receive(:update!)
 
       described_class.call(agent_run: agent_run, routes: routes, changed_files: [ "app/views/dashboard/show.html.erb" ])
 
       expect(AgentHarness).to have_received(:send_message).with(
-        a_string_including("dashboard — /dashboard", "Redesigned the dashboard", "app/views/dashboard/show.html.erb"),
+        a_string_including("dashboard — /dashboard", "app/views/dashboard/show.html.erb"),
         provider: :claude,
         model: described_class::DEFAULT_MODEL,
         timeout: described_class::TIMEOUT,
@@ -54,7 +53,7 @@ RSpec.describe Screenshots::DeriveHints, :no_db do
       )
     end
 
-    it "limits summary input by entry count and character count" do
+    it "does not reuse the agent summary in the hinting prompt" do
       captured_prompt = nil
       response = instance_double(AgentHarness::Response, success?: true, output: "{}")
       allow(AgentHarness).to receive(:send_message) do |prompt, **|
@@ -62,13 +61,11 @@ RSpec.describe Screenshots::DeriveHints, :no_db do
         response
       end
       allow(agent_run).to receive(:update!)
-      allow(agent_run).to receive(:agent_summary).with(limit: described_class::MAX_SUMMARY_ENTRIES).and_return("a" * 9_000)
+      expect(agent_run).not_to receive(:agent_summary)
 
       described_class.call(agent_run: agent_run, routes: routes)
 
-      expect(agent_run).to have_received(:agent_summary).with(limit: described_class::MAX_SUMMARY_ENTRIES)
-      expect(captured_prompt).to include("a" * described_class::MAX_SUMMARY_CHARS)
-      expect(captured_prompt).not_to include("a" * (described_class::MAX_SUMMARY_CHARS + 1))
+      expect(captured_prompt).not_to include("Agent change summary")
     end
 
     it "drops routes that are not in the configured catalog" do

--- a/spec/services/screenshots/pr_comment_spec.rb
+++ b/spec/services/screenshots/pr_comment_spec.rb
@@ -113,6 +113,103 @@ RSpec.describe Screenshots::PrComment do
       end
     end
 
+    context "with agent-derived change summaries" do
+      let(:annotated_screenshots) do
+        [
+          { route_name: "dashboard", url: "https://s3.example.com/dashboard.png", summary: "New weekly cost card" },
+          { route_name: "sign_in", url: "https://s3.example.com/sign_in.png" }
+        ]
+      end
+
+      def build(previous: {})
+        described_class.new(
+          github_client: github_client,
+          repo: repo,
+          pr_number: pr_number,
+          commit_sha: commit_sha,
+          screenshots: annotated_screenshots,
+          previous_screenshots: previous
+        ).build_comment_body
+      end
+
+      it "adds a 'What changed' column with the summary" do
+        body = build
+
+        expect(body).to include("| Page | What changed | Screenshot |")
+        expect(body).to include("| Dashboard | New weekly cost card | ![dashboard](https://s3.example.com/dashboard.png) |")
+      end
+
+      it "renders an em dash for pages without a summary" do
+        body = build
+
+        expect(body).to include("| Sign In | — | ![sign_in](https://s3.example.com/sign_in.png) |")
+      end
+
+      it "includes the 'What changed' column in the before/after table" do
+        body = build(previous: { "dashboard" => "https://s3.example.com/prev-dashboard.png" })
+
+        expect(body).to include("| Page | What changed | Before | After |")
+        expect(body).to include("| Dashboard | New weekly cost card | ![before-dashboard](https://s3.example.com/prev-dashboard.png) | ![dashboard](https://s3.example.com/dashboard.png) |")
+      end
+
+      it "escapes pipe characters so the table is not broken" do
+        service = described_class.new(
+          github_client: github_client,
+          repo: repo,
+          pr_number: pr_number,
+          commit_sha: commit_sha,
+          screenshots: [ { route_name: "dashboard", url: "https://s3.example.com/dashboard.png", summary: "a | b" } ]
+        )
+
+        expect(service.build_comment_body).to include("a \\| b")
+      end
+
+      it "neutralizes markdown/HTML so an agent summary cannot inject images or links" do
+        service = described_class.new(
+          github_client: github_client,
+          repo: repo,
+          pr_number: pr_number,
+          commit_sha: commit_sha,
+          screenshots: [
+            { route_name: "dashboard", url: "https://s3.example.com/dashboard.png",
+              summary: "![x](https://evil.example/track.png) <img src=y> [click](https://phish.example)" }
+          ]
+        )
+
+        body = service.build_comment_body
+
+        expect(body).not_to include("![x](https://evil.example/track.png)")
+        expect(body).not_to include("<img src=y>")
+        expect(body).not_to include("[click](https://phish.example)")
+        expect(body).to include("\\!\\[x\\]\\(https://evil.example/track.png\\)")
+      end
+
+      it "discloses that capture was scoped when summaries are present" do
+        service = described_class.new(
+          github_client: github_client,
+          repo: repo,
+          pr_number: pr_number,
+          commit_sha: commit_sha,
+          screenshots: annotated_screenshots
+        )
+
+        expect(service.build_comment_body).to include("scoped by Paid")
+      end
+
+      it "keeps the plain table when no screenshot has a summary" do
+        body = described_class.new(
+          github_client: github_client,
+          repo: repo,
+          pr_number: pr_number,
+          commit_sha: commit_sha,
+          screenshots: [ { route_name: "dashboard", url: "https://s3.example.com/dashboard.png" } ]
+        ).build_comment_body
+
+        expect(body).to include("| Page | Screenshot |")
+        expect(body).not_to include("What changed")
+      end
+    end
+
     it "handles empty screenshots" do
       service = described_class.new(
         github_client: github_client,


### PR DESCRIPTION
## Why

The screenshot system was effectively unscoped on the path that matters most. The **agent/container path captured every configured route** on every UI PR, and on the **GitHub Actions path** a single Stimulus controller change fanned out to all ~25 pages. Reviewers got a long, undifferentiated screenshot list with no signal about *what* actually changed — so the screenshots added noise instead of focus.

This PR scopes screenshots to the pages a change affects, and annotates each one with what changed.

## What changed

**Tighter scoping (CaptureTargets / GitHub Actions path)**
- When a Stimulus controller changes, scan the repo's views/components for `data-controller` usage — both the HTML attribute form and the Rails `data: { controller: }` hash form — and narrow to the pages that actually mount it, instead of fanning out to every shared target.
- Partials rendered directly from a layout stay global (e.g. the notification bell in the nav), so genuinely global controllers are never under-captured.
- Opt-in via `repo_path`, so existing callers are unaffected.

**Agent-derived hints (agent/container path)**
- New `Screenshots::DeriveHints` — a best-effort `agent_harness` call that maps the agent's change to the affected routes, with a one-line "what changed" summary and an optional highlight selector. Persisted to a new `agent_runs.screenshot_hints` jsonb column.
- `ContainerCapture` scopes capture to hinted routes (falls back to all routes when hints are empty/unmatched) and annotates each page with a highlight outline + caption banner.
- `PrComment` gains a **"What changed"** column plus a disclosure note that capture was scoped (so reviewers know to request a full capture if something looks missing).

## Safety / hardening (from adversarial review)
- Agent-influenced summaries are escaped to neutralize markdown/HTML injection (images, links, raw HTML, table breakout) in the PR comment.
- LLM-provided selectors are length-capped and single-line-validated.
- View scans are UTF-8-scrubbed so a stray bad byte can't abort target resolution; `repo_path` trailing slashes are normalized.
- Hint derivation is fully best-effort — any failure degrades to capturing all routes; it never blocks screenshot capture.

## Coverage tradeoff (intentional)
Scoping means a page the AI judges unrelated is skipped. The prompt biases strongly toward inclusion, the empty/unmatched case falls back to capturing everything, and the PR comment discloses that capture was scoped — so the narrowing is never silent.

## Testing
- `spec/services/screenshots/` — **276 examples, 0 failures**; rubocop clean.
- New tests cover: Stimulus identifier derivation (incl. nested/underscore + hash syntax), layout-rendered global partials, invalid-UTF-8 robustness, trailing-slash `repo_path`, hint sanitization (unknown routes, bad selectors), markdown-injection neutralization, and scoping/annotation in the capture config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)