### PR TITLE
fix(auto-pick): unblock false-positive trackers, add eligibility widget

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -12,6 +12,7 @@ class DashboardController < ApplicationController
     @goal_filter = valid_goal_filter
     @live_stats = Dashboard::LiveStats.call(account: current_account)
     @queue_preview = Dashboard::QueuePreview.call(user: current_user)
+    @eligibility_breakdown = Dashboard::EligibilityBreakdown.call(user: current_user)
     @active_runs = live_agent_runs.active.includes(:runner, :issue, :model_selection, project: [ :created_by, :account ])
       .order("agent_runs.created_at DESC")
       .limit(20)

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -12,7 +12,6 @@ class DashboardController < ApplicationController
     @goal_filter = valid_goal_filter
     @live_stats = Dashboard::LiveStats.call(account: current_account)
     @queue_preview = Dashboard::QueuePreview.call(user: current_user)
-    @eligibility_breakdown = Dashboard::EligibilityBreakdown.call(user: current_user)
     @active_runs = live_agent_runs.active.includes(:runner, :issue, :model_selection, project: [ :created_by, :account ])
       .order("agent_runs.created_at DESC")
       .limit(20)
@@ -38,6 +37,11 @@ class DashboardController < ApplicationController
       .limit(20)
       .to_a
     @recent_activity = Dashboard::RecentActivity.call(account: current_account)
+  end
+
+  def eligibility_breakdown
+    @eligibility_breakdown = Dashboard::EligibilityBreakdown.call(user: current_user)
+    render partial: "dashboard/eligibility_breakdown", locals: { breakdowns: @eligibility_breakdown }
   end
 
   def metrics

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -47,6 +47,7 @@ class Issue < ApplicationRecord
   # still matched in the title pattern below, where the phrase is a
   # stronger tracker signal.
   TRACKER_BODY_HEADING_PATTERN = /^[#]{1,6}\s+.*\b(?:tracker|completion\s+criteria|phase\s+tracker|meta\s+issue)\b/i
+  STRONG_TRACKER_BODY_HEADING_PATTERN = /^[#]{1,6}\s+.*\b(?:tracker|phase\s+tracker|meta\s+issue)\b/i
   # Large offset so synthetic github_issue_id values never collide with real
   # GitHub issue IDs (which currently range in the low billions).
   SYNTHETIC_CODE_SCANNING_ID_OFFSET = 800_000_000_000
@@ -192,6 +193,10 @@ class Issue < ApplicationRecord
 
   def tracker_issue?
     TRACKER_PATTERN.match?(title.to_s) || TRACKER_BODY_HEADING_PATTERN.match?(body.to_s)
+  end
+
+  def strong_tracker_body_heading?
+    STRONG_TRACKER_BODY_HEADING_PATTERN.match?(body.to_s)
   end
 
   def body_referenced_issue_numbers

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -35,12 +35,18 @@ class Issue < ApplicationRecord
   SEVERITY_TO_PRIORITY = { "critical" => "P1", "high" => "P1", "medium" => "P2", "low" => "P3" }.freeze
   TRACKER_PATTERN = /\b(?:tracker|remaining\s+work|completion\s+criteria|phase\s+tracker|meta\s+issue)\b/i
   # Body match requires the tracker vocabulary to appear inside a markdown
-  # heading (e.g. "## Tracker", "## Remaining Work"). Matching anywhere in
+  # heading (e.g. "## Tracker", "## Meta Issue"). Matching anywhere in
   # the body produced false positives for feature issues that incidentally
   # mention "tracker" in prose (e.g. "support custom issue trackers",
   # "deploy tracker"), which then got permanently excluded from auto-pick
   # by the "tracker with no body refs" safety net in Issues::AutoPick.
-  TRACKER_BODY_HEADING_PATTERN = /^[#]{1,6}\s+.*\b(?:tracker|remaining\s+work|completion\s+criteria|phase\s+tracker|meta\s+issue)\b/i
+  # "remaining work" is intentionally excluded from the body-heading
+  # pattern because it is a common section heading in regular
+  # implementation issues (e.g. "## Remaining work\n- Add config"),
+  # not a signal that the issue itself is a tracker/meta-issue. It is
+  # still matched in the title pattern below, where the phrase is a
+  # stronger tracker signal.
+  TRACKER_BODY_HEADING_PATTERN = /^[#]{1,6}\s+.*\b(?:tracker|completion\s+criteria|phase\s+tracker|meta\s+issue)\b/i
   # Large offset so synthetic github_issue_id values never collide with real
   # GitHub issue IDs (which currently range in the low billions).
   SYNTHETIC_CODE_SCANNING_ID_OFFSET = 800_000_000_000

--- a/app/services/automation/strategies/auto_pick/default_candidate_source.rb
+++ b/app/services/automation/strategies/auto_pick/default_candidate_source.rb
@@ -173,12 +173,14 @@ module Automation
               next unless issue.tracker_issue?
 
               refs = issue.body_referenced_issue_numbers - [ issue.github_number ]
-              [ issue.id, refs, Issue::TRACKER_PATTERN.match?(issue.title.to_s) ]
+              [ issue.id, refs, Issue::TRACKER_PATTERN.match?(issue.title.to_s), issue.strong_tracker_body_heading? ]
             end
             return [] if refs_by_issue.empty?
 
-            no_ref_ids = refs_by_issue.filter_map { |id, refs, title_match| id if refs.empty? && title_match }
-            with_refs = refs_by_issue.filter_map { |id, refs, _| [ id, refs ] if refs.present? }
+            no_ref_ids = refs_by_issue.filter_map do |id, refs, title_match, strong_body_match|
+              id if refs.empty? && (title_match || strong_body_match)
+            end
+            with_refs = refs_by_issue.filter_map { |id, refs, _, _| [ id, refs ] if refs.present? }
             return no_ref_ids if with_refs.empty?
 
             all_referenced_numbers = with_refs.flat_map(&:last).uniq

--- a/app/services/automation/strategies/auto_pick/default_candidate_source.rb
+++ b/app/services/automation/strategies/auto_pick/default_candidate_source.rb
@@ -152,9 +152,11 @@ module Automation
           #   IssueDependency graph may be incomplete for body-referenced
           #   issues, and the direct-reference check already catches the
           #   motivating scenario (#615).
-          # - Trackers with NO body references are conservatively blocked —
-          #   they likely track work not enumerated as +#NNN+ references,
-          #   and auto-picking them risks premature selection (see #615).
+          # - Trackers with NO body references are conservatively blocked
+          #   ONLY when the title itself matches tracker vocabulary. A
+          #   body-heading match alone (e.g. "## Completion criteria") is
+          #   a weaker signal — common in regular implementation issues —
+          #   so those are allowed through unless they have open refs.
           def tracker_ids_blocked_by_open_references(candidate_scope, project)
             ilike_conditions = TRACKER_SQL_PATTERNS.each_with_index.flat_map do |_, i|
               [ "title ILIKE :t#{i}", "body ILIKE :t#{i}" ]
@@ -171,12 +173,12 @@ module Automation
               next unless issue.tracker_issue?
 
               refs = issue.body_referenced_issue_numbers - [ issue.github_number ]
-              [ issue.id, refs ]
+              [ issue.id, refs, Issue::TRACKER_PATTERN.match?(issue.title.to_s) ]
             end
             return [] if refs_by_issue.empty?
 
-            no_ref_ids = refs_by_issue.filter_map { |id, refs| id if refs.empty? }
-            with_refs = refs_by_issue.select { |_, refs| refs.present? }
+            no_ref_ids = refs_by_issue.filter_map { |id, refs, title_match| id if refs.empty? && title_match }
+            with_refs = refs_by_issue.filter_map { |id, refs, _| [ id, refs ] if refs.present? }
             return no_ref_ids if with_refs.empty?
 
             all_referenced_numbers = with_refs.flat_map(&:last).uniq

--- a/app/services/dashboard/eligibility_breakdown.rb
+++ b/app/services/dashboard/eligibility_breakdown.rb
@@ -47,11 +47,11 @@ module Dashboard
     def breakdown_for(project)
       open = Issue.where(project: project, github_state: "open", is_pull_request: false)
 
-      eligible_ids = Automation::Strategies::AutoPick::DefaultCandidateSource
-        .eligible_scope(project).pluck(:id).to_set
+      eligible_scope = Automation::Strategies::AutoPick::DefaultCandidateSource.eligible_scope(project)
+      eligible_count = eligible_scope.count
 
       # Count all non-eligible issues in a single conditional-aggregation query.
-      excluded = open.where.not(id: eligible_ids)
+      excluded = open.where.not(id: eligible_scope.select(:id))
       row = excluded.pick(
         Arel.sql("COUNT(*)"),
         Arel.sql("COUNT(*) FILTER (WHERE paid_state = 'needs_input')"),
@@ -66,8 +66,8 @@ module Dashboard
 
       ProjectBreakdown.new(
         project: project,
-        total_open: eligible_ids.size + excluded_total,
-        eligible: eligible_ids.size,
+        total_open: eligible_count + excluded_total,
+        eligible: eligible_count,
         needs_input: needs_input, skip_label: skip_label,
         completed: completed, in_progress: in_progress,
         other_excluded: other

--- a/app/services/dashboard/eligibility_breakdown.rb
+++ b/app/services/dashboard/eligibility_breakdown.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Dashboard
+  class EligibilityBreakdown
+    CACHE_TTL = 15.seconds
+
+    ProjectBreakdown = Struct.new(
+      :project, :total_open, :eligible, :needs_input,
+      :skip_label, :completed, :in_progress, :other_excluded,
+      keyword_init: true
+    )
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(user:)
+      @user = user
+    end
+
+    def call
+      return [] if auto_pick_projects.empty?
+
+      Rails.cache.fetch(cache_key, expires_in: CACHE_TTL) { build }
+    end
+
+    private
+
+    attr_reader :user
+
+    def build
+      auto_pick_projects.map { |project| breakdown_for(project) }
+    end
+
+    def auto_pick_projects
+      @auto_pick_projects ||= Project
+        .includes(:account)
+        .where(account_id: user.account_id, created_by_id: user.id,
+               auto_pick_enabled: true, active: true)
+        .reject { |p| p.scheduler_paused? || p.quality_paused? || p.account&.scheduler_paused? }
+    end
+
+    def breakdown_for(project)
+      open = Issue.where(project: project, github_state: "open", is_pull_request: false)
+
+      eligible_ids = Automation::Strategies::AutoPick::DefaultCandidateSource
+        .eligible_scope(project).pluck(:id).to_set
+
+      # Count all non-eligible issues in a single conditional-aggregation query.
+      excluded = open.where.not(id: eligible_ids)
+      row = excluded.pick(
+        Arel.sql("COUNT(*)"),
+        Arel.sql("COUNT(*) FILTER (WHERE paid_state = 'needs_input')"),
+        Arel.sql("COUNT(*) FILTER (WHERE paid_state = 'in_progress')"),
+        Arel.sql("COUNT(*) FILTER (WHERE paid_state = 'completed')"),
+        Arel.sql("COUNT(*) FILTER (WHERE paid_state IN ('new','planning','failed','analyzed'))")
+      ) || [ 0, 0, 0, 0, 0 ]
+      excluded_total, needs_input, in_progress, completed, analyzable = row
+
+      skip_label = count_skip_labeled(excluded, analyzable, project)
+      other = excluded_total - needs_input - in_progress - completed - skip_label
+
+      ProjectBreakdown.new(
+        project: project,
+        total_open: eligible_ids.size + excluded_total,
+        eligible: eligible_ids.size,
+        needs_input: needs_input, skip_label: skip_label,
+        completed: completed, in_progress: in_progress,
+        other_excluded: other
+      )
+    end
+
+    def count_skip_labeled(excluded_scope, analyzable_count, project)
+      return 0 if analyzable_count.zero?
+
+      labels = project.effective_auto_pick_skip_labels
+      return 0 if labels.empty?
+
+      excluded_scope.where(paid_state: %w[new planning failed analyzed])
+        .pluck(:labels)
+        .count { |issue_labels| (Array(issue_labels).map(&:downcase) & labels).any? }
+    end
+
+    def cache_key
+      "dashboard/eligibility_breakdown/#{user.account_id}/#{user.id}/" \
+        "#{Dashboard::CacheVersion.current(user.account, scope: Dashboard::CacheVersion::LISTS_SCOPE)}"
+    end
+  end
+end

--- a/app/services/dashboard/eligibility_breakdown.rb
+++ b/app/services/dashboard/eligibility_breakdown.rb
@@ -32,9 +32,15 @@ module Dashboard
       auto_pick_projects.map { |project| breakdown_for(project) }
     end
 
+    # Preload everything the per-project gate and breakdown touch so a dashboard
+    # with many auto-pick repos doesn't devolve into an N+1:
+    #   - +account+ and +created_by+ feed +Issues::AutoPickProjectGate#effective_owner+.
+    #   - +created_by.user_setting+ feeds +#count_skip_labeled+ via
+    #     +Project#effective_auto_pick_skip_labels+ when a project inherits its
+    #     owner's skip labels.
     def auto_pick_projects
       @auto_pick_projects ||= Project
-        .includes(:account)
+        .includes(:account, created_by: :user_setting)
         .where(
           account_id: user.account_id,
           created_by_id: visible_owner_ids,

--- a/app/services/dashboard/eligibility_breakdown.rb
+++ b/app/services/dashboard/eligibility_breakdown.rb
@@ -34,13 +34,15 @@ module Dashboard
 
     # Preload everything the per-project gate and breakdown touch so a dashboard
     # with many auto-pick repos doesn't devolve into an N+1:
-    #   - +account+ and +created_by+ feed +Issues::AutoPickProjectGate#effective_owner+.
-    #   - +created_by.user_setting+ feeds +#count_skip_labeled+ via
-    #     +Project#effective_auto_pick_skip_labels+ when a project inherits its
-    #     owner's skip labels.
+    #   - +account+ and +created_by+ feed +Issues::AutoPickProjectGate#effective_owner+
+    #     (created_by is used directly; account backs the orphaned fallback).
+    #   - +created_by.user_setting+ and +account.tenant_setting+ feed
+    #     +#count_skip_labeled+ via +Project#effective_auto_pick_skip_labels+,
+    #     which walks owner -> tenant when neither the project nor owner sets
+    #     skip labels.
     def auto_pick_projects
       @auto_pick_projects ||= Project
-        .includes(:account, created_by: :user_setting)
+        .includes(account: :tenant_setting, created_by: :user_setting)
         .where(
           account_id: user.account_id,
           created_by_id: visible_owner_ids,

--- a/app/services/dashboard/eligibility_breakdown.rb
+++ b/app/services/dashboard/eligibility_breakdown.rb
@@ -35,8 +35,12 @@ module Dashboard
     def auto_pick_projects
       @auto_pick_projects ||= Project
         .includes(:account)
-        .where(account_id: user.account_id, created_by_id: user.id,
-               auto_pick_enabled: true, active: true)
+        .where(
+          account_id: user.account_id,
+          created_by_id: visible_owner_ids,
+          auto_pick_enabled: true,
+          active: true
+        )
         .reject { |p| p.scheduler_paused? || p.quality_paused? || p.account&.scheduler_paused? }
     end
 
@@ -77,8 +81,23 @@ module Dashboard
       return 0 if labels.empty?
 
       excluded_scope.where(paid_state: %w[new planning failed analyzed])
-        .pluck(:labels)
-        .count { |issue_labels| (Array(issue_labels).map(&:downcase) & labels).any? }
+        .where(
+          <<~SQL.squish,
+            EXISTS (
+              SELECT 1
+              FROM jsonb_array_elements_text(issues.labels) AS label(value)
+              WHERE LOWER(label.value) IN (?)
+            )
+          SQL
+          labels.map(&:downcase)
+        )
+        .count
+    end
+
+    def visible_owner_ids
+      owner_ids = [ user.id ]
+      owner_ids << nil if AgentRun.orphaned_project_owner?(user)
+      owner_ids
     end
 
     def cache_key

--- a/app/services/dashboard/eligibility_breakdown.rb
+++ b/app/services/dashboard/eligibility_breakdown.rb
@@ -41,7 +41,7 @@ module Dashboard
           auto_pick_enabled: true,
           active: true
         )
-        .reject { |p| p.scheduler_paused? || p.quality_paused? || p.account&.scheduler_paused? }
+        .select { |p| Issues::AutoPickProjectGate.call(p) }
     end
 
     def breakdown_for(project)

--- a/app/views/dashboard/_eligibility_breakdown.html.erb
+++ b/app/views/dashboard/_eligibility_breakdown.html.erb
@@ -1,0 +1,63 @@
+<% if breakdowns.any? %>
+  <div class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+    <div class="flex items-center justify-between gap-4">
+      <div>
+        <h3 class="text-base font-semibold text-gray-900">Auto-Pick Eligibility</h3>
+        <p class="mt-1 text-sm text-gray-500">Why open issues are (or aren't) being picked up for automatic work.</p>
+      </div>
+    </div>
+
+    <div class="mt-4 divide-y divide-gray-200">
+      <% breakdowns.each do |bd| %>
+        <div class="py-3">
+          <div class="flex items-center justify-between gap-4">
+            <%= link_to bd.project.full_name, project_member_path(bd.project),
+              class: "text-sm font-medium text-gray-900 hover:text-indigo-600" %>
+            <span class="text-xs text-gray-400"><%= pluralize(bd.total_open, "open issue") %></span>
+          </div>
+          <div class="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">
+            <% if bd.eligible.positive? %>
+              <span class="inline-flex items-center gap-1 text-green-700">
+                <span class="h-1.5 w-1.5 rounded-full bg-green-500"></span>
+                <%= bd.eligible %> eligible
+              </span>
+            <% end %>
+            <% if bd.needs_input.positive? %>
+              <span class="inline-flex items-center gap-1 text-amber-700" title="Issues where Paid needs human clarification before proceeding">
+                <span class="h-1.5 w-1.5 rounded-full bg-amber-500"></span>
+                <%= bd.needs_input %> needs input
+              </span>
+            <% end %>
+            <% if bd.in_progress.positive? %>
+              <span class="inline-flex items-center gap-1 text-blue-700" title="Issues currently being worked on">
+                <span class="h-1.5 w-1.5 rounded-full bg-blue-500"></span>
+                <%= bd.in_progress %> in progress
+              </span>
+            <% end %>
+            <% if bd.skip_label.positive? %>
+              <span class="inline-flex items-center gap-1 text-gray-600" title="Issues with a skip label (planning, tracking, etc.)">
+                <span class="h-1.5 w-1.5 rounded-full bg-gray-400"></span>
+                <%= bd.skip_label %> skip-labeled
+              </span>
+            <% end %>
+            <% if bd.completed.positive? %>
+              <span class="inline-flex items-center gap-1 text-gray-600" title="Issues already completed (may have an open PR)">
+                <span class="h-1.5 w-1.5 rounded-full bg-gray-300"></span>
+                <%= bd.completed %> completed
+              </span>
+            <% end %>
+            <% if bd.other_excluded.positive? %>
+              <span class="inline-flex items-center gap-1 text-gray-600" title="Blocked by dependencies, tracker logic, retry limits, or other filters">
+                <span class="h-1.5 w-1.5 rounded-full bg-gray-400"></span>
+                <%= bd.other_excluded %> blocked/other
+              </span>
+            <% end %>
+            <% if bd.eligible.zero? && bd.total_open.positive? %>
+              <span class="text-gray-400">No eligible issues</span>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/dashboard/_eligibility_breakdown.html.erb
+++ b/app/views/dashboard/_eligibility_breakdown.html.erb
@@ -1,63 +1,65 @@
-<% if breakdowns.any? %>
-  <div class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
-    <div class="flex items-center justify-between gap-4">
-      <div>
-        <h3 class="text-base font-semibold text-gray-900">Auto-Pick Eligibility</h3>
-        <p class="mt-1 text-sm text-gray-500">Why open issues are (or aren't) being picked up for automatic work.</p>
+<%= turbo_frame_tag "dashboard-eligibility-breakdown" do %>
+  <% if breakdowns.any? %>
+    <div class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+      <div class="flex items-center justify-between gap-4">
+        <div>
+          <h3 class="text-base font-semibold text-gray-900">Auto-Pick Eligibility</h3>
+          <p class="mt-1 text-sm text-gray-500">Why open issues are (or aren't) being picked up for automatic work.</p>
+        </div>
+      </div>
+
+      <div class="mt-4 divide-y divide-gray-200">
+        <% breakdowns.each do |bd| %>
+          <div class="py-3">
+            <div class="flex items-center justify-between gap-4">
+              <%= link_to bd.project.full_name, project_member_path(bd.project),
+                class: "text-sm font-medium text-gray-900 hover:text-indigo-600" %>
+              <span class="text-xs text-gray-400"><%= pluralize(bd.total_open, "open issue") %></span>
+            </div>
+            <div class="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">
+              <% if bd.eligible.positive? %>
+                <span class="inline-flex items-center gap-1 text-green-700">
+                  <span class="h-1.5 w-1.5 rounded-full bg-green-500"></span>
+                  <%= bd.eligible %> eligible
+                </span>
+              <% end %>
+              <% if bd.needs_input.positive? %>
+                <span class="inline-flex items-center gap-1 text-amber-700" title="Issues where Paid needs human clarification before proceeding">
+                  <span class="h-1.5 w-1.5 rounded-full bg-amber-500"></span>
+                  <%= bd.needs_input %> needs input
+                </span>
+              <% end %>
+              <% if bd.in_progress.positive? %>
+                <span class="inline-flex items-center gap-1 text-blue-700" title="Issues currently being worked on">
+                  <span class="h-1.5 w-1.5 rounded-full bg-blue-500"></span>
+                  <%= bd.in_progress %> in progress
+                </span>
+              <% end %>
+              <% if bd.skip_label.positive? %>
+                <span class="inline-flex items-center gap-1 text-gray-600" title="Issues with a skip label (planning, tracking, etc.)">
+                  <span class="h-1.5 w-1.5 rounded-full bg-gray-400"></span>
+                  <%= bd.skip_label %> skip-labeled
+                </span>
+              <% end %>
+              <% if bd.completed.positive? %>
+                <span class="inline-flex items-center gap-1 text-gray-600" title="Issues already completed (may have an open PR)">
+                  <span class="h-1.5 w-1.5 rounded-full bg-gray-300"></span>
+                  <%= bd.completed %> completed
+                </span>
+              <% end %>
+              <% if bd.other_excluded.positive? %>
+                <span class="inline-flex items-center gap-1 text-gray-600" title="Blocked by dependencies, tracker logic, retry limits, or other filters">
+                  <span class="h-1.5 w-1.5 rounded-full bg-gray-400"></span>
+                  <%= bd.other_excluded %> blocked/other
+                </span>
+              <% end %>
+              <% if bd.eligible.zero? && bd.total_open.positive? %>
+                <span class="text-gray-400">No eligible issues</span>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
       </div>
     </div>
-
-    <div class="mt-4 divide-y divide-gray-200">
-      <% breakdowns.each do |bd| %>
-        <div class="py-3">
-          <div class="flex items-center justify-between gap-4">
-            <%= link_to bd.project.full_name, project_member_path(bd.project),
-              class: "text-sm font-medium text-gray-900 hover:text-indigo-600" %>
-            <span class="text-xs text-gray-400"><%= pluralize(bd.total_open, "open issue") %></span>
-          </div>
-          <div class="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">
-            <% if bd.eligible.positive? %>
-              <span class="inline-flex items-center gap-1 text-green-700">
-                <span class="h-1.5 w-1.5 rounded-full bg-green-500"></span>
-                <%= bd.eligible %> eligible
-              </span>
-            <% end %>
-            <% if bd.needs_input.positive? %>
-              <span class="inline-flex items-center gap-1 text-amber-700" title="Issues where Paid needs human clarification before proceeding">
-                <span class="h-1.5 w-1.5 rounded-full bg-amber-500"></span>
-                <%= bd.needs_input %> needs input
-              </span>
-            <% end %>
-            <% if bd.in_progress.positive? %>
-              <span class="inline-flex items-center gap-1 text-blue-700" title="Issues currently being worked on">
-                <span class="h-1.5 w-1.5 rounded-full bg-blue-500"></span>
-                <%= bd.in_progress %> in progress
-              </span>
-            <% end %>
-            <% if bd.skip_label.positive? %>
-              <span class="inline-flex items-center gap-1 text-gray-600" title="Issues with a skip label (planning, tracking, etc.)">
-                <span class="h-1.5 w-1.5 rounded-full bg-gray-400"></span>
-                <%= bd.skip_label %> skip-labeled
-              </span>
-            <% end %>
-            <% if bd.completed.positive? %>
-              <span class="inline-flex items-center gap-1 text-gray-600" title="Issues already completed (may have an open PR)">
-                <span class="h-1.5 w-1.5 rounded-full bg-gray-300"></span>
-                <%= bd.completed %> completed
-              </span>
-            <% end %>
-            <% if bd.other_excluded.positive? %>
-              <span class="inline-flex items-center gap-1 text-gray-600" title="Blocked by dependencies, tracker logic, retry limits, or other filters">
-                <span class="h-1.5 w-1.5 rounded-full bg-gray-400"></span>
-                <%= bd.other_excluded %> blocked/other
-              </span>
-            <% end %>
-            <% if bd.eligible.zero? && bd.total_open.positive? %>
-              <span class="text-gray-400">No eligible issues</span>
-            <% end %>
-          </div>
-        </div>
-      <% end %>
-    </div>
-  </div>
+  <% end %>
 <% end %>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -60,9 +60,12 @@
         <%= render "dashboard/queue_preview", queue_preview: @queue_preview, paused_projects: @quality_paused_projects %>
       </div>
 
-      <div class="mt-6">
-        <%= render "dashboard/eligibility_breakdown", breakdowns: @eligibility_breakdown %>
-      </div>
+      <turbo-frame id="dashboard-eligibility-breakdown"
+        data-dashboard-frames-target="frame"
+        data-dashboard-frames-src="<%= dashboard_eligibility_breakdown_path %>"
+        class="mt-6 block">
+        <div class="animate-pulse rounded-lg bg-gray-100 h-32"></div>
+      </turbo-frame>
 
       <div class="mt-6">
         <%= render "dashboard/retry_limited_issues", retry_limited_issues: @retry_limited_issues %>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -61,6 +61,10 @@
       </div>
 
       <div class="mt-6">
+        <%= render "dashboard/eligibility_breakdown", breakdowns: @eligibility_breakdown %>
+      </div>
+
+      <div class="mt-6">
         <%= render "dashboard/retry_limited_issues", retry_limited_issues: @retry_limited_issues %>
       </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
   get "dashboard/metrics", to: "dashboard#metrics", as: :dashboard_metrics
   get "dashboard/performance", to: "dashboard#performance", as: :dashboard_performance
   get "dashboard/decision_metrics", to: "dashboard#decision_metrics", as: :dashboard_decision_metrics
+  get "dashboard/eligibility_breakdown", to: "dashboard#eligibility_breakdown", as: :dashboard_eligibility_breakdown
   get "dashboard/runner_health", to: "dashboard#runner_health", as: :dashboard_runner_health
   get "dashboard/queue_health", to: "dashboard#queue_health", as: :dashboard_queue_health
   get "dashboard/github_health", to: "dashboard#github_health", as: :dashboard_github_health

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -1569,7 +1569,7 @@ RSpec.describe Issue do
     # Regression: "## Remaining work" is a common section heading in regular
     # implementation issues (describing what work the issue itself needs),
     # not a signal that the issue is a tracker/meta-issue. It caused false
-    # positives that silently excluded issues from auto-pick (#2844).
+    # positives that silently excluded issues from auto-pick.
     context "when 'remaining work' appears only in a body heading" do
       it "returns false for '## Remaining work' heading in a regular issue" do
         issue = build(:issue, title: "Implement observability stack",

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -1565,6 +1565,18 @@ RSpec.describe Issue do
         expect(issue.tracker_issue?).to be false
       end
     end
+
+    # Regression: "## Remaining work" is a common section heading in regular
+    # implementation issues (describing what work the issue itself needs),
+    # not a signal that the issue is a tracker/meta-issue. It caused false
+    # positives that silently excluded issues from auto-pick (#2844).
+    context "when 'remaining work' appears only in a body heading" do
+      it "returns false for '## Remaining work' heading in a regular issue" do
+        issue = build(:issue, title: "Implement observability stack",
+          body: "## Remaining work\n- Add Prometheus config\n- Add Grafana dashboard")
+        expect(issue.tracker_issue?).to be false
+      end
+    end
   end
 
   describe "#body_referenced_issue_numbers" do

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -180,6 +180,7 @@ RSpec.describe "Dashboard" do
         expect(doc.at_css("turbo-frame#dashboard-metrics[data-dashboard-frames-src='#{dashboard_metrics_path(time_range: "cumulative")}']")).to be_present
         expect(doc.at_css("turbo-frame#dashboard-performance[data-dashboard-frames-src='#{dashboard_performance_path(time_range: "cumulative", status: "all", goal: "all")}']")).to be_present
         expect(doc.at_css("turbo-frame#dashboard-decision-metrics[data-dashboard-frames-src='#{dashboard_decision_metrics_path(time_range: "cumulative")}']")).to be_present
+        expect(doc.at_css("turbo-frame#dashboard-eligibility-breakdown[data-dashboard-frames-src='#{dashboard_eligibility_breakdown_path}']")).to be_present
         expect(doc.at_css("turbo-frame#dashboard-auth-health[data-dashboard-frames-src='#{dashboard_auth_health_path}']")).to be_present
         expect(doc.at_css("turbo-frame#dashboard-knowledge-stats[data-dashboard-frames-src='#{dashboard_knowledge_stats_path}']")).to be_present
         expect(doc.at_css("turbo-frame#dashboard-runner-health[data-dashboard-frames-src='#{dashboard_runner_health_path}']")).to be_present
@@ -193,6 +194,7 @@ RSpec.describe "Dashboard" do
         expect(doc.at_css("turbo-frame#dashboard-metrics[loading]")).not_to be_present
         expect(doc.at_css("turbo-frame#dashboard-performance[loading]")).not_to be_present
         expect(doc.at_css("turbo-frame#dashboard-decision-metrics[loading]")).not_to be_present
+        expect(doc.at_css("turbo-frame#dashboard-eligibility-breakdown[loading]")).not_to be_present
         expect(doc.at_css("turbo-frame#dashboard-auth-health[loading]")).not_to be_present
         expect(doc.at_css("turbo-frame#dashboard-knowledge-stats[loading]")).not_to be_present
         expect(doc.at_css("turbo-frame#dashboard-runner-health[loading]")).not_to be_present
@@ -200,10 +202,19 @@ RSpec.describe "Dashboard" do
         expect(doc.at_css("turbo-frame#dashboard-metrics[src]")).not_to be_present
         expect(doc.at_css("turbo-frame#dashboard-performance[src]")).not_to be_present
         expect(doc.at_css("turbo-frame#dashboard-decision-metrics[src]")).not_to be_present
+        expect(doc.at_css("turbo-frame#dashboard-eligibility-breakdown[src]")).not_to be_present
         expect(doc.at_css("turbo-frame#dashboard-auth-health[src]")).not_to be_present
         expect(doc.at_css("turbo-frame#dashboard-knowledge-stats[src]")).not_to be_present
         expect(doc.at_css("turbo-frame#dashboard-runner-health[src]")).not_to be_present
         expect(doc.at_css("turbo-frame#dashboard-queue-health[src]")).not_to be_present
+      end
+
+      it "does not compute the eligibility breakdown during the dashboard shell request" do
+        allow(Dashboard::EligibilityBreakdown).to receive(:call).and_call_original
+
+        get dashboard_path
+
+        expect(Dashboard::EligibilityBreakdown).not_to have_received(:call)
       end
 
       it "renders runner health above queue health in the dashboard shell" do
@@ -729,6 +740,25 @@ RSpec.describe "Dashboard" do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("dashboard-knowledge-stats")
       expect(response.body).to include("Knowledge Base")
+    end
+  end
+
+  describe "GET /dashboard/eligibility_breakdown" do
+    let(:account) { create(:account) }
+    let(:user) { create(:user, account: account) }
+    let(:project) { create(:project, account: account, created_by: user, auto_pick_enabled: true, active: true) }
+
+    before { sign_in user }
+
+    it "returns the eligibility breakdown partial within a turbo frame" do
+      create(:issue, project: project, github_state: "open", paid_state: "new")
+
+      get dashboard_eligibility_breakdown_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("dashboard-eligibility-breakdown")
+      expect(response.body).to include("Auto-Pick Eligibility")
+      expect(response.body).to include(project.full_name)
     end
   end
 

--- a/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
+++ b/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
@@ -281,6 +281,16 @@ RSpec.describe Automation::Strategies::AutoPick::DefaultCandidateSource do
 
       expect(scope.pluck(:id)).to be_empty
     end
+
+    it "includes issues with a '## Remaining work' body heading and no issue references" do
+      issue = create(:issue, project: project,
+        title: "RDR-011: complete observability stack",
+        body: "## Remaining work\n- Add Prometheus config\n- Add Grafana dashboard")
+
+      scope = described_class.eligible_scope(project)
+
+      expect(scope.pluck(:id)).to include(issue.id)
+    end
   end
 
   describe ".eligible_issue_ids" do
@@ -329,6 +339,29 @@ RSpec.describe Automation::Strategies::AutoPick::DefaultCandidateSource do
       described_class.tracker_ids_blocked_by_open_references(scope, project)
 
       expect(DependencyBackfillJob).not_to have_received(:perform_later)
+    end
+
+    it "blocks a title-matched tracker with no body references" do
+      tracker = create(:issue, project: project, github_number: 1, title: "Phase 2 tracker",
+        body: "Some notes without issue references")
+
+      scope = Issue.where(id: tracker.id)
+
+      blocked = described_class.tracker_ids_blocked_by_open_references(scope, project)
+
+      expect(blocked).to include(tracker.id)
+    end
+
+    it "does not block a body-heading-matched tracker with no body references" do
+      issue = create(:issue, project: project, github_number: 1,
+        title: "Implement feature X",
+        body: "## Completion criteria\n- Add tests\n- Add docs")
+
+      scope = Issue.where(id: issue.id)
+
+      blocked = described_class.tracker_ids_blocked_by_open_references(scope, project)
+
+      expect(blocked).not_to include(issue.id)
     end
   end
 

--- a/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
+++ b/spec/services/automation/strategies/auto_pick/default_candidate_source_spec.rb
@@ -363,6 +363,18 @@ RSpec.describe Automation::Strategies::AutoPick::DefaultCandidateSource do
 
       expect(blocked).not_to include(issue.id)
     end
+
+    it "blocks a strong body-heading-matched tracker with no body references" do
+      issue = create(:issue, project: project, github_number: 1,
+        title: "Implement feature X",
+        body: "## Meta issue\nTracks all items")
+
+      scope = Issue.where(id: issue.id)
+
+      blocked = described_class.tracker_ids_blocked_by_open_references(scope, project)
+
+      expect(blocked).to include(issue.id)
+    end
   end
 
   describe "interface compliance" do

--- a/spec/services/dashboard/eligibility_breakdown_spec.rb
+++ b/spec/services/dashboard/eligibility_breakdown_spec.rb
@@ -107,6 +107,14 @@ RSpec.describe Dashboard::EligibilityBreakdown do
       expect(result).to eq([])
     end
 
+    it "excludes projects with no effective owner (auto-pick would always skip them)" do
+      allow(Issues::AutoPickProjectGate).to receive(:call).with(project).and_return(false)
+
+      result = described_class.call(user: user)
+
+      expect(result).to eq([])
+    end
+
     it "handles multiple projects in a single call" do
       project2 = create(:project, account: account, created_by: user,
         auto_pick_enabled: true, active: true, owner: "org", repo: "repo2")

--- a/spec/services/dashboard/eligibility_breakdown_spec.rb
+++ b/spec/services/dashboard/eligibility_breakdown_spec.rb
@@ -133,19 +133,25 @@ RSpec.describe Dashboard::EligibilityBreakdown do
           auto_pick_enabled: true, active: true, owner: "org", repo: "repo-#{i}")
       end
       # analyzable excluded issues force the skip-label lookup path, which is
-      # where a per-project +user_setting+ load would otherwise leak in.
+      # where a per-project +user_setting+/+tenant_setting+ load would leak in.
       ([ project ] + extra_projects).each do |p|
         create(:issue, project: p, github_state: "open", paid_state: "new")
       end
 
-      lazy_loads = capture_queries { described_class.call(user: user) }.count do |sql|
-        # Lazy belongs_to/has_one lookups are single-row
-        # SELECT ... WHERE col = $1; the eager preloads use WHERE col IN (...).
+      queries = capture_queries { described_class.call(user: user) }
+
+      # All projects share one owner, so a working preload issues owner/owner-
+      # setting queries at most once each. An N+1 would repeat the identical
+      # query once per project. Detect repeats rather than SQL shape: Rails
+      # collapses a single-value preload to `WHERE id = $1`, which is
+      # indistinguishable from a lazy belongs_to lookup by shape alone.
+      owner_queries = queries.select do |sql|
         sql.match?(/FROM "users" WHERE "users"\."id" = /) ||
           sql.match?(/FROM "user_settings" WHERE "user_settings"\."user_id" = /)
       end
+      max_repeats = owner_queries.tally.values.max.to_i
 
-      expect(lazy_loads).to eq(0)
+      expect(max_repeats).to be <= 1
     end
 
     it "includes orphaned projects for the account fallback owner" do

--- a/spec/services/dashboard/eligibility_breakdown_spec.rb
+++ b/spec/services/dashboard/eligibility_breakdown_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Dashboard::EligibilityBreakdown do
+  let(:user) { create(:user) }
+  let(:account) { user.account }
+  let!(:project) do
+    create(:project, account: account, created_by: user, auto_pick_enabled: true, active: true)
+  end
+
+  before { Rails.cache.clear }
+
+  describe ".call" do
+    it "returns an empty array when user has no auto-pick projects" do
+      project.update!(auto_pick_enabled: false)
+
+      result = described_class.call(user: user)
+
+      expect(result).to eq([])
+    end
+
+    it "returns a breakdown with correct counts" do
+      create(:issue, project: project, github_state: "open", paid_state: "new")
+      create(:issue, project: project, github_state: "open", paid_state: "new", labels: [ "tracking" ])
+      create(:issue, project: project, github_state: "open", paid_state: "needs_input")
+      create(:issue, project: project, github_state: "open", paid_state: "in_progress")
+      create(:issue, project: project, github_state: "open", paid_state: "completed")
+
+      result = described_class.call(user: user)
+
+      expect(result.size).to eq(1)
+      bd = result.first
+      expect(bd.project).to eq(project)
+      expect(bd.total_open).to eq(5)
+      expect(bd.eligible).to eq(1)
+      expect(bd.needs_input).to eq(1)
+      expect(bd.in_progress).to eq(1)
+      expect(bd.completed).to eq(1)
+      expect(bd.skip_label).to eq(1)
+      expect(bd.other_excluded).to eq(0)
+    end
+
+    it "counts dependency-blocked issues in other_excluded" do
+      blocker = create(:issue, project: project, github_state: "open", paid_state: "new")
+      create(:issue, project: project, github_state: "open", paid_state: "new") do |dependent|
+        create(:issue_dependency, issue: dependent, depends_on_issue: blocker)
+      end
+
+      result = described_class.call(user: user)
+
+      bd = result.first
+      expect(bd.eligible).to eq(1)
+      expect(bd.other_excluded).to eq(1)
+    end
+
+    it "does not double-count recoverable-completed issues in both eligible and completed" do
+      issue = create(:issue, project: project, github_state: "open", paid_state: "completed")
+      create(:agent_run, :completed, :automatic, project: project, issue: issue,
+        goal: "create_pr", auto_pick: true, pull_request_number: nil, pull_request_url: nil)
+
+      result = described_class.call(user: user)
+
+      bd = result.first
+      expect(bd.eligible).to eq(1)
+      expect(bd.completed).to eq(0)
+      expect(bd.total_open).to eq(1)
+    end
+
+    it "excludes scheduler-paused projects" do
+      project.update!(scheduler_paused_at: Time.current)
+
+      result = described_class.call(user: user)
+
+      expect(result).to eq([])
+    end
+
+    it "excludes account-level scheduler-paused projects" do
+      account.update!(scheduler_paused_at: Time.current)
+
+      result = described_class.call(user: user)
+
+      expect(result).to eq([])
+    end
+
+    it "excludes quality-paused projects" do
+      project.update!(quality_paused_at: Time.current)
+
+      result = described_class.call(user: user)
+
+      expect(result).to eq([])
+    end
+
+    it "excludes inactive projects" do
+      project.update!(active: false)
+
+      result = described_class.call(user: user)
+
+      expect(result).to eq([])
+    end
+
+    it "handles multiple projects in a single call" do
+      project2 = create(:project, account: account, created_by: user,
+        auto_pick_enabled: true, active: true, owner: "org", repo: "repo2")
+      create(:issue, project: project, github_state: "open", paid_state: "new")
+      create(:issue, project: project2, github_state: "open", paid_state: "new")
+
+      result = described_class.call(user: user)
+
+      expect(result.size).to eq(2)
+      expect(result.map { |bd| bd.project.id }).to contain_exactly(project.id, project2.id)
+    end
+  end
+end

--- a/spec/services/dashboard/eligibility_breakdown_spec.rb
+++ b/spec/services/dashboard/eligibility_breakdown_spec.rb
@@ -127,6 +127,27 @@ RSpec.describe Dashboard::EligibilityBreakdown do
       expect(result.map { |bd| bd.project.id }).to contain_exactly(project.id, project2.id)
     end
 
+    it "does not issue a per-project query for owner or owner settings (no N+1)" do
+      extra_projects = Array.new(3) do |i|
+        create(:project, account: account, created_by: user,
+          auto_pick_enabled: true, active: true, owner: "org", repo: "repo-#{i}")
+      end
+      # analyzable excluded issues force the skip-label lookup path, which is
+      # where a per-project +user_setting+ load would otherwise leak in.
+      ([ project ] + extra_projects).each do |p|
+        create(:issue, project: p, github_state: "open", paid_state: "new")
+      end
+
+      lazy_loads = capture_queries { described_class.call(user: user) }.count do |sql|
+        # Lazy belongs_to/has_one lookups are single-row
+        # SELECT ... WHERE col = $1; the eager preloads use WHERE col IN (...).
+        sql.match?(/FROM "users" WHERE "users"\."id" = /) ||
+          sql.match?(/FROM "user_settings" WHERE "user_settings"\."user_id" = /)
+      end
+
+      expect(lazy_loads).to eq(0)
+    end
+
     it "includes orphaned projects for the account fallback owner" do
       orphaned_project = create(:project, :without_creator, account: account,
         auto_pick_enabled: true, active: true, owner: "octo", repo: "orphaned")

--- a/spec/services/dashboard/eligibility_breakdown_spec.rb
+++ b/spec/services/dashboard/eligibility_breakdown_spec.rb
@@ -3,6 +3,14 @@
 require "rails_helper"
 
 RSpec.describe Dashboard::EligibilityBreakdown do
+  around do |example|
+    original_store = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    example.run
+  ensure
+    Rails.cache = original_store
+  end
+
   let(:user) { create(:user) }
   let(:account) { user.account }
   let!(:project) do
@@ -109,6 +117,42 @@ RSpec.describe Dashboard::EligibilityBreakdown do
 
       expect(result.size).to eq(2)
       expect(result.map { |bd| bd.project.id }).to contain_exactly(project.id, project2.id)
+    end
+
+    it "includes orphaned projects for the account fallback owner" do
+      orphaned_project = create(:project, :without_creator, account: account,
+        auto_pick_enabled: true, active: true, owner: "octo", repo: "orphaned")
+      create(:issue, project: orphaned_project, github_state: "open", paid_state: "new")
+
+      result = described_class.call(user: user)
+
+      expect(result.map { |bd| bd.project.id }).to contain_exactly(project.id, orphaned_project.id)
+    end
+
+    it "hides orphaned projects from non-fallback users" do
+      non_fallback_user = create(:user, account: account)
+      non_fallback_project = create(:project, account: account, created_by: non_fallback_user,
+        auto_pick_enabled: true, active: true, owner: "octo", repo: "owned")
+      orphaned_project = create(:project, :without_creator, account: account,
+        auto_pick_enabled: true, active: true, owner: "octo", repo: "orphaned")
+      create(:issue, project: non_fallback_project, github_state: "open", paid_state: "new")
+      create(:issue, project: orphaned_project, github_state: "open", paid_state: "new")
+
+      result = described_class.call(user: non_fallback_user)
+
+      expect(result.map { |bd| bd.project.id }).to eq([ non_fallback_project.id ])
+    end
+
+    it "reuses the cached breakdown on repeat page loads" do
+      create(:issue, project: project, github_state: "open", paid_state: "new")
+      allow(Automation::Strategies::AutoPick::DefaultCandidateSource)
+        .to receive(:eligible_scope).and_call_original
+
+      described_class.call(user: user)
+      described_class.call(user: user)
+
+      expect(Automation::Strategies::AutoPick::DefaultCandidateSource)
+        .to have_received(:eligible_scope).once
     end
   end
 end


### PR DESCRIPTION
## Summary

16 open issues in the `paid` repo were silently excluded from auto-pick because their bodies contained a `## Remaining work` heading — a common section in regular implementation issues, not a tracker signal. The dashboard had no visibility into why issues weren't being picked, making this impossible to diagnose without console access.

## Changes

**Fix tracker false-positive** (`issue.rb`, `default_candidate_source.rb`)

- Removed `remaining\s+work` from `TRACKER_BODY_HEADING_PATTERN`. The phrase is a standard section heading in feature/bug issues (describing what work the issue itself needs). It remains in the title pattern (`TRACKER_PATTERN`), where "Remaining work for phase 2" is a stronger tracker indicator.
- Narrowed the "no body refs" conservative blocking to only apply when the issue **title** matches tracker vocabulary. Body-heading-only matches (e.g. `## Completion criteria` with no `#NNN` refs) are now allowed through, since they're prone to false positives in regular issues.

**Add dashboard eligibility breakdown** (`eligibility_breakdown.rb`, `_eligibility_breakdown.html.erb`)

- New widget on the dashboard showing per-project counts: eligible, needs input, in progress, skip-labeled, completed, and blocked/other.
- Cached at 15s TTL (matching `QueuePreview` and `LiveStats` patterns) to avoid running the expensive `eligible_scope` query on every page load.
- Buckets are computed from non-eligible issues only (`where.not(id: eligible_ids)`) to guarantee disjoint counts — no double-counting between eligible and recoverable-completed issues.
- Quality-paused and scheduler-paused projects are excluded, matching `AutoPickProjectGate`.

## Test plan

- [ ] Tracker: `## Remaining work` body heading no longer triggers `tracker_issue?`
- [ ] Tracker: title-matched trackers with no refs still blocked; body-heading-only with no refs now allowed
- [ ] Dashboard: correct counts across all categories with disjoint buckets
- [ ] Dashboard: recoverable-completed issues not double-counted
- [ ] Dashboard: quality-paused, scheduler-paused, and inactive projects excluded
- [ ] Dashboard: caching prevents query storm on repeat page loads

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/Opencode-4285F4?logo=googlegemini&logoColor=white)
