### PR TITLE
fix(devcontainer): pin temporal auto-setup image to 1.29.7

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -76,7 +76,7 @@ services:
       start_period: 10s
 
   temporal:
-    image: temporalio/auto-setup:1.30.1
+    image: temporalio/auto-setup:1.29.7
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       start_period: 30s
 
   temporal:
-    image: temporalio/auto-setup:1.30.1
+    image: temporalio/auto-setup:1.29.7
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- The devcontainer's `temporal` service was pinned to `temporalio/auto-setup:1.30.1`, which fails to build/start, breaking the devcontainer (and `bin/setup`, which depends on the container stack being healthy).
- Pin back to `temporalio/auto-setup:1.29.7`, a known-working version.

## Test plan
- [x] Rebuilt devcontainer stack with the pinned image and confirmed the `temporal` container starts healthy.
- [x] Ran `bin/setup` end-to-end and confirmed it completes successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)