### PR TITLE
fix(jobs): harden PerformTimeoutError propagation through call-stack rescues

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -35,7 +35,10 @@ class ApplicationJob < ActiveJob::Base
 
   around_perform :with_tenant_context
 
-  # Innermost around_perform so the timeout bounds the actual work only, not the
+  # IMPORTANT: must remain the last around_perform registration in this class.
+  # ActiveJob callbacks run in registration order, innermost last — adding
+  # another around_perform after this line silently places it inside the
+  # timeout ceiling. Keep the timeout scoped to the actual job work, not the
   # tenant/query-monitor setup around it.
   around_perform :with_perform_timeout
 

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -3,10 +3,13 @@
 require "timeout"
 
 class ApplicationJob < ActiveJob::Base
-  # Raised when a job exceeds its configured perform_timeout. Subclasses
-  # Timeout::Error so it is still caught by the base StandardError rescue (and
-  # reported as a terminal failure) while remaining identifiable in incidents.
-  class PerformTimeoutError < Timeout::Error; end
+  # Raised when a job exceeds its configured perform_timeout. Intentionally
+  # inherits from StandardError (NOT Timeout::Error) so that existing
+  # `rescue Timeout::Error` handlers in the call stacks — auth_health.rb,
+  # base_collector.rb, etc. — do not silently swallow the job-level abort
+  # signal. The base `rescue_from(StandardError)` hook in this class is what
+  # catches it, marks the job terminal, and reports an incident.
+  class PerformTimeoutError < StandardError; end
 
   class_attribute :notification_subsystem, default: "general"
   class_attribute :max_attempts, default: 1
@@ -81,8 +84,8 @@ class ApplicationJob < ActiveJob::Base
   end
 
   def with_perform_timeout(&block)
-    timeout = self.class.perform_timeout
-    return yield unless timeout
+    timeout = self.class.perform_timeout&.to_i
+    return yield if timeout.nil? || timeout <= 0
 
     Timeout.timeout(timeout, PerformTimeoutError, "#{self.class.name} exceeded perform_timeout of #{timeout}s", &block)
   end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,8 +1,23 @@
 # frozen_string_literal: true
 
+require "timeout"
+
 class ApplicationJob < ActiveJob::Base
+  # Raised when a job exceeds its configured perform_timeout. Subclasses
+  # Timeout::Error so it is still caught by the base StandardError rescue (and
+  # reported as a terminal failure) while remaining identifiable in incidents.
+  class PerformTimeoutError < Timeout::Error; end
+
   class_attribute :notification_subsystem, default: "general"
   class_attribute :max_attempts, default: 1
+
+  # Optional wall-clock ceiling (in seconds) for a single perform; nil disables
+  # it. Opt in per job as a backstop for work that can block indefinitely on
+  # external I/O (containers, network, git). Under GoodJob's :async_server mode
+  # jobs run on threads inside Puma, so a job that hangs forever also pins the
+  # code-reloader's load interlock and stalls every web request — this bound
+  # guarantees such a job eventually fails instead of hanging the process.
+  class_attribute :perform_timeout, default: nil
 
   rescue_from(StandardError) do |exception|
     notify_terminal_failure(exception) if executions >= self.class.max_attempts
@@ -16,6 +31,10 @@ class ApplicationJob < ActiveJob::Base
   end
 
   around_perform :with_tenant_context
+
+  # Innermost around_perform so the timeout bounds the actual work only, not the
+  # tenant/query-monitor setup around it.
+  around_perform :with_perform_timeout
 
   def notification_project_id
     nil
@@ -59,6 +78,13 @@ class ApplicationJob < ActiveJob::Base
     return TenantContext.with(account, &block) if account
 
     TenantContext.with_system_access(&block)
+  end
+
+  def with_perform_timeout(&block)
+    timeout = self.class.perform_timeout
+    return yield unless timeout
+
+    Timeout.timeout(timeout, PerformTimeoutError, "#{self.class.name} exceeded perform_timeout of #{timeout}s", &block)
   end
 
   def tenant_account

--- a/app/jobs/pool_replenishment_job.rb
+++ b/app/jobs/pool_replenishment_job.rb
@@ -5,6 +5,11 @@ class PoolReplenishmentJob < ApplicationJob
 
   queue_as :maintenance
 
+  # Backstop against container provisioning blocking indefinitely on the Docker
+  # daemon while replenishing pools across projects. Guarantees the job fails
+  # rather than pinning a worker thread (and the code reloader) forever.
+  self.perform_timeout = 15.minutes.to_i
+
   good_job_control_concurrency_with(
     total_limit: 1,
     enqueue_limit: 1,

--- a/app/jobs/run_collectors_job.rb
+++ b/app/jobs/run_collectors_job.rb
@@ -6,6 +6,11 @@ class RunCollectorsJob < ApplicationJob
   queue_as :knowledge
   self.notification_subsystem = "knowledge"
 
+  # Backstop against a collector run hanging indefinitely on container/git/network
+  # I/O. Inner per-command timeouts are 30s each; 20 minutes leaves ample room for
+  # a full multi-collector run while guaranteeing the job cannot hang forever.
+  self.perform_timeout = 20.minutes.to_i
+
   discard_on ActiveRecord::RecordNotFound
 
   # Prevent duplicate enqueues for the same project+SHA when staleness detection

--- a/app/services/containers/pool_manager.rb
+++ b/app/services/containers/pool_manager.rb
@@ -160,8 +160,9 @@ module Containers
         last_error: nil
       )
       entry
+    rescue ApplicationJob::PerformTimeoutError
+      raise
     rescue StandardError => e
-      raise if e.is_a?(ApplicationJob::PerformTimeoutError)
       remove_failed_provision(entry, service, e.message)
       nil
     end

--- a/app/services/containers/pool_manager.rb
+++ b/app/services/containers/pool_manager.rb
@@ -161,6 +161,7 @@ module Containers
       )
       entry
     rescue StandardError => e
+      raise if e.is_a?(ApplicationJob::PerformTimeoutError)
       remove_failed_provision(entry, service, e.message)
       nil
     end

--- a/app/services/knowledge/base_collector.rb
+++ b/app/services/knowledge/base_collector.rb
@@ -121,6 +121,11 @@ module Knowledge
             out_thread.join
             err_thread.join
           end
+        rescue ApplicationJob::PerformTimeoutError
+          # Job-level abort: kill the subprocess so it doesn't become an orphan,
+          # then re-raise to propagate the abort signal up through CollectorRunner.
+          kill_process_group(wait_thr.pid)
+          raise
         rescue Timeout::Error
           kill_process_group(wait_thr.pid)
           # Reap with a short timeout to avoid blocking forever if the process

--- a/app/services/knowledge/base_collector.rb
+++ b/app/services/knowledge/base_collector.rb
@@ -122,28 +122,12 @@ module Knowledge
             err_thread.join
           end
         rescue ApplicationJob::PerformTimeoutError
-          # Job-level abort: kill the subprocess so it doesn't become an orphan,
-          # then re-raise to propagate the abort signal up through CollectorRunner.
-          kill_process_group(wait_thr.pid)
+          # Job-level abort: tear down the subprocess and reader threads before
+          # re-raising so the timeout propagates without leaking local I/O work.
+          cleanup_timed_out_process(wait_thr:, stdout:, stderr:, out_thread:, err_thread:)
           raise
         rescue Timeout::Error
-          kill_process_group(wait_thr.pid)
-          # Reap with a short timeout to avoid blocking forever if the process
-          # cannot be signaled (e.g. EPERM from kill_process_group).
-          reap_thread = Thread.new { wait_thr.value }
-          unless reap_thread.join(5)
-            reap_thread.kill
-          end
-          stdout.close unless stdout.closed?
-          stderr.close unless stderr.closed?
-          out_thread.join(5) || begin
-            out_thread.kill
-            out_thread.join
-          end
-          err_thread.join(5) || begin
-            err_thread.kill
-            err_thread.join
-          end
+          cleanup_timed_out_process(wait_thr:, stdout:, stderr:, out_thread:, err_thread:)
           raise Timeout::Error, "Command timed out after #{timeout} seconds: #{argv.join(' ')}"
         ensure
           stdout.close unless stdout.closed?
@@ -167,6 +151,26 @@ module Knowledge
       Process.kill("KILL", -pgid)
     rescue Errno::ESRCH, Errno::EPERM
       # Process already exited or cannot be signaled
+    end
+
+    def cleanup_timed_out_process(wait_thr:, stdout:, stderr:, out_thread:, err_thread:)
+      kill_process_group(wait_thr.pid)
+      # Reap with a short timeout to avoid blocking forever if the process
+      # cannot be signaled (e.g. EPERM from kill_process_group).
+      reap_thread = Thread.new { wait_thr.value }
+      unless reap_thread.join(5)
+        reap_thread.kill
+      end
+      stdout.close unless stdout.closed?
+      stderr.close unless stderr.closed?
+      out_thread.join(5) || begin
+        out_thread.kill
+        out_thread.join
+      end
+      err_thread.join(5) || begin
+        err_thread.kill
+        err_thread.join
+      end
     end
 
     def timeout_kill_grace_seconds

--- a/app/services/knowledge/collector_runner.rb
+++ b/app/services/knowledge/collector_runner.rb
@@ -120,6 +120,7 @@ module Knowledge
         preserve_existing_artifacts: e.preserve_existing_artifacts?
       }
     rescue ApplicationJob::PerformTimeoutError
+      collector_run&.mark_failed!(error: "perform timeout") if collector_run&.persisted?
       raise
     rescue StandardError => e
       collector_run&.mark_failed!(error: e.message) if collector_run&.persisted?

--- a/app/services/knowledge/collector_runner.rb
+++ b/app/services/knowledge/collector_runner.rb
@@ -119,8 +119,9 @@ module Knowledge
         reason: e.reason,
         preserve_existing_artifacts: e.preserve_existing_artifacts?
       }
-    rescue => e
-      raise if e.is_a?(ApplicationJob::PerformTimeoutError)
+    rescue ApplicationJob::PerformTimeoutError
+      raise
+    rescue StandardError => e
       collector_run&.mark_failed!(error: e.message) if collector_run&.persisted?
       Rails.logger.error(
         message: "knowledge.collector_failed",

--- a/app/services/knowledge/collector_runner.rb
+++ b/app/services/knowledge/collector_runner.rb
@@ -120,6 +120,7 @@ module Knowledge
         preserve_existing_artifacts: e.preserve_existing_artifacts?
       }
     rescue => e
+      raise if e.is_a?(ApplicationJob::PerformTimeoutError)
       collector_run&.mark_failed!(error: e.message) if collector_run&.persisted?
       Rails.logger.error(
         message: "knowledge.collector_failed",

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -42,6 +42,56 @@ RSpec.describe ApplicationJob do
     end
   end
 
+  describe "perform_timeout" do
+    it "defaults to nil (disabled)" do
+      expect(described_class.perform_timeout).to be_nil
+    end
+
+    it "runs perform normally when no timeout is configured" do
+      ran = false
+      job_class = Class.new(described_class) do
+        define_method(:perform) { ran = true }
+      end
+      stub_const("NoTimeoutJob", job_class)
+
+      job_class.new.perform_now
+      expect(ran).to be(true)
+    end
+
+    it "raises PerformTimeoutError when perform exceeds the configured ceiling" do
+      job_class = Class.new(described_class) do
+        self.perform_timeout = 1
+        self.max_attempts = 1
+
+        def perform
+          sleep 5
+        end
+      end
+      stub_const("SlowTimeoutJob", job_class)
+
+      allow(Paid::ExceptionNotifier).to receive(:new).and_return(
+        instance_double(Paid::ExceptionNotifier, call: nil)
+      )
+
+      job = job_class.new
+      job.executions = 0
+      expect { job.perform_now }.to raise_error(ApplicationJob::PerformTimeoutError)
+    end
+
+    it "does not interrupt work that finishes within the ceiling" do
+      job_class = Class.new(described_class) do
+        self.perform_timeout = 5
+
+        def perform
+          "done"
+        end
+      end
+      stub_const("FastTimeoutJob", job_class)
+
+      expect { job_class.new.perform_now }.not_to raise_error
+    end
+  end
+
   describe "rescue_from terminal-failure hook" do
     let(:account) { create(:account) }
 

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -69,13 +69,16 @@ RSpec.describe ApplicationJob do
       end
       stub_const("SlowTimeoutJob", job_class)
 
-      allow(Paid::ExceptionNotifier).to receive(:new).and_return(
-        instance_double(Paid::ExceptionNotifier, call: nil)
-      )
+      notifier = instance_double(Paid::ExceptionNotifier, call: nil)
+      allow(Paid::ExceptionNotifier).to receive(:new).and_return(notifier)
 
       job = job_class.new
       job.executions = 0
       expect { job.perform_now }.to raise_error(ApplicationJob::PerformTimeoutError)
+      expect(notifier).to have_received(:call).with(
+        an_instance_of(ApplicationJob::PerformTimeoutError),
+        data: hash_including(subsystem: "general")
+      )
     end
 
     it "does not interrupt work that finishes within the ceiling" do

--- a/spec/jobs/pool_replenishment_job_spec.rb
+++ b/spec/jobs/pool_replenishment_job_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 RSpec.describe PoolReplenishmentJob do
+  it "has a 15-minute perform_timeout so a hung provisioning call cannot deadlock the Rails reloader" do
+    expect(described_class.perform_timeout).to eq(15.minutes.to_i)
+  end
+
   describe "#perform" do
     it "replenishes active projects" do
       active_project = create(:project)

--- a/spec/jobs/run_collectors_job_spec.rb
+++ b/spec/jobs/run_collectors_job_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe RunCollectorsJob do
   let(:project) { create(:project) }
   let(:commit_sha) { "a" * 40 }
 
+  it "has a 20-minute perform_timeout so a hung job cannot deadlock the Rails reloader" do
+    expect(described_class.perform_timeout).to eq(20.minutes.to_i)
+  end
+
   describe "#perform" do
     context "when Docker is unavailable" do
       before do

--- a/spec/services/containers/pool_manager_spec.rb
+++ b/spec/services/containers/pool_manager_spec.rb
@@ -375,6 +375,20 @@ RSpec.describe Containers::PoolManager do
       expect(project.container_pool_entries.reload.count).to eq(0)
       expect(provision).to have_received(:cleanup).with(force: true)
     end
+
+    it "re-raises perform timeouts instead of swallowing them as provisioning failures" do
+      provision = instance_double(Containers::Provision)
+
+      allow(Containers::Provision).to receive(:new).and_return(provision)
+      allow(provision).to receive(:network_name).and_return("paid_agent")
+      allow(provision).to receive(:provision).and_raise(ApplicationJob::PerformTimeoutError, "perform timeout")
+
+      expect {
+        described_class.new(project: project, target_size: 1).replenish
+      }.to raise_error(ApplicationJob::PerformTimeoutError, "perform timeout")
+
+      expect(project.container_pool_entries.reload.pluck(:status)).to eq([ "warming" ])
+    end
   end
 
   def expect_replenish_to_remove_stale_warm_entry(stale_entry)

--- a/spec/services/knowledge/collector_runner_spec.rb
+++ b/spec/services/knowledge/collector_runner_spec.rb
@@ -390,6 +390,55 @@ RSpec.describe Knowledge::CollectorRunner do
       end
     end
 
+    context "when a collector times out" do
+      let(:timing_out_collector_class) do
+        attempts = 0
+
+        Class.new(Knowledge::BaseCollector) do
+          define_method(:collect) do
+            attempts += 1
+            raise ApplicationJob::PerformTimeoutError, "perform timeout" if attempts == 1
+
+            [
+              {
+                artifact_type: "test_artifact",
+                scope_path: "app/models/user.rb",
+                identifier: "User",
+                content: '{"class": "User"}',
+                metadata: {},
+                chunks: []
+              }
+            ]
+          end
+
+          def collector_type
+            "timing_out_collector"
+          end
+        end
+      end
+
+      before do
+        described_class.reset_registry!
+        described_class.register("timing_out_collector", timing_out_collector_class)
+      end
+
+      it "marks the persisted run failed before re-raising so the same version can retry" do
+        expect {
+          described_class.call(project: project, commit_sha: commit_sha)
+        }.to raise_error(ApplicationJob::PerformTimeoutError, "perform timeout")
+
+        failed_run = CollectorRun.find_by!(collector_type: "timing_out_collector")
+        expect(failed_run.status).to eq("failed")
+        expect(failed_run.error_message).to eq("perform timeout")
+
+        retry_result = described_class.call(project: project, commit_sha: commit_sha)
+
+        expect(retry_result[:results]).to contain_exactly(
+          hash_including(collector_type: "timing_out_collector", status: "completed", artifacts_count: 1)
+        )
+      end
+    end
+
     context "when running a subset of collectors" do
       let(:other_collector_class) do
         Class.new(Knowledge::BaseCollector) do


### PR DESCRIPTION
## Summary

Follows up on the initial `perform_timeout` backstop (#2752 / fb3ad6c) with hardening found during code review. The original implementation had two independent failure modes that together meant neither job ever actually terminated on timeout.

### Root Causes

**`PerformTimeoutError < Timeout::Error` — wrong base class.** Existing `rescue Timeout::Error` handlers in `base_collector.rb` and `auth_health.rb` intercepted the abort signal and swallowed it silently. Changed to `< StandardError` so those handlers are bypassed; the `rescue_from(StandardError)` hook in ApplicationJob is what catches it.

**`CollectorRunner` and `PoolManager` bare rescues swallowed the signal.** `run_single_collector`'s `rescue => e` caught PerformTimeoutError, marked the collector failed, and continued — the job ran to completion with no effect from the timeout. `provision_entry`'s `rescue StandardError` did the same for PoolReplenishmentJob, independently of the inheritance fix. Added explicit re-raise guards to both.

### Additional Fixes

- `base_collector.rb`: inheritance change means `rescue Timeout::Error` no longer covers PerformTimeoutError — added a targeted rescue clause to kill the subprocess before re-raising (avoids orphaned Docker processes)
- `with_perform_timeout`: add `.to_i` coercion (handles ActiveSupport::Duration passthrough) and `<= 0` guard (treat zero as disabled)
- Tests: assert notifier fires on timeout; pin `perform_timeout` values in both job specs so a silent regression can't go undetected

## Test plan

- [ ] `bin/rspec spec/jobs/application_job_spec.rb` — timeout test now asserts notifier call
- [ ] `bin/rspec spec/jobs/run_collectors_job_spec.rb spec/jobs/pool_replenishment_job_spec.rb` — new value assertions
- [ ] `bin/rspec spec/services/knowledge/collector_runner_spec.rb spec/services/containers/pool_manager_spec.rb`
- [ ] `bin/rubocop` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)