### PR TITLE
fix(dashboard): apply amber dark-mode overrides globally

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -516,21 +516,21 @@
   background-color: rgb(0 0 0 / 0.7);
 }
 
-.dark .quality-pause-card.bg-amber-50 {
+.dark .bg-amber-50 {
   background-color: rgba(120, 53, 15, 0.2);
 }
 
-.dark .quality-pause-card .bg-amber-100 {
+.dark .bg-amber-100 {
   background-color: rgb(120 53 15 / 0.45);
 }
 
-.dark .quality-pause-card .text-amber-950,
-.dark .quality-pause-card .text-amber-900,
-.dark .quality-pause-card .text-amber-800,
-.dark .quality-pause-card .text-amber-700,
-.dark .quality-pause-card .text-amber-600,
-.dark .quality-pause-card .text-amber-400 {
-  color: #fcd34d; /* amber-300 — high-contrast text for dark-mode pause card */
+.dark .text-amber-950,
+.dark .text-amber-900,
+.dark .text-amber-800,
+.dark .text-amber-700,
+.dark .text-amber-600,
+.dark .text-amber-400 {
+  color: #fcd34d; /* amber-300 */
 }
 
 .dark .bg-sky-50 {
@@ -635,7 +635,7 @@
   border-color: rgba(120, 53, 15, 0.6);
 }
 
-.dark .quality-pause-card .divide-amber-200 > :not(:last-child) {
+.dark .divide-amber-200 > :not(:last-child) {
   border-color: rgba(120, 53, 15, 0.6);
 }
 

--- a/app/views/dashboard/_quality_paused_projects.html.erb
+++ b/app/views/dashboard/_quality_paused_projects.html.erb
@@ -1,5 +1,5 @@
 <% if projects.any? %>
-  <div class="quality-pause-card rounded-md border border-amber-200 bg-amber-50 p-4">
+  <div class="rounded-md border border-amber-200 bg-amber-50 p-4">
     <div class="flex items-start justify-between gap-4">
       <div>
         <h3 class="text-sm font-semibold text-amber-900">Quality-paused projects</h3>


### PR DESCRIPTION
## Summary
- The Claude auth health banner on the dashboard was unreadable in dark mode — bright cream background, low-contrast status badge, and an `auth_expired` code snippet rendering as a stray black pill.
- Root cause: `application.tailwind.css` has global `.dark` overrides for every other alert color (red/orange/green/sky/teal), but the amber overrides were scoped to a single `.quality-pause-card` class, so any other amber-styled component (like this banner) got no dark-mode treatment at all.
- Made the amber dark-mode rules global to match the existing pattern for other colors, and dropped the now-unnecessary `quality-pause-card` scoping class.

## Test plan
- [x] Rendered the auth health banner partial with representative data (mirroring the reported screenshot) and screenshotted it in both light and dark mode via a local browser session — dark mode now shows a properly tinted card, readable "Invalid" badge, and the code snippet blends into the card instead of floating as a black tag.
- [x] Confirmed `bin/lint --changed` passes.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)