### PR TITLE
fix(pr-review): stop re-escalating a PR in the same tick it is dismissed

### DIFF
--- a/app/services/automation/strategies/auto_continue.rb
+++ b/app/services/automation/strategies/auto_continue.rb
@@ -79,6 +79,16 @@ module Automation
       private
 
       def check_lifecycle_gates(context:, signals:)
+        # The scan already decided to dismiss escalation this cycle (the
+        # owner removed paid-escalated). DismissEscalationActivity preserves
+        # the failure streak by design, so it will still satisfy the gates
+        # below immediately after dismissal — without this check, the same
+        # scan tick would re-escalate before the dismissal ever takes
+        # effect, re-adding the label the owner just removed. Let the
+        # dismissal through; a still-stuck PR surfaces again on a later scan
+        # once it has re-entered a gated phase.
+        return nil if dismiss_escalation_pending?(signals)
+
         # Operational failure breaker — provider/infrastructure bursts only
         # escalate once the PR has also gone stale without meaningful
         # progress for too long.
@@ -117,9 +127,15 @@ module Automation
       end
 
       def review_followup_pending?(signals)
-        Array(signals.scan&.dig(:triggers) || signals.scan&.dig("triggers")).any? do |trigger|
-          REVIEW_FOLLOWUP_TRIGGER_TYPES.include?(trigger_type(trigger))
-        end
+        scan_trigger_types(signals).any? { |type| REVIEW_FOLLOWUP_TRIGGER_TYPES.include?(type) }
+      end
+
+      def dismiss_escalation_pending?(signals)
+        scan_trigger_types(signals).include?("dismiss_escalation")
+      end
+
+      def scan_trigger_types(signals)
+        Array(signals.scan&.dig(:triggers) || signals.scan&.dig("triggers")).map { |trigger| trigger_type(trigger) }
       end
 
       def trigger_type(trigger)

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -7080,6 +7080,44 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
+    context "when a failure-streak escalated PR has its label removed while the streak persists" do
+      before do
+        project.update!(max_pr_followup_runs: 3)
+        issue = create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "escalated",
+          pr_escalation_reason: "failure_streak",
+          paid_state: "completed")
+        issue.update_columns(last_pr_scan_at: 10.minutes.ago)
+        create_stale_review_runs!(issue, statuses: %w[failed failed failed])
+        stub_github_for_pr(head_committed_at: 4.hours.ago)
+      end
+
+      it "dismisses escalation instead of immediately re-escalating on the same scan tick" do
+        result = activity.execute(project_id: project.id)
+
+        trigger = automation_scan_results(result).first
+        expect(trigger[:triggers].first[:type]).to eq("dismiss_escalation")
+      end
+
+      it "does not re-escalate on the next tick while the follow-up run is still active" do
+        issue = project.issues.find_by!(github_number: 42)
+        # Simulate what DismissEscalationActivity + handle_dismiss_escalation
+        # do on the workflow side: dismiss to ready, then queue a follow-up run.
+        issue.dismiss_escalation!(draft: false)
+        issue.update_columns(last_pr_scan_at: 10.minutes.ago)
+        create(:agent_run,
+          project: project, issue: issue, source_pull_request_number: 42,
+          goal: "create_pr", trigger_type: "automatic", status: "running")
+
+        result = activity.execute(project_id: project.id)
+
+        decisions = automation_scan_results(result).flat_map { |entry| entry[:triggers] }.map { |t| t[:type] }
+        expect(decisions).not_to include("escalate_to_owner")
+      end
+    end
+
     context "when a non-operational escalation no longer has any operational failures" do
       before do
         issue = create(:issue, :pull_request,


### PR DESCRIPTION
## Summary
- Removing the `paid-escalated` label was supposed to de-escalate a PR, but Paid immediately re-added it.
- Root cause: `ScanPaidPrsActivity` correctly emitted a `dismiss_escalation` trigger, but `Automation::Strategies::AutoContinue#check_lifecycle_gates` re-evaluated the (unchanged, by-design preserved) failure streak in the *same* scan cycle and escalated again before the dismissal ever took effect.
- Fix: `check_lifecycle_gates` now defers to a pending `dismiss_escalation` scan decision instead of preempting it with a stale escalation gate. Verified this doesn't just push the bug to the next poll tick — the workflow queues a follow-up run immediately after dismissal, which gates re-escalation via the `active_run_exists` check and resets the staleness clock once it completes.

## Test plan
- [x] `bin/rspec spec/temporal/activities/scan_paid_prs_activity_spec.rb spec/services/automation/strategies/auto_continue_spec.rb spec/services/coordination/escalation_service_spec.rb spec/services/automation/pull_request_evaluator_spec.rb spec/temporal/activities/dismiss_escalation_activity_spec.rb spec/temporal/activities/mark_escalated_activity_spec.rb` — 493 examples, 0 failures
- [x] `bin/rubocop` on changed files — no offenses
- [x] New regression tests cover both the same-tick fix and the next-tick follow-up-run interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)