### PR TITLE
fix(quality-pause): do not auto-pause projects with quality gates disabled

### DIFF
--- a/app/services/quality_pause/check.rb
+++ b/app/services/quality_pause/check.rb
@@ -21,6 +21,7 @@ module QualityPause
 
     def call
       return if project.quality_paused?
+      return unless project.quality_gates_enabled?
 
       breached = breached_threshold
       return unless breached

--- a/app/views/dashboard/_quality_paused_projects.html.erb
+++ b/app/views/dashboard/_quality_paused_projects.html.erb
@@ -1,5 +1,5 @@
 <% if projects.any? %>
-  <div class="rounded-md border border-amber-200 bg-amber-50 p-4">
+  <div id="quality-paused-projects" class="rounded-md border border-amber-200 bg-amber-50 p-4">
     <div class="flex items-start justify-between gap-4">
       <div>
         <h3 class="text-sm font-semibold text-amber-900">Quality-paused projects</h3>

--- a/app/views/dashboard/_queue_preview.html.erb
+++ b/app/views/dashboard/_queue_preview.html.erb
@@ -36,6 +36,19 @@
       </div>
     </div>
   <% else %>
-    <p class="mt-4 text-sm text-gray-500">No queued runs for your projects.</p>
+    <% paused_autopick = Array(local_assigns[:paused_projects]).count(&:auto_pick_enabled?) %>
+    <% if paused_autopick.positive? %>
+      <div class="mt-4 rounded-md bg-amber-50 p-3 ring-1 ring-inset ring-amber-200">
+        <p class="text-sm text-amber-800">
+          <%= pluralize(paused_autopick, "project") %> with auto-pick enabled
+          <%= paused_autopick == 1 ? "is" : "are" %>
+          <%= link_to "quality-paused", "#quality-paused-projects",
+            class: "font-medium text-amber-900 underline hover:text-amber-700" %>,
+          so no work is being queued. Resume a project to start picking up its issues.
+        </p>
+      </div>
+    <% else %>
+      <p class="mt-4 text-sm text-gray-500">No queued runs for your projects.</p>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -53,7 +53,11 @@
       </div>
 
       <div class="mt-6">
-        <%= render "dashboard/queue_preview", queue_preview: @queue_preview %>
+        <%= render "dashboard/quality_paused_projects", projects: @quality_paused_projects %>
+      </div>
+
+      <div class="mt-6">
+        <%= render "dashboard/queue_preview", queue_preview: @queue_preview, paused_projects: @quality_paused_projects %>
       </div>
 
       <div class="mt-6">
@@ -89,10 +93,6 @@
       </turbo-frame>
 
       <div id="dashboard-alerts" class="mt-6 space-y-3"></div>
-
-      <div class="mt-6">
-        <%= render "dashboard/quality_paused_projects", projects: @quality_paused_projects %>
-      </div>
     </div>
   </details>
 

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -78,7 +78,9 @@
                 <% if pause_metadata["metric_type"].present? %>
                   (<%= pause_metadata["metric_type"].humanize.downcase %>)
                 <% end %>.
-                <%= link_to "Review details", edit_project_path(@project), class: "font-medium text-amber-800 underline hover:text-amber-900" %>
+                <% if policy(@project).update? %>
+                  <%= link_to "Review details", edit_project_path(@project), class: "font-medium text-amber-800 underline hover:text-amber-900" %>
+                <% end %>
               </p>
             <% end %>
           </div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -56,6 +56,42 @@
     </div>
   <% end %>
 
+  <% if @project.quality_paused? %>
+    <% pause_metadata = @project.quality_pause_metadata || {} %>
+    <div class="mb-4 rounded-md bg-amber-50 p-4 ring-1 ring-inset ring-amber-200" data-testid="quality-paused-banner">
+      <div class="flex items-center justify-between">
+        <div class="flex">
+          <div class="flex-shrink-0">
+            <svg class="h-5 w-5 text-amber-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495ZM10 5a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 10 5Zm0 9a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z" clip-rule="evenodd" />
+            </svg>
+          </div>
+          <div class="ml-3">
+            <h3 class="text-sm font-medium text-amber-800">Quality Paused</h3>
+            <p class="mt-1 text-sm text-amber-700">
+              Automatic work has been paused since <%= local_time(@project.quality_paused_at) %> after recent runs fell below the quality threshold.
+            </p>
+            <% if pause_metadata["composite_score"].present? && pause_metadata["threshold"].present? %>
+              <p class="mt-1 text-sm text-amber-700">
+                Score <%= format("%.1f%%", pause_metadata["composite_score"].to_f * 100) %>
+                below threshold <%= format("%.1f%%", pause_metadata["threshold"].to_f * 100) %>
+                <% if pause_metadata["metric_type"].present? %>
+                  (<%= pause_metadata["metric_type"].humanize.downcase %>)
+                <% end %>.
+                <%= link_to "Review details", edit_project_path(@project), class: "font-medium text-amber-800 underline hover:text-amber-900" %>
+              </p>
+            <% end %>
+          </div>
+        </div>
+        <% if policy(@project).update? %>
+          <%= button_to "Resume", quality_resume_project_path(@project), method: :post,
+            class: "ml-4 flex-shrink-0 rounded-md bg-amber-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-amber-500 cursor-pointer",
+            data: { turbo_confirm: "Resume automatic work for this project?" } %>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+
   <% if @paused_agent_runs.any? %>
     <%= render "projects/paused_work", project: @project, paused_runs: @paused_agent_runs %>
   <% end %>

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -478,6 +478,35 @@ RSpec.describe "Dashboard" do
         expect(response.body).to include(edit_project_path(project))
       end
 
+      it "shows the quality-paused notice above the queue and explains the empty queue" do
+        project.update!(
+          name: "Paused Project",
+          auto_pick_enabled: true,
+          quality_paused_at: 30.minutes.ago,
+          quality_pause_metadata: { "composite_score" => 0.34, "threshold" => 0.5 }
+        )
+
+        get dashboard_path
+
+        body = response.body
+        expect(body.index("Quality-paused projects")).to be < body.index("Upcoming Queue")
+        expect(body).not_to include("No queued runs for your projects.")
+        expect(body).to include("no work is being queued")
+      end
+
+      it "does not blame the empty queue on a quality-paused project with auto-pick off" do
+        project.update!(
+          auto_pick_enabled: false,
+          quality_paused_at: 30.minutes.ago,
+          quality_pause_metadata: { "composite_score" => 0.34, "threshold" => 0.5 }
+        )
+
+        get dashboard_path
+
+        expect(response.body).to include("Quality-paused projects")
+        expect(response.body).to include("No queued runs for your projects.")
+      end
+
       it "shows paused runs with resume actions on the dashboard" do
         issue = create(:issue, :pull_request, project: project,
           github_number: 88, title: "Handle paused runs better")

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -585,6 +585,25 @@ RSpec.describe "Projects" do
         expect(response.body).to include("32.0%")
         expect(response.body).to include("50.0%")
         expect(response.body).to include(quality_resume_project_path(project))
+        expect(response.body).to include("Review details")
+      end
+
+      it "hides the quality pause review details link and resume action for users without update permission" do
+        viewer = create(:user, :viewer, account: account)
+        project = create(:project, account: account, github_token: github_token,
+          quality_paused_at: 1.hour.ago,
+          quality_pause_metadata: {
+            "composite_score" => 0.32,
+            "threshold" => 0.5,
+            "metric_type" => "composite_score"
+          })
+
+        sign_in viewer
+        get project_path(project)
+
+        expect(response.body).to include("Quality Paused")
+        expect(response.body).not_to include("Review details")
+        expect(response.body).not_to include(quality_resume_project_path(project))
       end
 
       it "does not show a quality pause banner when not quality-paused" do

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -570,6 +570,31 @@ RSpec.describe "Projects" do
         expect(response.body).not_to include("Average Quality Score")
       end
 
+      it "shows a quality pause banner with resume action when quality-paused" do
+        project = create(:project, account: account, github_token: github_token,
+          quality_paused_at: 1.hour.ago,
+          quality_pause_metadata: {
+            "composite_score" => 0.32,
+            "threshold" => 0.5,
+            "metric_type" => "composite_score"
+          })
+
+        get project_path(project)
+
+        expect(response.body).to include("Quality Paused")
+        expect(response.body).to include("32.0%")
+        expect(response.body).to include("50.0%")
+        expect(response.body).to include(quality_resume_project_path(project))
+      end
+
+      it "does not show a quality pause banner when not quality-paused" do
+        project = create(:project, account: account, github_token: github_token)
+
+        get project_path(project)
+
+        expect(response.body).not_to include("Quality Paused")
+      end
+
       it "shows recent agent runs" do
         project = create(:project, account: account, github_token: github_token)
         run = create(:agent_run, project: project, agent_type: "claude_code", status: "completed")

--- a/spec/services/quality_pause/check_spec.rb
+++ b/spec/services/quality_pause/check_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe QualityPause::Check do
-  let(:project) { create(:project) }
+  let(:project) { create(:project, quality_gate_settings: Project::DEFAULT_QUALITY_GATE_SETTINGS.merge("enabled" => true)) }
   let(:agent_run) { create(:agent_run, :completed, project: project) }
   let(:prompt) { create(:prompt, :with_version, project: project, account: project.account) }
   let(:prompt_version) { prompt.current_version }
@@ -16,6 +16,16 @@ RSpec.describe QualityPause::Check do
       described_class.call(agent_run: agent_run)
 
       expect(project.reload.quality_paused?).to be false
+    end
+
+    it "does nothing when quality gates are disabled for the project" do
+      disabled_project = create(:project)
+      run = create(:agent_run, :completed, project: disabled_project)
+      create_quality_metrics(disabled_project, scores: [ 0.0, 0.0, 0.0, 0.0, 0.0 ])
+
+      described_class.call(agent_run: run)
+
+      expect(disabled_project.reload.quality_paused?).to be false
     end
 
     it "does nothing when project is already paused" do


### PR DESCRIPTION
## Summary

- **Root-cause bug fix:** `QualityPause::Check` paused projects even when quality gates were explicitly disabled (the model default). Unlike the pre-run gate (`CheckQualityGateActivity`) and post-run alerts (`Collect`), it never consulted `quality_gates_enabled?`. A disabled-gate project that tripped the threshold would pause, and since `final_pause` is terminal with no auto-resume, its auto-pick-enabled issues silently never reached the upcoming queue. Added an entry-point `quality_gates_enabled?` guard so all four callers honor the setting.
- **UX surfacing (dashboard):** moved the "Quality-paused projects" notice from the bottom of Live Metrics to directly above the Upcoming Queue, and replaced the misleading empty-queue message with an explanation when auto-pick-enabled projects are quality-paused.
- **UX surfacing (project page):** added a `quality_paused?` banner mirroring the existing `paused?`/`scheduler_paused?` banners, with score vs threshold and a resume action.

## Notes

- The empty-queue hint is gated on `auto_pick_enabled?` (the controller query is not filtered by auto-pick) and uses a nil-safe in-memory count to avoid both an inaccurate statement and AR `Relation#count` ignoring the block.
- Existing pauses incurred while gates were disabled are not auto-cleared; they require a manual resume (the one known instance was resumed during diagnosis).

## Verification

- `spec/services/quality_pause/check_spec.rb`, `spec/services/quality_metrics/collect_spec.rb`, the quality_recovery/quality_pause/quality_metrics suites, plus the webhook/feedback callers: 298 examples, 0 failures.
- `spec/requests/dashboard_spec.rb` (65) and `spec/requests/projects_spec.rb` (215): 0 failures, incl. new ordering/empty-queue-hint (and negative) cases.
- RuboCop + Herb ERB clean; pre-commit hook passed.