### PR TITLE
Fix token polling lifecycle and code scanning backoff

### DIFF
--- a/app/jobs/github_token_health_check_job.rb
+++ b/app/jobs/github_token_health_check_job.rb
@@ -85,10 +85,12 @@ class GithubTokenHealthCheckJob < ApplicationJob
       error: e.message
     )
     # No was_already_failed guard here intentionally: the service is idempotent
-    # (only pauses projects where scheduler_paused_at IS NULL), and new projects
-    # can be associated with a failed token between health-check runs. Skipping
-    # this call when the token was already failed would leave those new projects
-    # unpaused until the token is fixed and fails again.
+    # (scheduler_pause! no-ops if already paused; stop_polling is a safe repeat
+    # cancel), and new projects can be associated with a failed token between
+    # health-check runs. Skipping this call when the token was already failed
+    # would leave those new projects unpaused, and previously auto-paused ones
+    # with a still-running poll workflow, until the token is fixed and fails
+    # again.
     GithubTokens::AutoPauseProjects.call(github_token: token)
     false
   rescue GithubClient::RateLimitError, GithubClient::ApiError => e

--- a/app/services/github_tokens/auto_pause_projects.rb
+++ b/app/services/github_tokens/auto_pause_projects.rb
@@ -18,11 +18,21 @@ module GithubTokens
     end
 
     def call
-      projects = @github_token.projects.active.where(scheduler_paused_at: nil)
+      # Scoped to .active only (not .where(scheduler_paused_at: nil)) so that
+      # projects auto-paused by an earlier run of this service still get
+      # stop_polling retried below. scheduler_pause! is idempotent (no-op
+      # when already paused), so this call runs safely every time the health
+      # check confirms the token is still failing. Manually scheduler-paused
+      # projects are left alone here because AutoResumeProjects will not
+      # clear their pause reason or restart polling when the token recovers.
+      projects = @github_token.projects.active
       paused_ids = []
 
       projects.find_each do |project|
-        paused_ids << project.id if project.scheduler_pause!(reason: pause_reason)
+        was_already_auto_paused = self.class.auto_pause_reason?(project.scheduler_pause_reason)
+        was_paused = project.scheduler_pause!(reason: pause_reason)
+        paused_ids << project.id if was_paused
+        stop_polling(project) if was_paused || was_already_auto_paused
       end
 
       if paused_ids.any?
@@ -38,6 +48,25 @@ module GithubTokens
     end
 
     private
+
+    # Stops the project's GitHubPollWorkflow so it doesn't keep hitting the
+    # known-dead credential every poll cycle indefinitely -- a stopped
+    # credential means every subsequent poll attempt is guaranteed to fail
+    # identically, so continuing to poll only burns worker capacity and API
+    # quota until a human fixes the token. scheduler_pause! (above) already
+    # stops new agent runs from being scheduled; this additionally stops the
+    # underlying GitHub sync itself. AutoResumeProjects restarts polling
+    # when the token becomes valid again.
+    def stop_polling(project)
+      ProjectWorkflowManager.stop_polling(project)
+    rescue => e
+      Rails.logger.error(
+        message: "github_token.auto_pause.stop_polling_failed",
+        github_token_id: @github_token.id,
+        project_id: project.id,
+        error: e.message
+      )
+    end
 
     def pause_reason
       "GitHub token '#{@github_token.name}' failed validation: #{@github_token.validation_error}"

--- a/app/services/github_tokens/auto_resume_projects.rb
+++ b/app/services/github_tokens/auto_resume_projects.rb
@@ -15,10 +15,9 @@ module GithubTokens
 
       paused_projects.find_each do |project|
         next unless GithubTokens::AutoPauseProjects.auto_pause_reason?(project.scheduler_pause_reason)
-        next unless project.scheduler_resume!
+        next unless resume_project(project)
 
         resumed_ids << project.id
-        start_polling(project) if project.active?
       end
 
       if resumed_ids.any?
@@ -34,10 +33,18 @@ module GithubTokens
 
     private
 
+    def resume_project(project)
+      return project.scheduler_resume! unless project.active?
+      return false unless start_polling(project)
+
+      project.scheduler_resume!
+    end
+
     # Restarts the project's GitHubPollWorkflow, undoing AutoPauseProjects'
     # stop_polling now that the credential is valid again.
     def start_polling(project)
       ProjectWorkflowManager.start_polling(project, restart_reason: "github_token_restored")
+      true
     rescue => e
       Rails.logger.error(
         message: "github_token.auto_resume.start_polling_failed",
@@ -45,6 +52,7 @@ module GithubTokens
         project_id: project.id,
         error: e.message
       )
+      false
     end
 
     def paused_projects

--- a/app/services/github_tokens/auto_resume_projects.rb
+++ b/app/services/github_tokens/auto_resume_projects.rb
@@ -15,8 +15,10 @@ module GithubTokens
 
       paused_projects.find_each do |project|
         next unless GithubTokens::AutoPauseProjects.auto_pause_reason?(project.scheduler_pause_reason)
+        next unless project.scheduler_resume!
 
-        resumed_ids << project.id if project.scheduler_resume!
+        resumed_ids << project.id
+        start_polling(project) if project.active?
       end
 
       if resumed_ids.any?
@@ -31,6 +33,19 @@ module GithubTokens
     end
 
     private
+
+    # Restarts the project's GitHubPollWorkflow, undoing AutoPauseProjects'
+    # stop_polling now that the credential is valid again.
+    def start_polling(project)
+      ProjectWorkflowManager.start_polling(project, restart_reason: "github_token_restored")
+    rescue => e
+      Rails.logger.error(
+        message: "github_token.auto_resume.start_polling_failed",
+        github_token_id: @github_token.id,
+        project_id: project.id,
+        error: e.message
+      )
+    end
 
     def paused_projects
       @github_token.projects.where.not(scheduler_paused_at: nil)

--- a/app/temporal/activities/scan_security_alerts_activity.rb
+++ b/app/temporal/activities/scan_security_alerts_activity.rb
@@ -13,6 +13,16 @@ module Activities
   class ScanSecurityAlertsActivity < BaseActivity
     activity_name "ScanSecurityAlerts"
 
+    # Backoff for a confirmed permission/configuration error (403 -- missing
+    # security_events / code_scanning_alerts:read). Deliberately much shorter
+    # than code_scanning_interval_hours: a stale credential is retried every
+    # poll cycle otherwise (every 1-2 minutes in some environments), which
+    # wastes worker capacity and API quota on a call that will fail
+    # identically until a human fixes the token/App permission. An hour still
+    # picks up a fix promptly without the full-interval "stale blackout" the
+    # original no-backoff design was written to avoid.
+    PERMISSION_ERROR_BACKOFF = 1.hour
+
     def execute(input)
       project_id = input[:project_id]
       project = Project.find_by(id: project_id)
@@ -54,7 +64,7 @@ module Activities
       all_alerts = fetch_code_scanning_alerts(project)
 
       if all_alerts.nil?
-        project.update_column(:last_code_scanning_scan_at, Time.current)
+        project.update_columns(last_code_scanning_scan_at: Time.current, code_scanning_permission_error_at: nil)
         return
       end
 
@@ -71,7 +81,7 @@ module Activities
       # Record scan timestamp only after successful processing. Retryable
       # errors (5xx) intentionally skip this so Temporal retries within the
       # same interval window.
-      project.update_column(:last_code_scanning_scan_at, Time.current)
+      project.update_columns(last_code_scanning_scan_at: Time.current, code_scanning_permission_error_at: nil)
 
       logger.info(
         message: "github_sync.code_scanning_scan_complete",
@@ -79,20 +89,29 @@ module Activities
         alerts_fetched: all_alerts.size,
         alerts_actionable: open_alerts.size
       )
-    rescue SecurityAlerts::ConfigurationError
+    rescue SecurityAlerts::CodeScanningPermissionsError
       # Do NOT advance last_code_scanning_scan_at here. A 403 means the token
       # lacks the required scope — advancing the timestamp would suppress
       # retries for the full code_scanning_interval_hours window, turning a
-      # recoverable misconfiguration into a stale blackout. The workflow
-      # catches ConfigurationError and logs a warning; rate-limit budget
-      # checks in the poll loop already prevent excessive API calls.
+      # recoverable misconfiguration into a stale blackout. Instead, record
+      # code_scanning_permission_error_at so should_scan_code_scanning? backs
+      # off for PERMISSION_ERROR_BACKOFF (much shorter than the full
+      # interval) instead of retrying every poll cycle. The workflow also
+      # catches ConfigurationError and logs a warning.
+      project.update_column(:code_scanning_permission_error_at, Time.current)
       raise
     end
 
     def should_scan_code_scanning?(project)
+      return false if recent_permission_error?(project)
       return true if project.last_code_scanning_scan_at.nil?
 
       project.last_code_scanning_scan_at <= project.code_scanning_interval_hours.hours.ago
+    end
+
+    def recent_permission_error?(project)
+      project.code_scanning_permission_error_at.present? &&
+        project.code_scanning_permission_error_at > PERMISSION_ERROR_BACKOFF.ago
     end
 
     def fetch_code_scanning_alerts(project)

--- a/db/migrate/20260713233921_add_code_scanning_permission_error_at_to_projects.rb
+++ b/db/migrate/20260713233921_add_code_scanning_permission_error_at_to_projects.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddCodeScanningPermissionErrorAtToProjects < ActiveRecord::Migration[8.1]
+  def change
+    add_column :projects, :code_scanning_permission_error_at, :datetime,
+      comment: "Timestamp of the most recent 403 (missing security_events/code_scanning_alerts:read " \
+        "permission) hit while scanning for code scanning alerts. Used to back off retrying a scan " \
+        "that will fail identically until a human fixes the token/App permission, without waiting the " \
+        "full code_scanning_interval_hours window. Cleared on the next successful scan."
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_08_034227) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_13_233921) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1845,6 +1845,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_08_034227) do
     t.string "automation_label_name", default: "paid-automation", null: false
     t.boolean "automation_on_label_enabled", default: true, null: false
     t.integer "code_scanning_interval_hours", default: 24, null: false
+    t.datetime "code_scanning_permission_error_at", comment: "Timestamp of the most recent 403 (missing security_events/code_scanning_alerts:read permission) hit while scanning for code scanning alerts. Used to back off retrying a scan that will fail identically until a human fixes the token/App permission, without waiting the full code_scanning_interval_hours window. Cleared on the next successful scan."
     t.integer "completed_agent_runs_count", default: 0, null: false, comment: "Counter cache for completed agent runs"
     t.datetime "created_at", null: false
     t.bigint "created_by_id"

--- a/spec/services/github_tokens/auto_pause_projects_spec.rb
+++ b/spec/services/github_tokens/auto_pause_projects_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe GithubTokens::AutoPauseProjects do
       validation_error: "Token is invalid or has been revoked: Bad credentials")
   end
 
+  before do
+    allow(ProjectWorkflowManager).to receive(:stop_polling)
+  end
+
   describe ".call" do
     context "with active projects using the failed token" do
       let!(:project) { create(:project, account: account, github_token: github_token) }
@@ -17,6 +21,24 @@ RSpec.describe GithubTokens::AutoPauseProjects do
         described_class.call(github_token: github_token)
 
         expect(project.reload.scheduler_paused_at).to be_present
+      end
+
+      it "stops the project's poll workflow so it doesn't keep hitting the dead credential" do
+        described_class.call(github_token: github_token)
+
+        expect(ProjectWorkflowManager).to have_received(:stop_polling).with(project)
+      end
+
+      it "still pauses the project even if stopping the poll workflow errors" do
+        allow(ProjectWorkflowManager).to receive(:stop_polling).and_raise(StandardError, "boom")
+        allow(Rails.logger).to receive(:error)
+
+        described_class.call(github_token: github_token)
+
+        expect(project.reload.scheduler_paused_at).to be_present
+        expect(Rails.logger).to have_received(:error).with(
+          hash_including(message: "github_token.auto_pause.stop_polling_failed", project_id: project.id)
+        )
       end
 
       it "sets the pause reason" do
@@ -50,14 +72,40 @@ RSpec.describe GithubTokens::AutoPauseProjects do
     context "with already-paused projects" do
       let!(:project) do
         create(:project, account: account, github_token: github_token,
-          scheduler_paused_at: 1.hour.ago, scheduler_pause_reason: "previously paused")
+          scheduler_paused_at: 1.hour.ago,
+          scheduler_pause_reason: "GitHub token '#{github_token.name}' failed validation: Bad credentials")
       end
 
       it "does not double-pause" do
         result = described_class.call(github_token: github_token)
 
         expect(result).to be_empty
-        expect(project.reload.scheduler_pause_reason).to eq("previously paused")
+        expect(project.reload.scheduler_pause_reason).to include("failed validation")
+      end
+
+      it "still stops polling for previously auto-paused projects, even though it doesn't re-pause" do
+        # stop_polling is retried on every call regardless of prior pause
+        # state for auto-paused projects, so a project paused before this
+        # behavior existed (or one whose poll workflow was independently
+        # restarted) still converges to stopped once the token is confirmed
+        # dead.
+        described_class.call(github_token: github_token)
+
+        expect(ProjectWorkflowManager).to have_received(:stop_polling).with(project)
+      end
+    end
+
+    context "with manually paused projects" do
+      let!(:project) do
+        create(:project, account: account, github_token: github_token,
+          scheduler_paused_at: 1.hour.ago, scheduler_pause_reason: "manually paused")
+      end
+
+      it "does not stop polling because auto-resume will not restart it" do
+        described_class.call(github_token: github_token)
+
+        expect(project.reload.scheduler_pause_reason).to eq("manually paused")
+        expect(ProjectWorkflowManager).not_to have_received(:stop_polling)
       end
     end
 
@@ -69,6 +117,12 @@ RSpec.describe GithubTokens::AutoPauseProjects do
 
         expect(result).to be_empty
         expect(project.reload.scheduler_paused_at).to be_nil
+      end
+
+      it "does not stop polling" do
+        described_class.call(github_token: github_token)
+
+        expect(ProjectWorkflowManager).not_to have_received(:stop_polling)
       end
     end
 

--- a/spec/services/github_tokens/auto_resume_projects_spec.rb
+++ b/spec/services/github_tokens/auto_resume_projects_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe GithubTokens::AutoResumeProjects do
   let(:account) { create(:account) }
   let(:github_token) { create(:github_token, account: account) }
 
+  before do
+    allow(ProjectWorkflowManager).to receive(:start_polling)
+  end
+
   describe ".call" do
     context "with active projects auto-paused by the token" do
       let!(:project) do
@@ -19,6 +23,25 @@ RSpec.describe GithubTokens::AutoResumeProjects do
 
         expect(project.reload.scheduler_paused_at).to be_nil
         expect(project.reload.scheduler_pause_reason).to be_nil
+      end
+
+      it "restarts the project's poll workflow" do
+        described_class.call(github_token: github_token)
+
+        expect(ProjectWorkflowManager).to have_received(:start_polling)
+          .with(project, restart_reason: "github_token_restored")
+      end
+
+      it "still resumes the project even if restarting the poll workflow errors" do
+        allow(ProjectWorkflowManager).to receive(:start_polling).and_raise(StandardError, "boom")
+        allow(Rails.logger).to receive(:error)
+
+        described_class.call(github_token: github_token)
+
+        expect(project.reload.scheduler_paused_at).to be_nil
+        expect(Rails.logger).to have_received(:error).with(
+          hash_including(message: "github_token.auto_resume.start_polling_failed", project_id: project.id)
+        )
       end
 
       it "returns resumed project ids" do
@@ -55,6 +78,15 @@ RSpec.describe GithubTokens::AutoResumeProjects do
         expect(project.reload.scheduler_paused_at).to be_present
         expect(project.reload.scheduler_pause_reason).to eq("manually paused")
       end
+
+      it "does not restart polling" do
+        described_class.call(github_token: github_token)
+
+        # Project creation itself triggers an unrelated start_polling(project) call;
+        # assert specifically that AutoResumeProjects' own restart call never fires.
+        expect(ProjectWorkflowManager).not_to have_received(:start_polling)
+          .with(project, restart_reason: "github_token_restored")
+      end
     end
 
     context "with inactive projects" do
@@ -69,6 +101,13 @@ RSpec.describe GithubTokens::AutoResumeProjects do
 
         expect(result).to eq([ project.id ])
         expect(project.reload.scheduler_paused_at).to be_nil
+      end
+
+      it "does not restart polling until the project is reactivated" do
+        described_class.call(github_token: github_token)
+
+        expect(ProjectWorkflowManager).not_to have_received(:start_polling)
+          .with(project, restart_reason: "github_token_restored")
       end
     end
 

--- a/spec/services/github_tokens/auto_resume_projects_spec.rb
+++ b/spec/services/github_tokens/auto_resume_projects_spec.rb
@@ -32,13 +32,15 @@ RSpec.describe GithubTokens::AutoResumeProjects do
           .with(project, restart_reason: "github_token_restored")
       end
 
-      it "still resumes the project even if restarting the poll workflow errors" do
+      it "leaves the project paused if restarting the poll workflow errors" do
         allow(ProjectWorkflowManager).to receive(:start_polling).and_raise(StandardError, "boom")
         allow(Rails.logger).to receive(:error)
 
-        described_class.call(github_token: github_token)
+        result = described_class.call(github_token: github_token)
 
-        expect(project.reload.scheduler_paused_at).to be_nil
+        expect(result).to be_empty
+        expect(project.reload.scheduler_paused_at).to be_present
+        expect(project.scheduler_pause_reason).to include("failed validation")
         expect(Rails.logger).to have_received(:error).with(
           hash_including(message: "github_token.auto_resume.start_polling_failed", project_id: project.id)
         )

--- a/spec/temporal/activities/scan_security_alerts_activity_spec.rb
+++ b/spec/temporal/activities/scan_security_alerts_activity_spec.rb
@@ -90,6 +90,15 @@ RSpec.describe Activities::ScanSecurityAlertsActivity do
         expect(project.last_code_scanning_scan_at).to be_nil
       end
 
+      it "records code_scanning_permission_error_at on 403 so subsequent cycles back off" do
+        allow(github_client).to receive(:code_scanning_alerts)
+          .and_raise(GithubClient::ApiError.new("Forbidden", status: 403))
+
+        expect { activity.execute(project_id: project.id) }.to raise_error(Temporalio::Error::ApplicationError)
+
+        expect(project.reload.code_scanning_permission_error_at).to be_present
+      end
+
       it "re-raises non-403 ApiError without updating last_code_scanning_scan_at" do
         allow(github_client).to receive(:code_scanning_alerts)
           .and_raise(GithubClient::ApiError.new("Server error", status: 500))
@@ -98,6 +107,57 @@ RSpec.describe Activities::ScanSecurityAlertsActivity do
 
         project.reload
         expect(project.last_code_scanning_scan_at).to be_nil
+      end
+
+      it "does not record permission backoff for non-permission configuration errors" do
+        project.update_column(:allowed_github_usernames, [])
+        allow(github_client).to receive(:code_scanning_alerts).and_return([
+          {
+            number: 42, state: "open", severity: "high",
+            rule_id: "test/rule", rule_description: "Test",
+            tool_name: "CodeQL", summary: "Test alert",
+            html_url: "https://github.com/o/r/security/code-scanning/42",
+            created_at: 1.day.ago.iso8601, updated_at: 1.hour.ago.iso8601
+          }
+        ])
+
+        expect { activity.execute(project_id: project.id) }
+          .to raise_error(Temporalio::Error::ApplicationError) do |e|
+            expect(e.type).to eq("ConfigurationError")
+          end
+
+        expect(project.reload.code_scanning_permission_error_at).to be_nil
+      end
+    end
+
+    context "with a recorded permission error" do
+      before { project.update_column(:last_code_scanning_scan_at, nil) }
+
+      it "skips the scan entirely while within the backoff window" do
+        allow(github_client).to receive(:code_scanning_alerts)
+        project.update_column(:code_scanning_permission_error_at, 5.minutes.ago)
+
+        activity.execute(project_id: project.id)
+
+        expect(github_client).not_to have_received(:code_scanning_alerts)
+      end
+
+      it "retries once the backoff window has elapsed" do
+        project.update_column(:code_scanning_permission_error_at, 2.hours.ago)
+        allow(github_client).to receive(:code_scanning_alerts).and_return([])
+
+        activity.execute(project_id: project.id)
+
+        expect(github_client).to have_received(:code_scanning_alerts)
+      end
+
+      it "clears the flag once a scan succeeds again" do
+        project.update_column(:code_scanning_permission_error_at, 2.hours.ago)
+        allow(github_client).to receive(:code_scanning_alerts).and_return([])
+
+        activity.execute(project_id: project.id)
+
+        expect(project.reload.code_scanning_permission_error_at).to be_nil
       end
     end
 


### PR DESCRIPTION
## Summary

- stop GitHub polling only for token auto-paused projects, leaving manually scheduler-paused projects' sync lifecycle untouched
- restart polling after token recovery only for active projects
- back off code scanning permission failures without suppressing unrelated configuration errors

## Root Cause

The token health change stopped polling for any already-paused active project, but auto-resume intentionally skips manual pause reasons. That could leave manually paused projects with polling stopped after token recovery. Auto-resume also restarted polling for inactive projects, and code scanning permission backoff was recorded for the broader configuration error class instead of only GitHub permission failures.

## Validation

- bin/rspec spec/services/github_tokens/auto_pause_projects_spec.rb spec/services/github_tokens/auto_resume_projects_spec.rb spec/temporal/activities/scan_security_alerts_activity_spec.rb
- bin/rubocop app/jobs/github_token_health_check_job.rb app/services/github_tokens/auto_pause_projects.rb app/services/github_tokens/auto_resume_projects.rb app/temporal/activities/scan_security_alerts_activity.rb spec/services/github_tokens/auto_pause_projects_spec.rb spec/services/github_tokens/auto_resume_projects_spec.rb spec/temporal/activities/scan_security_alerts_activity_spec.rb db/migrate/20260713233921_add_code_scanning_permission_error_at_to_projects.rb
- git diff --check