### PR TITLE
fix(containers): increase codex tmpfs size

### DIFF
--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -135,6 +135,7 @@ module Containers
       timeout_seconds: 3600,                     # 1 hour default timeout
       tmpfs_tmp_size: 1024 * 1024 * 1024,        # 1GB for /tmp
       tmpfs_cache_size: 512 * 1024 * 1024,       # 512MB for /home/agent/.cache
+      tmpfs_codex_size: 256 * 1024 * 1024,       # 256MB for /home/agent/.codex
       image: "paid-agent:latest",
       user: "agent",
       workspace_mount: "/workspace"
@@ -158,6 +159,7 @@ module Containers
     # @option options [Integer] :cpu_quota CPU quota (100_000 per CPU)
     # @option options [Integer] :pids_limit Maximum number of processes
     # @option options [Integer] :timeout_seconds Default command timeout
+    # @option options [Integer] :tmpfs_codex_size Size of the writable ~/.codex tmpfs
     # @option options [String] :image Docker image to use
     def initialize(agent_run: nil, project: nil, worktree_path: nil, pool_entry: nil, workspace_volume: nil,
       backend: Containers.backend, credential_maintenance: false, **options)
@@ -1915,7 +1917,7 @@ module Containers
     #   /tmp                - tmpfs (1GB, for scratch files)
     #   /home/agent/.cache  - tmpfs (512MB, for tool caches: Codex CLI, npm, etc.)
     #   /home/agent/.claude - tmpfs (256MB, for Claude CLI session/project data)
-    #   /home/agent/.codex    - tmpfs (64MB, for Codex CLI config/session data)
+    #   /home/agent/.codex    - tmpfs (256MB, for Codex CLI config/session data)
     #   /home/agent/.gemini   - tmpfs (64MB, for Gemini CLI config/session data)
     #   /home/agent/.cursor-agent - tmpfs (64MB, for Cursor agent CLI config/session data)
     #   /home/agent/.kilocode - tmpfs (64MB, for Kilocode CLI config/session data)
@@ -2014,7 +2016,7 @@ module Containers
       # Codex CLI stores config and session data under ~/.codex.
       # Host-backed auth/config files are mounted into this tmpfs so session
       # state stays ephemeral while OAuth refreshes can still persist.
-      tmpfs["/home/agent/.codex"] = "size=#{64 * 1024 * 1024},mode=0700"
+      tmpfs["/home/agent/.codex"] = "size=#{options[:tmpfs_codex_size]},mode=0700"
 
       # Gemini CLI stores config and session data under ~/.gemini.
       # Ownership is fixed by fix_gemini_tmpfs_ownership! after container start.

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -164,6 +164,10 @@ RSpec.describe Containers::Provision do
       expect(described_class::DEFAULTS[:timeout_seconds]).to eq(3600)
     end
 
+    it "defines default Codex tmpfs size of 256MB" do
+      expect(described_class::DEFAULTS[:tmpfs_codex_size]).to eq(256 * 1024 * 1024)
+    end
+
     it "defines default image name" do
       expect(described_class::DEFAULTS[:image]).to eq("paid-agent:latest")
     end
@@ -409,6 +413,7 @@ RSpec.describe Containers::Provision do
           tmpfs = config["HostConfig"]["Tmpfs"]
           expect(tmpfs["/tmp"]).to eq("exec,size=#{1024 * 1024 * 1024},mode=1777")
           expect(tmpfs["/home/agent/.cache"]).to eq("exec,size=#{512 * 1024 * 1024},mode=0755")
+          expect(tmpfs["/home/agent/.codex"]).to eq("size=#{256 * 1024 * 1024},mode=0700")
           mock_container
         end
 
@@ -446,7 +451,23 @@ RSpec.describe Containers::Provision do
           tmpfs = config["HostConfig"]["Tmpfs"]
           expect(tmpfs).to have_key("/home/agent/.codex")
           expect(tmpfs["/home/agent/.codex"]).to include("mode=0700")
-          expect(tmpfs["/home/agent/.codex"]).to include("size=#{64 * 1024 * 1024}")
+          expect(tmpfs["/home/agent/.codex"]).to include("size=#{256 * 1024 * 1024}")
+          mock_container
+        end
+
+        service.provision
+      end
+
+      it "allows the Codex tmpfs size to be overridden" do
+        service = described_class.new(
+          agent_run: agent_run,
+          worktree_path: worktree_path,
+          tmpfs_codex_size: 384 * 1024 * 1024
+        )
+
+        expect(Docker::Container).to receive(:create) do |config|
+          tmpfs = config["HostConfig"]["Tmpfs"]
+          expect(tmpfs["/home/agent/.codex"]).to eq("size=#{384 * 1024 * 1024},mode=0700")
           mock_container
         end
 


### PR DESCRIPTION
## Summary

Increase the writable `/home/agent/.codex` tmpfs from 64MB to 256MB and expose the size through `Containers::Provision::DEFAULTS` as `tmpfs_codex_size`.

## Root Cause

Codex CLI writes session and rollout JSONL data under `~/.codex`. Agent run 29063 showed Codex failing during smoke preflight with `No space left on device (os error 28)` while writing `/home/agent/.codex/sessions/.../rollout-*.jsonl`, followed by exit 137. Docker did not report an OOM kill, so the failure was disk exhaustion in the small Codex tmpfs rather than memory pressure.

## Impact

Codex preflight and fallback runs get a tmpfs budget aligned with Claude's session-data mount, reducing false runner failures from rollout/session logging while keeping Codex state ephemeral and rootfs read-only.

## Validation

- `bundle exec rspec spec/services/containers/provision_spec.rb`
- `bundle exec rubocop app/services/containers/provision.rb spec/services/containers/provision_spec.rb`
- `git diff --check`
- pre-commit lint suite on commit