### PR TITLE
fix(mcp): allow chat to create GitHub issues from a prompt

### DIFF
--- a/app/mcp/tools/trigger_agent_run.rb
+++ b/app/mcp/tools/trigger_agent_run.rb
@@ -9,8 +9,9 @@ module Tools
 
     def self.description
       "Start an agent run on a project. Pass issue_id to target an existing issue. To open a brand-new " \
-        "GitHub issue, use goal=create_issue with custom_prompt instead of issue_id — the agent turns the " \
-        "prompt into the new issue's title and body. Requires explicit confirmation."
+        "GitHub issue, use goal=create_issue with custom_prompt instead of issue_id — custom_prompt tells " \
+        "the agent what to investigate or implement; the agent writes the resulting issue title and body " \
+        "from its own output. Requires explicit confirmation."
     end
 
     def self.available_to?(user:)
@@ -27,7 +28,11 @@ module Tools
           custom_prompt: { type: "string", description: "Description of the work for the agent to do. Required when goal is create_issue and no issue_id is given." },
           confirmed: { type: "boolean", description: "Must be true to execute this write operation" }
         },
-        required: %w[project_id confirmed]
+        required: %w[project_id confirmed],
+        anyOf: [
+          { required: %w[issue_id] },
+          { required: %w[custom_prompt] }
+        ]
       }
     end
 

--- a/app/mcp/tools/trigger_agent_run.rb
+++ b/app/mcp/tools/trigger_agent_run.rb
@@ -8,7 +8,9 @@ module Tools
     def self.write_operation? = true
 
     def self.description
-      "Start an agent run on an issue. Requires explicit confirmation."
+      "Start an agent run on a project. Pass issue_id to target an existing issue. To open a brand-new " \
+        "GitHub issue, use goal=create_issue with custom_prompt instead of issue_id — the agent turns the " \
+        "prompt into the new issue's title and body. Requires explicit confirmation."
     end
 
     def self.available_to?(user:)
@@ -20,20 +22,23 @@ module Tools
         type: "object",
         properties: {
           project_id: { type: "integer", description: "The project ID" },
-          issue_id: { type: "integer", description: "The issue ID" },
+          issue_id: { type: "integer", description: "The issue ID. Omit when goal is create_issue and custom_prompt is provided instead." },
           goal: { type: "string", description: "Run goal", enum: AgentRun::GOALS, default: "create_pr" },
+          custom_prompt: { type: "string", description: "Description of the work for the agent to do. Required when goal is create_issue and no issue_id is given." },
           confirmed: { type: "boolean", description: "Must be true to execute this write operation" }
         },
-        required: %w[project_id issue_id confirmed]
+        required: %w[project_id confirmed]
       }
     end
 
-    def perform(project_id:, issue_id:, confirmed: false, goal: "create_pr")
+    def perform(project_id:, confirmed: false, issue_id: nil, goal: "create_pr", custom_prompt: nil)
       raise ArgumentError, "Confirmation required: set confirmed=true to trigger an agent run" unless confirmed
 
       project = project_for(project_id)
+      issue = issue_id ? project.issues.find(issue_id) : nil
+      custom_prompt = custom_prompt&.strip.presence
 
-      issue = project.issues.find(issue_id)
+      raise ArgumentError, "issue_id or custom_prompt is required" if issue.nil? && custom_prompt.nil?
 
       runner_id, agent_type = AgentRuns::RunnerResolver.call(
         project: project,
@@ -47,6 +52,7 @@ module Tools
         runner_id: runner_id,
         agent_type: agent_type,
         goal: goal,
+        custom_prompt: custom_prompt,
         status: "queued",
         trigger_type: "manual"
       )

--- a/spec/mcp/tools/trigger_agent_run_spec.rb
+++ b/spec/mcp/tools/trigger_agent_run_spec.rb
@@ -71,5 +71,29 @@ RSpec.describe Tools::TriggerAgentRun do
         tool.call(project_id: project.id, issue_id: issue.id, confirmed: true)
       }.to raise_error(ArgumentError, "An agent run is already queued or in progress for this issue")
     end
+
+    context "with goal create_issue and no issue_id" do
+      it "creates an agent run from custom_prompt alone" do
+        result = tool.call(
+          project_id: project.id,
+          goal: "create_issue",
+          custom_prompt: "Fix the invisible chat popup overlay blocking clicks.",
+          confirmed: true
+        )
+
+        expect(result[:status]).to eq("queued")
+        expect(result[:issue_id]).to be_nil
+
+        run = AgentRun.find(result[:id])
+        expect(run.issue_id).to be_nil
+        expect(run.custom_prompt).to eq("Fix the invisible chat popup overlay blocking clicks.")
+      end
+
+      it "raises when neither issue_id nor custom_prompt is given" do
+        expect {
+          tool.call(project_id: project.id, goal: "create_issue", confirmed: true)
+        }.to raise_error(ArgumentError, "issue_id or custom_prompt is required")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- The `trigger_agent_run` chat/MCP tool always required `issue_id`, even though `AgentRun` already supports `goal=create_issue` driven purely by `custom_prompt` — the same path the "New Agent Run" web form (`Projects::AgentRunsController#create`) uses to open a brand-new GitHub issue from scratch.
- This meant the chat agent had no way to create an issue that didn't already exist, only to act on existing ones. It could genuinely say "I don't have a tool to create issues" even though the underlying capability already existed in Paid — the chat tool's schema just never exposed it.
- `issue_id` is now optional in the tool schema/`perform` signature; a new `custom_prompt` argument was added, and either `issue_id` or `custom_prompt` is required at runtime (mirroring the web form's own validation). Updated the tool's `description` so the model knows to use `goal=create_issue` + `custom_prompt` for net-new issues.

## Test plan
- [x] `bin/rspec spec/mcp/tools/trigger_agent_run_spec.rb spec/mcp/tools/registry_spec.rb spec/mcp/tools/registry_authorization_parity_spec.rb spec/mcp/paid_mcp_server_spec.rb` — 35 examples, 0 failures
- [x] `bin/rubocop app/mcp/tools/trigger_agent_run.rb spec/mcp/tools/trigger_agent_run_spec.rb` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)