### PR TITLE
[codex] Fix worktree post-checkout database setup

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -36,6 +36,27 @@ if [ -z "$removed" ] && [ -z "$added" ]; then
   exit 0
 fi
 
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Migration changes detected on branch switch"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+worktree_database_suffix() {
+  ruby <<'RUBY'
+require File.expand_path("config/worktree_database_names", Dir.pwd)
+
+puts Paid::WorktreeDatabaseNames.suffix.to_s
+RUBY
+}
+
+if command -v bin/ensure-worktree-databases &>/dev/null && [ -n "$(worktree_database_suffix)" ]; then
+  echo "  Ensuring worktree databases..."
+  if ! bin/ensure-worktree-databases 2>&1; then
+    echo "  ⚠  Could not ensure worktree databases. Migration guard skipped."
+    exit 0
+  fi
+fi
+
 restored_files=()
 
 cleanup() {
@@ -44,11 +65,6 @@ cleanup() {
   done
 }
 trap cleanup EXIT
-
-echo ""
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "  Migration changes detected on branch switch"
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
 if [ -n "$removed" ]; then
   echo ""

--- a/bin/ensure-worktree-databases
+++ b/bin/ensure-worktree-databases
@@ -84,11 +84,25 @@ can_create_databases() {
 
 database_exists() {
   local db_name="$1"
-  local creator_password="$2"
+  local query_password="$2"
   shift 2
   local -a args=("$@")
 
-  [[ "$(query_psql "$creator_password" "${args[@]}" -c "SELECT 1 FROM pg_database WHERE datname = '$db_name'")" == "1" ]]
+  [[ "$(query_psql "$query_password" "${args[@]}" -c "SELECT 1 FROM pg_database WHERE datname = '$db_name'")" == "1" ]]
+}
+
+all_databases_exist() {
+  local query_password="$1"
+  shift
+  local -a args=("$@")
+
+  for db_name in "$DEV_DB" "$CABLE_DB" "$TEST_DB"; do
+    if ! database_exists "$db_name" "$query_password" "${args[@]}"; then
+      return 1
+    fi
+  done
+
+  return 0
 }
 
 create_database() {
@@ -120,6 +134,12 @@ validate_identifier "role name" "$APP_DB_USER" "DB_USERNAME / DB_USER"
 # database creation entirely — Rails will use DATABASE_URL.
 if [[ -n "${DATABASE_URL:-}" ]]; then
   echo "DATABASE_URL is set — skipping automatic worktree database creation."
+  exit 0
+fi
+
+mapfile -d '' -t APP_QUERY_ARGS < <(psql_base_args "$APP_DB_HOST" "$APP_DB_USER" "$MAINTENANCE_DB")
+if all_databases_exist "$APP_DB_PASSWORD" "${APP_QUERY_ARGS[@]}"; then
+  echo "Worktree databases already exist."
   exit 0
 fi
 

--- a/spec/scripts/ensure_worktree_databases_script_spec.rb
+++ b/spec/scripts/ensure_worktree_databases_script_spec.rb
@@ -42,7 +42,20 @@ RSpec.describe EnsureWorktreeDatabasesScript do
     end
   end
 
-  def prepare_script_fixture(dir)
+  it "succeeds without creator privileges when all worktree databases already exist" do
+    Dir.mktmpdir("ensure-worktree-databases-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir, psql_stub: existing_databases_psql_stub(dir))
+
+      stdout, stderr, status = Open3.capture3(base_env(dir), script_path, chdir: dir)
+
+      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(stdout).to include("Worktree databases already exist.")
+      expect(File.read(File.join(dir, "psql-queries.log"))).to include("SELECT 1 FROM pg_database")
+      expect(File.read(File.join(dir, "psql-queries.log"))).not_to include("SELECT rolcreatedb")
+    end
+  end
+
+  def prepare_script_fixture(dir, psql_stub: default_psql_stub(dir))
     FileUtils.mkdir_p(File.join(dir, "bin"))
     FileUtils.mkdir_p(File.join(dir, "config"))
     FileUtils.mkdir_p(File.join(dir, "stubbin"))
@@ -72,11 +85,7 @@ RSpec.describe EnsureWorktreeDatabasesScript do
 
     write_executable(
       File.join(dir, "stubbin", "psql"),
-      <<~BASH
-        #!/usr/bin/env bash
-        echo invoked > "#{dir}/psql-invoked.log"
-        exit 0
-      BASH
+      psql_stub
     )
 
     File.write(File.join(dir, ".git"), "gitdir: #{dir}/.git/worktrees/test\n")
@@ -96,5 +105,33 @@ RSpec.describe EnsureWorktreeDatabasesScript do
   def write_executable(path, contents)
     File.write(path, contents)
     FileUtils.chmod("+x", path)
+  end
+
+  def default_psql_stub(dir)
+    <<~BASH
+      #!/usr/bin/env bash
+      echo invoked > "#{dir}/psql-invoked.log"
+      exit 0
+    BASH
+  end
+
+  def existing_databases_psql_stub(dir)
+    <<~BASH
+      #!/usr/bin/env bash
+      printf '%s\n' "$*" >> "#{dir}/psql-queries.log"
+
+      case "$*" in
+        *"SELECT 1 FROM pg_database WHERE datname = '"*)
+          echo 1
+          exit 0
+          ;;
+        *"SELECT rolcreatedb FROM pg_roles WHERE rolname = current_user"*)
+          echo "creator check should not run" >&2
+          exit 1
+          ;;
+      esac
+
+      exit 1
+    BASH
   end
 end

--- a/spec/scripts/post_checkout_hook_spec.rb
+++ b/spec/scripts/post_checkout_hook_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fileutils"
+require "open3"
+require "shellwords"
+require "tmpdir"
+require_relative "../support/exec_tmpdir"
+
+RSpec.describe "post-checkout hook" do # rubocop:disable RSpec/DescribeClass
+  include ExecTmpdir
+
+  it "ensures worktree databases before running added migrations" do
+    Dir.mktmpdir("post-checkout-hook-spec", exec_tmpdir) do |dir|
+      hook_path = prepare_hook_fixture(dir)
+      write_worktree_database_names(dir, suffix: "feature_123")
+      write_git_stub(dir, previous_migrations: "", new_migrations: "db/migrate/20260630000000_create_widgets.rb")
+      write_bin_stub(dir, "ensure-worktree-databases", "printf 'ensure\\n' >> #{shellescape(File.join(dir, 'calls.log'))}\n")
+      write_bin_stub(dir, "rails", "printf 'rails %s\\n' \"$*\" >> #{shellescape(File.join(dir, 'calls.log'))}\n")
+
+      stdout, stderr, status = Open3.capture3(base_env(dir), hook_path, "previous", "new", "1", chdir: dir)
+
+      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(File.read(File.join(dir, "calls.log")).lines.map(&:chomp)).to eq([
+        "ensure",
+        "rails db:migrate"
+      ])
+    end
+  end
+
+  it "skips migrations without failing checkout when worktree database creation fails" do
+    Dir.mktmpdir("post-checkout-hook-spec", exec_tmpdir) do |dir|
+      hook_path = prepare_hook_fixture(dir)
+      write_worktree_database_names(dir, suffix: "feature_123")
+      write_git_stub(dir, previous_migrations: "", new_migrations: "db/migrate/20260630000000_create_widgets.rb")
+      write_bin_stub(dir, "ensure-worktree-databases", "printf 'ensure\\n' >> #{shellescape(File.join(dir, 'calls.log'))}\nexit 1\n")
+      write_bin_stub(dir, "rails", "printf 'rails %s\\n' \"$*\" >> #{shellescape(File.join(dir, 'calls.log'))}\n")
+
+      stdout, stderr, status = Open3.capture3(base_env(dir), hook_path, "previous", "new", "1", chdir: dir)
+
+      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(stdout).to include("Migration guard skipped")
+      expect(File.read(File.join(dir, "calls.log")).lines.map(&:chomp)).to eq([ "ensure" ])
+    end
+  end
+
+  it "does not require CREATEDB checks for the primary checkout database" do
+    Dir.mktmpdir("post-checkout-hook-spec", exec_tmpdir) do |dir|
+      hook_path = prepare_hook_fixture(dir)
+      write_worktree_database_names(dir, suffix: nil)
+      write_git_stub(dir, previous_migrations: "", new_migrations: "db/migrate/20260630000000_create_widgets.rb")
+      write_bin_stub(dir, "ensure-worktree-databases", "printf 'ensure\\n' >> #{shellescape(File.join(dir, 'calls.log'))}\nexit 1\n")
+      write_bin_stub(dir, "rails", "printf 'rails %s\\n' \"$*\" >> #{shellescape(File.join(dir, 'calls.log'))}\n")
+
+      stdout, stderr, status = Open3.capture3(base_env(dir), hook_path, "previous", "new", "1", chdir: dir)
+
+      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(File.read(File.join(dir, "calls.log")).lines.map(&:chomp)).to eq([ "rails db:migrate" ])
+    end
+  end
+
+  def prepare_hook_fixture(dir)
+    FileUtils.mkdir_p(File.join(dir, ".githooks"))
+    FileUtils.mkdir_p(File.join(dir, "bin"))
+    FileUtils.mkdir_p(File.join(dir, "config"))
+    FileUtils.mkdir_p(File.join(dir, "stubbin"))
+
+    hook_path = File.join(dir, ".githooks", "post-checkout")
+    FileUtils.cp(File.expand_path("../../.githooks/post-checkout", __dir__), hook_path)
+    FileUtils.chmod("+x", hook_path)
+    hook_path
+  end
+
+  def write_worktree_database_names(dir, suffix:)
+    value = suffix.nil? ? "nil" : suffix.inspect
+    File.write(File.join(dir, "config", "worktree_database_names.rb"), <<~RUBY)
+      # frozen_string_literal: true
+
+      module Paid
+        module WorktreeDatabaseNames
+          module_function
+
+          def suffix
+            #{value}
+          end
+        end
+      end
+    RUBY
+  end
+
+  def write_git_stub(dir, previous_migrations:, new_migrations:)
+    path = File.join(dir, "stubbin", "git")
+    File.write(path, <<~BASH)
+      #!/usr/bin/env bash
+      if [[ "$1" == "ls-tree" && "$4" == "previous" ]]; then
+        printf '%s\\n' #{shellescape(previous_migrations)}
+        exit 0
+      fi
+
+      if [[ "$1" == "ls-tree" && "$4" == "new" ]]; then
+        printf '%s\\n' #{shellescape(new_migrations)}
+        exit 0
+      fi
+
+      exit 1
+    BASH
+    FileUtils.chmod("+x", path)
+  end
+
+  def write_bin_stub(dir, name, body)
+    path = File.join(dir, "bin", name)
+    File.write(path, <<~BASH)
+      #!/usr/bin/env bash
+      set -euo pipefail
+      #{body}
+    BASH
+    FileUtils.chmod("+x", path)
+  end
+
+  def base_env(dir)
+    {
+      "PATH" => "#{File.join(dir, 'stubbin')}:#{ENV.fetch('PATH')}",
+      "SKIP_MIGRATION_GUARD" => "0"
+    }
+  end
+
+  def shellescape(value)
+    Shellwords.escape(value)
+  end
+end


### PR DESCRIPTION
## Summary

Fixes the local post-checkout migration guard for linked git worktrees that derive disposable database names.

The hook now ensures worktree-scoped development, cable, and test databases exist before running migration rollback or migrate commands. It only performs that ensure step when a worktree database suffix is present, so primary checkouts do not need CREATEDB privileges just to run ordinary branch-switch migrations.

## Root Cause

`config/database.yml` derives unique database names for linked worktrees, but `.githooks/post-checkout` could be the first Rails command to touch the derived database. When a branch switch introduced migrations, the hook ran `bin/rails db:migrate` before the disposable database existed.

## Validation

- `bin/rspec spec/scripts/post_checkout_hook_spec.rb spec/scripts/ensure_worktree_databases_script_spec.rb`
- `bin/rubocop spec/scripts/post_checkout_hook_spec.rb`
- `shellcheck -x .githooks/post-checkout`
- `bin/lint --changed`
- `git diff --check -- .githooks/post-checkout spec/scripts/post_checkout_hook_spec.rb`
