### PR TITLE
ci: auto-remove stray ephemeral tests left on main

### DIFF
--- a/.ephemeral-tests/README.md
+++ b/.ephemeral-tests/README.md
@@ -18,6 +18,9 @@ in CI for the PR but are not merged to `main`.
 3. Results are posted as a PR comment.
 4. Remove the test files from `.ephemeral-tests/` before merging — a CI
    guard on `main` rejects stray test files.
+5. Safety net: if files are left behind, the `ephemeral-cleanup.yml` workflow
+   auto-opens a PR removing them after the merge, so `main` self-heals. Clean
+   up before merge anyway — the guard is briefly red until that PR merges.
 
 ## Security
 

--- a/.github/workflows/ephemeral-cleanup.yml
+++ b/.github/workflows/ephemeral-cleanup.yml
@@ -1,0 +1,82 @@
+name: Ephemeral Cleanup
+
+# Ephemeral PR tests (.ephemeral-tests/*_spec.rb) are meant to live only on PR
+# branches and be removed before merge (see .ephemeral-tests/README.md). When an
+# author forgets, the files land on main and the "No ephemeral tests on main"
+# guard in ci.yml turns red on every subsequent push.
+#
+# This workflow auto-removes them: after any PR merges into main, if stray
+# ephemeral test files are present, it opens an auto-merging cleanup PR that
+# deletes them. main is protected (no direct pushes), so cleanup goes through a
+# PR rather than a direct push. The ci.yml guard remains as the backstop alarm.
+#
+# This is a no-op (no PR opened) when no stray files exist, including when the
+# cleanup PR itself merges — so it does not loop.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [ main ]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ephemeral-cleanup
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Remove stray ephemeral tests from main
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Detect and remove stray ephemeral test files
+        id: detect
+        run: |
+          stray=$(find .ephemeral-tests -type f \( -name '*_spec.rb' -o -name '*_test.js' -o -name '*_test.ts' \) 2>/dev/null || true)
+          if [ -z "$stray" ]; then
+            echo "No stray ephemeral test files on main; nothing to clean up."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "::warning::Stray ephemeral test files found on main; opening cleanup PR:"
+          echo "$stray"
+          echo "$stray" | xargs git rm
+          {
+            echo "files<<EOF"
+            echo "$stray"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Open auto-merging cleanup PR
+        if: steps.detect.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MERGED_PR: ${{ github.event.pull_request.number }}
+          FILES: ${{ steps.detect.outputs.files }}
+        run: |
+          set -euo pipefail
+          branch="ci/auto-remove-ephemeral-tests-${MERGED_PR}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git commit \
+            -m "fix(ci): remove stray ephemeral test files from main" \
+            -m "Ephemeral test files are meant to live only on PR branches and be removed before merge (see .ephemeral-tests/README.md). Left behind by #${MERGED_PR}; this auto-generated cleanup removes them so the \"No ephemeral tests on main\" guard goes green again."
+          git push origin "$branch"
+          body=$(printf 'Auto-generated cleanup. #%s merged with ephemeral test files left on `main`, which trips the **No ephemeral tests on main** guard in ci.yml.\n\nRemoving:\n```\n%s\n```\n\nSee [.ephemeral-tests/README.md](.ephemeral-tests/README.md) — these files are meant to be deleted before merge.' "$MERGED_PR" "$FILES")
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "fix(ci): remove stray ephemeral test files from main" \
+            --body "$body"
+          gh pr merge "$branch" --squash --auto --delete-branch


### PR DESCRIPTION
## Why

When a PR merges with ephemeral test files still in `.ephemeral-tests/`, the **No ephemeral tests on main** guard in [ci.yml](.github/workflows/ci.yml) goes red on every subsequent push to `main` — exactly what just happened with #2693 (fixed in #2753). The guard is a post-merge *detector*; it can't block the merge because ephemeral files legitimately exist on PR branches (the guard is skipped there).

## What

New `ephemeral-cleanup.yml` workflow, triggered on `pull_request: closed` into `main` (merged only). If stray ephemeral files exist, it opens an **auto-merging cleanup PR** that deletes them, so `main` self-heals.

- `main` is protected (no direct pushes), so cleanup goes through a PR using the default `GITHUB_TOKEN`.
- No-op when no stray files exist — including when the cleanup PR itself merges, so it can't loop.
- The existing ci.yml guard stays as the backstop alarm.

## Trade-off

The guard is briefly red until the cleanup PR's CI passes and it auto-merges. Authors should still remove ephemeral tests before merge; this is a safety net, not a license to skip cleanup. (For instant, zero-window cleanup we'd need a branch-protection-bypass token; we chose the zero-secret PR approach.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)