### PR TITLE
[codex] Update msgpack for security audit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -378,7 +378,7 @@ GEM
       equalizer (~> 0.0.9)
       ice_nine (~> 0.11.1)
       procto (~> 0.0.2)
-    msgpack (1.8.1)
+    msgpack (1.8.3)
     multi_json (1.20.1)
     multipart-post (2.4.1)
     net-http (0.9.1)
@@ -908,7 +908,7 @@ CHECKSUMS
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
   morpher (0.4.2) sha256=0a7afa16acfd8b619b0bc3dd9269c5fa42b502f496358e60e48027c58d1aa07b
   mprelude (0.1.0) sha256=d851de873ed07eb4b40ffb70f1da3afd5c22f62148a0178a03fe095b49c55dd4
-  msgpack (1.8.1) sha256=3fef787cd3965fd119c08a22724a56a93ca25008c3421fc15039f603a8b7c86c
+  msgpack (1.8.3) sha256=8bda4a6428d3244e50d6bd55854d354edbada88a4e1f4f5731a39a0f86bee6a1
   multi_json (1.20.1) sha256=2f3934e805cc45ef91b551a1f89d0e9191abd06a5e04a2ef09a6a036c452ca6d
   multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
   mutant (0.10.0)


### PR DESCRIPTION
## Summary
- Update `msgpack` from 1.8.1 to 1.8.3 in `Gemfile.lock`
- Resolve the bundler-audit failure for CVE-2026-54522 / GHSA-4mrv-5p47-p938

## Validation
- `bin/audit` passed locally
- pre-commit checks passed