### PR TITLE
chore: set Rails time zone to Pacific Time

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -59,7 +59,7 @@ module Paid
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Pacific Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Don't generate system test files.


### PR DESCRIPTION
## Summary

Sets the application time zone from the default UTC to Pacific Time (US & Canada) by uncommenting and updating `config.time_zone` in `config/application.rb`.

## Rationale

Aligns the app's default time zone with the team's local Pacific Time for consistent display of timestamps.