### PR TITLE
[codex] Fallback chat turns on provider rate limits

### DIFF
--- a/app/controllers/chat_messages_controller.rb
+++ b/app/controllers/chat_messages_controller.rb
@@ -105,6 +105,8 @@ class ChatMessagesController < ApplicationController
     write_sse_event("error", { message: e.message }) rescue IOError
   rescue ArgumentError => e
     write_sse_event("error", { message: e.message }) rescue IOError
+  rescue AgentHarness::RateLimitError => e
+    write_sse_event("error", { message: ChatSessions::ErrorMessage.for(e) }) rescue IOError
   rescue StandardError => e
     Rails.logger.error(message: "chat_messages.stream_failed", session_id: @chat_session.id, error: e.message)
     write_sse_event("error", { message: "An unexpected error occurred" }) rescue IOError
@@ -123,13 +125,15 @@ class ChatMessagesController < ApplicationController
       )
     end
 
-      render json: assistant_response_payload(assistant_message), status: :created
+    render json: assistant_response_payload(assistant_message), status: :created
   rescue NotImplementedError => e
     render json: { error: e.message }, status: :service_unavailable
   rescue ChatSessions::LlmClientConfigurationError => e
     render json: { error: e.message }, status: :service_unavailable
   rescue ArgumentError => e
     render json: { error: e.message }, status: :unprocessable_content
+  rescue AgentHarness::RateLimitError => e
+    render json: { error: ChatSessions::ErrorMessage.for(e) }, status: :too_many_requests
   rescue StandardError => e
     Rails.logger.error(message: "chat_messages.send_failed", session_id: @chat_session.id, error: e.message)
     render json: { error: "An unexpected error occurred" }, status: :internal_server_error
@@ -140,6 +144,14 @@ class ChatMessagesController < ApplicationController
   end
 
   def write_sse_tool_event(message, stream_message_id: nil)
+    if fallback_notice?(message)
+      write_sse_event("message_created", message_json(message).merge(
+        fallback_notice: true,
+        stream_message_id: nil
+      ))
+      return
+    end
+
     event_type = if message.role == "tool"
       "message_tool_result"
     elsif message.role == "assistant" && message.tool_name.present? && message.content.nil?
@@ -160,6 +172,10 @@ class ChatMessagesController < ApplicationController
       tool_status: message.tool_status,
       stream_message_id: stream_message_id
     })
+  end
+
+  def fallback_notice?(message)
+    message.metadata.is_a?(Hash) && message.metadata["fallback_notice"] == true
   end
 
   def stream_resolve_response(tool_call_message, decision)
@@ -206,6 +222,8 @@ class ChatMessagesController < ApplicationController
     write_sse_event("error", { message: e.message }) rescue IOError
   rescue ArgumentError => e
     write_sse_event("error", { message: e.message }) rescue IOError
+  rescue AgentHarness::RateLimitError => e
+    write_sse_event("error", { message: ChatSessions::ErrorMessage.for(e) }) rescue IOError
   rescue StandardError => e
     Rails.logger.error(message: "chat_messages.resolve_stream_failed", session_id: @chat_session.id, error: e.message)
     write_sse_event("error", { message: "An unexpected error occurred" }) rescue IOError
@@ -232,6 +250,8 @@ class ChatMessagesController < ApplicationController
     render json: { error: e.message }, status: :service_unavailable
   rescue ArgumentError => e
     render json: { error: e.message }, status: :unprocessable_content
+  rescue AgentHarness::RateLimitError => e
+    render json: { error: ChatSessions::ErrorMessage.for(e) }, status: :too_many_requests
   rescue StandardError => e
     Rails.logger.error(message: "chat_messages.resolve_failed", session_id: @chat_session.id, error: e.message)
     render json: { error: "An unexpected error occurred" }, status: :internal_server_error

--- a/app/javascript/controllers/chat_controller.js
+++ b/app/javascript/controllers/chat_controller.js
@@ -252,6 +252,10 @@ export default class extends Controller {
   handleMessageCreated(data) {
     if (!data.html) return
 
+    if (data.fallback_notice) {
+      this.removeCurrentAssistantMessage()
+    }
+
     const messageElement = this.buildMessageElement(data.html)
     if (!messageElement) return
 
@@ -284,6 +288,13 @@ export default class extends Controller {
     if (contentTarget?.dataset.rawContent) return
 
     pendingMessage.closest("div")?.remove()
+  }
+
+  removeCurrentAssistantMessage() {
+    if (!this.currentStreamId) return
+
+    const pendingMessage = this.messagesTarget.querySelector(`article[data-stream-message-id="${this.currentStreamId}"]`)
+    pendingMessage?.closest("div")?.remove()
   }
 
   messageElementById(messageId) {

--- a/app/jobs/chat_sessions/process_message_job.rb
+++ b/app/jobs/chat_sessions/process_message_job.rb
@@ -53,6 +53,8 @@ class ChatSessions::ProcessMessageJob < ApplicationJob
     broadcast_error(chat_session_id, stream_message_id, e.message)
   rescue ChatSessions::TokenLimitExceededError => e
     broadcast_error(chat_session_id, stream_message_id, e.message)
+  rescue AgentHarness::RateLimitError => e
+    broadcast_error(chat_session_id, stream_message_id, ChatSessions::ErrorMessage.for(e))
   rescue ActiveRecord::RecordNotFound
     raise
   rescue StandardError => e
@@ -84,12 +86,17 @@ class ChatSessions::ProcessMessageJob < ApplicationJob
       tool_call_id: message.tool_call_id,
       tool_arguments: message.tool_arguments,
       tool_result: message.tool_result,
+      fallback_notice: fallback_notice?(message),
       stream_message_id: stream_message_id,
       html: ApplicationController.render(
         partial: "chat_messages/message",
         locals: { message: message }
       )
     })
+  end
+
+  def fallback_notice?(message)
+    message.metadata.is_a?(Hash) && message.metadata["fallback_notice"] == true
   end
 
   def broadcast_error(chat_session_id, stream_message_id, error_message)

--- a/app/jobs/chat_sessions/resolve_tool_call_job.rb
+++ b/app/jobs/chat_sessions/resolve_tool_call_job.rb
@@ -58,6 +58,8 @@ class ChatSessions::ResolveToolCallJob < ApplicationJob
     broadcast_error(chat_session_id, stream_message_id, e.message)
   rescue ChatSessions::TokenLimitExceededError => e
     broadcast_error(chat_session_id, stream_message_id, e.message)
+  rescue AgentHarness::RateLimitError => e
+    broadcast_error(chat_session_id, stream_message_id, ChatSessions::ErrorMessage.for(e))
   rescue ActiveRecord::RecordNotFound
     raise
   rescue StandardError => e
@@ -105,12 +107,17 @@ class ChatSessions::ResolveToolCallJob < ApplicationJob
       tool_call_id: message.tool_call_id,
       tool_arguments: message.tool_arguments,
       tool_result: message.tool_result,
+      fallback_notice: fallback_notice?(message),
       stream_message_id: stream_message_id,
       html: ApplicationController.render(
         partial: "chat_messages/message",
         locals: { message: message }
       )
     })
+  end
+
+  def fallback_notice?(message)
+    message.metadata.is_a?(Hash) && message.metadata["fallback_notice"] == true
   end
 
   def broadcast_error(chat_session_id, stream_message_id, error_message)

--- a/app/services/chat_sessions/agent_loop.rb
+++ b/app/services/chat_sessions/agent_loop.rb
@@ -129,6 +129,8 @@ module ChatSessions
       messages = messages.last(MAX_CONVERSATION_MESSAGES)
 
       messages.each_with_object([]) do |msg, conversation|
+        next if fallback_notice?(msg)
+
         if assistant_tool_call_message?(msg)
           append_assistant_tool_call_entry(conversation, msg)
         else
@@ -142,6 +144,10 @@ module ChatSessions
         message.content.blank? &&
         message.tool_call_id.present? &&
         message.tool_name.present?
+    end
+
+    def fallback_notice?(message)
+      message.metadata.is_a?(Hash) && message.metadata["fallback_notice"] == true
     end
 
     def conversation_content_for(message)

--- a/app/services/chat_sessions/error_message.rb
+++ b/app/services/chat_sessions/error_message.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module ChatSessions
+  module ErrorMessage
+    module_function
+
+    def for(error)
+      case error
+      when AgentHarness::RateLimitError
+        rate_limit_message(error)
+      else
+        error.message
+      end
+    end
+
+    def rate_limit_message(error)
+      reset_time = error.respond_to?(:reset_time) ? error.reset_time : nil
+      return error.message if reset_time.blank?
+
+      "#{error.message} (resets at #{I18n.l(reset_time, format: :long)})"
+    end
+  end
+end

--- a/app/services/chat_sessions/fallback_runners.rb
+++ b/app/services/chat_sessions/fallback_runners.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "set"
+
+module ChatSessions
+  module FallbackRunners
+    module_function
+
+    def for(chat_session:, excluding: [])
+      user = chat_session.created_by
+      return [] unless user&.settings
+
+      excluded_ids = excluded_runner_ids(excluding)
+
+      Array(user.settings.kb_chat_fallback_runners).filter_map do |identifier|
+        runner = runner_for_identifier(user, identifier, excluding_ids: excluded_ids)
+        next unless usable_runner?(runner)
+        next if excluded_ids.include?(runner.id)
+
+        runner
+      end.uniq
+    end
+
+    def switch!(chat_session:, runner:)
+      chat_session.update!(runner: runner, model: model_for(runner))
+    end
+
+    def model_for(runner)
+      runner.direct_outbound_model_id.presence || default_model_for_service_type(service_type_for(runner))
+    end
+
+    def notice_for(error:, runner:)
+      "The selected chat runner hit a rate limit: #{ErrorMessage.for(error)} Switching to #{runner.display_name} and continuing."
+    end
+
+    def usable_runner?(runner)
+      runner&.enabled_for_chat? && runner.effective_api_secret.present?
+    end
+
+    def runner_for_identifier(user, identifier, excluding_ids:)
+      if Runner.routing_key?(identifier)
+        Runner.for_identifier(user, identifier)
+      else
+        user.runners.kept_only.where(runner_key: identifier).ordered.find do |runner|
+          usable_runner?(runner) && !excluding_ids.include?(runner.id)
+        end
+      end
+    end
+
+    def excluded_runner_ids(runners)
+      Array(runners).each_with_object(Set.new) do |runner, ids|
+        next unless runner
+
+        ids << runner.id
+      end
+    end
+
+    def service_type_for(runner)
+      runner.provider_api_key&.api_service_type || runner.required_api_service_type
+    end
+
+    def default_model_for_service_type(service_type)
+      return AgentHarness::TextTransport::DEFAULT_MODEL if service_type == BuildLlmClient::ANTHROPIC_SERVICE_TYPE
+
+      "gpt-4o"
+    end
+  end
+end

--- a/app/services/chat_sessions/resolve_tool_call.rb
+++ b/app/services/chat_sessions/resolve_tool_call.rb
@@ -120,13 +120,44 @@ module ChatSessions
     end
 
     def resume_loop
-      ChatSessions::AgentLoop.new(
+      attempted_runners = [ chat_session.runner ].compact
+
+      loop do
+        return ChatSessions::AgentLoop.new(**loop_kwargs).run
+      rescue AgentHarness::RateLimitError => e
+        fallback_runner = ChatSessions::FallbackRunners.for(chat_session: chat_session, excluding: attempted_runners).first
+        raise unless fallback_runner
+
+        attempted_runners << fallback_runner
+        switch_to_fallback_runner(fallback_runner, e)
+      end
+    end
+
+    def loop_kwargs
+      {
         chat_session: chat_session,
         llm_client: llm_client,
         on_chunk: on_chunk,
         on_message_persisted: on_message_persisted,
         stream_message_id: stream_message_id
-      ).run
+      }
+    end
+
+    def switch_to_fallback_runner(runner, error)
+      ChatSessions::FallbackRunners.switch!(chat_session: chat_session, runner: runner)
+      @llm_client = ChatSessions::BuildLlmClient.call(chat_session: chat_session)
+      persist_fallback_notice(runner, error)
+    end
+
+    def persist_fallback_notice(runner, error)
+      message = chat_session.messages.create!(
+        role: "assistant",
+        content: ChatSessions::FallbackRunners.notice_for(error: error, runner: runner),
+        metadata: { "fallback_notice" => true }
+      )
+
+      on_message_persisted&.call(message)
+      message
     end
 
     def update_session_activity

--- a/app/services/chat_sessions/send_message.rb
+++ b/app/services/chat_sessions/send_message.rb
@@ -37,7 +37,7 @@ module ChatSessions
       resume_session_if_needed!
 
       persist_user_message
-      assistant_message = ChatSessions::AgentLoop.new(**loop_kwargs).run
+      assistant_message = run_agent_loop_with_fallbacks
       update_session_activity
       assistant_message
     end
@@ -102,6 +102,37 @@ module ChatSessions
         on_message_persisted: on_message_persisted,
         stream_message_id: stream_message_id
       }
+    end
+
+    def run_agent_loop_with_fallbacks
+      attempted_runners = [ chat_session.runner ].compact
+
+      loop do
+        return ChatSessions::AgentLoop.new(**loop_kwargs).run
+      rescue AgentHarness::RateLimitError => e
+        fallback_runner = ChatSessions::FallbackRunners.for(chat_session: chat_session, excluding: attempted_runners).first
+        raise unless fallback_runner
+
+        attempted_runners << fallback_runner
+        switch_to_fallback_runner(fallback_runner, e)
+      end
+    end
+
+    def switch_to_fallback_runner(runner, error)
+      ChatSessions::FallbackRunners.switch!(chat_session: chat_session, runner: runner)
+      @llm_client = ChatSessions::BuildLlmClient.call(chat_session: chat_session)
+      persist_fallback_notice(runner, error)
+    end
+
+    def persist_fallback_notice(runner, error)
+      message = chat_session.messages.create!(
+        role: "assistant",
+        content: ChatSessions::FallbackRunners.notice_for(error: error, runner: runner),
+        metadata: { "fallback_notice" => true }
+      )
+
+      on_message_persisted&.call(message)
+      message
     end
 
     def update_session_activity

--- a/spec/jobs/chat_sessions/process_message_job_spec.rb
+++ b/spec/jobs/chat_sessions/process_message_job_spec.rb
@@ -208,6 +208,42 @@ RSpec.describe ChatSessions::ProcessMessageJob, type: :job do
       .with(hash_including(type: "error", message: "limit reached"))
   end
 
+  it "broadcasts provider rate limit errors" do
+    allow(ChatSessions::SendMessage).to receive(:call)
+      .and_raise(AgentHarness::RateLimitError, "API rate limit exceeded: Weekly/Monthly Limit Exhausted")
+
+    expect {
+      described_class.perform_now(
+        chat_session_id: chat_session.id,
+        content: "Hello",
+        stream_message_id: stream_message_id
+      )
+    }.to have_broadcasted_to(stream_name)
+      .with(hash_including(type: "error", message: "API rate limit exceeded: Weekly/Monthly Limit Exhausted"))
+  end
+
+  it "broadcasts a fallback notice and continues when a fallback runner is configured" do
+    fallback_runner = configure_chat_fallback
+    allow(ChatSessions::BuildLlmClient).to receive(:call)
+      .and_return(rate_limited_llm_client, successful_fallback_llm_client)
+
+    expect {
+      described_class.perform_now(
+        chat_session_id: chat_session.id,
+        content: "Hello",
+        stream_message_id: stream_message_id
+      )
+    }.to have_broadcasted_to(stream_name)
+      .with(hash_including(type: "message_created", role: "assistant",
+        fallback_notice: true,
+        html: include("Switching to #{fallback_runner.display_name} and continuing.")))
+      .and have_broadcasted_to(stream_name)
+      .with(hash_including(type: "message_created", role: "assistant",
+        html: include("Fallback answer")))
+      .and have_broadcasted_to(stream_name)
+      .with(hash_including(type: "message_complete", tokens: { input: 10, output: 5 }))
+  end
+
   it "broadcasts generic error for unexpected failures" do
     allow(ChatSessions::SendMessage).to receive(:call)
       .and_raise(StandardError, "provider timeout")
@@ -230,5 +266,35 @@ RSpec.describe ChatSessions::ProcessMessageJob, type: :job do
         stream_message_id: stream_message_id
       )
     }.not_to raise_error
+  end
+
+  def rate_limited_llm_client
+    Class.new do
+      def call(*)
+        raise AgentHarness::RateLimitError, "API rate limit exceeded"
+      end
+    end.new
+  end
+
+  def successful_fallback_llm_client
+    instance_double(Proc, call: {
+      content: "Fallback answer",
+      tool_calls: [],
+      tokens_input: 10,
+      tokens_output: 5,
+      model: "claude"
+    })
+  end
+
+  def configure_chat_fallback
+    primary_runner = create(:runner, :api_key, user: user, runner_key: "opencode",
+      provider_api_key: create(:provider_api_key, user: user, api_service_type: "openrouter"),
+      config: { "opencode" => { "api_provider" => "openrouter", "model" => "moonshotai/kimi-k2" } })
+    fallback_runner = create(:runner, :api_key, user: user, runner_key: "claude",
+      provider_api_key: create(:provider_api_key, user: user, api_service_type: "anthropic"))
+
+    user.settings.update!(kb_chat_fallback_runners: [ "claude" ])
+    chat_session.update!(runner: primary_runner)
+    fallback_runner
   end
 end

--- a/spec/requests/chat_messages_spec.rb
+++ b/spec/requests/chat_messages_spec.rb
@@ -130,6 +130,19 @@ RSpec.describe "ChatMessages" do
           "error" => "Chat requires a configured API-key runner. Add a chat-enabled runner with an API key and select it for this session."
         )
       end
+
+      it "returns provider rate limit errors as too many requests" do
+        allow(ChatSessions::BuildLlmClient).to receive(:call).with(chat_session: chat_session).and_return(instance_double(Proc))
+        allow(ChatSessions::SendMessage).to receive(:call)
+          .and_raise(AgentHarness::RateLimitError, "API rate limit exceeded: Weekly/Monthly Limit Exhausted")
+
+        post chat_session_chat_messages_path(chat_session), params: { content: "Hello" }
+
+        expect(response).to have_http_status(:too_many_requests)
+        expect(response.parsed_body).to eq(
+          "error" => "API rate limit exceeded: Weekly/Monthly Limit Exhausted"
+        )
+      end
     end
 
     context "when authenticated with SSE response" do
@@ -195,6 +208,29 @@ RSpec.describe "ChatMessages" do
         data = JSON.parse(response.body.scan(/event: message_tool_result\ndata: (.+)\n/).flatten.first)
         expect(data).to include("tool_name" => "search", "tool_call_id" => "call_abc",
           "role" => "tool", "tool_result" => { "results" => [ "item" ] }, "stream_message_id" => stream_id)
+      end
+
+      it "emits message_created for fallback notices" do
+        assistant_msg = create(:chat_message, :assistant, chat_session: chat_session, tokens_input: 10, tokens_output: 5)
+        fallback_notice = create(:chat_message, :assistant, chat_session: chat_session,
+          content: "Switching to Claude and continuing.",
+          metadata: { "fallback_notice" => true })
+        allow(ChatSessions::BuildLlmClient).to receive(:call).and_return(instance_double(Proc))
+        allow(ChatSessions::SendMessage).to receive(:call) do |**args|
+          args[:on_message_persisted].call(fallback_notice, stream_message_id: SecureRandom.uuid)
+          assistant_msg
+        end
+
+        post chat_session_chat_messages_path(chat_session),
+          params: { content: "Hello" }, headers: { "Accept" => "text/event-stream" }
+
+        data = JSON.parse(response.body.scan(/event: message_created\ndata: (.+)\n/).flatten.first)
+        expect(data).to include(
+          "role" => "assistant",
+          "content" => "Switching to Claude and continuing.",
+          "fallback_notice" => true,
+          "stream_message_id" => nil
+        )
       end
 
       it "does not emit tool events for regular user or assistant messages" do

--- a/spec/services/chat_sessions/fallback_runners_spec.rb
+++ b/spec/services/chat_sessions/fallback_runners_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ChatSessions::FallbackRunners do
+  describe ".for" do
+    let(:account) { create(:account) }
+    let(:user) { create(:user, account: account) }
+    let(:chat_session) { create(:chat_session, account: account, created_by: user, runner: primary_runner) }
+    let(:primary_runner) { create_openrouter_runner(name: "Primary") }
+
+    it "allows fallback to another API-key runner with the same runner key" do
+      fallback_runner = create_openrouter_runner(name: "Fallback")
+      user.settings.update!(kb_chat_fallback_runners: [ "opencode" ])
+
+      expect(described_class.for(chat_session: chat_session, excluding: [ primary_runner ])).to eq([ fallback_runner ])
+    end
+
+    it "does not return the exact excluded runner for routing-key fallbacks" do
+      user.settings.update_columns(kb_chat_fallback_runners: [ primary_runner.routing_key ])
+
+      expect(described_class.for(chat_session: chat_session, excluding: [ primary_runner ])).to eq([])
+    end
+  end
+
+  def create_openrouter_runner(name:)
+    create(:runner, :api_key, user: user, runner_key: "opencode", name: name,
+      provider_api_key: create(:provider_api_key, user: user, api_service_type: "openrouter"),
+      config: { "opencode" => { "api_provider" => "openrouter", "model" => "moonshotai/kimi-k2" } })
+  end
+end

--- a/spec/services/chat_sessions/send_message_spec.rb
+++ b/spec/services/chat_sessions/send_message_spec.rb
@@ -313,6 +313,26 @@ RSpec.describe ChatSessions::SendMessage do
       }.not_to raise_error
     end
 
+    it "falls back to a configured chat runner on provider rate limits without duplicating the user message" do
+      primary_client = rate_limited_llm_client
+      fallback_client = inspecting_llm_client(llm_response)
+      fallback_runner = configure_chat_fallback
+      allow(ChatSessions::BuildLlmClient).to receive(:call).with(chat_session: chat_session).and_return(fallback_client)
+
+      result = described_class.call(chat_session: chat_session, content: "Hello", llm_client: primary_client)
+
+      messages = chat_session.messages.order(:created_at)
+      expect(result.content).to eq("I can help with that.")
+      expect(chat_session.reload.runner).to eq(fallback_runner)
+      expect(messages.where(role: "user", content: "Hello").count).to eq(1)
+      expect(messages.pluck(:role)).to eq(%w[user assistant assistant])
+      expect(messages.second.content).to include("Switching to #{fallback_runner.display_name} and continuing.")
+      expect(messages.second.metadata).to include("fallback_notice" => true)
+      expect(fallback_client.seen_conversations.last).not_to include(
+        hash_including(content: messages.second.content)
+      )
+    end
+
     context "with tool calls in response" do
       let(:tool_llm_client) { build_stateful_llm_client(successful_tool_llm_responses) }
 
@@ -481,6 +501,43 @@ RSpec.describe ChatSessions::SendMessage do
         responses.fetch(seen_conversations.length - 1)
       end
     end.new(responses)
+  end
+
+  def rate_limited_llm_client
+    Class.new do
+      def call(*)
+        raise AgentHarness::RateLimitError, "API rate limit exceeded"
+      end
+    end.new
+  end
+
+  def inspecting_llm_client(response)
+    Class.new do
+      attr_reader :seen_conversations
+
+      def initialize(response)
+        @response = response
+        @seen_conversations = []
+      end
+
+      def call(conversation, **)
+        @seen_conversations << conversation.deep_dup
+        @response
+      end
+    end.new(response)
+  end
+
+  def configure_chat_fallback
+    primary_runner = create(:runner, :api_key, user: user, runner_key: "opencode",
+      provider_api_key: create(:provider_api_key, user: user, api_service_type: "openrouter"),
+      config: { "opencode" => { "api_provider" => "openrouter", "model" => "moonshotai/kimi-k2" } })
+    user.runners.find_or_create_by!(runner_key: "claude", auth_type: "subscription")
+    fallback_runner = create(:runner, :api_key, user: user, runner_key: "claude",
+      provider_api_key: create(:provider_api_key, user: user, api_service_type: "anthropic"))
+
+    user.settings.update!(kb_chat_fallback_runners: [ "claude" ])
+    chat_session.update!(runner: primary_runner)
+    fallback_runner
   end
 
   def successful_tool_llm_responses


### PR DESCRIPTION
## Summary

- retry chat sends and tool-call continuations on configured chat fallback runners when the selected provider rate-limits
- show a user-visible fallback notice while keeping that notice out of future LLM context
- surface provider rate-limit errors instead of the generic unexpected-error message when no fallback can continue
- clear stale partial streamed output before rendering a fallback notice

## Root Cause

Chat sessions only fell back during setup when the selected runner lacked an API key. Runtime provider rate limits from `agent_harness` fell through the generic rescue path, so users saw `An unexpected error occurred` and the chat stopped even when `kb_chat_fallback_runners` was configured.

## Validation

- `bin/rspec spec/services/chat_sessions/fallback_runners_spec.rb spec/services/chat_sessions/send_message_spec.rb spec/jobs/chat_sessions/process_message_job_spec.rb spec/requests/chat_messages_spec.rb spec/services/chat_sessions/resolve_tool_call_spec.rb`
- `bin/rubocop app/services/chat_sessions/error_message.rb app/services/chat_sessions/fallback_runners.rb app/services/chat_sessions/send_message.rb app/services/chat_sessions/resolve_tool_call.rb app/services/chat_sessions/agent_loop.rb app/jobs/chat_sessions/process_message_job.rb app/jobs/chat_sessions/resolve_tool_call_job.rb app/controllers/chat_messages_controller.rb spec/services/chat_sessions/fallback_runners_spec.rb spec/services/chat_sessions/send_message_spec.rb spec/jobs/chat_sessions/process_message_job_spec.rb spec/requests/chat_messages_spec.rb`
- `yarn eslint app/javascript/controllers/chat_controller.js`
- pre-commit hook lint suite