### PR TITLE
feat(chat): raise tool iteration limit to 50 with soft-stop and configurable budget guard

### DIFF
--- a/app/controllers/tenant_configurations_controller.rb
+++ b/app/controllers/tenant_configurations_controller.rb
@@ -13,6 +13,7 @@ class TenantConfigurationsController < ApplicationController
 
     ActiveRecord::Base.transaction do
       @tenant_setting.update!(tenant_setting_params)
+      update_chat_settings! if params.dig(:tenant_setting, :chat_settings).present?
       update_feature_flag_rollouts! if feature_flag_rollout_params.present?
 
       if @tenant_setting.saved_changes.except("updated_at").any? ||
@@ -134,5 +135,14 @@ class TenantConfigurationsController < ApplicationController
     CostBudget::BUDGET_TYPES.index_with do
       %i[enabled limit_cents alert_threshold_percent enforcement_mode grace_buffer_percent]
     end
+  end
+
+  def update_chat_settings!
+    permitted = params.require(:tenant_setting).permit(
+      chat_settings: %i[chat_session_token_limit chat_monthly_token_limit chat_max_tool_iterations]
+    )[:chat_settings].to_h
+
+    @tenant_setting.chat_settings = permitted
+    @tenant_setting.save!
   end
 end

--- a/app/controllers/tenant_configurations_controller.rb
+++ b/app/controllers/tenant_configurations_controller.rb
@@ -13,17 +13,26 @@ class TenantConfigurationsController < ApplicationController
 
     ActiveRecord::Base.transaction do
       @tenant_setting.update!(tenant_setting_params)
+
+      # update_chat_settings!'s second save resets saved_changes, so capture the
+      # first save's change set now and merge the second save into it. The form
+      # submits chat_settings on every PATCH; without this an unrelated field
+      # changed by the first save (e.g. max_concurrent_runs) would be dropped
+      # from the activity record.
+      saved_changes = @tenant_setting.saved_changes.except("updated_at")
       update_chat_settings! if params.dig(:tenant_setting, :chat_settings).present?
+      saved_changes.merge!(@tenant_setting.saved_changes.except("updated_at"))
+
       update_feature_flag_rollouts! if feature_flag_rollout_params.present?
 
-      if @tenant_setting.saved_changes.except("updated_at").any? ||
+      if saved_changes.any? ||
           (feature_flag_rollout_params.present? && changed_feature_flag_rollouts.any?)
         Accounts::RecordActivity.call(
           account: current_account,
           actor: current_user,
           action: "tenant_configuration.updated",
           subject: @tenant_setting,
-          metadata: { changed_fields: @tenant_setting.saved_changes.except("updated_at").keys }
+          metadata: { changed_fields: saved_changes.keys }
         )
       end
     end

--- a/app/models/tenant_setting.rb
+++ b/app/models/tenant_setting.rb
@@ -25,7 +25,8 @@ class TenantSetting < ApplicationRecord
   }.freeze
   DEFAULT_CHAT_SETTINGS = {
     "chat_session_token_limit" => 100_000,
-    "chat_monthly_token_limit" => nil
+    "chat_monthly_token_limit" => nil,
+    "chat_max_tool_iterations" => 50
   }.freeze
   DEFAULT_QUALITY_THRESHOLDS = Project::DEFAULT_QUALITY_GATE_SETTINGS.freeze
   DEFAULT_AGENT_SETTINGS = {
@@ -187,6 +188,7 @@ class TenantSetting < ApplicationRecord
   validate :validate_default_budgets
   validate :validate_agent_settings
   validate :validate_worker_settings
+  validate :validate_chat_settings
   validate :validate_quality_thresholds
   validate :validate_deployment_assurance
   validate :validate_enterprise_operations
@@ -315,6 +317,16 @@ class TenantSetting < ApplicationRecord
     effective_chat_settings["chat_monthly_token_limit"]
   end
 
+  def chat_max_tool_iterations
+    effective_chat_settings["chat_max_tool_iterations"]
+  end
+
+  def chat_settings=(value)
+    merged_features = normalize_hash(features)
+    merged_features["chat_settings"] = normalize_chat_settings(value)
+    self.features = merged_features
+  end
+
   def cap_max_concurrent_runs(limit)
     [ limit, max_concurrent_runs ].compact.min
   end
@@ -439,6 +451,29 @@ class TenantSetting < ApplicationRecord
       elsif key.to_s == "good_job_queues"
         next if value.is_a?(String) && value.match?(/\A([a-z_]+:\d+)(;[a-z_]+:\d+)*\z/)
         errors.add(:worker_settings, "good_job_queues must match format 'name:count;name:count'")
+      end
+    end
+  end
+
+  def validate_chat_settings
+    return unless features.is_a?(Hash)
+
+    chat = features.fetch("chat_settings", nil)
+    return unless chat.is_a?(Hash)
+
+    if chat.key?("chat_max_tool_iterations") && chat["chat_max_tool_iterations"].present?
+      val = chat["chat_max_tool_iterations"]
+      unless val.is_a?(Integer) && val >= 1 && val <= 200
+        errors.add(:features, "chat_settings.chat_max_tool_iterations must be an integer between 1 and 200")
+      end
+    end
+
+    %w[chat_session_token_limit chat_monthly_token_limit].each do |key|
+      next unless chat.key?(key) && chat[key].present?
+
+      val = chat[key]
+      unless val.is_a?(Integer) && val >= 1
+        errors.add(:features, "chat_settings.#{key} must be a positive integer")
       end
     end
   end
@@ -634,6 +669,16 @@ class TenantSetting < ApplicationRecord
 
       normalized["auto_continue"] = ActiveModel::Type::Boolean.new.cast(normalized["auto_continue"]) if normalized.key?("auto_continue")
       normalized["marketplace_auto_attach_required"] = ActiveModel::Type::Boolean.new.cast(normalized["marketplace_auto_attach_required"]) if normalized.key?("marketplace_auto_attach_required")
+    end
+  end
+
+  def normalize_chat_settings(value)
+    normalize_hash(value).slice(*DEFAULT_CHAT_SETTINGS.keys).tap do |normalized|
+      next unless normalized.is_a?(Hash)
+
+      %w[chat_session_token_limit chat_monthly_token_limit chat_max_tool_iterations].each do |key|
+        normalized[key] = normalize_integer_value(normalized[key]) if normalized.key?(key)
+      end
     end
   end
 

--- a/app/services/chat_sessions/agent_loop.rb
+++ b/app/services/chat_sessions/agent_loop.rb
@@ -12,10 +12,11 @@ module ChatSessions
   class AgentLoop
     include ToolDispatch
 
-    MAX_TOOL_ITERATIONS = 8
+    DEFAULT_MAX_TOOL_ITERATIONS = 50
     MAX_CONVERSATION_MESSAGES = 200
     EMPTY_RESPONSE_MESSAGE = "I couldn't complete that turn because the model returned an empty response. Please try again."
-    TOOL_ITERATION_LIMIT_MESSAGE = "I hit the maximum number of tool iterations for this turn. Please try again with a narrower request."
+    SOFT_STOP_PROMPT = "You've reached the maximum number of tool calls for this turn. Summarize what you've found so far and suggest what the user should do next. Do not call any more tools."
+    SOFT_STOP_FALLBACK_MESSAGE = "I've reached the maximum number of tool calls for this turn. Please send another message to continue."
 
     attr_reader :chat_session, :llm_client, :on_chunk, :on_message_persisted, :stream_message_id,
       :created_message_ids
@@ -44,21 +45,33 @@ module ChatSessions
       aggregate_tokens = { input: 0, output: 0 }
       final_assistant_message = nil
       last_response_model = nil
+      limit = max_tool_iterations
+      budget = token_budget_remaining
 
-      MAX_TOOL_ITERATIONS.times do |iteration|
+      limit.times do |iteration|
         response = call_llm(conversation)
         aggregate_tokens[:input] += response[:tokens_input].to_i
         aggregate_tokens[:output] += response[:tokens_output].to_i
         last_response_model = response[:model]
 
-        final_assistant_message = create_assistant_message(response) if response[:content].present?
         if response[:tool_calls].blank?
+          final_assistant_message = create_assistant_message(response) if response[:content].present?
           final_assistant_message ||= create_empty_response_message(
             model: last_response_model,
             aggregate_tokens: aggregate_tokens
           )
           break
         end
+
+        # Check budget BEFORE persisting the response or processing tools. This
+        # prevents an orphaned assistant message that promises a tool action the
+        # loop will never execute.
+        if budget && (aggregate_tokens[:input] + aggregate_tokens[:output]) > budget
+          final_assistant_message = run_soft_stop(conversation, aggregate_tokens:, model: last_response_model)
+          break
+        end
+
+        final_assistant_message = create_assistant_message(response) if response[:content].present?
 
         conversation << {
           role: "assistant",
@@ -93,15 +106,56 @@ module ChatSessions
           return pause_for_confirmation(aggregate_tokens:, model: last_response_model)
         end
 
-        next unless iteration == (MAX_TOOL_ITERATIONS - 1)
+        next unless iteration == (limit - 1)
 
-        final_assistant_message = create_assistant_message(
-          content: TOOL_ITERATION_LIMIT_MESSAGE,
-          model: last_response_model
-        )
+        final_assistant_message = run_soft_stop(conversation, aggregate_tokens:, model: last_response_model)
       end
 
       stamp_aggregate_tokens(final_assistant_message, aggregate_tokens, last_response_model)
+    end
+
+    def max_tool_iterations
+      @max_tool_iterations ||= begin
+        limit = chat_session.account.tenant_setting&.chat_max_tool_iterations
+        (limit.is_a?(Integer) && limit.positive?) ? limit : DEFAULT_MAX_TOOL_ITERATIONS
+      end
+    end
+
+    # Injects a wrap-up instruction and calls the model one final time without
+    # tools so it must produce a text summary. Used both when the iteration cap
+    # is reached and when the token budget is exhausted mid-loop.
+    def run_soft_stop(conversation, aggregate_tokens:, model:)
+      conversation << { role: "user", content: SOFT_STOP_PROMPT }
+
+      response = call_llm(conversation, exclude_tools: true)
+      aggregate_tokens[:input] += response[:tokens_input].to_i
+      aggregate_tokens[:output] += response[:tokens_output].to_i
+
+      create_assistant_message(
+        content: response[:content].presence || SOFT_STOP_FALLBACK_MESSAGE,
+        model: response[:model] || model
+      )
+    end
+
+    # Fetches the remaining token budget once per turn (memoized). Returns nil
+    # when there is no limit configured or the DB query fails (fail-open — the
+    # pre-loop check in SendMessage#check_token_limit! provides the first line
+    # of defense, and transient DB errors should not abort an otherwise healthy
+    # turn). The in-memory aggregate_tokens comparison in run_loop catches
+    # runaway turns without re-querying the database every iteration.
+    def token_budget_remaining
+      return @token_budget_remaining if defined?(@token_budget_remaining)
+
+      @token_budget_remaining = begin
+        ChatSessions::CheckTokenLimit.call(chat_session: chat_session)[:remaining_tokens]
+      rescue => e
+        Rails.logger.warn(
+          message: "chat_agent_loop.token_budget_check_failed",
+          chat_session_id: chat_session.id,
+          error: e.class.name
+        )
+        nil
+      end
     end
 
     # When the model requests one or more write tools in a batch, run the
@@ -200,7 +254,7 @@ module ChatSessions
       nil
     end
 
-    def call_llm(conversation)
+    def call_llm(conversation, exclude_tools: false)
       chunk_streamed = false
       chunk_callback = lambda do |chunk|
         next if chunk.blank?
@@ -210,7 +264,7 @@ module ChatSessions
       end
 
       if llm_client
-        invoke_llm_client(conversation, chunk_callback).tap do |response|
+        invoke_llm_client(conversation, chunk_callback, exclude_tools: exclude_tools).tap do |response|
           replay_response_content(response, chunk_callback) unless chunk_streamed
         end
       else
@@ -218,10 +272,10 @@ module ChatSessions
       end
     end
 
-    def invoke_llm_client(conversation, chunk_callback)
+    def invoke_llm_client(conversation, chunk_callback, exclude_tools: false)
       call_llm_client(
         conversation,
-        include_tools: llm_client_supports_tools?,
+        include_tools: !exclude_tools && llm_client_supports_tools?,
         include_on_chunk: on_chunk && llm_client_supports_chunk_callback?,
         chunk_callback: chunk_callback
       )

--- a/app/services/chat_sessions/agent_loop.rb
+++ b/app/services/chat_sessions/agent_loop.rb
@@ -21,13 +21,15 @@ module ChatSessions
     attr_reader :chat_session, :llm_client, :on_chunk, :on_message_persisted, :stream_message_id,
       :created_message_ids
 
-    def initialize(chat_session:, llm_client:, on_chunk: nil, on_message_persisted: nil, stream_message_id: nil)
+    def initialize(chat_session:, llm_client:, on_chunk: nil, on_message_persisted: nil, stream_message_id: nil,
+      token_budget: nil)
       @chat_session = chat_session
       @llm_client = llm_client
       @on_chunk = on_chunk
       @on_message_persisted = on_message_persisted
       @stream_message_id = stream_message_id
       @created_message_ids = []
+      @token_budget_override = token_budget
     end
 
     # @return [ChatMessage, nil] the final assistant message, or +nil+ when the
@@ -46,9 +48,10 @@ module ChatSessions
       final_assistant_message = nil
       last_response_model = nil
       limit = max_tool_iterations
-      budget = token_budget_remaining
+      budget = token_budget
 
       limit.times do |iteration|
+        conversation = trim_conversation(conversation)
         response = call_llm(conversation)
         aggregate_tokens[:input] += response[:tokens_input].to_i
         aggregate_tokens[:output] += response[:tokens_output].to_i
@@ -65,8 +68,10 @@ module ChatSessions
 
         # Check budget BEFORE persisting the response or processing tools. This
         # prevents an orphaned assistant message that promises a tool action the
-        # loop will never execute.
-        if budget && (aggregate_tokens[:input] + aggregate_tokens[:output]) > budget
+        # loop will never execute. Stop on equality as well: once aggregate usage
+        # reaches the remaining budget there is nothing left for another
+        # LLM round-trip, so continuing would overrun the configured limit.
+        if budget && (aggregate_tokens[:input] + aggregate_tokens[:output]) >= budget
           final_assistant_message = run_soft_stop(conversation, aggregate_tokens:, model: last_response_model)
           break
         end
@@ -137,25 +142,40 @@ module ChatSessions
       )
     end
 
-    # Fetches the remaining token budget once per turn (memoized). Returns nil
-    # when there is no limit configured or the DB query fails (fail-open — the
-    # pre-loop check in SendMessage#check_token_limit! provides the first line
-    # of defense, and transient DB errors should not abort an otherwise healthy
-    # turn). The in-memory aggregate_tokens comparison in run_loop catches
-    # runaway turns without re-querying the database every iteration.
-    def token_budget_remaining
-      return @token_budget_remaining if defined?(@token_budget_remaining)
+    # The remaining token budget for the turn. Callers that already ran the
+    # pre-loop guard (SendMessage#check_token_limit!) pass the value via the
+    # `token_budget:` constructor arg to avoid a redundant SUM aggregation per
+    # turn. Callers without a pre-loop guard (ResolveToolCall, or direct
+    # AgentLoop use) leave it unset and we fetch it once here. Fail-open on DB
+    # errors: a transient failure degrades to no mid-loop budget enforcement
+    # rather than aborting a healthy turn — the pre-loop
+    # SendMessage#check_token_limit! provides the first line of defense.
+    def token_budget
+      return @token_budget if defined?(@token_budget)
 
-      @token_budget_remaining = begin
-        ChatSessions::CheckTokenLimit.call(chat_session: chat_session)[:remaining_tokens]
-      rescue => e
-        Rails.logger.warn(
-          message: "chat_agent_loop.token_budget_check_failed",
-          chat_session_id: chat_session.id,
-          error: e.class.name
-        )
-        nil
-      end
+      @token_budget = @token_budget_override || fetch_token_budget
+    end
+
+    def fetch_token_budget
+      ChatSessions::CheckTokenLimit.call(chat_session: chat_session)[:remaining_tokens]
+    rescue => e
+      Rails.logger.warn(
+        message: "chat_agent_loop.token_budget_check_failed",
+        chat_session_id: chat_session.id,
+        error: e.class.name
+      )
+      nil
+    end
+
+    # Bounds the conversation sent to the LLM so a long tool-driven turn cannot
+    # grow it past MAX_CONVERSATION_MESSAGES. build_conversation already caps the
+    # persisted history; this trims the in-turn entries the loop appends. Leading
+    # tool results are dropped so the window never starts with an orphaned tool
+    # message whose matching assistant tool_calls were trimmed away.
+    def trim_conversation(conversation)
+      return conversation if conversation.length <= MAX_CONVERSATION_MESSAGES
+
+      conversation.last(MAX_CONVERSATION_MESSAGES).drop_while { |entry| entry[:role] == "tool" }
     end
 
     # When the model requests one or more write tools in a batch, run the

--- a/app/services/chat_sessions/fallback_loop.rb
+++ b/app/services/chat_sessions/fallback_loop.rb
@@ -37,7 +37,13 @@ module ChatSessions
         on_chunk: on_chunk,
         on_message_persisted: on_message_persisted,
         stream_message_id: stream_message_id
-      }
+      }.merge(extra_agent_loop_kwargs)
+    end
+
+    # Hosts may override to pass additional kwargs into AgentLoop (e.g. a
+    # pre-computed token budget). Default: none.
+    def extra_agent_loop_kwargs
+      {}
     end
 
     # Remove only the rows the failed attempt itself persisted, identified by the

--- a/app/services/chat_sessions/send_message.rb
+++ b/app/services/chat_sessions/send_message.rb
@@ -75,6 +75,9 @@ module ChatSessions
 
     def check_token_limit!
       result = ChatSessions::CheckTokenLimit.call(chat_session: chat_session)
+      # Capture the baseline so AgentLoop can guard mid-loop without re-running
+      # the same SUM aggregation (see AgentLoop#token_budget).
+      @token_budget = result[:remaining_tokens]
       return if result[:within_limit]
 
       raise TokenLimitExceededError.new(
@@ -100,6 +103,13 @@ module ChatSessions
       chat_session.update!(
         idle_timeout_at: ChatSession::IDLE_TIMEOUT_DURATION.from_now
       )
+    end
+
+    # Reuse the pre-loop budget baseline so the mid-loop guard does not issue a
+    # second SUM query per turn. Only forward when a limit is configured; a nil
+    # baseline means "unlimited" and AgentLoop re-derives nil cheaply.
+    def extra_agent_loop_kwargs
+      @token_budget ? { token_budget: @token_budget } : {}
     end
   end
 end

--- a/app/views/tenant_configurations/edit.html.erb
+++ b/app/views/tenant_configurations/edit.html.erb
@@ -235,6 +235,28 @@
       </div>
     </section>
 
+    <section>
+      <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Chat Settings</h2>
+      <% chat = @tenant_setting.effective_chat_settings %>
+      <div class="mt-4 grid gap-4 sm:grid-cols-3">
+        <div>
+          <%= label_tag "tenant_setting_chat_settings_chat_max_tool_iterations", "Max tool calls per turn", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+          <%= number_field_tag "tenant_setting[chat_settings][chat_max_tool_iterations]", chat["chat_max_tool_iterations"], min: 1, max: 200, class: "mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-800 dark:text-white" %>
+          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Maximum LLM round-trips (tool calls) per user message before the agent summarizes and stops. Default: 50.</p>
+        </div>
+        <div>
+          <%= label_tag "tenant_setting_chat_settings_chat_session_token_limit", "Session token limit", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+          <%= number_field_tag "tenant_setting[chat_settings][chat_session_token_limit]", chat["chat_session_token_limit"], min: 1, class: "mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-800 dark:text-white" %>
+          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Total tokens allowed per chat session. Leave blank for no limit. Default: 100,000.</p>
+        </div>
+        <div>
+          <%= label_tag "tenant_setting_chat_settings_chat_monthly_token_limit", "Monthly token limit", class: "block text-sm font-medium text-gray-700 dark:text-gray-200" %>
+          <%= number_field_tag "tenant_setting[chat_settings][chat_monthly_token_limit]", chat["chat_monthly_token_limit"], min: 1, class: "mt-1 block w-full rounded-md border-gray-300 text-sm shadow-sm dark:border-gray-600 dark:bg-gray-800 dark:text-white" %>
+          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Total chat tokens allowed per month across all sessions. Leave blank for no limit.</p>
+        </div>
+      </div>
+    </section>
+
     <div class="flex justify-end">
       <%= form.submit "Save configuration", class: "rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500" %>
     </div>

--- a/spec/requests/tenant_configurations_spec.rb
+++ b/spec/requests/tenant_configurations_spec.rb
@@ -66,6 +66,30 @@ RSpec.describe "TenantConfigurations" do
       expect(account.account_activity_events.recent.first.action).to eq("tenant_configuration.updated")
     end
 
+    it "records every changed field when chat_settings are submitted alongside another change" do
+      # The form submits chat_settings on every PATCH; the second save it
+      # triggers must not reset saved_changes and drop an unrelated change made
+      # by the first save from the activity record.
+      account.tenant_setting!.update!(max_concurrent_runs: 5)
+
+      expect do
+        patch tenant_configuration_path, params: {
+          tenant_setting: {
+            guardrails: { max_concurrent_runs: "4" },
+            chat_settings: {
+              chat_max_tool_iterations: "60",
+              chat_session_token_limit: "100000",
+              chat_monthly_token_limit: ""
+            }
+          }
+        }
+      end.to change(AccountActivityEvent, :count).by(1)
+
+      event = account.account_activity_events.recent.first
+      expect(event.action).to eq("tenant_configuration.updated")
+      expect(event.metadata["changed_fields"]).to include("max_concurrent_runs")
+    end
+
     it "updates the tenant marketplace auto-attach override" do
       api_key = create(:provider_api_key, user: user, api_service_type: "anthropic")
 

--- a/spec/services/chat_sessions/agent_loop_spec.rb
+++ b/spec/services/chat_sessions/agent_loop_spec.rb
@@ -231,6 +231,139 @@ RSpec.describe ChatSessions::AgentLoop do
         ))
       end
     end
+
+    context "when the iteration limit is reached" do
+      let(:tool_response) do
+        {
+          content: nil,
+          tool_calls: [ { id: "call_1", name: "search", arguments: { "query" => "test" } } ],
+          tokens_input: 10, tokens_output: 5, model: "gpt-4o"
+        }
+      end
+      let(:summary_response) do
+        { content: "Here is a summary of what I found.", tool_calls: [], tokens_input: 20, tokens_output: 15, model: "gpt-4o" }
+      end
+
+      before do
+        create(:tenant_setting, account: account,
+          features: { "chat_settings" => { "chat_max_tool_iterations" => 2 } })
+        allow(Tools::Registry).to receive(:chat_definitions_for).with(user: user, session: anything).and_return(tool_definitions)
+        allow(Tools::Registry).to receive(:dispatch).and_return({ "status" => "ok" })
+      end
+
+      it "injects the soft-stop prompt and calls the model without tools for the summary" do
+        seen_without_tools = []
+        client = Class.new do
+          attr_reader :seen_conversations
+
+          def initialize(responses, seen_without_tools)
+            @responses = responses
+            @seen_conversations = []
+            @seen_without_tools = seen_without_tools
+          end
+
+          def call(conversation, tools: nil)
+            @seen_conversations << conversation.deep_dup
+            @seen_without_tools << conversation.deep_dup if tools.nil?
+            @responses.fetch(@seen_conversations.length - 1)
+          end
+        end.new([ tool_response, tool_response, summary_response ], seen_without_tools)
+
+        result = described_class.new(chat_session: chat_session, llm_client: client).run
+
+        expect(result.content).to eq("Here is a summary of what I found.")
+        expect(client.seen_conversations.length).to eq(3)
+        expect(seen_without_tools.length).to eq(1)
+        expect(seen_without_tools.first.last[:content]).to include("maximum number of tool calls")
+        expect(chat_session.messages.where(role: "tool").count).to eq(2)
+      end
+
+      it "uses the fallback message when the soft-stop response is empty" do
+        client = Class.new do
+          def initialize(responses)
+            @responses = responses
+            @index = 0
+          end
+
+          def call(_conversation, tools: nil)
+            @index += 1
+            @responses.fetch(@index - 1)
+          end
+        end.new([ tool_response, tool_response, { content: nil, tool_calls: [], tokens_input: 5, tokens_output: 0, model: "gpt-4o" } ])
+
+        result = described_class.new(chat_session: chat_session, llm_client: client).run
+
+        expect(result.content).to eq(described_class::SOFT_STOP_FALLBACK_MESSAGE)
+      end
+    end
+
+    context "when the token budget is exhausted mid-loop" do
+      before do
+        create(:tenant_setting, account: account,
+          features: { "chat_settings" => { "chat_session_token_limit" => 25 } })
+        allow(Tools::Registry).to receive(:chat_definitions_for).with(user: user, session: anything).and_return(tool_definitions)
+        allow(Tools::Registry).to receive(:dispatch).and_return({ "status" => "ok" })
+      end
+
+      it "triggers the soft-stop instead of continuing to call tools" do
+        client = build_token_budget_client
+
+        result = described_class.new(chat_session: chat_session, llm_client: client).run
+
+        # Iteration 0: 15 tokens (10+5), 15 <= 25 → continue
+        # Iteration 1: +15 = 30 tokens, 30 > 25 → soft-stop (3rd call)
+        expect(result.content).to include("token budget")
+        expect(client.seen_conversations.length).to eq(3)
+        expect(chat_session.messages.where(role: "tool").count).to eq(1)
+      end
+
+      def build_token_budget_client
+        Class.new do
+          attr_reader :seen_conversations
+
+          def initialize
+            @seen_conversations = []
+            @index = 0
+          end
+
+          def call(conversation, tools: nil)
+            @seen_conversations << conversation.deep_dup
+            @index += 1
+            @index <= 2 ? tool_response : summary_response
+          end
+
+          private
+
+          def tool_response
+            {
+              content: nil,
+              tool_calls: [ { id: "call_#{@index}", name: "search", arguments: { "query" => "test" } } ],
+              tokens_input: 10, tokens_output: 5, model: "gpt-4o"
+            }
+          end
+
+          def summary_response
+            { content: "I hit the token budget. Here is what I have so far.", tool_calls: [], tokens_input: 5, tokens_output: 10, model: "gpt-4o" }
+          end
+        end.new
+      end
+    end
+
+    context "when the iteration limit is configurable via tenant settings" do
+      it "defaults to DEFAULT_MAX_TOOL_ITERATIONS when no tenant setting exists" do
+        service = described_class.new(chat_session: chat_session, llm_client: instance_double(Proc))
+
+        expect(service.send(:max_tool_iterations)).to eq(described_class::DEFAULT_MAX_TOOL_ITERATIONS)
+      end
+
+      it "uses the tenant setting when configured" do
+        create(:tenant_setting, account: account,
+          features: { "chat_settings" => { "chat_max_tool_iterations" => 25 } })
+        service = described_class.new(chat_session: chat_session, llm_client: instance_double(Proc))
+
+        expect(service.send(:max_tool_iterations)).to eq(25)
+      end
+    end
   end
 
   describe "#build_conversation" do

--- a/spec/services/chat_sessions/agent_loop_spec.rb
+++ b/spec/services/chat_sessions/agent_loop_spec.rb
@@ -449,7 +449,7 @@ RSpec.describe ChatSessions::AgentLoop do
       user_entry = { role: "user", content: "u" }
       tool_entry = { role: "tool", content: "r", tool_call_id: "c", tool_name: "search" }
       # cap + 1 entries; after taking the last `cap`, the first is a tool entry
-      conversation = [user_entry, tool_entry] + Array.new(cap - 1) { user_entry }
+      conversation = [ user_entry, tool_entry ] + Array.new(cap - 1) { user_entry }
 
       trimmed = service.send(:trim_conversation, conversation)
 
@@ -466,7 +466,7 @@ RSpec.describe ChatSessions::AgentLoop do
       tool_entry = { role: "tool", content: "r", tool_call_id: "c", tool_name: "search" }
       user_entry = { role: "user", content: "u" }
       # One entry over the cap; the window starts at the assistant whose result follows
-      conversation = [user_entry, assistant_entry, tool_entry] + Array.new(cap - 2) { user_entry }
+      conversation = [ user_entry, assistant_entry, tool_entry ] + Array.new(cap - 2) { user_entry }
 
       trimmed = service.send(:trim_conversation, conversation)
 

--- a/spec/services/chat_sessions/agent_loop_spec.rb
+++ b/spec/services/chat_sessions/agent_loop_spec.rb
@@ -299,22 +299,40 @@ RSpec.describe ChatSessions::AgentLoop do
 
     context "when the token budget is exhausted mid-loop" do
       before do
-        create(:tenant_setting, account: account,
-          features: { "chat_settings" => { "chat_session_token_limit" => 25 } })
         allow(Tools::Registry).to receive(:chat_definitions_for).with(user: user, session: anything).and_return(tool_definitions)
         allow(Tools::Registry).to receive(:dispatch).and_return({ "status" => "ok" })
       end
 
-      it "triggers the soft-stop instead of continuing to call tools" do
+      it "triggers the soft-stop once usage exceeds the budget" do
+        configure_session_token_limit(25)
         client = build_token_budget_client
 
         result = described_class.new(chat_session: chat_session, llm_client: client).run
 
-        # Iteration 0: 15 tokens (10+5), 15 <= 25 → continue
+        # Iteration 0: 15 tokens (10+5), under 25 → continue
         # Iteration 1: +15 = 30 tokens, 30 > 25 → soft-stop (3rd call)
         expect(result.content).to include("token budget")
         expect(client.seen_conversations.length).to eq(3)
         expect(chat_session.messages.where(role: "tool").count).to eq(1)
+      end
+
+      it "triggers the soft-stop when usage reaches the budget exactly (not only above)" do
+        configure_session_token_limit(30)
+        client = build_token_budget_client
+
+        result = described_class.new(chat_session: chat_session, llm_client: client).run
+
+        # Iteration 0: 15 tokens, under 30 → continue
+        # Iteration 1: +15 = exactly 30 → soft-stop fires before the 2nd tool runs
+        expect(result.content).to include("token budget")
+        expect(client.seen_conversations.length).to eq(3)
+        expect(chat_session.messages.where(role: "tool").count).to eq(1)
+      end
+
+      def configure_session_token_limit(limit)
+        account.tenant_setting&.destroy
+        create(:tenant_setting, account: account,
+          features: { "chat_settings" => { "chat_session_token_limit" => limit } })
       end
 
       def build_token_budget_client
@@ -401,6 +419,60 @@ RSpec.describe ChatSessions::AgentLoop do
         tool_call_id: "call_1", tool_name: "search", tool_arguments: { "query" => "test" })
       create(:chat_message, :tool, chat_session: chat_session,
         tool_call_id: "call_1", tool_name: "search", content: result.to_json, tool_result: result)
+    end
+  end
+
+  describe "#trim_conversation" do
+    let(:service) { described_class.new(chat_session: chat_session, llm_client: instance_double(Proc)) }
+    let(:cap) { described_class::MAX_CONVERSATION_MESSAGES }
+
+    it "returns the conversation unchanged when at or under the cap" do
+      conversation = Array.new(cap) { { role: "user", content: "x" } }
+
+      trimmed = service.send(:trim_conversation, conversation)
+
+      expect(trimmed.length).to eq(cap)
+      expect(trimmed).to equal(conversation)
+    end
+
+    it "keeps only the most recent entries once the cap is exceeded" do
+      conversation = Array.new(cap + 5) { |i| { role: "user", content: "m#{i}" } }
+
+      trimmed = service.send(:trim_conversation, conversation)
+
+      expect(trimmed.length).to eq(cap)
+      expect(trimmed.first[:content]).to eq("m5")
+      expect(trimmed.last[:content]).to eq("m#{cap + 4}")
+    end
+
+    it "drops leading tool entries so the window never starts with an orphaned tool result" do
+      user_entry = { role: "user", content: "u" }
+      tool_entry = { role: "tool", content: "r", tool_call_id: "c", tool_name: "search" }
+      # cap + 1 entries; after taking the last `cap`, the first is a tool entry
+      conversation = [user_entry, tool_entry] + Array.new(cap - 1) { user_entry }
+
+      trimmed = service.send(:trim_conversation, conversation)
+
+      expect(trimmed.length).to eq(cap - 1)
+      expect(trimmed.first[:role]).to eq("user")
+      expect(trimmed).not_to include(tool_entry)
+    end
+
+    it "preserves an assistant tool-call entry and its following tool results when they lead the window" do
+      assistant_entry = {
+        role: "assistant", content: "ok",
+        tool_calls: [ { id: "c", name: "search", arguments: {} } ]
+      }
+      tool_entry = { role: "tool", content: "r", tool_call_id: "c", tool_name: "search" }
+      user_entry = { role: "user", content: "u" }
+      # One entry over the cap; the window starts at the assistant whose result follows
+      conversation = [user_entry, assistant_entry, tool_entry] + Array.new(cap - 2) { user_entry }
+
+      trimmed = service.send(:trim_conversation, conversation)
+
+      expect(trimmed.length).to eq(cap)
+      expect(trimmed.first).to eq(assistant_entry)
+      expect(trimmed.second).to eq(tool_entry)
     end
   end
 end

--- a/spec/services/chat_sessions/send_message_spec.rb
+++ b/spec/services/chat_sessions/send_message_spec.rb
@@ -457,6 +457,20 @@ RSpec.describe ChatSessions::SendMessage do
         expect(assistant_message.tokens_output).to eq(65)
       end
 
+      it "reuses the pre-loop token budget so the mid-loop guard does not re-query the limit" do
+        create(:tenant_setting, account: account,
+          features: { "chat_settings" => { "chat_session_token_limit" => 1_000_000 } })
+
+        # SendMessage#check_token_limit! runs CheckTokenLimit once before the
+        # loop; AgentLoop must reuse that baseline rather than aggregating again
+        # mid-turn.
+        expect(ChatSessions::CheckTokenLimit).to receive(:call).once.and_call_original
+
+        described_class.call(
+          chat_session: chat_session, content: "Search for test", llm_client: tool_llm_client
+        )
+      end
+
       it "notifies tool messages so live threads can render them" do
         roles = []
 

--- a/spec/services/chat_sessions/send_message_spec.rb
+++ b/spec/services/chat_sessions/send_message_spec.rb
@@ -532,21 +532,49 @@ RSpec.describe ChatSessions::SendMessage do
           model: "gpt-4o"
         }
       end
-      let(:tool_llm_client) do
-        build_stateful_llm_client(Array.new(ChatSessions::AgentLoop::MAX_TOOL_ITERATIONS, tool_loop_response))
+      let(:soft_stop_response) do
+        {
+          content: "I searched but need more specific queries. Try narrowing your request.",
+          tool_calls: [],
+          tokens_input: 20,
+          tokens_output: 15,
+          model: "gpt-4o"
+        }
       end
 
-      it "caps the loop and persists a final user-visible note" do
+      before do
+        create(:tenant_setting, account: account,
+          features: { "chat_settings" => { "chat_max_tool_iterations" => 3 } })
         allow(Tools::Registry).to receive(:chat_definitions_for).with(user: user, session: anything).and_return(tool_definitions)
         allow(Tools::Registry).to receive(:dispatch).and_return({ "status" => "ok" })
+      end
+
+      it "caps at the configured limit and runs a soft-stop summary" do
+        tool_llm_client = build_stateful_llm_client(
+          [ tool_loop_response, tool_loop_response, tool_loop_response, soft_stop_response ]
+        )
 
         result = described_class.call(
           chat_session: chat_session, content: "Keep going", llm_client: tool_llm_client
         )
 
-        expect(tool_llm_client.seen_conversations.length).to eq(ChatSessions::AgentLoop::MAX_TOOL_ITERATIONS)
-        expect(result.content).to include("maximum number of tool iterations")
-        expect(chat_session.messages.where(role: "tool").count).to eq(ChatSessions::AgentLoop::MAX_TOOL_ITERATIONS)
+        expect(tool_llm_client.seen_conversations.length).to eq(4)
+        expect(result.content).to include("I searched but need more specific queries")
+        expect(chat_session.messages.where(role: "tool").count).to eq(3)
+      end
+
+      it "uses the soft-stop prompt on the final call (tools excluded)" do
+        tool_llm_client = build_stateful_llm_client(
+          [ tool_loop_response, tool_loop_response, tool_loop_response, soft_stop_response ]
+        )
+
+        described_class.call(
+          chat_session: chat_session, content: "Keep going", llm_client: tool_llm_client
+        )
+
+        last_conversation = tool_llm_client.seen_conversations.last
+        expect(last_conversation.last[:role]).to eq("user")
+        expect(last_conversation.last[:content]).to include("maximum number of tool calls")
       end
     end
   end


### PR DESCRIPTION
## Summary

Chat sessions were hitting a hard error after just 8 tool calls per turn — too few for real work, with a dead-end "please narrow your request" message. This replaces the hard cap with a soft-stop pattern (inspired by OpenCode) that lets the model summarize its progress, raises the default to 50, makes it configurable, and adds a mid-loop token budget guard so runaway turns can't silently burn past cost limits.

## What changed

**Soft-stop instead of hard error.** On the last allowed iteration, the loop injects a wrap-up prompt ("Summarize what you've found and suggest next steps") and calls the LLM one final time without tools. The user gets a useful summary instead of an error. This matches how OpenCode, Roo Code, and other open-source agents handle step limits — none of them hard-kill with an error.

**Default raised 8 → 50, now configurable.** The iteration limit is now a tenant setting (`chat_max_tool_iterations`) stored in the existing `features.chat_settings` jsonb, with a form section in the tenant configuration page. Research showed Claude Code, Codex, OpenCode, Roo Code, Cline, and Continue.dev all default to unlimited — 50 is conservative but far more usable than 8.

**Mid-loop token budget check.** Previously, `CheckTokenLimit` only ran once before the loop. A single turn with 50 iterations could burn unbounded tokens between pre-loop checks. Now the loop fetches the remaining budget once at turn start and compares in-memory each iteration — no per-iteration DB queries. The fetch is wrapped in `rescue` so a transient DB failure degrades gracefully instead of aborting the turn.

**Server-side validation.** Tenant settings for chat are validated at the model level (rejecting non-integer, negative, or out-of-range values) following the same pattern as `validate_worker_settings`. Without this, a non-numeric `chat_max_tool_iterations` value would crash every chat turn for the tenant with `NoMethodError`.

## Design decisions

| Decision | Rationale |
|---|---|
| Soft-stop (not hard kill) | Matches OpenCode pattern; user gets a summary, not an error. The model is called without tools so it can only produce text. |
| Budget fetched once, tracked in-memory | Avoids 2 SUM queries × N iterations (up to 100/turn). Aggregate tokens are already tracked locally; only the DB baseline needs fetching. |
| Budget check runs before `create_assistant_message` | Prevents orphaned messages that promise tool execution ("Let me search for that") when the budget is exhausted before tools run. |
| Budget fetch fails open (returns nil) | A transient DB timeout shouldn't abort an otherwise-successful turn. The pre-loop `SendMessage#check_token_limit!` provides the first line of defense. |
| `max_tool_iterations` hardens with `is_a?(Integer)` | Belt-and-suspenders alongside model validation — bad data that somehow bypasses validation won't crash the loop. |

## Test plan

- [x] Soft-stop injects prompt and calls LLM without tools on last iteration
- [x] Fallback message used when soft-stop response is empty
- [x] Token budget exhaustion triggers soft-stop instead of continuing
- [x] Configurable limit reads from tenant settings
- [x] Default applies when no tenant setting configured
- [x] Integration test through `SendMessage` verifies soft-stop prompt on final call
- [x] All 54 existing chat specs pass, lint clean, tenant_setting model specs pass

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/GLM_5.1-6366f1?logo=claude&logoColor=white)
