### PR TITLE
fix(agent-runs): reroute pinned runs to healthy alternative instead of stalling

### DIFF
--- a/app/jobs/process_run_queue_job.rb
+++ b/app/jobs/process_run_queue_job.rb
@@ -56,10 +56,12 @@ class ProcessRunQueueJob < ApplicationJob
       # healthy alternative; only when no alternative exists is the run
       # added to +skipped_ids+.
       blocked_runner_ids = Set.new
-      # Maps original (blocked) runner IDs to their reroute resolution:
+      # Maps reroute resolution context to its resolved alternative:
       # { runner_id:, agent_type:, from_key:, to_key: } or nil when no
-      # healthy alternative exists. Avoids re-running the resolver for
-      # every queued run pinned to the same unavailable runner.
+      # healthy alternative exists. The cache is scoped to the blocked
+      # runner plus the run's resolver inputs (project + goal), because
+      # different projects/goals can legitimately resolve to different
+      # healthy alternatives.
       reroute_cache = {}
       blocked_account_create_pr_ids = Set.new
       blocked_account_dispatch_ids = Set.new
@@ -235,43 +237,59 @@ class ProcessRunQueueJob < ApplicationJob
   # availability is a hard filter, so a rate-limited / circuit-open runner must
   # never block the run.
   #
-  # Resolutions are cached per original runner ID so that multiple queued runs
-  # pinned to the same blocked runner share one resolver call. When no healthy
-  # alternative exists the run's original pin is *restored* (not silently
-  # downgraded) and the run is skipped for the rest of this pass — the preferred
-  # runner is retried on the next tick.
+  # Resolutions are cached per blocked runner + resolution context so that
+  # multiple queued runs with the same resolver inputs share one resolver call
+  # without leaking a reroute across projects/goals. When no healthy alternative
+  # exists the run's original pin is *restored* (not silently downgraded) and
+  # the run is skipped for the rest of this pass — the preferred runner is
+  # retried on the next tick.
   def reroute_unavailable_runner(agent_run, blocked_runner_ids, skipped_ids, reroute_cache)
     original_id = agent_run.runner_id
+    cache_key = reroute_cache_key(agent_run, original_id)
 
-    if reroute_cache.key?(original_id)
-      cached = reroute_cache[original_id]
+    if reroute_cache.key?(cache_key)
+      cached = reroute_cache[cache_key]
       return skipped_ids.add(agent_run.id) if cached.nil?
       return apply_cached_reroute(agent_run, cached) unless blocked_runner_ids.include?(cached[:runner_id])
     end
 
     agent_run.update_columns(runner_id: nil)
     if AgentRuns::BindRunner.call(agent_run: agent_run, exclude_runner_ids: blocked_runner_ids)
-      cache_reroute_resolution(agent_run, original_id, reroute_cache)
+      cache_reroute_resolution(agent_run, original_id, cache_key, reroute_cache)
     else
       agent_run.update_columns(runner_id: original_id)
-      reroute_cache[original_id] = nil
+      reroute_cache[cache_key] = nil
       skipped_ids.add(agent_run.id)
     end
   end
 
   def apply_cached_reroute(agent_run, cached)
     agent_run.update_columns(runner_id: cached[:runner_id], agent_type: cached[:agent_type])
-    agent_run.log_runner_switch!(cached[:from_key], cached[:to_key], "dispatch_reroute")
+    log_runner_reroute(agent_run, cached[:from_key], cached[:to_key])
   end
 
-  def cache_reroute_resolution(agent_run, original_id, reroute_cache)
-    from_key = Runner.find_by(id: original_id)&.routing_key
-    to_key = Runner.find_by(id: agent_run.runner_id)&.routing_key
-    reroute_cache[original_id] = {
+  def cache_reroute_resolution(agent_run, original_id, cache_key, reroute_cache)
+    from_key = runner_routing_key(original_id)
+    to_key = runner_routing_key(agent_run.runner_id)
+    reroute_cache[cache_key] = {
       runner_id: agent_run.runner_id, agent_type: agent_run.agent_type,
       from_key: from_key, to_key: to_key
     }
-    agent_run.log_runner_switch!(from_key, to_key, "dispatch_reroute") if from_key && to_key
+    log_runner_reroute(agent_run, from_key, to_key)
+  end
+
+  def reroute_cache_key(agent_run, original_id)
+    [ original_id, agent_run.project_id, agent_run.goal ]
+  end
+
+  def runner_routing_key(runner_id)
+    Runner.find_by(id: runner_id)&.routing_key
+  end
+
+  def log_runner_reroute(agent_run, from_key, to_key)
+    return unless from_key && to_key
+
+    agent_run.log_runner_switch!(from_key, to_key, "dispatch_reroute")
   end
 
   def log_preflight_skip(agent_run, result)

--- a/app/jobs/process_run_queue_job.rb
+++ b/app/jobs/process_run_queue_job.rb
@@ -52,11 +52,15 @@ class ProcessRunQueueJob < ApplicationJob
       blocked_user_ids = Set.new
       # Runner-agnostic queue (#2563): a runner id in this set means
       # "do not pick this runner again on this pass", not "skip the
-      # run". For pinned runs the corresponding run is also added to
-      # +skipped_ids+ so it is not retried; for unbound runs the run
-      # stays queued and the resolver will pick a different runner next
-      # pass if one is healthy.
+      # run". Pinned runs whose runner is blocked are rerouted to a
+      # healthy alternative; only when no alternative exists is the run
+      # added to +skipped_ids+.
       blocked_runner_ids = Set.new
+      # Maps original (blocked) runner IDs to their reroute resolution:
+      # { runner_id:, agent_type:, from_key:, to_key: } or nil when no
+      # healthy alternative exists. Avoids re-running the resolver for
+      # every queued run pinned to the same unavailable runner.
+      reroute_cache = {}
       blocked_account_create_pr_ids = Set.new
       blocked_account_dispatch_ids = Set.new
       started_priority_by_project = {}
@@ -138,33 +142,25 @@ class ProcessRunQueueJob < ApplicationJob
           next
         end
 
-        # Late-bind a runner for runner-agnostic queued runs (#2563).
-        # The resolver is constrained to runnable runners AND excludes any
-        # runner that already failed preflight during this pass
-        # (+blocked_runner_ids+), so a healthy alternative is picked when the
-        # preferred runner is rate-limited / circuit-open. If no runnable
-        # runner can be resolved the run stays queued and we move on to the
-        # next peek.
-        bound_for_this_iteration = false
+        # Resolve a runner for the queued run. Runner-agnostic (auto-pick)
+        # runs are late-bound here from the healthy runner pool. Any run whose
+        # pinned or just-bound runner is unavailable is *rerouted* to a healthy
+        # alternative configured for the same context (agent runs only consider
+        # agent-run-enabled runners). Weighting/preference is a soft preference
+        # — availability is a hard filter that never blocks work from running.
         if next_run.runner_unbound?
           bound_runner = AgentRuns::BindRunner.call(agent_run: next_run, exclude_runner_ids: blocked_runner_ids)
           unless bound_runner
             log_no_runnable_runner(next_run)
             next
           end
-          bound_for_this_iteration = true
         end
 
         if next_run.runner_id && blocked_runner_ids.include?(next_run.runner_id)
-          if bound_for_this_iteration
-            # Defense in depth: a late-bound run should never resolve to a
-            # blocked runner (the resolver excludes them), but if it does,
-            # clear the pin so the next pass re-resolves rather than
-            # stranding the run on it.
-            next_run.update_columns(runner_id: nil)
-          else
-            skipped_ids.add(next_run.id)
-          end
+          # Runner already failed preflight earlier this pass — reroute to a
+          # healthy alternative without re-checking (preserves the bulk-skip
+          # optimization for runs sharing one bad runner).
+          reroute_unavailable_runner(next_run, blocked_runner_ids, skipped_ids, reroute_cache)
           next
         end
 
@@ -172,18 +168,7 @@ class ProcessRunQueueJob < ApplicationJob
         if preflight_result && !preflight_result.pass?
           log_preflight_skip(next_run, preflight_result)
           blocked_runner_ids.add(preflight_result.runner_id) if preflight_result.runner_id
-          if bound_for_this_iteration
-            # Late-bound on this pass: clear the pin so the next pass
-            # re-resolves (a different healthy runner may be available
-            # by then). The run stays queued; the runner was just
-            # unhealthy, not the run.
-            next_run.update_columns(runner_id: nil)
-          else
-            # Pinned (manually assigned) runs are stuck to one
-            # runner — keep the run skipped for the rest of this pass
-            # and try again next tick.
-            skipped_ids.add(next_run.id)
-          end
+          reroute_unavailable_runner(next_run, blocked_runner_ids, skipped_ids, reroute_cache)
           next
         end
 
@@ -243,6 +228,50 @@ class ProcessRunQueueJob < ApplicationJob
     return nil unless runner
 
     Runners::PreflightCheck.call(runner: runner, user: user)
+  end
+
+  # Reroutes a run whose pinned/bound runner is unavailable to a healthy
+  # alternative configured for the same context. Weighting is a preference;
+  # availability is a hard filter, so a rate-limited / circuit-open runner must
+  # never block the run.
+  #
+  # Resolutions are cached per original runner ID so that multiple queued runs
+  # pinned to the same blocked runner share one resolver call. When no healthy
+  # alternative exists the run's original pin is *restored* (not silently
+  # downgraded) and the run is skipped for the rest of this pass — the preferred
+  # runner is retried on the next tick.
+  def reroute_unavailable_runner(agent_run, blocked_runner_ids, skipped_ids, reroute_cache)
+    original_id = agent_run.runner_id
+
+    if reroute_cache.key?(original_id)
+      cached = reroute_cache[original_id]
+      return skipped_ids.add(agent_run.id) if cached.nil?
+      return apply_cached_reroute(agent_run, cached) unless blocked_runner_ids.include?(cached[:runner_id])
+    end
+
+    agent_run.update_columns(runner_id: nil)
+    if AgentRuns::BindRunner.call(agent_run: agent_run, exclude_runner_ids: blocked_runner_ids)
+      cache_reroute_resolution(agent_run, original_id, reroute_cache)
+    else
+      agent_run.update_columns(runner_id: original_id)
+      reroute_cache[original_id] = nil
+      skipped_ids.add(agent_run.id)
+    end
+  end
+
+  def apply_cached_reroute(agent_run, cached)
+    agent_run.update_columns(runner_id: cached[:runner_id], agent_type: cached[:agent_type])
+    agent_run.log_runner_switch!(cached[:from_key], cached[:to_key], "dispatch_reroute")
+  end
+
+  def cache_reroute_resolution(agent_run, original_id, reroute_cache)
+    from_key = Runner.find_by(id: original_id)&.routing_key
+    to_key = Runner.find_by(id: agent_run.runner_id)&.routing_key
+    reroute_cache[original_id] = {
+      runner_id: agent_run.runner_id, agent_type: agent_run.agent_type,
+      from_key: from_key, to_key: to_key
+    }
+    agent_run.log_runner_switch!(from_key, to_key, "dispatch_reroute") if from_key && to_key
   end
 
   def log_preflight_skip(agent_run, result)

--- a/app/services/agent_runs/bind_runner.rb
+++ b/app/services/agent_runs/bind_runner.rb
@@ -10,21 +10,20 @@ module AgentRuns
   # pick a healthy runner over the runnable set.
   #
   # This service only ever handles runner-agnostic (auto-pick) queued runs.
-  # Manual runs are created with their runner already pinned
+  # Manual and resume runs are created with their runner already pinned
   # (Projects::AgentRunsController#create_agent_run), so they reach
   # ProcessRunQueueJob already bound (+runner_id.present?+) and never flow
-  # through here. A manual run whose pinned runner is unhealthy is skipped
-  # for the rest of the pass and stays queued — it is *not* silently
-  # re-routed to a different agent_type — which is how the "manual explicit
-  # choice is not switched" policy from #2563 is enforced.
+  # through here on the first dispatch. When such a pinned runner is
+  # unavailable (rate-limited, circuit-open), ProcessRunQueueJob clears the
+  # pin and re-invokes this service to fall back to a healthy alternative —
+  # weighting/preference is a soft preference and never blocks work.
   #
-  # Failover policy for auto-pick: any healthy runner is acceptable (the
-  # project just wants a PR), so +agent_type+ is updated to whatever the
-  # resolver returns, including a different agent family. The
-  # +exclude_runner_ids+ set (runners that already failed preflight during
-  # the current dequeue pass) is threaded into the resolver so the run is
-  # never pinned back to a runner known-unhealthy this pass — it falls
-  # through to a healthy alternative instead.
+  # Failover policy: any healthy runner is acceptable (the project just wants
+  # the work done), so +agent_type+ is updated to whatever the resolver returns,
+  # including a different agent family. The +exclude_runner_ids+ set (runners
+  # that already failed preflight during the current dequeue pass) is threaded
+  # into the resolver so the run is never pinned back to a runner known-unhealthy
+  # this pass — it falls through to a healthy alternative instead.
   class BindRunner
     def self.call(...)
       new(...).call

--- a/spec/jobs/process_run_queue_job_spec.rb
+++ b/spec/jobs/process_run_queue_job_spec.rb
@@ -811,23 +811,27 @@ RSpec.describe ProcessRunQueueJob do
         ))
       end
 
-      it "skips the run when an API-key runner has no secret" do
+      it "falls back to a healthy runner when an API-key runner has no secret" do
         project = create(:project)
         user = project.created_by
         provider_api_key = create(:provider_api_key, user: user)
         runner = create(:runner, user: user, runner_key: "cursor", auth_type: "api_key", provider_api_key: provider_api_key)
+        claude_runner = user.runners.kept_only.find_by!(runner_key: "claude", auth_type: "subscription")
         queued_run = create(:agent_run, :queued, project: project, runner: runner)
         allow(Rails.logger).to receive(:info)
 
+        allow(Runners::PreflightCheck).to receive(:call).and_call_original
         allow(Runners::PreflightCheck).to receive(:call)
           .with(runner: runner, user: user)
           .and_return(Runners::PreflightCheck::Result.new(pass?: false, reason: "missing_api_key", runner_id: runner.id))
 
-        expect(temporal_client).not_to receive(:start_workflow)
+        expect(temporal_client).to receive(:start_workflow).once.and_return(workflow_handle)
 
         described_class.new.perform
 
-        expect(queued_run.reload.status).to eq("queued")
+        queued_run.reload
+        expect(queued_run.runner_id).to eq(claude_runner.id)
+        expect(queued_run.temporal_workflow_id).to be_present
         expect(Rails.logger).to have_received(:info).with(hash_including(
           message: "process_run_queue.preflight_skip",
           reason: "missing_api_key"
@@ -869,6 +873,96 @@ RSpec.describe ProcessRunQueueJob do
         described_class.new.perform
 
         expect(Runners::PreflightCheck).to have_received(:call).once
+      end
+
+      it "reroutes a pinned run to a healthy alternative when its runner is rate limited" do
+        project = create(:project)
+        user = project.created_by
+        claude_runner = user.runners.kept_only.find_by!(runner_key: "claude", auth_type: "subscription")
+        create(:runner_state, :rate_limited, user: user, runner_name: claude_runner.state_key)
+        codex_runner = create(:runner, user: user, runner_key: "codex")
+        queued_run = create(:agent_run, :queued, project: project, runner: claude_runner)
+
+        expect(temporal_client).to receive(:start_workflow).once.and_return(workflow_handle)
+
+        described_class.new.perform
+
+        queued_run.reload
+        expect(queued_run.status).to eq("queued")
+        expect(queued_run.runner_id).to eq(codex_runner.id)
+        expect(queued_run.agent_type).to eq("codex")
+        expect(queued_run.temporal_workflow_id).to be_present
+        expect(queued_run.runner_switches).to eq(1)
+      end
+
+      it "reroutes a manually pinned run when its runner circuit is open" do
+        project = create(:project)
+        user = project.created_by
+        claude_runner = user.runners.kept_only.find_by!(runner_key: "claude", auth_type: "subscription")
+        create(:runner_state, :circuit_open, user: user, runner_name: claude_runner.state_key)
+        codex_runner = create(:runner, user: user, runner_key: "codex")
+        queued_run = create(:agent_run, :queued, project: project, runner: claude_runner, trigger_type: "manual")
+
+        expect(temporal_client).to receive(:start_workflow).once.and_return(workflow_handle)
+
+        described_class.new.perform
+
+        expect(queued_run.reload.runner_id).to eq(codex_runner.id)
+      end
+
+      it "restores the pin and keeps the run queued when no healthy alternative exists" do
+        project = create(:project)
+        user = project.created_by
+        runner = user.runners.kept_only.find_by!(runner_key: "claude", auth_type: "subscription")
+        create(:runner_state, :rate_limited, user: user, runner_name: runner.state_key)
+        queued_run = create(:agent_run, :queued, project: project, runner: runner)
+
+        expect(temporal_client).not_to receive(:start_workflow)
+
+        described_class.new.perform
+
+        queued_run.reload
+        expect(queued_run.status).to eq("queued")
+        expect(queued_run.runner_id).to eq(runner.id)
+      end
+
+      it "caches reroute resolution so BindRunner is called once per blocked runner" do
+        stub_const("#{described_class}::MAX_ITERATIONS_PER_PERFORM", 5)
+
+        project = create(:project)
+        user = project.created_by
+        user.settings.update!(max_concurrent_runs: 10)
+        claude_runner = user.runners.kept_only.find_by!(runner_key: "claude", auth_type: "subscription")
+        create(:runner_state, :rate_limited, user: user, runner_name: claude_runner.state_key)
+        codex_runner = create(:runner, user: user, runner_key: "codex")
+
+        3.times { |i| create(:agent_run, :queued, project: project, runner: claude_runner, created_at: (10 - i).minutes.ago) }
+
+        allow(AgentRuns::BindRunner).to receive(:call).and_call_original
+
+        described_class.new.perform
+
+        expect(AgentRuns::BindRunner).to have_received(:call).once
+        expect(AgentRun.where(runner_id: codex_runner.id).count).to eq(3)
+      end
+
+      it "logs runner switch in audit trail when rerouting" do
+        project = create(:project)
+        user = project.created_by
+        claude_runner = user.runners.kept_only.find_by!(runner_key: "claude", auth_type: "subscription")
+        create(:runner_state, :rate_limited, user: user, runner_name: claude_runner.state_key)
+        create(:runner, user: user, runner_key: "codex")
+        queued_run = create(:agent_run, :queued, project: project, runner: claude_runner)
+
+        expect(temporal_client).to receive(:start_workflow).once.and_return(workflow_handle)
+
+        described_class.new.perform
+
+        queued_run.reload
+        log_entry = queued_run.agent_run_logs.find { |l| l.content.include?("Runner fallback") }
+        expect(log_entry).to be_present
+        expect(log_entry.content).to include("dispatch_reroute")
+        expect(queued_run.runner_switches).to eq(1)
       end
     end
 

--- a/spec/jobs/process_run_queue_job_spec.rb
+++ b/spec/jobs/process_run_queue_job_spec.rb
@@ -926,7 +926,7 @@ RSpec.describe ProcessRunQueueJob do
         expect(queued_run.runner_id).to eq(runner.id)
       end
 
-      it "caches reroute resolution so BindRunner is called once per blocked runner" do
+      it "caches reroute resolution so BindRunner is called once per blocked runner context" do
         stub_const("#{described_class}::MAX_ITERATIONS_PER_PERFORM", 5)
 
         project = create(:project)
@@ -946,6 +946,29 @@ RSpec.describe ProcessRunQueueJob do
         expect(AgentRun.where(runner_id: codex_runner.id).count).to eq(3)
       end
 
+      it "does not reuse a cached reroute across projects with different resolver context" do
+        owner = create(:user, :owner)
+        account = owner.account
+        first_project = create(:project, account: account, created_by: owner,
+          model_preferences: { "preferred_agent_type" => "codex" })
+        second_project = create(:project, account: account, created_by: owner,
+          model_preferences: { "preferred_agent_type" => "cursor" })
+        claude_runner = owner.runners.kept_only.find_by!(runner_key: "claude", auth_type: "subscription")
+        create(:runner_state, :rate_limited, user: owner, runner_name: claude_runner.state_key)
+        codex_runner = create(:runner, user: owner, runner_key: "codex")
+        cursor_runner = create(:runner, user: owner, runner_key: "cursor")
+        codex_run = create(:agent_run, :queued, project: first_project, runner: claude_runner, created_at: 2.minutes.ago)
+        cursor_run = create(:agent_run, :queued, project: second_project, runner: claude_runner, created_at: 1.minute.ago)
+
+        allow(AgentRuns::BindRunner).to receive(:call).and_call_original
+
+        described_class.new.perform
+
+        expect(AgentRuns::BindRunner).to have_received(:call).twice
+        expect(codex_run.reload.runner_id).to eq(codex_runner.id)
+        expect(cursor_run.reload.runner_id).to eq(cursor_runner.id)
+      end
+
       it "logs runner switch in audit trail when rerouting" do
         project = create(:project)
         user = project.created_by
@@ -963,6 +986,29 @@ RSpec.describe ProcessRunQueueJob do
         expect(log_entry).to be_present
         expect(log_entry.content).to include("dispatch_reroute")
         expect(queued_run.runner_switches).to eq(1)
+      end
+
+      it "skips reroute audit logging when a routing key cannot be resolved" do
+        stub_const("#{described_class}::MAX_ITERATIONS_PER_PERFORM", 5)
+
+        project = create(:project)
+        user = project.created_by
+        claude_runner = user.runners.kept_only.find_by!(runner_key: "claude", auth_type: "subscription")
+        create(:runner_state, :rate_limited, user: user, runner_name: claude_runner.state_key)
+        create(:runner, user: user, runner_key: "codex")
+        first_run = create(:agent_run, :queued, project: project, runner: claude_runner, created_at: 2.minutes.ago)
+        second_run = create(:agent_run, :queued, project: project, runner: claude_runner, created_at: 1.minute.ago)
+        job = described_class.new
+
+        allow(job).to receive(:runner_routing_key).and_call_original
+        allow(job).to receive(:runner_routing_key).with(claude_runner.id).and_return(nil)
+
+        job.perform
+
+        expect(first_run.reload.runner_switches).to eq(0)
+        expect(second_run.reload.runner_switches).to eq(0)
+        expect(first_run.agent_run_logs.none? { |log| log.content.include?("dispatch_reroute") }).to be(true)
+        expect(second_run.agent_run_logs.none? { |log| log.content.include?("dispatch_reroute") }).to be(true)
       end
     end
 


### PR DESCRIPTION
## Problem

When a run's pinned runner is rate-limited or circuit-open, the dispatcher skipped the run every tick with no fallback. All 6 queued runs were pinned to a single rate-limited Claude runner (#16, rate-limited until 2026-07-10T10:00:00Z), while healthy Codex runners sat idle — the queue was completely stalled.

**Root cause**: pinned runs bypassed the late-binding fallback path. `AgentRuns::BindRunner` hard-exits when `runner_id.present?`, and the dispatcher's skip-vs-reresolve branching meant pinned runs were never rerouted.

## Solution

Replace the skip-vs-clear branching with unconditional rerouting. When a run's pinned/bound runner is unavailable (rate-limited, circuit-open, missing secret, disabled, discarded), the dispatcher now:

1. **Clears the pin** and re-resolves to any healthy runner configured for the same context (agent-run-enabled runners for agent runs)
2. **Restores the pin** when no healthy alternative exists — the preferred runner retries next tick rather than silently downgrading to auto-pick
3. **Caches the resolution** per blocked runner ID so N runs sharing one unavailable runner share a single resolver call (~15 queries each)
4. **Logs the switch** via `log_runner_switch!` for operator/dash visibility

Design principle: **weighting/preference is a soft filter — availability is a hard filter that never blocks work from running.**

## Changes

- `app/jobs/process_run_queue_job.rb` — new `reroute_unavailable_runner` helper with cache + pin restoration, replaces old skip-vs-clear branching
- `app/services/agent_runs/bind_runner.rb` — doc comment updated to reflect rerouting policy
- `spec/jobs/process_run_queue_job_spec.rb` — 5 new tests (reroute on rate-limit, circuit-open, pin restore, cache, audit trail) + 1 updated (missing-secret now asserts fallback)

## Test plan

- [x] All 60 ProcessRunQueueJob specs pass
- [x] All 14 RunnerResolver specs pass
- [x] RuboCop clean on all 3 files
- [ ] CI green on PR