### PR TITLE
[codex] Align generated schema

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -952,27 +952,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_28_182451) do
     t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
-  create_table "github_app_installations", comment: "GitHub App installations for org/repo access without PATs", force: :cascade do |t|
-    t.bigint "account_id", null: false
-    t.string "app_id", null: false, comment: "GitHub App ID used for this installation"
-    t.string "app_slug", null: false, comment: "GitHub App slug for display and bot identity"
-    t.datetime "created_at", null: false
-    t.bigint "installation_id", null: false, comment: "GitHub installation ID from the App installation event"
-    t.bigint "installed_by_id"
-    t.jsonb "metadata", default: {}, null: false, comment: "Additional installation metadata from GitHub"
-    t.jsonb "repositories", default: [], null: false, comment: "Cached list of installed repository metadata"
-    t.datetime "repositories_synced_at", comment: "Last time the repository list was synced from GitHub"
-    t.string "repository_selection", default: "selected", null: false, comment: "GitHub installation repository_selection: all or selected"
-    t.datetime "revoked_at", comment: "When the installation was revoked or uninstalled"
-    t.string "status", default: "active", null: false, comment: "Installation status: active, suspended, uninstalled"
-    t.datetime "updated_at", null: false
-    t.index ["account_id", "installation_id"], name: "idx_on_account_id_installation_id_effaccd2e5", unique: true
-    t.index ["account_id"], name: "index_github_app_installations_on_account_id"
-    t.index ["installation_id"], name: "index_github_app_installations_on_installation_id", unique: true
-    t.index ["installed_by_id"], name: "index_github_app_installations_on_installed_by_id"
-    t.index ["status"], name: "index_github_app_installations_on_status"
-  end
-
   create_table "github_health_states", force: :cascade do |t|
     t.datetime "circuit_opened_at"
     t.string "circuit_state", limit: 20, default: "closed", null: false
@@ -980,7 +959,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_28_182451) do
     t.string "endpoint", limit: 50, default: "api", null: false
     t.integer "failure_count", default: 0, null: false
     t.text "last_error_message"
-    t.integer "rate_limit_limit"
+    t.integer "rate_limit_limit", comment: "Total hourly request cap reported by GitHub for this credential (5,000 for PATs, 15,000 for App installations)."
     t.datetime "rate_limit_observed_at", comment: "When the remaining/limit rate-limit figures were last sampled from the GitHub API for this credential endpoint."
     t.integer "rate_limit_remaining"
     t.datetime "rate_limit_reset_at"
@@ -2479,20 +2458,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_28_182451) do
     t.index ["uuid"], name: "index_tracker_configurations_on_uuid", unique: true
   end
 
-  create_table "user_identities", comment: "Links users to external identity providers (SSO/OIDC/SAML)", force: :cascade do |t|
-    t.bigint "account_id", null: false
-    t.jsonb "auth_data", default: {}, null: false, comment: "Raw auth data from provider (serialized for audit trail)"
-    t.datetime "created_at", null: false
-    t.string "provider", null: false, comment: "Identity provider name: saml, oidc, github, etc."
-    t.string "uid", null: false, comment: "External user identifier from the IdP"
-    t.datetime "updated_at", null: false
-    t.bigint "user_id", null: false
-    t.index ["account_id"], name: "index_user_identities_on_account_id"
-    t.index ["provider", "uid"], name: "index_user_identities_on_provider_and_uid", unique: true
-    t.index ["user_id", "provider"], name: "index_user_identities_on_user_id_and_provider", unique: true
-    t.index ["user_id"], name: "index_user_identities_on_user_id"
-  end
-
   create_table "user_settings", force: :cascade do |t|
     t.integer "agent_timeout_seconds", default: 5400, null: false
     t.string "agent_update_comment_mode", default: "off", null: false, comment: "Controls whether existing-PR agent followups post no comment or generate a paid summary comment."
@@ -2829,6 +2794,26 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_28_182451) do
   add_foreign_key "workflow_states", "projects"
   add_foreign_key "worktrees", "agent_runs", on_delete: :nullify
   add_foreign_key "worktrees", "projects", on_delete: :cascade
+
+  create_function :paid_current_account_id, sql_definition: <<-'SQL'
+      CREATE OR REPLACE FUNCTION public.paid_current_account_id()
+       RETURNS bigint
+       LANGUAGE sql
+       STABLE
+      AS $function$
+        SELECT NULLIF(current_setting('paid.current_account_id', true), '')::bigint
+      $function$
+  SQL
+
+  create_function :paid_tenant_bypass, sql_definition: <<-'SQL'
+      CREATE OR REPLACE FUNCTION public.paid_tenant_bypass()
+       RETURNS boolean
+       LANGUAGE sql
+       STABLE
+      AS $function$
+        SELECT current_setting('paid.bypass_tenant_rls', true) = 'true'
+      $function$
+  SQL
 
   create_function :logidze_capture_exception, sql_definition: <<-'SQL'
       CREATE OR REPLACE FUNCTION public.logidze_capture_exception(error_data jsonb)
@@ -3601,26 +3586,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_28_182451) do
       $function$
   SQL
 
-  create_function :paid_current_account_id, sql_definition: <<-'SQL'
-      CREATE OR REPLACE FUNCTION public.paid_current_account_id()
-       RETURNS bigint
-       LANGUAGE sql
-       STABLE
-      AS $function$
-        SELECT NULLIF(current_setting('paid.current_account_id', true), '')::bigint
-      $function$
-  SQL
-
-  create_function :paid_tenant_bypass, sql_definition: <<-'SQL'
-      CREATE OR REPLACE FUNCTION public.paid_tenant_bypass()
-       RETURNS boolean
-       LANGUAGE sql
-       STABLE
-      AS $function$
-        SELECT current_setting('paid.bypass_tenant_rls', true) = 'true'
-      $function$
-  SQL
-
   create_trigger :logidze_on_account_memberships, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_account_memberships BEFORE INSERT OR UPDATE ON public.account_memberships FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
@@ -3710,7 +3675,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_28_182451) do
   SQL
 
   create_trigger :logidze_on_runner_credentials, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_runner_credentials BEFORE INSERT OR UPDATE ON public.runner_credentials FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{token}')
+      CREATE TRIGGER logidze_on_runner_credentials BEFORE INSERT OR UPDATE ON public.runner_credentials FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
 
   create_trigger :logidze_on_providers, sql_definition: <<-SQL


### PR DESCRIPTION
## Summary

Aligns `db/schema.rb` with the schema generated from the current database/migration state.

This removes stale dumped definitions for `github_app_installations` and `user_identities`, restores the generated comment on `github_health_states.rate_limit_limit`, keeps fx-managed function ordering as dumped, and updates the dumped `logidze_on_runner_credentials` trigger definition to match the database output.

## Why

`db/schema.rb` had drifted from the generated schema. The current Rails guidance says schema changes should be represented through migrations and schema dumps rather than manual schema edits.

## Validation

- `RAILS_ENV=test bin/rails db:drop db:create db:migrate db:schema:dump` in `/workspaces/paid` completed and produced this schema diff.
- `git diff --check` passed.
- Commit pre-commit hook passed: RuboCop, ESLint, markdownlint, ShellCheck, and Herb.

## Notes

A separate branch-local worktree migration attempt using the worktree-specific test database hit an existing migration-path error at `20260509233216_seed_baseline_orchestration_strategies` with `PG::InvalidObjectDefinition: infinite recursion detected in policy for relation "strategies"`. I did not expand this schema alignment PR to address that unrelated migration issue.