### PR TITLE
fix(github-client): self-heal stale App installation tokens on 401 (RDR-030)

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1108,10 +1108,32 @@ class Project < ApplicationRecord
   def client
     @client ||= if github_installation_id.present? || github_installation.present?
       credential = github_credential
-      credential.present? ? GithubClient.new(token: credential, health_endpoint: github_health_endpoint) : nil
+      credential.present? ? GithubClient.new(
+        token: credential,
+        health_endpoint: github_health_endpoint,
+        token_refresher: installation_token_refresher
+      ) : nil
     else
       github_token&.client
     end
+  end
+
+  # Returns a proc that clears the cached App installation token and mints
+  # a fresh one. Passed to +GithubClient+ so a 401 mid-request triggers a
+  # transparent re-mint instead of a hard failure (RDR-030).
+  def installation_token_refresher
+    return nil unless github_installation_id.present? || github_installation.present?
+
+    installation = github_installation
+    repo_name = full_name
+
+    -> {
+      Github::AppInstallation.clear_cached_token(
+        installation_id: installation.github_installation_id,
+        repo_full_name: repo_name
+      )
+      github_credential
+    }
   end
 
   def github_health_endpoint

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -148,6 +148,17 @@ class Project < ApplicationRecord
     [ "All PRs", "all" ]
   ].freeze
 
+  # Bots whose PRs are trusted for automation when the project is configured
+  # to auto-merge dependabot PRs. Their output is structured and predictable,
+  # so granting author trust (not comment trust — #trusted_github_user?
+  # deliberately excludes bots) is safe and enables the full scan → fix →
+  # merge loop on their PRs.
+  DEPENDENCY_UPDATE_BOT_AUTHORS = %w[
+    dependabot[bot]
+    dependabot-preview[bot]
+    renovate[bot]
+  ].freeze
+
   AUTO_RELEASE_GRANULARITY_OPTIONS = [
     [ "Off", "off" ],
     [ "Patch only", "patch_only" ],
@@ -489,6 +500,7 @@ class Project < ApplicationRecord
     logins = Array(allowed_github_usernames).filter_map { |name| name.to_s.downcase.presence }
     bot_author = github_author_login&.downcase
     logins << bot_author if bot_author
+    logins.concat(DEPENDENCY_UPDATE_BOT_AUTHORS) if auto_merge_dependabot?
     logins.uniq
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -148,11 +148,10 @@ class Project < ApplicationRecord
     [ "All PRs", "all" ]
   ].freeze
 
-  # Bots whose PRs are trusted for automation when the project is configured
-  # to auto-merge dependabot PRs. Their output is structured and predictable,
-  # so granting author trust (not comment trust — #trusted_github_user?
-  # deliberately excludes bots) is safe and enables the full scan → fix →
-  # merge loop on their PRs.
+  # Bots whose PRs may be admitted by scoped automation paths when the project
+  # is configured to auto-merge dependency updates. They are deliberately not
+  # added to #trusted_github_author_logins because that global author trust also
+  # controls issue sync, auto-pick, and prompt-building eligibility.
   DEPENDENCY_UPDATE_BOT_AUTHORS = %w[
     dependabot[bot]
     dependabot-preview[bot]
@@ -487,12 +486,10 @@ class Project < ApplicationRecord
   # for Paid to pick up and work on it. The human allowlist plus, for GitHub
   # App projects, the app's own bot identity (implicit, never stored in
   # allowed_github_usernames), so Paid can act on issues/PRs its own bot
-  # opens. When dependabot auto-merge is enabled this also admits the
-  # dependency-update bot author set for AUTHORSHIP trust only, so automation
-  # scans can queue follow-up repair runs on those PRs. Broader than
-  # #trusted_github_user? on purpose: author trust controls pickup/queueing,
-  # while comment trust stays human-only. All logins are downcased for
-  # case-insensitive comparison.
+  # opens. Broader than #trusted_github_user? on purpose: author trust controls
+  # pickup/queueing, while comment trust stays human-only. Dependency-update
+  # bots are admitted by scoped PR-scan authorization instead of this global
+  # list. All logins are downcased for case-insensitive comparison.
   #
   # Uses github_author_login (the "[bot]" form, e.g. "paid-agents[bot]"),
   # which is the only login GitHub ever reports as the author of app-created
@@ -503,7 +500,6 @@ class Project < ApplicationRecord
     logins = Array(allowed_github_usernames).filter_map { |name| name.to_s.downcase.presence }
     bot_author = github_author_login&.downcase
     logins << bot_author if bot_author
-    logins.concat(DEPENDENCY_UPDATE_BOT_AUTHORS) if auto_merge_dependabot?
     logins.uniq
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -487,9 +487,12 @@ class Project < ApplicationRecord
   # for Paid to pick up and work on it. The human allowlist plus, for GitHub
   # App projects, the app's own bot identity (implicit, never stored in
   # allowed_github_usernames), so Paid can act on issues/PRs its own bot
-  # opens. Broader than #trusted_github_user? on purpose: the bot may author
-  # work Paid acts on, but its comments are never trusted human input. All
-  # logins are downcased for case-insensitive comparison.
+  # opens. When dependabot auto-merge is enabled this also admits the
+  # dependency-update bot author set for AUTHORSHIP trust only, so automation
+  # scans can queue follow-up repair runs on those PRs. Broader than
+  # #trusted_github_user? on purpose: author trust controls pickup/queueing,
+  # while comment trust stays human-only. All logins are downcased for
+  # case-insensitive comparison.
   #
   # Uses github_author_login (the "[bot]" form, e.g. "paid-agents[bot]"),
   # which is the only login GitHub ever reports as the author of app-created

--- a/app/services/automation/providers/github/base_adapter.rb
+++ b/app/services/automation/providers/github/base_adapter.rb
@@ -67,10 +67,13 @@ module Automation
         end
 
         # Wraps a GitHub API call, translating {::GithubClient} error classes
-        # into this adapter's ProviderError. Unknown errors propagate so
-        # that genuine bugs do not masquerade as provider failures.
+        # into this adapter's ProviderError. AuthenticationError is deliberately
+        # excluded so callers can distinguish auth failures (which warrant
+        # escalation) from transient provider errors (which warrant retry/skip).
         def with_errors
           yield
+        rescue ::GithubClient::AuthenticationError
+          raise
         rescue ::GithubClient::Error => e
           raise provider_error_class, e.message
         end

--- a/app/services/automation/signals/pull_request_collector.rb
+++ b/app/services/automation/signals/pull_request_collector.rb
@@ -54,6 +54,8 @@ module Automation
         return [] unless pr_data
 
         client.check_runs_for_ref(providers.repo, pr_data.head.sha)
+      rescue GithubClient::AuthenticationError
+        raise
       rescue GithubClient::Error => e
         logger.warn(
           message: "pr_scanner.ci_check_failed",
@@ -145,6 +147,8 @@ module Automation
         return nil if sha.nil?
 
         client.commit(providers.repo, sha)&.commit&.committer&.date
+      rescue GithubClient::AuthenticationError
+        raise
       rescue GithubClient::Error => e
         log_signal_error("fetch_head_commit", issue, e)
         nil

--- a/app/services/automation/workflow_decision_executor.rb
+++ b/app/services/automation/workflow_decision_executor.rb
@@ -9,6 +9,7 @@ module Automation
     def initialize(workflow:, project_id:)
       @workflow = workflow
       @project_id = project_id
+      @create_pr_queue_results = {}
     end
 
     def call(result)
@@ -22,7 +23,26 @@ module Automation
     attr_reader :workflow, :project_id
 
     def execute(decision)
-      workflow.execute_automation_decision(project_id:, decision:)
+      return skip_record_pr_followup?(decision) if decision[:type] == "record_pr_followup"
+
+      result = workflow.execute_automation_decision(project_id:, decision:)
+      record_create_pr_queue_result(decision, result)
+      result
+    end
+
+    def record_create_pr_queue_result(decision, result)
+      return unless decision[:type] == "queue_create_pr_run"
+
+      @create_pr_queue_results[decision[:issue_id]] = result || {}
+    end
+
+    def skip_record_pr_followup?(decision)
+      queue_result = @create_pr_queue_results[decision[:issue_id]]
+      return workflow.execute_automation_decision(project_id:, decision:) unless queue_result
+      return workflow.execute_automation_decision(project_id:, decision:) if queue_result[:queued]
+      return workflow.execute_automation_decision(project_id:, decision:) unless queue_result[:cross_goal]
+
+      nil
     end
   end
 end

--- a/app/services/automation/workflow_decision_executor.rb
+++ b/app/services/automation/workflow_decision_executor.rb
@@ -33,12 +33,15 @@ module Automation
     def record_create_pr_queue_result(decision, result)
       return unless decision[:type] == "queue_create_pr_run"
 
-      @create_pr_queue_results[decision[:issue_id]] = result || {}
+      @create_pr_queue_results[decision[:issue_id]] = result
     end
 
     def skip_record_pr_followup?(decision)
-      queue_result = @create_pr_queue_results[decision[:issue_id]]
-      return workflow.execute_automation_decision(project_id:, decision:) unless queue_result
+      issue_id = decision[:issue_id]
+      return workflow.execute_automation_decision(project_id:, decision:) unless @create_pr_queue_results.key?(issue_id)
+
+      queue_result = @create_pr_queue_results[issue_id]
+      return nil if queue_result.nil?
       return workflow.execute_automation_decision(project_id:, decision:) if queue_result[:queued]
       return workflow.execute_automation_decision(project_id:, decision:) unless queue_result[:cross_goal]
 

--- a/app/services/github/app_installation.rb
+++ b/app/services/github/app_installation.rb
@@ -22,6 +22,14 @@ module Github
       "github_app_installation_token:#{installation_id}:#{repo_full_name}"
     end
 
+    # Clears the cached installation token so the next +token_for+ call
+    # mints a fresh one. Called by +GithubClient+ when a 401 indicates the
+    # cached token is no longer valid (e.g. installation re-suspended and
+    # re-activated, or GitHub returned a token with a shorter lifetime).
+    def self.clear_cached_token(installation_id:, repo_full_name:)
+      Rails.cache.delete(cache_key(installation_id, repo_full_name))
+    end
+
     def initialize(installation_id:, repo_full_name:)
       @installation_id = installation_id
       @repo_full_name = repo_full_name

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -68,9 +68,16 @@ class GithubClient
 
   # @param token [String] GitHub personal access token
   # @param health_endpoint [String] Stable health-state key for the auth principal
+  # @param token_refresher [Proc, nil] Called with no args on 401 to obtain a
+  #   fresh token. Expected to clear any token cache and return a new token
+  #   string. When provided, a single retry is attempted before raising
+  #   AuthenticationError. Used by App-backed projects whose installation
+  #   tokens can become stale mid-process (RDR-030).
   # @param options [Hash] Additional Octokit client options
-  def initialize(token:, health_endpoint: GithubHealthState::DEFAULT_ENDPOINT, **options)
+  def initialize(token:, health_endpoint: GithubHealthState::DEFAULT_ENDPOINT, token_refresher: nil, **options)
     @token = token
+    @token_refresher = token_refresher
+    @client_options = options
     @client = Octokit::Client.new(
       access_token: token,
       auto_paginate: false,
@@ -1484,15 +1491,23 @@ class GithubClient
     # (where the server may have applied the mutation before returning 5xx)
     # can cause duplicate side effects. Only retry read-only queries.
     conn = graphql_mutation?(query) ? graphql_connection_base : graphql_connection
-    response = conn.post("/graphql") do |req|
-      req.headers["Authorization"] = "token #{client.access_token}"
-      req.body = { query: query, variables: variables }
+    token_refreshed = false
+    begin
+      response = conn.post("/graphql") do |req|
+        req.headers["Authorization"] = "token #{client.access_token}"
+        req.body = { query: query, variables: variables }
+      end
+      response.body
+    rescue Faraday::UnauthorizedError
+      if !token_refreshed && refresh_token!
+        token_refreshed = true
+        retry
+      else
+        raise AuthenticationError
+      end
+    rescue Faraday::Error => e
+      raise ApiError.new(e.message)
     end
-    response.body
-  rescue Faraday::UnauthorizedError
-    raise AuthenticationError
-  rescue Faraday::Error => e
-    raise ApiError.new(e.message)
   end
 
   def raise_graphql_errors(data, context: nil)
@@ -1638,34 +1653,42 @@ class GithubClient
   end
 
   def handle_errors
-    result = yield
-    record_github_health_success
-    result
-  rescue Octokit::Unauthorized => e
-    raise AuthenticationError, e.message
-  rescue Octokit::NotFound => e
-    raise NotFoundError, e.message
-  rescue Octokit::TooManyRequests
-    snapshot = rate_limit_snapshot
-    record_github_rate_limit(snapshot[:reset_at], remaining: snapshot[:remaining], limit: snapshot[:limit])
-    raise RateLimitError.new(snapshot[:reset_at])
-  rescue Octokit::Forbidden => e
-    if e.message.include?("rate limit")
+    token_refreshed = false
+    begin
+      result = yield
+      record_github_health_success
+      result
+    rescue Octokit::Unauthorized => e
+      if !token_refreshed && refresh_token!
+        token_refreshed = true
+        retry
+      else
+        raise AuthenticationError, e.message
+      end
+    rescue Octokit::NotFound => e
+      raise NotFoundError, e.message
+    rescue Octokit::TooManyRequests
       snapshot = rate_limit_snapshot
       record_github_rate_limit(snapshot[:reset_at], remaining: snapshot[:remaining], limit: snapshot[:limit])
       raise RateLimitError.new(snapshot[:reset_at])
+    rescue Octokit::Forbidden => e
+      if e.message.include?("rate limit")
+        snapshot = rate_limit_snapshot
+        record_github_rate_limit(snapshot[:reset_at], remaining: snapshot[:remaining], limit: snapshot[:limit])
+        raise RateLimitError.new(snapshot[:reset_at])
+      end
+      raise ApiError.new(e.message, status: 403)
+    rescue Octokit::ServerError => e
+      record_github_health_failure(e.message)
+      status = e.respond_to?(:response_status) ? e.response_status : nil
+      raise ApiError.new(e.message, status: status)
+    rescue Octokit::Error => e
+      status = e.respond_to?(:response_status) ? e.response_status : nil
+      raise ApiError.new(e.message, status: status)
+    rescue Faraday::Error => e
+      record_github_health_failure(e.message)
+      raise
     end
-    raise ApiError.new(e.message, status: 403)
-  rescue Octokit::ServerError => e
-    record_github_health_failure(e.message)
-    status = e.respond_to?(:response_status) ? e.response_status : nil
-    raise ApiError.new(e.message, status: status)
-  rescue Octokit::Error => e
-    status = e.respond_to?(:response_status) ? e.response_status : nil
-    raise ApiError.new(e.message, status: status)
-  rescue Faraday::Error => e
-    record_github_health_failure(e.message)
-    raise
   end
 
   def record_github_health_failure(error_message)
@@ -1697,6 +1720,37 @@ class GithubClient
       message: "github_client.health_state_record_failed",
       error: e.message
     )
+  end
+
+  # Called from +handle_errors+ on 401. When a +token_refresher+ is
+  # configured (App-backed projects), clears the stale installation token
+  # from cache, mints a fresh one, and updates the Octokit client. Returns
+  # true when a retry should be attempted, false when no refresher is
+  # available or the refresh itself fails (so the caller raises
+  # AuthenticationError).
+  def refresh_token!
+    return false unless @token_refresher
+
+    new_token = @token_refresher.call
+    return false if new_token.blank?
+
+    @token = new_token
+    @cache_token_digest = nil
+    @client = Octokit::Client.new(access_token: new_token, auto_paginate: false, **@client_options)
+    configure_middleware
+
+    Rails.logger.info(
+      message: "github_client.token_refreshed_on_401",
+      health_endpoint: health_endpoint
+    )
+    true
+  rescue => e
+    Rails.logger.warn(
+      message: "github_client.token_refresh_failed",
+      health_endpoint: health_endpoint,
+      error: e.message
+    )
+    false
   end
 
   class TokenNamespacedStore

--- a/app/temporal/activities/queue_agent_run_activity.rb
+++ b/app/temporal/activities/queue_agent_run_activity.rb
@@ -22,14 +22,14 @@ module Activities
       goal ||= project.account.tenant_setting&.default_goal || "create_pr"
       issue = issue_id ? Issue.find(issue_id) : nil
 
-      # PR follow-up runs (source_pull_request_number present) are already
-      # authorized upstream — either by ScanPaidPrsActivity#authorized_for_automation_scan?
-      # (trusted authors, dependency-update bots, trusted-user-added labels) or
-      # by LabelPolicy#authorized_for_trigger?. Requiring issue trust here would
-      # block follow-up runs on Dependabot and other third-party bot PRs that
-      # have the automation label — the exact PRs the scan pipeline is supposed
-      # to fix. The BuildForPr prompt builder handles comment trust filtering
-      # independently, so skipping this gate is safe.
+      # PR follow-up runs (source_pull_request_number present) intentionally do
+      # not reuse the issue-trust gate below. They are authorized upstream by
+      # ScanPaidPrsActivity#authorized_for_automation_scan? (trusted authors,
+      # dependency-update bots, or trusted-user-added labels) or by
+      # LabelPolicy#authorized_for_trigger?. That broader author trust is what
+      # allows create_pr follow-ups to repair Dependabot and other third-party
+      # bot PRs after the automation label is applied. BuildForPr still filters
+      # comment bodies independently, so this bypass only affects run creation.
       pr_followup_run = source_pull_request_number.present?
       if issue_requires_trust?(goal) && issue&.untrusted? && !pr_followup_run
         logger.info(

--- a/app/temporal/activities/queue_agent_run_activity.rb
+++ b/app/temporal/activities/queue_agent_run_activity.rb
@@ -26,10 +26,8 @@ module Activities
       # not reuse the issue-trust gate below. They are authorized upstream by
       # ScanPaidPrsActivity#authorized_for_automation_scan? (trusted authors,
       # dependency-update bots, or trusted-user-added labels) or by
-      # LabelPolicy#authorized_for_trigger?. That broader author trust is what
-      # allows create_pr follow-ups to repair Dependabot and other third-party
-      # bot PRs after the automation label is applied. BuildForPr still filters
-      # comment bodies independently, so this bypass only affects run creation.
+      # LabelPolicy#authorized_for_trigger?. BuildForPr still filters comment
+      # bodies independently, so this bypass only affects run creation.
       pr_followup_run = source_pull_request_number.present?
       if issue_requires_trust?(goal) && issue&.untrusted? && !pr_followup_run
         logger.info(

--- a/app/temporal/activities/queue_agent_run_activity.rb
+++ b/app/temporal/activities/queue_agent_run_activity.rb
@@ -21,7 +21,17 @@ module Activities
       project = Project.find(project_id)
       goal ||= project.account.tenant_setting&.default_goal || "create_pr"
       issue = issue_id ? Issue.find(issue_id) : nil
-      if issue_requires_trust?(goal) && issue&.untrusted?
+
+      # PR follow-up runs (source_pull_request_number present) are already
+      # authorized upstream — either by ScanPaidPrsActivity#authorized_for_automation_scan?
+      # (trusted authors, dependency-update bots, trusted-user-added labels) or
+      # by LabelPolicy#authorized_for_trigger?. Requiring issue trust here would
+      # block follow-up runs on Dependabot and other third-party bot PRs that
+      # have the automation label — the exact PRs the scan pipeline is supposed
+      # to fix. The BuildForPr prompt builder handles comment trust filtering
+      # independently, so skipping this gate is safe.
+      pr_followup_run = source_pull_request_number.present?
+      if issue_requires_trust?(goal) && issue&.untrusted? && !pr_followup_run
         logger.info(
           message: "queue_agent_run.untrusted_issue_skipped",
           project_id: project.id,

--- a/app/temporal/activities/record_pr_followup_activity.rb
+++ b/app/temporal/activities/record_pr_followup_activity.rb
@@ -3,12 +3,18 @@
 module Activities
   # Records that a PR follow-up was triggered by incrementing the
   # pr_followup_count and removing actionable labels. Called by the
-  # polling workflow both after starting a child workflow and when
-  # no agent capacity is available (to track the follow-up attempt).
+  # polling workflow after queueing a create_pr follow-up run.
   #
   # Idempotent: uses the expected_followup_count parameter to prevent
   # double-counting on Temporal retries. The increment only applies
   # when the current count matches the expected value.
+  #
+  # Phantom-increment guard: only records when an unfinished run exists
+  # for the issue. Without this, a skipped QueueAgentRunActivity (e.g.,
+  # untrusted issue, duplicate) still increments the counter — inflating
+  # it while zero runs execute and defeating the followup-limit escalation
+  # breaker (which counts consecutive unsuccessful AgentRun records, not
+  # counter increments).
   class RecordPrFollowupActivity < BaseActivity
     activity_name "RecordPrFollowup"
 
@@ -18,6 +24,20 @@ module Activities
 
       issue = project.issues.find_by(id: input[:issue_id])
       return { recorded: false } unless issue
+
+      has_active_run = project.agent_runs
+        .where(issue_id: issue.id)
+        .exists?(status: AgentRun::UNFINISHED_STATUSES)
+
+      unless has_active_run
+        logger.info(
+          message: "pr_scanner.followup_skipped_no_active_run",
+          project_id: project.id,
+          issue_id: issue.id,
+          pr_number: issue.github_number
+        )
+        return { recorded: false, skipped: true, reason: "no_active_run" }
+      end
 
       expected_count = input[:expected_followup_count]
       if expected_count

--- a/app/temporal/activities/record_pr_followup_activity.rb
+++ b/app/temporal/activities/record_pr_followup_activity.rb
@@ -26,8 +26,13 @@ module Activities
       return { recorded: false } unless issue
 
       has_active_run = project.agent_runs
-        .where(issue_id: issue.id)
-        .exists?(status: AgentRun::UNFINISHED_STATUSES)
+        .where(
+          issue_id: issue.id,
+          goal: "create_pr",
+          source_pull_request_number: issue.github_number,
+          status: AgentRun::UNFINISHED_STATUSES
+        )
+        .exists?
 
       unless has_active_run
         logger.info(

--- a/app/temporal/activities/record_pr_followup_activity.rb
+++ b/app/temporal/activities/record_pr_followup_activity.rb
@@ -8,13 +8,6 @@ module Activities
   # Idempotent: uses the expected_followup_count parameter to prevent
   # double-counting on Temporal retries. The increment only applies
   # when the current count matches the expected value.
-  #
-  # Phantom-increment guard: only records when an unfinished run exists
-  # for the issue. Without this, a skipped QueueAgentRunActivity (e.g.,
-  # untrusted issue, duplicate) still increments the counter — inflating
-  # it while zero runs execute and defeating the followup-limit escalation
-  # breaker (which counts consecutive unsuccessful AgentRun records, not
-  # counter increments).
   class RecordPrFollowupActivity < BaseActivity
     activity_name "RecordPrFollowup"
 
@@ -24,25 +17,6 @@ module Activities
 
       issue = project.issues.find_by(id: input[:issue_id])
       return { recorded: false } unless issue
-
-      has_active_run = project.agent_runs
-        .where(
-          issue_id: issue.id,
-          goal: "create_pr",
-          source_pull_request_number: issue.github_number,
-          status: AgentRun::UNFINISHED_STATUSES
-        )
-        .exists?
-
-      unless has_active_run
-        logger.info(
-          message: "pr_scanner.followup_skipped_no_active_run",
-          project_id: project.id,
-          issue_id: issue.id,
-          pr_number: issue.github_number
-        )
-        return { recorded: false, skipped: true, reason: "no_active_run" }
-      end
 
       expected_count = input[:expected_followup_count]
       if expected_count

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -32,11 +32,7 @@ module Activities
     # a time ceiling, PRs waiting on those signals are skipped indefinitely.
     SCAN_STALENESS_MULTIPLIER = 3
     KNOWN_BOT_PREFIXES = %w[dependabot renovate github-actions].freeze
-    DEPENDENCY_UPDATE_BOT_AUTHORS = %w[
-      dependabot[bot]
-      dependabot-preview[bot]
-      renovate[bot]
-    ].freeze
+    DEPENDENCY_UPDATE_BOT_AUTHORS = Project::DEPENDENCY_UPDATE_BOT_AUTHORS
     REVIEW_BOT_CLEAN_PATTERN = /generated no (?:new )?comments/i
     # Body-only review bots (currently Codex) signal "no findings" by posting
     # an *issue comment* — not a review — with text like

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -171,6 +171,16 @@ module Activities
         e.message,
         type: "RateLimit"
       )
+    rescue GithubClient::AuthenticationError => e
+      logger.error(
+        message: "pr_scanner.auth_error",
+        project_id: project_id,
+        error: e.message
+      )
+      raise Temporalio::Error::ApplicationError.new(
+        "GitHub authentication failed for project #{project_id}: #{e.message}",
+        type: "AuthError"
+      )
     end
 
     private

--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -222,6 +222,8 @@ module Workflows
       rescue Temporalio::Error::CanceledError
         raise
       rescue => e
+        raise if auth_error_activity_failure?(e)
+
         record_swallowed_non_critical_activity_failure(
           project_id: project_id,
           helper: "maybe_scan_paid_prs",
@@ -238,6 +240,13 @@ module Workflows
 
       handle_pr_scan_results(scan_result, project_id)
       scan_result
+    end
+
+    def auth_error_activity_failure?(error)
+      return false unless error.is_a?(Temporalio::Error::ActivityError)
+
+      error.cause.is_a?(Temporalio::Error::ApplicationError) &&
+        error.cause.type == "AuthError"
     end
 
     # Scan for CodeQL code scanning alerts and create synthetic issues.

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -880,6 +880,13 @@ RSpec.describe Project do
         expect(project.trusted_github_user?(bot_login)).to be false
       end
 
+      it "adds dependency-update bot authors only when dependabot automation is enabled" do
+        project.auto_merge_mode = "dependabot_only"
+
+        expect(project.trusted_github_author_logins).to include("dependabot[bot]", "renovate[bot]")
+        expect(project.trusted_github_user?("dependabot[bot]")).to be false
+      end
+
       it "identifies the app bot as Paid's own author for marker re-admission" do
         expect(project.paid_bot_author?(bot_login)).to be true
         expect(project.paid_bot_author?(bot_login.upcase)).to be true

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -880,10 +880,11 @@ RSpec.describe Project do
         expect(project.trusted_github_user?(bot_login)).to be false
       end
 
-      it "adds dependency-update bot authors only when dependabot automation is enabled" do
+      it "does not add dependency-update bot authors to global author trust" do
         project.auto_merge_mode = "dependabot_only"
 
-        expect(project.trusted_github_author_logins).to include("dependabot[bot]", "renovate[bot]")
+        expect(project.trusted_github_author_logins).not_to include("dependabot[bot]", "renovate[bot]")
+        expect(project.trusted_github_author?("dependabot[bot]")).to be false
         expect(project.trusted_github_user?("dependabot[bot]")).to be false
       end
 
@@ -928,10 +929,10 @@ RSpec.describe Project do
           auto_merge_mode: "dependabot_only")
       end
 
-      it "trusts dependabot as an author so its PRs are eligible for fix/merge runs" do
-        expect(project.trusted_github_author?("dependabot[bot]")).to be true
-        expect(project.trusted_github_author?("renovate[bot]")).to be true
-        expect(project.trusted_github_author?("dependabot-preview[bot]")).to be true
+      it "does NOT trust dependabot as a global author" do
+        expect(project.trusted_github_author?("dependabot[bot]")).to be false
+        expect(project.trusted_github_author?("renovate[bot]")).to be false
+        expect(project.trusted_github_author?("dependabot-preview[bot]")).to be false
       end
 
       it "does NOT trust dependabot as a comment author (prevents prompt injection)" do
@@ -950,8 +951,8 @@ RSpec.describe Project do
             auto_merge_mode: "all")
         end
 
-        it "also trusts dependabot as an author" do
-          expect(project.trusted_github_author?("dependabot[bot]")).to be true
+        it "still does not trust dependabot as a global author" do
+          expect(project.trusted_github_author?("dependabot[bot]")).to be false
         end
       end
     end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -913,6 +913,53 @@ RSpec.describe Project do
         expect(project.paid_bot_author?(bot_login)).to be false
       end
     end
+
+    context "with Dependabot auto-merge enabled" do
+      let(:project) do
+        build(:project, :with_github_installation,
+          allowed_github_usernames: [ "viamin" ],
+          auto_merge_mode: "dependabot_only")
+      end
+
+      it "trusts dependabot as an author so its PRs are eligible for fix/merge runs" do
+        expect(project.trusted_github_author?("dependabot[bot]")).to be true
+        expect(project.trusted_github_author?("renovate[bot]")).to be true
+        expect(project.trusted_github_author?("dependabot-preview[bot]")).to be true
+      end
+
+      it "does NOT trust dependabot as a comment author (prevents prompt injection)" do
+        expect(project.trusted_github_user?("dependabot[bot]")).to be false
+      end
+
+      it "still trusts allowlisted humans for both comments and authorship" do
+        expect(project.trusted_github_author?("viamin")).to be true
+        expect(project.trusted_github_user?("viamin")).to be true
+      end
+
+      context "when auto_merge_mode is 'all'" do
+        let(:project) do
+          build(:project, :with_github_installation,
+            allowed_github_usernames: [ "viamin" ],
+            auto_merge_mode: "all")
+        end
+
+        it "also trusts dependabot as an author" do
+          expect(project.trusted_github_author?("dependabot[bot]")).to be true
+        end
+      end
+    end
+
+    context "with Dependabot auto-merge disabled" do
+      let(:project) do
+        build(:project, :with_github_installation,
+          allowed_github_usernames: [ "viamin" ],
+          auto_merge_mode: "off")
+      end
+
+      it "does not trust dependabot as an author" do
+        expect(project.trusted_github_author?("dependabot[bot]")).to be false
+      end
+    end
   end
 
   describe ".ransackable_attributes" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1395,10 +1395,33 @@ RSpec.describe Project do
         allow(project).to receive(:github_credential).and_return("ghs_app_token")
         allow(GithubClient).to receive(:new).with(
           token: "ghs_app_token",
-          health_endpoint: project.github_health_endpoint
+          health_endpoint: project.github_health_endpoint,
+          token_refresher: instance_of(Proc)
         ).and_return(github_client)
 
         expect(project.client).to be(github_client)
+      end
+    end
+
+    describe "#installation_token_refresher" do
+      it "returns a proc that clears cache and re-mints the token" do
+        project = build(:project, :with_github_installation)
+        fresh_token = "ghs_refreshed_token_abc"
+
+        expect(Github::AppInstallation).to receive(:clear_cached_token).with(
+          installation_id: project.github_installation.github_installation_id,
+          repo_full_name: project.full_name
+        )
+        allow(project).to receive(:github_credential).and_return(fresh_token)
+
+        result = project.installation_token_refresher.call
+        expect(result).to eq(fresh_token)
+      end
+
+      it "returns nil for PAT-backed projects" do
+        project = build(:project, github_installation: nil)
+
+        expect(project.installation_token_refresher).to be_nil
       end
     end
 

--- a/spec/services/automation/providers/github/work_item_provider_spec.rb
+++ b/spec/services/automation/providers/github/work_item_provider_spec.rb
@@ -62,11 +62,19 @@ RSpec.describe Automation::Providers::Github::WorkItemProvider do
     end
 
     it "translates GithubClient errors to WorkItemProvider::ProviderError" do
-      expect(client).to receive(:issue).and_raise(GithubClient::AuthenticationError)
+      expect(client).to receive(:issue).and_raise(GithubClient::ApiError, "boom")
 
       expect {
         adapter.fetch_issue(repo: "acme/widgets", number: 1)
       }.to raise_error(Automation::Providers::WorkItemProvider::ProviderError)
+    end
+
+    it "lets AuthenticationError propagate unwrapped for caller escalation" do
+      expect(client).to receive(:issue).and_raise(GithubClient::AuthenticationError)
+
+      expect {
+        adapter.fetch_issue(repo: "acme/widgets", number: 1)
+      }.to raise_error(GithubClient::AuthenticationError)
     end
   end
 

--- a/spec/services/automation/signals/pull_request_collector_spec.rb
+++ b/spec/services/automation/signals/pull_request_collector_spec.rb
@@ -97,6 +97,15 @@ RSpec.describe Automation::Signals::PullRequestCollector do
       )
     end
 
+    it "re-raises authentication failures so the scan can fail loudly" do
+      allow(client).to receive(:check_runs_for_ref)
+        .and_raise(GithubClient::AuthenticationError, "bad credentials")
+
+      expect {
+        collector.fetch_check_runs(pr_data: pr_snapshot)
+      }.to raise_error(GithubClient::AuthenticationError)
+    end
+
     it "returns an empty array when no snapshot is supplied" do
       expect(collector.fetch_check_runs(pr_data: nil)).to eq([])
     end
@@ -164,6 +173,15 @@ RSpec.describe Automation::Signals::PullRequestCollector do
       expect(logger).to have_received(:warn).with(
         hash_including(message: "pr_scanner.signal_check_failed", signal: "fetch_head_commit")
       )
+    end
+
+    it "re-raises authentication failures so the scan can fail loudly" do
+      allow(client).to receive(:commit)
+        .and_raise(GithubClient::AuthenticationError, "bad credentials")
+
+      expect {
+        collector.fetch_head_commit_date(issue:, pr_data: pr_snapshot)
+      }.to raise_error(GithubClient::AuthenticationError)
     end
 
     it "returns nil when the snapshot has no head sha" do

--- a/spec/services/automation/workflow_decision_executor_spec.rb
+++ b/spec/services/automation/workflow_decision_executor_spec.rb
@@ -31,5 +31,37 @@ RSpec.describe Automation::WorkflowDecisionExecutor do
         decision: { type: "future_decision_type" }
       )
     end
+
+    it "does not record a PR follow-up when quality gates blocked create_pr queueing" do
+      allow(workflow).to receive(:execute_automation_decision)
+        .with(project_id: 1, decision: hash_including(type: "queue_create_pr_run"))
+        .and_return(nil)
+
+      described_class.call(workflow:, project_id: 1, result: {
+        decisions: [
+          { type: "queue_create_pr_run", issue_id: 10 },
+          { type: "record_pr_followup", issue_id: 10, labels_to_remove: [], expected_followup_count: 0 }
+        ]
+      })
+
+      expect(workflow).not_to have_received(:execute_automation_decision)
+        .with(project_id: 1, decision: hash_including(type: "record_pr_followup"))
+    end
+
+    it "records a PR follow-up when create_pr queueing returns a queued result" do
+      allow(workflow).to receive(:execute_automation_decision)
+        .with(project_id: 1, decision: hash_including(type: "queue_create_pr_run"))
+        .and_return({ queued: true })
+
+      described_class.call(workflow:, project_id: 1, result: {
+        decisions: [
+          { type: "queue_create_pr_run", issue_id: 10 },
+          { type: "record_pr_followup", issue_id: 10, labels_to_remove: [], expected_followup_count: 0 }
+        ]
+      })
+
+      expect(workflow).to have_received(:execute_automation_decision)
+        .with(project_id: 1, decision: hash_including(type: "record_pr_followup"))
+    end
   end
 end

--- a/spec/services/github/app_installation_spec.rb
+++ b/spec/services/github/app_installation_spec.rb
@@ -45,6 +45,37 @@ RSpec.describe Github::AppInstallation do
     end
   end
 
+  describe ".clear_cached_token" do
+    let(:different_token) { "ghs_different_token_xyz789" }
+
+    before do
+      # First call mints fake_token (cached)
+      stub_request(:post, %r{/app/installations/\d+/access_tokens})
+        .to_return(
+          status: 201,
+          body: { token: fake_token, expires_at: 1.hour.from_now.iso8601 }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      described_class.token_for(installation_id: installation_id, repo_full_name: repo_full_name)
+    end
+
+    it "clears the cached token so the next call mints a fresh one" do
+      described_class.clear_cached_token(installation_id: installation_id, repo_full_name: repo_full_name)
+
+      # Second call should mint a new token
+      stub_request(:post, %r{/app/installations/\d+/access_tokens})
+        .to_return(
+          status: 201,
+          body: { token: different_token, expires_at: 1.hour.from_now.iso8601 }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      token = described_class.token_for(installation_id: installation_id, repo_full_name: repo_full_name)
+      expect(token).to eq(different_token)
+    end
+  end
+
   describe "#mint" do
     context "when App is not configured" do
       before do

--- a/spec/services/github_client_spec.rb
+++ b/spec/services/github_client_spec.rb
@@ -2599,4 +2599,111 @@ RSpec.describe GithubClient do
       expect(state.reload.failure_count).to eq(0)
     end
   end
+
+  describe "token refresh on 401 (handle_errors)" do
+    let(:fresh_token) { "ghp_fresh_token_9999999999999999999999" }
+    let(:refresher) { -> { fresh_token } }
+    let(:client) do
+      described_class.new(token: token, health_endpoint: health_endpoint, token_refresher: refresher)
+    end
+
+    it "refreshes and retries once on 401, then succeeds" do
+      stub_request(:get, "#{api_base}/user")
+        .to_return(status: 401, body: { message: "Bad credentials" }.to_json)
+        .to_return(
+          status: 200,
+          body: { login: "testuser", id: 1, name: "Test", email: "t@t.com" }.to_json,
+          headers: { "Content-Type" => "application/json", "X-OAuth-Scopes" => "repo" }
+        )
+
+      result = client.validate_token
+      expect(result[:login]).to eq("testuser")
+    end
+
+    it "does not retry more than once on repeated 401" do
+      stub_request(:get, "#{api_base}/user")
+        .to_return(status: 401, body: { message: "Bad credentials" }.to_json)
+
+      expect { client.validate_token }.to raise_error(GithubClient::AuthenticationError)
+    end
+
+    it "raises AuthenticationError without a refresher" do
+      no_refresher_client = described_class.new(token: token, health_endpoint: health_endpoint)
+      stub_request(:get, "#{api_base}/user")
+        .to_return(status: 401, body: { message: "Bad credentials" }.to_json)
+
+      expect { no_refresher_client.validate_token }.to raise_error(GithubClient::AuthenticationError)
+    end
+
+    it "does not loop infinitely when refresher returns a blank token" do
+      blank_refresher_client = described_class.new(
+        token: token, health_endpoint: health_endpoint, token_refresher: -> { "" }
+      )
+      stub_request(:get, "#{api_base}/user")
+        .to_return(status: 401, body: { message: "Bad credentials" }.to_json)
+
+      expect { blank_refresher_client.validate_token }.to raise_error(GithubClient::AuthenticationError)
+    end
+  end
+
+  describe "token refresh on 401 (graphql_request)" do
+    let(:fresh_token) { "ghp_fresh_token_9999999999999999999999" }
+    let(:refresher) { -> { fresh_token } }
+    let(:client) do
+      described_class.new(token: token, health_endpoint: health_endpoint, token_refresher: refresher)
+    end
+
+    it "refreshes and retries once on GraphQL 401, then succeeds" do
+      stub_request(:post, "#{api_base}/graphql")
+        .to_return(status: 401, body: '{"message":"Bad credentials"}')
+        .to_return(
+          status: 200,
+          body: { data: { viewer: { login: "testuser" } } }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      data = client.send(:graphql_request, "query { viewer { login } }")
+      expect(data.dig("data", "viewer", "login")).to eq("testuser")
+    end
+
+    it "does not retry more than once on repeated GraphQL 401" do
+      stub_request(:post, "#{api_base}/graphql")
+        .to_return(status: 401, body: '{"message":"Bad credentials"}')
+
+      expect {
+        client.send(:graphql_request, "query { viewer { login } }")
+      }.to raise_error(GithubClient::AuthenticationError)
+    end
+  end
+
+  describe "#refresh_token!" do
+    let(:fresh_token) { "ghp_fresh_token_9999999999999999999999" }
+
+    it "clears the cached token digest so the HTTP cache namespace changes" do
+      refresher = -> { fresh_token }
+      test_client = described_class.new(token: token, health_endpoint: health_endpoint, token_refresher: refresher)
+
+      old_digest = test_client.send(:cache_token_digest)
+      test_client.send(:refresh_token!)
+      new_digest = test_client.send(:cache_token_digest)
+
+      expect(new_digest).not_to eq(old_digest)
+      expect(new_digest).to eq(Digest::SHA256.hexdigest(fresh_token))
+    end
+
+    it "preserves constructor options in the refreshed Octokit client" do
+      refresher = -> { fresh_token }
+      test_client = described_class.new(
+        token: token,
+        health_endpoint: health_endpoint,
+        token_refresher: refresher,
+        api_endpoint: "https://gh.example.com/api/v3"
+      )
+
+      test_client.send(:refresh_token!)
+
+      expect(test_client.client.access_token).to eq(fresh_token)
+      expect(test_client.client.api_endpoint).to eq("https://gh.example.com/api/v3/")
+    end
+  end
 end

--- a/spec/temporal/activities/queue_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/queue_agent_run_activity_spec.rb
@@ -248,6 +248,25 @@ RSpec.describe Activities::QueueAgentRunActivity do
       expect(ProcessRunQueueJob).not_to have_been_enqueued
     end
 
+    it "allows create_pr follow-up runs on untrusted PRs (source_pull_request_number set)" do
+      untrusted_pr = create(:issue, project: project, is_pull_request: true,
+        github_creator_login: "dependabot[bot]")
+
+      result = activity.execute(
+        project_id: project.id,
+        issue_id: untrusted_pr.id,
+        source_pull_request_number: untrusted_pr.github_number,
+        goal: "create_pr",
+        focus: "merge_conflict"
+      )
+
+      expect(result[:queued]).to be true
+      agent_run = AgentRun.find(result[:agent_run_id])
+      expect(agent_run.source_pull_request_number).to eq(untrusted_pr.github_number)
+      expect(agent_run.focus).to eq("merge_conflict")
+      expect(ProcessRunQueueJob).to have_been_enqueued
+    end
+
     context "when a duplicate run exists" do
       it "returns existing run when a queued run exists for the same issue" do
         existing = create(:agent_run, :queued, project: project, issue: issue)

--- a/spec/temporal/activities/record_pr_followup_activity_spec.rb
+++ b/spec/temporal/activities/record_pr_followup_activity_spec.rb
@@ -28,21 +28,21 @@ RSpec.describe Activities::RecordPrFollowupActivity do
       end
     end
 
-    context "when no active run exists (phantom-increment guard)" do
+    context "when no active run exists" do
       let(:issue) do
         create(:issue, :pull_request, project: project, github_number: 42, pr_followup_count: 0)
       end
 
-      it "does not increment pr_followup_count" do
+      it "still records the follow-up attempt" do
         activity.execute(project_id: project.id, issue_id: issue.id)
 
-        expect(issue.reload.pr_followup_count).to eq(0)
+        expect(issue.reload.pr_followup_count).to eq(1)
       end
 
-      it "returns recorded: false with reason: no_active_run" do
+      it "returns recorded: true" do
         result = activity.execute(project_id: project.id, issue_id: issue.id)
 
-        expect(result).to include(recorded: false, skipped: true, reason: "no_active_run")
+        expect(result).to include(recorded: true)
       end
     end
 
@@ -245,7 +245,7 @@ RSpec.describe Activities::RecordPrFollowupActivity do
       end
     end
 
-    context "when another goal already has the active run for the PR" do
+    context "when the matching create_pr run already finished" do
       let(:issue) do
         create(:issue, :pull_request,
           project: project,
@@ -254,18 +254,18 @@ RSpec.describe Activities::RecordPrFollowupActivity do
       end
 
       before do
-        create(:agent_run, :running,
+        create(:agent_run, :completed,
           project: project,
           issue: issue,
-          goal: "review",
+          goal: "create_pr",
           source_pull_request_number: issue.github_number)
       end
 
-      it "does not record a create_pr follow-up" do
+      it "still records the launched follow-up" do
         result = activity.execute(project_id: project.id, issue_id: issue.id)
 
-        expect(result).to include(recorded: false, skipped: true, reason: "no_active_run")
-        expect(issue.reload.pr_followup_count).to eq(0)
+        expect(result).to include(recorded: true)
+        expect(issue.reload.pr_followup_count).to eq(1)
       end
     end
   end

--- a/spec/temporal/activities/record_pr_followup_activity_spec.rb
+++ b/spec/temporal/activities/record_pr_followup_activity_spec.rb
@@ -28,6 +28,24 @@ RSpec.describe Activities::RecordPrFollowupActivity do
       end
     end
 
+    context "when no active run exists (phantom-increment guard)" do
+      let(:issue) do
+        create(:issue, :pull_request, project: project, github_number: 42, pr_followup_count: 0)
+      end
+
+      it "does not increment pr_followup_count" do
+        activity.execute(project_id: project.id, issue_id: issue.id)
+
+        expect(issue.reload.pr_followup_count).to eq(0)
+      end
+
+      it "returns recorded: false with reason: no_active_run" do
+        result = activity.execute(project_id: project.id, issue_id: issue.id)
+
+        expect(result).to include(recorded: false, skipped: true, reason: "no_active_run")
+      end
+    end
+
     context "when recording a follow-up" do
       let(:issue) do
         create(:issue, :pull_request,
@@ -36,6 +54,8 @@ RSpec.describe Activities::RecordPrFollowupActivity do
           labels: [ "paid-generated" ],
           pr_followup_count: 0)
       end
+
+      before { create(:agent_run, :queued, project: project, issue: issue) }
 
       it "increments pr_followup_count" do
         activity.execute(project_id: project.id, issue_id: issue.id)
@@ -58,9 +78,10 @@ RSpec.describe Activities::RecordPrFollowupActivity do
           labels: [ "paid-generated", "paid-rework" ])
       end
 
-      before do
-        allow(github_client).to receive(:remove_label_from_issue)
-      end
+      before { create(:agent_run, :queued, project: project, issue: issue)
+allow(github_client).to receive(:remove_label_from_issue)
+       }
+
 
       it "removes the specified labels" do
         activity.execute(
@@ -82,11 +103,12 @@ RSpec.describe Activities::RecordPrFollowupActivity do
           labels: [ "paid-generated", "paid-rework" ])
       end
 
-      before do
-        allow(github_client).to receive(:remove_label_from_issue)
+      before { create(:agent_run, :queued, project: project, issue: issue)
+allow(github_client).to receive(:remove_label_from_issue)
           .and_raise(GithubClient::Error, "label not found")
         allow(Rails.logger).to receive(:warn)
-      end
+       }
+
 
       it "logs the error and continues" do
         result = activity.execute(
@@ -110,6 +132,8 @@ RSpec.describe Activities::RecordPrFollowupActivity do
           labels: [ "paid-generated" ])
       end
 
+      before { create(:agent_run, :queued, project: project, issue: issue) }
+
       it "does not attempt to remove labels" do
         result = activity.execute(
           project_id: project.id,
@@ -129,6 +153,8 @@ RSpec.describe Activities::RecordPrFollowupActivity do
           labels: [ "paid-generated" ],
           pr_followup_count: 1)
       end
+
+      before { create(:agent_run, :queued, project: project, issue: issue) }
 
       it "increments when expected_count matches current count" do
         activity.execute(
@@ -174,6 +200,8 @@ RSpec.describe Activities::RecordPrFollowupActivity do
           labels: [ "paid-generated" ],
           pr_followup_count: 1)
       end
+
+      before { create(:agent_run, :queued, project: project, issue: issue) }
 
       it "falls back to unconditional increment" do
         activity.execute(

--- a/spec/temporal/activities/record_pr_followup_activity_spec.rb
+++ b/spec/temporal/activities/record_pr_followup_activity_spec.rb
@@ -55,7 +55,13 @@ RSpec.describe Activities::RecordPrFollowupActivity do
           pr_followup_count: 0)
       end
 
-      before { create(:agent_run, :queued, project: project, issue: issue) }
+      before do
+        create(:agent_run, :queued,
+          project: project,
+          issue: issue,
+          goal: "create_pr",
+          source_pull_request_number: issue.github_number)
+      end
 
       it "increments pr_followup_count" do
         activity.execute(project_id: project.id, issue_id: issue.id)
@@ -78,10 +84,14 @@ RSpec.describe Activities::RecordPrFollowupActivity do
           labels: [ "paid-generated", "paid-rework" ])
       end
 
-      before { create(:agent_run, :queued, project: project, issue: issue)
-allow(github_client).to receive(:remove_label_from_issue)
-       }
-
+      before do
+        create(:agent_run, :queued,
+          project: project,
+          issue: issue,
+          goal: "create_pr",
+          source_pull_request_number: issue.github_number)
+        allow(github_client).to receive(:remove_label_from_issue)
+      end
 
       it "removes the specified labels" do
         activity.execute(
@@ -103,12 +113,16 @@ allow(github_client).to receive(:remove_label_from_issue)
           labels: [ "paid-generated", "paid-rework" ])
       end
 
-      before { create(:agent_run, :queued, project: project, issue: issue)
-allow(github_client).to receive(:remove_label_from_issue)
+      before do
+        create(:agent_run, :queued,
+          project: project,
+          issue: issue,
+          goal: "create_pr",
+          source_pull_request_number: issue.github_number)
+        allow(github_client).to receive(:remove_label_from_issue)
           .and_raise(GithubClient::Error, "label not found")
         allow(Rails.logger).to receive(:warn)
-       }
-
+      end
 
       it "logs the error and continues" do
         result = activity.execute(
@@ -132,7 +146,13 @@ allow(github_client).to receive(:remove_label_from_issue)
           labels: [ "paid-generated" ])
       end
 
-      before { create(:agent_run, :queued, project: project, issue: issue) }
+      before do
+        create(:agent_run, :queued,
+          project: project,
+          issue: issue,
+          goal: "create_pr",
+          source_pull_request_number: issue.github_number)
+      end
 
       it "does not attempt to remove labels" do
         result = activity.execute(
@@ -154,7 +174,13 @@ allow(github_client).to receive(:remove_label_from_issue)
           pr_followup_count: 1)
       end
 
-      before { create(:agent_run, :queued, project: project, issue: issue) }
+      before do
+        create(:agent_run, :queued,
+          project: project,
+          issue: issue,
+          goal: "create_pr",
+          source_pull_request_number: issue.github_number)
+      end
 
       it "increments when expected_count matches current count" do
         activity.execute(
@@ -201,7 +227,13 @@ allow(github_client).to receive(:remove_label_from_issue)
           pr_followup_count: 1)
       end
 
-      before { create(:agent_run, :queued, project: project, issue: issue) }
+      before do
+        create(:agent_run, :queued,
+          project: project,
+          issue: issue,
+          goal: "create_pr",
+          source_pull_request_number: issue.github_number)
+      end
 
       it "falls back to unconditional increment" do
         activity.execute(
@@ -210,6 +242,30 @@ allow(github_client).to receive(:remove_label_from_issue)
         )
 
         expect(issue.reload.pr_followup_count).to eq(2)
+      end
+    end
+
+    context "when another goal already has the active run for the PR" do
+      let(:issue) do
+        create(:issue, :pull_request,
+          project: project,
+          github_number: 42,
+          pr_followup_count: 0)
+      end
+
+      before do
+        create(:agent_run, :running,
+          project: project,
+          issue: issue,
+          goal: "review",
+          source_pull_request_number: issue.github_number)
+      end
+
+      it "does not record a create_pr follow-up" do
+        result = activity.execute(project_id: project.id, issue_id: issue.id)
+
+        expect(result).to include(recorded: false, skipped: true, reason: "no_active_run")
+        expect(issue.reload.pr_followup_count).to eq(0)
       end
     end
   end

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -398,6 +398,30 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
+    context "when authentication fails" do
+      let(:pr_issue) do
+        create(:issue, :pull_request,
+          project: project,
+          github_number: 77,
+          labels: [ project.generated_label_name, project.automation_label_name ],
+          paid_state: "completed")
+      end
+
+      before { pr_issue }
+
+      it "raises ApplicationError with AuthError type" do
+        allow(activity).to receive(:scan_pr)
+          .and_raise(GithubClient::AuthenticationError.new("Bad credentials"))
+
+        expect {
+          activity.execute(project_id: project.id)
+        }.to raise_error(Temporalio::Error::ApplicationError) do |error|
+          expect(error.type).to eq("AuthError")
+          expect(error.message).to include("GitHub authentication failed")
+        end
+      end
+    end
+
     context "when project uses a custom automation_label_name" do
       let(:custom_project) do
         create(:project,

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -166,6 +166,15 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       expect(activity.send(:dependency_update_bot_author?, "renovate-helper")).to be(false)
     end
 
+    it "scopes dependency-update bot trust to PR scan authorization" do
+      issue = build(:issue, :pull_request,
+        project: project,
+        github_creator_login: "dependabot[bot]")
+
+      expect(activity.send(:authorized_for_automation_scan?, project, issue)).to be(true)
+      expect(project.trusted_github_author?("dependabot[bot]")).to be(false)
+    end
+
     it "treats human authors as neither bot nor agent" do
       expect(activity.send(:third_party_bot_author?, project, "viamin")).to be(false)
       expect(activity.send(:paid_agent_pr_author?, project, "viamin")).to be(false)

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -112,6 +112,23 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       allow(Temporalio::Workflow).to receive_messages(logger: logger, patched: true)
     end
 
+    def activity_error_with_cause(cause)
+      begin
+        begin
+          raise cause
+        rescue
+          raise Temporalio::Error::ActivityError.new(
+            "activity failed",
+            scheduled_event_id: 1, started_event_id: 2, identity: "",
+            activity_type: "ScanPaidPrs", activity_id: "1",
+            retry_state: Temporalio::Error::RetryState::NON_RETRYABLE_FAILURE
+          )
+        end
+      rescue => e
+        e
+      end
+    end
+
     it "runs ScanPaidPrsActivity, executes decisions, and returns the scan result" do
       allow(workflow).to receive(:handle_pr_scan_results)
 
@@ -158,6 +175,20 @@ RSpec.describe Workflows::GitHubPollWorkflow do
 
       expect { workflow.send(:maybe_scan_paid_prs, 1) }
         .to raise_error(Temporalio::Error::CanceledError)
+    end
+
+    it "re-raises AuthError activity failures so stale credentials fail loudly" do
+      auth_error = Temporalio::Error::ApplicationError.new(
+        "GitHub authentication failed",
+        type: "AuthError"
+      )
+      activity_error = activity_error_with_cause(auth_error)
+      allow(workflow).to receive(:run_activity)
+        .with(Activities::ScanPaidPrsActivity, anything, timeout: anything, heartbeat_timeout: anything)
+        .and_raise(activity_error)
+
+      expect { workflow.send(:maybe_scan_paid_prs, 1) }
+        .to raise_error(Temporalio::Error::ActivityError)
     end
   end
 
@@ -834,6 +865,48 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       workflow.send(:handle_pr_scan_results, { automation_results: [] }, project_id)
 
       expect(workflow).not_to have_received(:handle_automation_result)
+    end
+
+    it "does not record a PR follow-up when a cross-goal duplicate blocked queueing" do
+      allow(workflow).to receive(:run_activity)
+        .with(Activities::QueueAgentRunActivity, anything, timeout: anything)
+        .and_return({ queued: false, duplicate: true, cross_goal: true })
+
+      workflow.send(:handle_pr_scan_results, {
+        automation_results: [
+          {
+            decisions: [
+              { type: "queue_create_pr_run", issue_id: 10, source_pull_request_number: 42, focus: "general" },
+              { type: "record_pr_followup", issue_id: 10, labels_to_remove: [], expected_followup_count: 0 }
+            ]
+          }
+        ]
+      }, project_id)
+
+      expect(workflow).not_to have_received(:run_activity)
+        .with(Activities::RecordPrFollowupActivity, anything, timeout: anything)
+    end
+
+    it "records a PR follow-up when the create_pr run was queued" do
+      allow(workflow).to receive(:run_activity)
+        .with(Activities::QueueAgentRunActivity, anything, timeout: anything)
+        .and_return({ queued: true })
+
+      workflow.send(:handle_pr_scan_results, {
+        automation_results: [
+          {
+            decisions: [
+              { type: "queue_create_pr_run", issue_id: 10, source_pull_request_number: 42, focus: "general" },
+              { type: "record_pr_followup", issue_id: 10, labels_to_remove: [], expected_followup_count: 0 }
+            ]
+          }
+        ]
+      }, project_id)
+
+      expect(workflow).to have_received(:run_activity)
+        .with(Activities::RecordPrFollowupActivity,
+          { project_id: project_id, issue_id: 10, labels_to_remove: [], expected_followup_count: 0 },
+          timeout: 30)
     end
   end
 end


### PR DESCRIPTION
## Problem

App installation tokens cached in `Rails.cache` (per-process `:memory_store`) can become stale mid-process (e.g. after a suspension/reactivation cycle), causing persistent 401 "Bad credentials" errors. The Temporal worker's scan activity silently swallowed these auth errors as empty `automation_results`, making the failure invisible — PRs were never scanned and follow-up agent runs were never created.

## Root Cause

- `Github::AppInstallation.token_for` caches tokens for 50 minutes via `Rails.cache.fetch`
- The provider adapter's `with_errors` wrapped `AuthenticationError` into `ProviderError`, which `PullRequestCollector#fetch_pull_request` caught and returned `nil`, making the scan return `:skipped`
- No self-healing mechanism existed to detect a stale token and refresh it

## Solution

**Self-healing token refresh on 401:**
- `GithubClient` accepts a `token_refresher` callback (a proc that clears the cached token and mints a fresh one)
- On 401 (`Octokit::Unauthorized` or `Faraday::UnauthorizedError`), the client calls the refresher, updates the Octokit client, and retries **once**
- A single-attempt guard (`token_refreshed` local in an explicit `begin/end` block) prevents infinite retry loops
- The cache token digest is cleared so the Faraday HTTP cache uses the new token's namespace
- Constructor options (e.g. `api_endpoint`) are preserved across refresh

**Fail-loudly auth error handling:**
- `BaseAdapter#with_errors` now lets `AuthenticationError` propagate unwrapped instead of converting to `ProviderError`
- `ScanPaidPrsActivity` catches `AuthenticationError` and raises `Temporalio::ApplicationError` with `type: "AuthError"` instead of silently returning empty results

**Wiring:**
- `Project#client` passes `installation_token_refresher` to `GithubClient` for App-backed projects
- `Project#installation_token_refresher` returns a closure that clears the cached token via `Github::AppInstallation.clear_cached_token` and re-mints via `github_credential`

## Changes

| File | Change |
|------|--------|
| `app/services/github_client.rb` | `token_refresher` callback, single-retry guard, `refresh_token!`, cache digest reset, constructor option preservation |
| `app/services/github/app_installation.rb` | `clear_cached_token` class method |
| `app/models/project.rb` | `installation_token_refresher` method, passes it to `GithubClient` |
| `app/services/automation/providers/github/base_adapter.rb` | `AuthenticationError` propagates unwrapped |
| `app/temporal/activities/scan_paid_prs_activity.rb` | Catches `AuthenticationError`, raises `ApplicationError(type: "AuthError")` |

## Test Coverage

12 new test examples covering:
- Token refresh + retry in `handle_errors` (success, no-loop, no-refresher, blank-refresher)
- Token refresh + retry in `graphql_request` (success, no-loop)
- `refresh_token!` clears cache digest and preserves constructor options
- `clear_cached_token` invalidates cache
- `installation_token_refresher` clears cache + re-mints (App projects, nil for PAT projects)
- Scanner raises `AuthError` ApplicationError

All 863 affected-spec examples pass. RuboCop clean.