### PR TITLE
[codex] Fix review feedback loop

### DIFF
--- a/app/services/automation/strategies/auto_review.rb
+++ b/app/services/automation/strategies/auto_review.rb
@@ -257,8 +257,10 @@ module Automation
         decisions.concat(non_bot_request_decisions(plugins))
 
         if trigger_types.include?(Automation::ReviewMethods::Copilot::TRIGGER_TYPE)
+          # posted_bot_feedback_trigger? was already handled by the early
+          # return at the top of this method, so no follow-up is appended
+          # here — only the bot review request.
           decisions.concat(review_bot_request_decisions(plugins))
-          decisions.concat(followup_decisions(signals)) if posted_bot_feedback_trigger?(trigger_types)
           return decisions
         end
 

--- a/app/services/automation/strategies/auto_review.rb
+++ b/app/services/automation/strategies/auto_review.rb
@@ -151,6 +151,13 @@ module Automation
         # queue_review_run decision and suppress create_pr follow-up runs
         # while the review is outstanding (#1135).
         #
+        # Exception: posted bot feedback is already actionable. Queue a
+        # create_pr follow-up to address it before asking paid_agent to
+        # review the same findings again.
+        if !review_actively_running?(signals) && posted_bot_feedback_trigger?(signals.trigger_types)
+          return followup_decisions(signals)
+        end
+
         # Exception: when merge_conflicts is also present and the review
         # isn't currently running, address the conflict via create_pr first
         # (#2324). A review of code with conflicts can't produce meaningful
@@ -220,6 +227,10 @@ module Automation
       end
 
       def review_goal_retry_decisions(signals, plugins, outcomes, trigger_types)
+        if posted_bot_feedback_trigger?(trigger_types)
+          return followup_decisions(signals)
+        end
+
         paid_decision = plugins.find { |p| p.name == :paid_agent }&.decision
         retry_decision = Automation::Decision.record_review_goal_retry(
           issue_id: signals.issue_id,

--- a/spec/services/automation/strategies/auto_review_retry_semantics_spec.rb
+++ b/spec/services/automation/strategies/auto_review_retry_semantics_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Automation::Strategies::AutoReview do
   end
 
   describe "review_goal_retry with posted bot feedback" do
-    it "keeps follow-up decisions when bot has already posted feedback" do
+    it "queues a follow-up instead of retrying review when bot has already posted feedback" do
       result = evaluate(scan: {
         issue_id: pull_request.id,
         pr_number: 42,
@@ -92,8 +92,7 @@ RSpec.describe Automation::Strategies::AutoReview do
       })
 
       types = decision_types(result)
-      expect(types).to include("record_review_goal_retry", "queue_review_run", "request_review")
-      expect(types).to include("queue_create_pr_run", "record_pr_followup")
+      expect(types).to eq(%w[queue_create_pr_run record_pr_followup])
     end
   end
 

--- a/spec/services/automation/strategies/auto_review_spec.rb
+++ b/spec/services/automation/strategies/auto_review_spec.rb
@@ -266,7 +266,7 @@ RSpec.describe Automation::Strategies::AutoReview do
       expect(types).not_to include("queue_create_pr_run", "record_pr_followup")
     end
 
-    it "keeps retry follow-up decisions for posted bot feedback while review_bot_review_pending is outstanding" do
+    it "queues a follow-up instead of retrying review when bot has already posted feedback" do
       result = evaluate(scan: {
         issue_id: pull_request.id,
         pr_number: 42,
@@ -282,8 +282,24 @@ RSpec.describe Automation::Strategies::AutoReview do
       })
 
       types = result.to_h[:decisions].map { |d| d[:type] }
-      expect(types).to include("record_review_goal_retry", "queue_review_run", "request_review")
-      expect(types).to include("queue_create_pr_run", "record_pr_followup")
+      expect(types).to eq(%w[queue_create_pr_run record_pr_followup])
+    end
+
+    it "routes posted review feedback to create_pr instead of another paid_agent review" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "ready",
+        current_followup_count: 0,
+        labels_to_remove: [],
+        triggers: [
+          { type: "paid_agent_review_pending" },
+          { type: "review_bot_comments", details: "Latest review bot review generated comments" }
+        ]
+      })
+
+      types = result.to_h[:decisions].map { |d| d[:type] }
+      expect(types).to eq(%w[queue_create_pr_run record_pr_followup])
     end
 
     it "marks ready on ready_for_owner triggers" do

--- a/spec/services/automation/strategies/auto_review_spec.rb
+++ b/spec/services/automation/strategies/auto_review_spec.rb
@@ -302,6 +302,24 @@ RSpec.describe Automation::Strategies::AutoReview do
       expect(types).to eq(%w[queue_create_pr_run record_pr_followup])
     end
 
+    it "suppresses create_pr follow-ups while a paid_agent review is actively running, even with posted bot feedback" do
+      result = evaluate(scan: {
+        issue_id: pull_request.id,
+        pr_number: 42,
+        phase: "ready",
+        current_followup_count: 0,
+        labels_to_remove: [],
+        triggers: [
+          { type: "paid_agent_review_pending", active_run: true },
+          { type: "review_bot_comments", details: "Latest review bot review generated comments" }
+        ]
+      })
+
+      types = result.to_h[:decisions].map { |d| d[:type] }
+      expect(types).to eq([ "noop" ])
+      expect(types).not_to include("queue_create_pr_run", "record_pr_followup")
+    end
+
     it "marks ready on ready_for_owner triggers" do
       result = evaluate(scan: {
         issue_id: pull_request.id,


### PR DESCRIPTION
## Summary

Fixes the automation decision priority that could keep queueing paid-agent review runs even after review feedback had already been posted. Posted bot feedback now routes to a create_pr follow-up before requesting another review of the same findings.

## Root Cause

`paid_agent_review_pending` and `review_goal_retry` were evaluated before actionable `review_bot_comments` / `review_bot_threads`, so a PR could keep receiving review-goal runs instead of a follow-up run to address existing comments.

## Changes

- Route posted bot feedback plus paid-agent pending state to `queue_create_pr_run`.
- Route posted bot feedback plus review-goal retry state to `queue_create_pr_run`.
- Preserve review retry behavior when no actionable review feedback is present.
- Add focused specs for the new priority behavior.

## Validation

- `bin/rspec spec/services/automation/strategies/auto_review_spec.rb spec/services/automation/strategies/auto_review_retry_semantics_spec.rb spec/services/automation/strategy_parity_spec.rb spec/services/automation/pull_request_evaluator_spec.rb`
- `bin/rubocop app/services/automation/strategies/auto_review.rb spec/services/automation/strategies/auto_review_spec.rb spec/services/automation/strategies/auto_review_retry_semantics_spec.rb`
- `git diff --check`