### PR TITLE
fix(pr-scanner): raise ScanPaidPrsActivity timeout from 120s to 300s

### DIFF
--- a/app/temporal/workflows/git_hub_poll_workflow.rb
+++ b/app/temporal/workflows/git_hub_poll_workflow.rb
@@ -215,7 +215,7 @@ module Workflows
     # allowed to propagate so automation failures surface immediately,
     # matching evaluate_issues_batch.
     def maybe_scan_paid_prs(project_id)
-      activity_options = poll_activity_options(timeout: 120)
+      activity_options = poll_activity_options(timeout: 300)
       scan_result = begin
         run_activity(Activities::ScanPaidPrsActivity,
           { project_id: project_id }, **activity_options)

--- a/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
+++ b/spec/temporal/workflows/git_hub_poll_workflow_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       result = workflow.send(:maybe_scan_paid_prs, 1)
 
       expect(workflow).to have_received(:run_activity)
-        .with(Activities::ScanPaidPrsActivity, { project_id: 1 }, timeout: 120, heartbeat_timeout: described_class::DEFAULT_HEARTBEAT_TIMEOUT)
+        .with(Activities::ScanPaidPrsActivity, { project_id: 1 }, timeout: 300, heartbeat_timeout: described_class::DEFAULT_HEARTBEAT_TIMEOUT)
       expect(workflow).to have_received(:handle_pr_scan_results).with({ automation_results: [] }, 1)
       expect(result).to eq({ automation_results: [] })
     end
@@ -258,7 +258,7 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       workflow.send(:maybe_run_non_critical_activities, 1)
 
       expect(workflow).to have_received(:run_activity)
-        .with(Activities::ScanPaidPrsActivity, { project_id: 1 }, timeout: 120, heartbeat_timeout: described_class::DEFAULT_HEARTBEAT_TIMEOUT)
+        .with(Activities::ScanPaidPrsActivity, { project_id: 1 }, timeout: 300, heartbeat_timeout: described_class::DEFAULT_HEARTBEAT_TIMEOUT)
     end
 
     it "runs the rate limit check before the non-critical activities" do
@@ -274,7 +274,7 @@ RSpec.describe Workflows::GitHubPollWorkflow do
       expect(workflow).to have_received(:run_activity)
         .with(Activities::CheckRateLimitActivity, { project_id: 1 }, timeout: 10)
       expect(workflow).to have_received(:run_activity)
-        .with(Activities::ScanPaidPrsActivity, { project_id: 1 }, timeout: 120, heartbeat_timeout: described_class::DEFAULT_HEARTBEAT_TIMEOUT)
+        .with(Activities::ScanPaidPrsActivity, { project_id: 1 }, timeout: 300, heartbeat_timeout: described_class::DEFAULT_HEARTBEAT_TIMEOUT)
     end
   end
 
@@ -690,7 +690,7 @@ RSpec.describe Workflows::GitHubPollWorkflow do
           { issues: [], project_id: project_id, project_missing: true }
         )
       allow(workflow).to receive(:run_activity)
-        .with(Activities::ScanPaidPrsActivity, { project_id: project_id }, timeout: 120, heartbeat_timeout: described_class::DEFAULT_HEARTBEAT_TIMEOUT)
+        .with(Activities::ScanPaidPrsActivity, { project_id: project_id }, timeout: 300, heartbeat_timeout: described_class::DEFAULT_HEARTBEAT_TIMEOUT)
         .and_return(trigger_result)
       allow(workflow).to receive(:run_activity)
         .with(Activities::QueueAgentRunActivity, anything, timeout: anything)


### PR DESCRIPTION
## Problem

The PR scanner (`ScanPaidPrsActivity`) was chronically timing out at 120s when scanning the 33 open paid PRs in this project. Each PR scan takes ~3.2s (3 sequential GitHub API calls: `fetch_pr_data`, `fetch_reviews`, `fetch_unresolved_threads`), so a full scan needs ~106s — right at the 120s ceiling.

When the scan exceeded the timeout, the error was **silently swallowed** by the generic `rescue => e` in `maybe_scan_paid_prs` (`git_hub_poll_workflow.rb:224`). This meant `handle_pr_scan_results` never ran, so:

- No auto-continue runs were created from PR review feedback
- No auto-review runs were triggered
- PRs with unaddressed review comments stayed stuck indefinitely

The `skip_unchanged_pr?` optimization was almost useless — only 1 of 33 PRs qualified for skipping because CI transitions and bot reviews don't bump GitHub's `updated_at`, and the staleness ceiling (3 × poll_interval = 3 min) forced rescans.

## Fix

Raise the `ScanPaidPrsActivity` timeout from 120s → 300s in `maybe_scan_paid_prs`.

This gives the scanner enough headroom to complete the full scan of all open paid PRs. The activity already heartbeats per-PR, so Temporal knows it is making progress and won't kill it prematurely.

## Testing

- All 44 `git_hub_poll_workflow_spec.rb` specs pass
- RuboCop clean on both files

## Follow-up considerations

This is an immediate-relief fix. Longer-term options to reduce rate budget consumption (currently 66% of the hourly limit):

- **Round-robin batch scanning**: scan a rotating subset of PRs per cycle instead of all PRs every cycle
- **ETag/conditional requests**: GitHub returns `304 Not Modified` at 0 rate cost for unchanged resources, but the `GithubClient` doesn't currently support this
- **Parallel API calls within each PR**: `fetch_pr_data` + `fetch_reviews` + `fetch_unresolved_threads` could run concurrently, cutting per-PR time from ~3.2s to ~1.5s