### PR TITLE
fix(dev): give worker_poll and worker_agent distinct Prometheus ports

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,8 +1,8 @@
 web: bin/rails server -b 0.0.0.0
 js: yarn build --watch
 css: yarn build:css --watch
-worker_poll: TEMPORAL_WORKER_MODE=poll bin/temporal_worker
-worker_agent: TEMPORAL_WORKER_MODE=agent bin/temporal_worker
+worker_poll: TEMPORAL_WORKER_MODE=poll TEMPORAL_PROMETHEUS_BIND_ADDRESS=0.0.0.0:9464 bin/temporal_worker
+worker_agent: TEMPORAL_WORKER_MODE=agent TEMPORAL_PROMETHEUS_BIND_ADDRESS=0.0.0.0:9465 bin/temporal_worker
 
 # Connect to a running process by running `overmind connect <process name>`
 # e.g. `overmind connect web` or `overmind connect worker_agent`


### PR DESCRIPTION
## Summary
- `worker_poll` and `worker_agent` in `Procfile.dev` both bound the Temporal Prometheus metrics exporter to the same default address (`0.0.0.0:9464`), introduced by #2802.
- Whichever worker started second crashed with `Address already in use`, and Overmind tore down the entire session in response — killing the healthy `web` process too. `bin/setup` would finish with no dev server actually running.
- Fix: assign each worker its own `TEMPORAL_PROMETHEUS_BIND_ADDRESS` (`9464` / `9465`) in `Procfile.dev`. `lib/paid/temporal_observability.rb` already reads this env var, so no code changes were needed.

## Test plan
- [x] Ran `bin/dev --detach --restart-if-running` and confirmed via `overmind status` that all 5 processes (`web`, `js`, `css`, `worker_poll`, `worker_agent`) report `running` with no dead panes
- [x] Confirmed `curl localhost:3000` returns `HTTP 302` (normal Rails redirect)
- [x] Confirmed ports `9464` and `9465` are both listening independently
- [x] Confirmed `log/dev-update/overmind.log` shows no `Interrupting...`/crash on this startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)