### PR TITLE
fix(pr-description): retry LLM generation and use deterministic fallback

### DIFF
--- a/app/services/llm/generate_pr_description.rb
+++ b/app/services/llm/generate_pr_description.rb
@@ -6,8 +6,11 @@ module Llm
   # full scope, and surfaces design decisions — following the guidelines in
   # GitHub issue #581.
   #
-  # Raises on LLM errors so the caller can log with full context (e.g.
-  # agent_run_id, issue_number) and fall back to the raw agent summary.
+  # Transient errors (provider failures, timeouts, rate limits) are retried
+  # up to MAX_ATTEMPTS times with exponential backoff. After exhausting
+  # retries the method returns nil so the caller can fall back to a
+  # deterministic description. Non-retryable errors (auth, configuration)
+  # and unexpected errors propagate to the caller for contextual logging.
   #
   # @example
   #   body = Llm::GeneratePrDescription.call(
@@ -23,6 +26,14 @@ module Llm
     MAX_SUMMARY_INPUT = 20_000
     MAX_ISSUE_BODY_INPUT = 4_000
     TIMEOUT = 30
+    MAX_ATTEMPTS = 3
+    RETRY_DELAYS = [ 2, 4 ].freeze
+
+    RETRYABLE_ERRORS = [
+      AgentHarness::ProviderError,
+      AgentHarness::TimeoutError,
+      AgentHarness::RateLimitError
+    ].freeze
 
     PROMPT_SLUG = "generation.pr_description"
 
@@ -77,6 +88,23 @@ module Llm
     private
 
     def request_description
+      MAX_ATTEMPTS.times do |attempt|
+        outcome = attempt_single_request
+        return outcome[:description] if outcome[:done]
+
+        break if attempt == MAX_ATTEMPTS - 1
+
+        log_retry(attempt, outcome[:error])
+        sleep RETRY_DELAYS[attempt] || RETRY_DELAYS.last
+      end
+
+      nil
+    end
+
+    # Returns a hash with :done (true when the result is final — success or
+    # empty-but-successful) and :description (the text, or nil). When :done
+    # is false the caller should retry.
+    def attempt_single_request
       response = AgentHarness.send_message(
         prompt,
         provider: :claude,
@@ -85,9 +113,23 @@ module Llm
         tools: :none,
         **TextMode.options
       )
-      return nil unless response.success?
 
-      normalize_output(response.output).presence
+      if response.success?
+        { done: true, description: normalize_output(response.output).presence }
+      else
+        { done: false, error: "LLM response unsuccessful: #{response.error}" }
+      end
+    rescue *RETRYABLE_ERRORS => e
+      { done: false, error: "#{e.class.name}: #{e.message}" }
+    end
+
+    def log_retry(attempt, error)
+      Rails.logger.info(
+        message: "llm.generate_pr_description_retrying",
+        attempt: attempt + 2,
+        max_attempts: MAX_ATTEMPTS,
+        error: error
+      )
     end
 
     def normalize_output(text)

--- a/app/temporal/activities/create_pull_request_activity.rb
+++ b/app/temporal/activities/create_pull_request_activity.rb
@@ -4,8 +4,6 @@ module Activities
   class CreatePullRequestActivity < BaseActivity
     activity_name "CreatePullRequest"
 
-    MAX_FALLBACK_SUMMARY_LENGTH = 10_000
-
     def execute(input)
       agent_run_id = input[:agent_run_id]
       agent_run = AgentRun.find(agent_run_id)
@@ -213,7 +211,7 @@ module Activities
       body = if template
         render_pr_template(template, issue, agent_run, description, quality_warnings)
       else
-        build_default_pr_body(issue, description, summary: summary, quality_warnings: quality_warnings)
+        build_default_pr_body(issue, description, quality_warnings: quality_warnings)
       end
 
       {
@@ -222,13 +220,13 @@ module Activities
       }
     end
 
-    def build_default_pr_body(issue, description, summary: nil, quality_warnings: nil)
+    def build_default_pr_body(issue, description, quality_warnings: nil)
       parts = []
 
       if description.present?
         parts << description
       else
-        parts << fallback_body(issue, summary: summary)
+        parts << fallback_body(issue)
       end
 
       if quality_warnings.present?
@@ -303,14 +301,14 @@ module Activities
       metadata["output_preview"].to_s
     end
 
-    def fallback_body(issue, summary: nil)
-      parts = []
-      parts << "## Summary"
-      parts << ""
+    # Deterministic fallback used when the LLM description generator fails or
+    # returns nothing. Never uses raw agent stdout — that output may contain
+    # debugging commentary, error-chasing notes, or other non-summary text
+    # that is unsuitable as a PR description (see PR #2859).
+    def fallback_body(issue)
+      parts = [ "## Summary", "" ]
 
-      if suitable_fallback_summary?(summary)
-        parts << summary.truncate(MAX_FALLBACK_SUMMARY_LENGTH, omission: "\n\n[truncated]")
-      elsif issue
+      if issue
         parts << issue.title
         parts << ""
         parts << "See ##{issue.github_number} for context."
@@ -319,14 +317,6 @@ module Activities
       end
 
       parts.join("\n")
-    end
-
-    def suitable_fallback_summary?(text)
-      return false if text.blank?
-      return false if text.start_with?("{", "[")
-      return false if text.start_with?("Agent encountered an error:")
-
-      true
     end
 
     def generate_description(summary, issue, agent_run_id:)

--- a/app/temporal/workflows/agent_execution_workflow.rb
+++ b/app/temporal/workflows/agent_execution_workflow.rb
@@ -349,7 +349,7 @@ module Workflows
           else
             # Step 6: Create PR
             pr_result = run_activity(Activities::CreatePullRequestActivity,
-              { agent_run_id: agent_run_id }, timeout: 60)
+              { agent_run_id: agent_run_id }, timeout: 120)
 
             unless pr_result[:skipped] || pr_result[:pull_request_url].blank?
               # Step 7: Update issue with PR link

--- a/spec/services/llm/generate_pr_description_spec.rb
+++ b/spec/services/llm/generate_pr_description_spec.rb
@@ -3,7 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Llm::GeneratePrDescription do
-  before { allow(Llm::TextMode).to receive(:options).and_return(mode: :text) }
+  before do
+    allow(Llm::TextMode).to receive(:options).and_return(mode: :text)
+    allow_any_instance_of(described_class).to receive(:sleep) # rubocop:disable RSpec/AnyInstance
+  end
 
   let(:agent_summary) { "Added OAuth middleware and user session management." }
   let(:issue_title) { "Add OAuth support" }
@@ -130,13 +133,14 @@ RSpec.describe Llm::GeneratePrDescription do
       expect(described_class.call(agent_summary: nil)).to be_nil
     end
 
-    it "returns nil when agent_harness returns a failed response" do
-      response = instance_double(AgentHarness::Response, success?: false, output: "")
+    it "returns nil when agent_harness returns a failed response after exhausting retries" do
+      response = instance_double(AgentHarness::Response, success?: false, output: "", error: "overloaded")
       allow(AgentHarness).to receive(:send_message).and_return(response)
 
       result = described_class.call(agent_summary: agent_summary)
 
       expect(result).to be_nil
+      expect(AgentHarness).to have_received(:send_message).exactly(described_class::MAX_ATTEMPTS).times
     end
 
     it "returns nil when output is blank" do
@@ -148,22 +152,79 @@ RSpec.describe Llm::GeneratePrDescription do
       expect(result).to be_nil
     end
 
-    it "lets AgentHarness errors propagate to the caller for contextual logging" do
+    it "retries on ProviderError and returns nil after exhausting attempts" do
       allow(AgentHarness).to receive(:send_message)
         .and_raise(AgentHarness::ProviderError.new("Provider unavailable"))
 
-      expect {
-        described_class.call(agent_summary: agent_summary)
-      }.to raise_error(AgentHarness::ProviderError)
+      result = described_class.call(agent_summary: agent_summary)
+
+      expect(result).to be_nil
+      expect(AgentHarness).to have_received(:send_message).exactly(described_class::MAX_ATTEMPTS).times
     end
 
-    it "lets timeout errors propagate to the caller for contextual logging" do
+    it "retries on TimeoutError and returns nil after exhausting attempts" do
       allow(AgentHarness).to receive(:send_message)
         .and_raise(AgentHarness::TimeoutError.new("Timed out"))
 
+      result = described_class.call(agent_summary: agent_summary)
+
+      expect(result).to be_nil
+      expect(AgentHarness).to have_received(:send_message).exactly(described_class::MAX_ATTEMPTS).times
+    end
+
+    it "retries on RateLimitError and returns nil after exhausting attempts" do
+      allow(AgentHarness).to receive(:send_message)
+        .and_raise(AgentHarness::RateLimitError.new("Rate limited"))
+
+      result = described_class.call(agent_summary: agent_summary)
+
+      expect(result).to be_nil
+      expect(AgentHarness).to have_received(:send_message).exactly(described_class::MAX_ATTEMPTS).times
+    end
+
+    it "succeeds when a transient failure is followed by success on retry" do
+      failed = instance_double(AgentHarness::Response, success?: false, output: "", error: "overloaded")
+      success = instance_double(AgentHarness::Response, success?: true, output: generated_description)
+      allow(AgentHarness).to receive(:send_message)
+        .and_return(failed, success)
+
+      result = described_class.call(agent_summary: agent_summary)
+
+      expect(result).to eq(generated_description.strip)
+      expect(AgentHarness).to have_received(:send_message).twice
+    end
+
+    it "succeeds when a raised exception is followed by success on retry" do
+      success = instance_double(AgentHarness::Response, success?: true, output: generated_description)
+      attempts = 0
+      allow(AgentHarness).to receive(:send_message) do
+        attempts += 1
+        raise AgentHarness::ProviderError.new("Provider unavailable") if attempts == 1
+        success
+      end
+
+      result = described_class.call(agent_summary: agent_summary)
+
+      expect(result).to eq(generated_description.strip)
+      expect(AgentHarness).to have_received(:send_message).twice
+    end
+
+    it "does not retry when a successful response has blank output" do
+      response = instance_double(AgentHarness::Response, success?: true, output: "  \n  ")
+      allow(AgentHarness).to receive(:send_message).and_return(response)
+
+      described_class.call(agent_summary: agent_summary)
+
+      expect(AgentHarness).to have_received(:send_message).once
+    end
+
+    it "lets non-retryable AgentHarness errors propagate to the caller" do
+      allow(AgentHarness).to receive(:send_message)
+        .and_raise(AgentHarness::AuthenticationError.new("Invalid key"))
+
       expect {
         described_class.call(agent_summary: agent_summary)
-      }.to raise_error(AgentHarness::TimeoutError)
+      }.to raise_error(AgentHarness::AuthenticationError)
     end
 
     it "truncates long agent summaries in the prompt" do

--- a/spec/temporal/activities/create_pull_request_activity_spec.rb
+++ b/spec/temporal/activities/create_pull_request_activity_spec.rb
@@ -39,9 +39,10 @@ RSpec.describe Activities::CreatePullRequestActivity do
     )
     allow(github_client).to receive(:add_labels_to_issue)
     # Stub external agent harness so Llm::GeneratePrDescription runs without real external calls.
-    # By default, return a failed response so the activity falls back to raw summary.
+    # By default, return a failed response so the activity falls back to a deterministic description.
     allow(AgentHarness).to receive(:send_message)
-      .and_return(instance_double(AgentHarness::Response, success?: false, output: ""))
+      .and_return(instance_double(AgentHarness::Response, success?: false, output: "", error: nil))
+    allow_any_instance_of(Llm::GeneratePrDescription).to receive(:sleep) # rubocop:disable RSpec/AnyInstance
   end
 
   describe "#execute" do
@@ -222,19 +223,21 @@ RSpec.describe Activities::CreatePullRequestActivity do
       expect(log.content).to include("https://github.com/owner/repo/pull/42")
     end
 
-    it "uses agent summary as fallback body when LLM description is nil" do
+    it "uses deterministic fallback body when LLM description is nil" do
       agent_run.log!("stdout", "Here are the changes I made to fix the issue.")
 
-      expect(github_client).to receive(:create_pull_request).with(
-        anything,
-        hash_including(
-          body: a_string_including("## Summary")
-            .and(including("Here are the changes I made to fix the issue."))
-            .and(including("Closes ##{issue.github_number}"))
-        )
-      ).and_return(pr_response)
+      captured_body = nil
+      allow(github_client).to receive(:create_pull_request) do |*_args, **kwargs|
+        captured_body = kwargs[:body]
+        pr_response
+      end
 
       activity.execute(agent_run_id: agent_run.id)
+
+      expect(captured_body).to include("## Summary")
+      expect(captured_body).to include(issue.title)
+      expect(captured_body).to include("Closes ##{issue.github_number}")
+      expect(captured_body).not_to include("Here are the changes I made to fix the issue.")
     end
 
     it "does not use raw JSON as fallback body" do
@@ -459,27 +462,26 @@ RSpec.describe Activities::CreatePullRequestActivity do
         )
       end
 
-      it "falls back to agent summary when LLM runner fails and logs with context" do
+      it "falls back to issue-title description when LLM retries are exhausted" do
         agent_run.log!("stdout", "Raw agent output here")
         allow(AgentHarness).to receive(:send_message)
           .and_raise(AgentHarness::ProviderError.new("Provider unavailable"))
         mock_logger = instance_double(ActiveSupport::Logger, info: nil)
         allow(activity).to receive(:logger).and_return(mock_logger)
         expect(mock_logger).to receive(:warn).with(hash_including(
-          message: "agent_execution.pr_description_failed",
+          message: "agent_execution.pr_description_llm_unsuccessful",
           agent_run_id: agent_run.id,
-          issue_number: issue.github_number,
-          error_class: "AgentHarness::ProviderError"
+          issue_number: issue.github_number
         ))
         expect(github_client).to receive(:create_pull_request).with(
           anything,
-          hash_including(body: a_string_including("Raw agent output here"))
+          hash_including(body: a_string_including(issue.title))
         ).and_return(pr_response)
 
         activity.execute(agent_run_id: agent_run.id)
       end
 
-      it "falls back to agent summary when LLM raises an unexpected error and logs with context" do
+      it "falls back to issue-title description when LLM raises a non-retryable error" do
         agent_run.log!("stdout", "Raw agent output here")
         allow(AgentHarness).to receive(:send_message)
           .and_raise(RuntimeError.new("unexpected failure"))
@@ -493,26 +495,26 @@ RSpec.describe Activities::CreatePullRequestActivity do
         ))
         expect(github_client).to receive(:create_pull_request).with(
           anything,
-          hash_including(body: a_string_including("Raw agent output here"))
+          hash_including(body: a_string_including(issue.title))
         ).and_return(pr_response)
 
         activity.execute(agent_run_id: agent_run.id)
       end
 
-      it "falls back to agent summary when LLM returns a failed response" do
+      it "falls back to issue-title description when LLM returns a failed response after retries" do
         agent_run.log!("stdout", "Raw agent output here")
 
         expect(github_client).to receive(:create_pull_request).with(
           anything,
           hash_including(
-            body: a_string_including("Raw agent output here")
+            body: a_string_including(issue.title)
           )
         ).and_return(pr_response)
 
         activity.execute(agent_run_id: agent_run.id)
       end
 
-      it "does not record a PR description metric when the LLM call raises" do
+      it "does not record a PR description metric when LLM retries are exhausted" do
         agent_run.log!("stdout", "Raw agent output here")
         allow(AgentHarness).to receive(:send_message)
           .and_raise(AgentHarness::ProviderError.new("Provider unavailable"))


### PR DESCRIPTION
## Summary

When the LLM PR-description generator failed, the fallback used raw agent stdout as the PR body — which could contain debugging commentary, error-chasing notes, or mid-run status updates instead of a coherent change summary (see PR #2859 for a real example where the agent's internal debugging about a test deadlock became the PR description).

This gives the LLM multiple attempts to succeed before falling back to a safe, deterministic description built from the issue title.

## Changes

- **Retry transient failures in `GeneratePrDescription`**: 3 attempts with exponential backoff (2s, 4s) on `ProviderError`, `TimeoutError`, and `RateLimitError`. Non-retryable errors still propagate. Successful-but-empty responses are not retried (the LLM responded; retrying won't help).
- **Deterministic fallback**: When all retries are exhausted, the PR body uses the issue title + a reference link — never raw agent stdout. This eliminates the class of bug where debugging output, JSON envelopes, or error messages leak into PR descriptions.
- **Activity timeout**: Bumped CreatePullRequest from 60s to 120s to accommodate worst-case retry timing (3×30s + 6s backoff = 96s).

Closes #2859
