### PR TITLE
[codex] Render chat markdown and collapse tool output

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -2,6 +2,142 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
+.chat-markdown {
+  overflow-wrap: anywhere;
+  line-height: 1.7;
+}
+
+.chat-markdown > :first-child {
+  margin-top: 0;
+}
+
+.chat-markdown > :last-child {
+  margin-bottom: 0;
+}
+
+.chat-markdown p,
+.chat-markdown ul,
+.chat-markdown ol,
+.chat-markdown blockquote,
+.chat-markdown pre,
+.chat-markdown table {
+  margin-bottom: 0.9rem;
+}
+
+.chat-markdown [data-code-block-wrapper] pre {
+  margin-bottom: 0;
+}
+
+.chat-markdown h1,
+.chat-markdown h2,
+.chat-markdown h3,
+.chat-markdown h4 {
+  margin: 1rem 0 0.45rem;
+  color: #111827;
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+.chat-markdown h1 {
+  font-size: 1.25rem;
+}
+
+.chat-markdown h2 {
+  font-size: 1.125rem;
+}
+
+.chat-markdown h3,
+.chat-markdown h4 {
+  font-size: 1rem;
+}
+
+.chat-markdown ul,
+.chat-markdown ol {
+  padding-left: 1.25rem;
+}
+
+.chat-markdown ul {
+  list-style: disc;
+}
+
+.chat-markdown ol {
+  list-style: decimal;
+}
+
+.chat-markdown li + li {
+  margin-top: 0.25rem;
+}
+
+.chat-markdown a {
+  color: #2563eb;
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.chat-markdown blockquote {
+  border-left: 3px solid #cbd5e1;
+  color: #475569;
+  padding-left: 0.9rem;
+}
+
+.chat-markdown :not(pre) > code {
+  border-radius: 0.375rem;
+  background: #f1f5f9;
+  color: #0f172a;
+  font-size: 0.85em;
+  padding: 0.12rem 0.32rem;
+}
+
+.chat-markdown table {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+  border-collapse: collapse;
+}
+
+.chat-markdown th,
+.chat-markdown td {
+  border: 1px solid #e5e7eb;
+  padding: 0.45rem 0.6rem;
+  text-align: left;
+}
+
+.chat-markdown th {
+  background: #f8fafc;
+  font-weight: 700;
+}
+
+.dark .chat-markdown h1,
+.dark .chat-markdown h2,
+.dark .chat-markdown h3,
+.dark .chat-markdown h4 {
+  color: #f3f4f6;
+}
+
+.dark .chat-markdown a {
+  color: #93c5fd;
+}
+
+.dark .chat-markdown blockquote {
+  border-left-color: #475569;
+  color: #cbd5e1;
+}
+
+.dark .chat-markdown :not(pre) > code {
+  background: #334155;
+  color: #f8fafc;
+}
+
+.dark .chat-markdown th,
+.dark .chat-markdown td {
+  border-color: #374151;
+}
+
+.dark .chat-markdown th {
+  background: #111827;
+}
+
 /* ========================================
    Dark mode global overrides (unlayered)
    ========================================

--- a/app/helpers/chat_sessions_helper.rb
+++ b/app/helpers/chat_sessions_helper.rb
@@ -142,6 +142,16 @@ module ChatSessionsHelper
     CHAT_TOOL_STATUS_BADGES.fetch(message.tool_status, message.role == "tool" ? "bg-blue-100 text-blue-700" : "bg-blue-100 text-blue-700")
   end
 
+  def chat_tool_summary(message)
+    payload = chat_tool_payload(message.role == "tool" ? (message.tool_result || message.content) : message.tool_arguments)
+    summary = chat_tool_payload_summary(payload)
+    [ message.tool_name.presence || "Unknown tool", chat_tool_status_label(message), summary ].compact.join(" · ")
+  end
+
+  def chat_tool_expanded_by_default?(message)
+    message.pending_confirmation?
+  end
+
   def pretty_chat_tool_payload(value)
     payload = chat_tool_payload(value)
     return payload if payload.is_a?(String)
@@ -186,5 +196,41 @@ module ChatSessionsHelper
 
   def badge_label(label, classes)
     tag.span(label, class: "inline-flex items-center rounded-full px-2 py-1 text-xs font-medium #{classes}")
+  end
+
+  def chat_tool_payload_summary(payload)
+    case payload
+    when Array
+      "#{payload.size} #{'item'.pluralize(payload.size)}"
+    when Hash
+      chat_tool_hash_payload_summary(payload)
+    when String
+      payload.squish.truncate(72)
+    end
+  end
+
+  def chat_tool_hash_payload_summary(payload)
+    return chat_tool_error_summary(payload) if chat_tool_payload_value(payload, "error").present?
+
+    count = chat_tool_payload_value(payload, "total_count")
+    return "#{count} #{'match'.pluralize(count.to_i)}" if count
+
+    collection_key = %w[matches projects results items].find { |key| chat_tool_payload_value(payload, key).is_a?(Array) }
+    return "#{chat_tool_payload_value(payload, collection_key).size} #{collection_key.humanize(capitalize: false)}" if collection_key
+
+    path = chat_tool_payload_value(payload, "path")
+    size = chat_tool_payload_value(payload, "size")
+    return [ path, number_to_human_size(size) ].compact.join(" · ") if path || size
+
+    "#{payload.size} #{'field'.pluralize(payload.size)}"
+  end
+
+  def chat_tool_error_summary(payload)
+    message = chat_tool_payload_value(payload, "message") || chat_tool_payload_value(payload, "error")
+    "error: #{message.to_s.squish.truncate(64)}"
+  end
+
+  def chat_tool_payload_value(payload, key)
+    payload[key] || payload[key.to_sym]
   end
 end

--- a/app/javascript/controllers/chat_controller.js
+++ b/app/javascript/controllers/chat_controller.js
@@ -170,6 +170,7 @@ export default class extends Controller {
     meta.append(roleBadge, modelLabel, timestamp)
 
     const content = document.createElement("div")
+    content.className = "chat-markdown"
     content.dataset.chatMessageTarget = "content"
     content.dataset.rawContent = ""
 

--- a/app/javascript/controllers/chat_message_controller.js
+++ b/app/javascript/controllers/chat_message_controller.js
@@ -46,6 +46,7 @@ export default class extends Controller {
     const safeContent = this.escapeHtml(rawContent)
 
     try {
+      this.disablePlainTextFallback()
       this.contentTarget.innerHTML = marked.parse(safeContent, {
         breaks: true,
         gfm: true,
@@ -54,6 +55,7 @@ export default class extends Controller {
 
       this.decorateCodeBlocks()
     } catch {
+      this.enablePlainTextFallback()
       this.contentTarget.textContent = rawContent
     }
   }
@@ -128,5 +130,13 @@ export default class extends Controller {
       .replaceAll("&", "&amp;")
       .replaceAll("<", "&lt;")
       .replaceAll(">", "&gt;")
+  }
+
+  enablePlainTextFallback() {
+    this.contentTarget.classList.add("whitespace-pre-wrap", "break-words")
+  }
+
+  disablePlainTextFallback() {
+    this.contentTarget.classList.remove("whitespace-pre-wrap", "break-words")
   }
 }

--- a/app/javascript/controllers/chat_message_controller.js
+++ b/app/javascript/controllers/chat_message_controller.js
@@ -4,17 +4,25 @@ import hljs from "highlight.js/lib/common"
 
 const SAFE_URL_SCHEMES = /^(https?|mailto):/i
 
-const renderer = {
-  link({ href, text }) {
-    if (!href) return text
-    if (!SAFE_URL_SCHEMES.test(href)) return text
-    const escaped = href.replaceAll("&", "&amp;").replaceAll('"', "&quot;")
-    return `<a href="${escaped}" rel="noopener noreferrer">${text}</a>`
-  },
-  image({ text }) {
-    return text || ""
-  }
+function escapeAttribute(value) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
 }
+
+const renderer = new marked.Renderer()
+
+renderer.link = function ({ href, tokens, text }) {
+  const label = tokens ? this.parser.parseInline(tokens) : text
+  if (!href) return label
+  if (!SAFE_URL_SCHEMES.test(href)) return label
+  const escaped = escapeAttribute(href)
+  return `<a href="${escaped}" rel="noopener noreferrer">${label}</a>`
+}
+
+renderer.image = ({ text }) => text || ""
 
 export default class extends Controller {
   static targets = ["content"]
@@ -36,13 +44,18 @@ export default class extends Controller {
 
     const rawContent = this.contentTarget.dataset.rawContent || ""
     const safeContent = this.escapeHtml(rawContent)
-    this.contentTarget.innerHTML = marked.parse(safeContent, {
-      breaks: true,
-      gfm: true,
-      renderer
-    })
 
-    this.decorateCodeBlocks()
+    try {
+      this.contentTarget.innerHTML = marked.parse(safeContent, {
+        breaks: true,
+        gfm: true,
+        renderer
+      })
+
+      this.decorateCodeBlocks()
+    } catch {
+      this.contentTarget.textContent = rawContent
+    }
   }
 
   async copyCode(event) {
@@ -62,7 +75,11 @@ export default class extends Controller {
     this.contentTarget.querySelectorAll("pre > code").forEach((codeBlock) => {
       if (codeBlock.closest("[data-code-block-wrapper]")) return
 
-      hljs.highlightElement(codeBlock)
+      try {
+        hljs.highlightElement(codeBlock)
+      } catch {
+        // Keep the raw code visible if syntax highlighting cannot classify it.
+      }
 
       const pre = codeBlock.parentElement
       const language = [...codeBlock.classList].find((name) => name.startsWith("language-"))?.replace("language-", "") || "text"

--- a/app/views/chat_messages/_bubble.html.erb
+++ b/app/views/chat_messages/_bubble.html.erb
@@ -12,7 +12,8 @@
   <% if message.tool_name.present? || message.role == "tool" %>
     <%= render "chat_messages/tool_call", message: message %>
   <% elsif message.role == "assistant" %>
-    <div data-chat-message-target="content"
+    <div class="chat-markdown"
+         data-chat-message-target="content"
          data-raw-content="<%= message.content.to_s %>">
       <%= simple_format(h(message.content.to_s)) %>
     </div>

--- a/app/views/chat_messages/_tool_call.html.erb
+++ b/app/views/chat_messages/_tool_call.html.erb
@@ -1,10 +1,18 @@
 <% tool_title = message.role == "tool" ? "Tool Result" : "Tool Call" %>
 <% payload = message.role == "tool" ? (message.tool_result || message.content) : message.tool_arguments %>
-<details class="rounded-lg border border-blue-200 bg-white <%= "ring-2 ring-amber-300" if message.pending_confirmation? %>" <% if message.role == "tool" || message.resolved_tool_confirmation? %>open<% end %>>
-  <summary class="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-sm font-semibold text-gray-800">
-    <span><%= tool_title %>: <%= message.tool_name.presence || "Unknown tool" %></span>
-    <span class="inline-flex items-center rounded-md px-2 py-1 text-xs font-medium <%= chat_tool_status_classes(message) %>">
-      <%= chat_tool_status_label(message) %>
+<details class="group rounded-lg border border-blue-200 bg-blue-50/70 <%= "ring-2 ring-amber-300" if message.pending_confirmation? %>" <% if chat_tool_expanded_by_default?(message) %>open<% end %>>
+  <summary class="flex cursor-pointer list-none items-center justify-between gap-3 px-3 py-2 text-xs font-medium text-gray-700">
+    <span class="min-w-0 truncate">
+      <span class="font-semibold text-gray-800"><%= tool_title %></span>
+      <span class="text-gray-500"><%= chat_tool_summary(message) %></span>
+    </span>
+    <span class="inline-flex shrink-0 items-center gap-2">
+      <span class="inline-flex items-center rounded-md px-2 py-1 text-xs font-medium <%= chat_tool_status_classes(message) %>">
+        <%= chat_tool_status_label(message) %>
+      </span>
+      <svg class="h-3.5 w-3.5 text-gray-400 transition-transform group-open:rotate-180" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+      </svg>
     </span>
   </summary>
   <div class="border-t border-blue-100 px-4 py-3">

--- a/spec/helpers/chat_sessions_helper_spec.rb
+++ b/spec/helpers/chat_sessions_helper_spec.rb
@@ -68,4 +68,38 @@ RSpec.describe ChatSessionsHelper do
       expect(helper.chat_session_projects(chat_session)).to contain_exactly(primary_project, reference_project)
     end
   end
+
+  describe "#chat_tool_summary" do
+    it "summarizes grep-style match counts" do
+      message = build(:chat_message, :tool,
+        tool_name: "grep_repo",
+        tool_result: { "total_count" => 81, "matches" => [ { "path" => "app.rb" } ] })
+
+      expect(helper.chat_tool_summary(message)).to eq("grep_repo · result · 81 matches")
+    end
+
+    it "summarizes list-style result arrays" do
+      message = build(:chat_message, :tool,
+        tool_name: "list_projects",
+        tool_result: [ { "name" => "paid" }, { "name" => "mutant" } ])
+
+      expect(helper.chat_tool_summary(message)).to eq("list_projects · result · 2 items")
+    end
+
+    it "summarizes tool errors without expanding the full payload" do
+      message = build(:chat_message, :tool,
+        tool_name: "search_code",
+        tool_result: { error: "internal_error", message: "key not found: :project_id" })
+
+      expect(helper.chat_tool_summary(message)).to eq("search_code · result · error: key not found: :project_id")
+    end
+
+    it "expands only pending tool confirmations by default" do
+      completed = build(:chat_message, :tool)
+      pending = build(:chat_message, :tool_call, tool_status: "pending")
+
+      expect(helper.chat_tool_expanded_by_default?(completed)).to be(false)
+      expect(helper.chat_tool_expanded_by_default?(pending)).to be(true)
+    end
+  end
 end

--- a/spec/lib/chat_message_controller_node_harness_spec.rb
+++ b/spec/lib/chat_message_controller_node_harness_spec.rb
@@ -18,11 +18,26 @@ class ChatMessageControllerNodeHarness
     const ChatMessageController = new Function("marked", transformed)(marked);
 
     function makeController(rawContent) {
+      const classes = new Set(["chat-markdown"]);
       const controller = Object.create(ChatMessageController.prototype);
       const content = {
         dataset: { rawContent },
         innerHTML: "",
         textContent: "",
+        className: "chat-markdown",
+        classList: {
+          add(...tokens) {
+            tokens.forEach((token) => classes.add(token));
+            content.className = [...classes].join(" ");
+          },
+          remove(...tokens) {
+            tokens.forEach((token) => classes.delete(token));
+            content.className = [...classes].join(" ");
+          },
+          contains(token) {
+            return classes.has(token);
+          }
+        },
         querySelectorAll: () => []
       };
 
@@ -68,14 +83,29 @@ class ChatMessageControllerNodeHarness
       if (content.textContent !== "<script>alert(1)</script>") {
         throw new Error(`Expected raw text fallback, got: ${content.textContent}`);
       }
+      if (!content.classList.contains("whitespace-pre-wrap") || !content.classList.contains("break-words")) {
+        throw new Error(`Expected fallback to preserve whitespace, got classes: ${content.className}`);
+      }
       if (content.innerHTML) {
         throw new Error(`Expected fallback not to write innerHTML, got: ${content.innerHTML}`);
+      }
+    }
+
+    function testMarkdownSuccessRemovesFallbackFormatting() {
+      const { controller, content } = makeController("line one\\nline two");
+      content.classList.add("whitespace-pre-wrap", "break-words");
+
+      controller.render();
+
+      if (content.classList.contains("whitespace-pre-wrap") || content.classList.contains("break-words")) {
+        throw new Error(`Expected successful parse to clear fallback classes, got: ${content.className}`);
       }
     }
 
     function run() {
       testMarkdownRendersSafeHtml();
       testMarkdownFailureFallsBackToText();
+      testMarkdownSuccessRemovesFallbackFormatting();
     }
 
     try {

--- a/spec/lib/chat_message_controller_node_harness_spec.rb
+++ b/spec/lib/chat_message_controller_node_harness_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "open3"
+require "rails_helper"
+
+class ChatMessageControllerNodeHarness
+  SCRIPT = <<~JAVASCRIPT
+    const fs = require("node:fs");
+    const { marked } = require("marked");
+
+    const source = fs.readFileSync("app/javascript/controllers/chat_message_controller.js", "utf8");
+    const transformed = source
+      .replace('import { Controller } from "@hotwired/stimulus"', "class Controller {}")
+      .replace('import { marked } from "marked"', "")
+      .replace('import hljs from "highlight.js/lib/common"', "const hljs = { highlightElement() {} }")
+      .replace("export default class extends Controller {", "return class ChatMessageController extends Controller {");
+
+    const ChatMessageController = new Function("marked", transformed)(marked);
+
+    function makeController(rawContent) {
+      const controller = Object.create(ChatMessageController.prototype);
+      const content = {
+        dataset: { rawContent },
+        innerHTML: "",
+        textContent: "",
+        querySelectorAll: () => []
+      };
+
+      controller.markdownValue = true;
+      controller.hasContentTarget = true;
+      controller.contentTarget = content;
+
+      return { controller, content };
+    }
+
+    function testMarkdownRendersSafeHtml() {
+      const { controller, content } = makeController(
+        "**safe** [ok](https://example.com) [bad](javascript:alert(1)) ![hidden](https://example.com/image.png)"
+      );
+
+      controller.render();
+
+      if (!content.innerHTML.includes("<strong>safe</strong>")) {
+        throw new Error(`Expected bold Markdown to render, got: ${content.innerHTML}`);
+      }
+      if (!content.innerHTML.includes('href="https://example.com"')) {
+        throw new Error(`Expected safe link to render, got: ${content.innerHTML}`);
+      }
+      if (content.innerHTML.includes("javascript:")) {
+        throw new Error(`Expected unsafe link href to be stripped, got: ${content.innerHTML}`);
+      }
+      if (content.innerHTML.includes("<img")) {
+        throw new Error(`Expected images to be suppressed, got: ${content.innerHTML}`);
+      }
+    }
+
+    function testMarkdownFailureFallsBackToText() {
+      const originalParse = marked.parse;
+      const { controller, content } = makeController("<script>alert(1)</script>");
+
+      marked.parse = () => { throw new Error("parse failed"); };
+      try {
+        controller.render();
+      } finally {
+        marked.parse = originalParse;
+      }
+
+      if (content.textContent !== "<script>alert(1)</script>") {
+        throw new Error(`Expected raw text fallback, got: ${content.textContent}`);
+      }
+      if (content.innerHTML) {
+        throw new Error(`Expected fallback not to write innerHTML, got: ${content.innerHTML}`);
+      }
+    }
+
+    function run() {
+      testMarkdownRendersSafeHtml();
+      testMarkdownFailureFallsBackToText();
+    }
+
+    try {
+      run();
+    } catch (error) {
+      console.error(error.message || error);
+      process.exit(1);
+    }
+  JAVASCRIPT
+
+  def self.run
+    Open3.capture3("node", "-e", SCRIPT, chdir: Rails.root.to_s)
+  end
+end
+
+RSpec.describe ChatMessageControllerNodeHarness, :no_db do
+  it "renders Markdown safely and fails closed" do
+    stdout, stderr, status = described_class.run
+
+    expect(status.success?).to be(true), <<~MESSAGE
+      Node regression harness failed.
+      stdout:
+      #{stdout}
+      stderr:
+      #{stderr}
+    MESSAGE
+  end
+end

--- a/spec/views/chat_messages/tool_call_partial_spec.rb
+++ b/spec/views/chat_messages/tool_call_partial_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "chat_messages/_tool_call", :no_db, type: :view do
+  def tool_message(**attrs)
+    defaults = {
+      role: "tool",
+      tool_name: "grep_repo",
+      tool_status: nil,
+      tool_result: { "total_count" => 3 },
+      tool_arguments: nil,
+      content: nil
+    }
+
+    Struct.new(*defaults.keys, keyword_init: true) do
+      def pending_confirmation?
+        tool_status == "pending"
+      end
+    end.new(**defaults.merge(attrs))
+  end
+
+  it "collapses completed tool results by default" do
+    render partial: "chat_messages/tool_call", locals: { message: tool_message }
+
+    expect(rendered).to include("grep_repo · result · 3 matches")
+    expect(rendered).not_to match(/<details[^>]*open/)
+  end
+
+  it "keeps pending confirmations open for review" do
+    render partial: "chat_messages/tool_call", locals: {
+      message: tool_message(
+        role: "assistant",
+        tool_status: "pending",
+        tool_name: "trigger_agent_run",
+        tool_arguments: { "issue_id" => 42 },
+        tool_result: nil
+      )
+    }
+
+    expect(rendered).to match(/<details[^>]*open/)
+    expect(rendered).to include("Assistant wants to run this action")
+  end
+end


### PR DESCRIPTION
## Summary
- render assistant chat output as styled Markdown with safer client-side parsing
- collapse completed tool calls and results behind compact summaries by default
- keep pending tool confirmations expanded for review
- add regression coverage for tool presentation and Markdown safety/fallback behavior

## Why
Chat transcripts with tool-heavy agent runs were difficult to scan because JSON payloads dominated the screen, and assistant Markdown could remain visible as raw text when the client renderer failed. This improves readability while preserving access to raw tool payloads when needed.

## Validation
- bin/rspec spec/helpers/chat_sessions_helper_spec.rb spec/views/chat_messages/tool_call_partial_spec.rb spec/lib/chat_controller_node_harness_spec.rb spec/lib/chat_message_controller_node_harness_spec.rb
- npx eslint app/javascript/controllers/chat_message_controller.js app/javascript/controllers/chat_controller.js
- bin/lint --changed
- bin/rubocop spec/lib/chat_message_controller_node_harness_spec.rb spec/views/chat_messages/tool_call_partial_spec.rb