### PR TITLE
fix(agent-runs): inherit manual priority on PR retries

### DIFF
--- a/app/controllers/projects/agent_runs_controller.rb
+++ b/app/controllers/projects/agent_runs_controller.rb
@@ -734,7 +734,11 @@ module Projects
         source_pull_request_number: pr.github_number,
         runner_identifier: settings_owner&.settings&.default_runner_identifier_for_goal("create_pr"),
         goal: "create_pr",
-        trigger_type: "automatic"
+        trigger_type: AgentRun.retry_trigger_type_for(
+          project: @project,
+          source_pull_request_number: pr.github_number,
+          goal: "create_pr"
+        )
       )
       ProcessRunQueueJob.perform_later
       :enqueued

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -1340,14 +1340,19 @@ class AgentRun < ApplicationRecord
   def self.retry_trigger_type_for(project:, source_pull_request_number:, goal:)
     return "automatic" if project.blank? || source_pull_request_number.blank?
 
-    latest_unsuccessful_pr_run = where(
+    # A completed run for the same PR/goal is a cycle reset boundary (mirrors
+    # PullRequests::ProgressState#create_pr_progress?), so only the failure
+    # streak after the most recent successful run is eligible for inheritance.
+    latest_pr_run = where(
       project: project,
       source_pull_request_number: source_pull_request_number,
       goal: goal,
-      status: RETRY_PRIORITY_INHERITANCE_STATUSES
+      status: (RETRY_PRIORITY_INHERITANCE_STATUSES + %w[completed])
     ).order(Arel.sql("COALESCE(completed_at, updated_at, created_at) DESC"), id: :desc).first
 
-    latest_unsuccessful_pr_run&.trigger_type == "manual" ? "manual" : "automatic"
+    return "automatic" if latest_pr_run.blank? || latest_pr_run.status == "completed"
+
+    latest_pr_run.trigger_type == "manual" ? "manual" : "automatic"
   end
 
   def runner_belongs_to_project_owner

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -25,6 +25,7 @@ class AgentRun < ApplicationRecord
   FINISHED_STATUSES = %w[completed no_output failed cancelled timeout token_budget_exceeded retried auth_expired rate_limited].freeze
   FAILURE_STATUSES = %w[failed timeout token_budget_exceeded auth_expired rate_limited].freeze
   TERMINAL_FAILURE_STATUSES = (FAILURE_STATUSES + %w[cancelled]).freeze
+  RETRY_PRIORITY_INHERITANCE_STATUSES = (FAILURE_STATUSES + %w[no_output]).freeze
   QUALITY_EXCLUDED_STATUSES = %w[timeout token_budget_exceeded auth_expired rate_limited].freeze
   STDOUT_TAIL_LINES = 500
 
@@ -1335,6 +1336,19 @@ class AgentRun < ApplicationRecord
     scope.reorder(SCHEDULER_QUEUE_ORDER).first
   end
   private_class_method :next_queued_run_from
+
+  def self.retry_trigger_type_for(project:, source_pull_request_number:, goal:)
+    return "automatic" if project.blank? || source_pull_request_number.blank?
+
+    latest_unsuccessful_pr_run = where(
+      project: project,
+      source_pull_request_number: source_pull_request_number,
+      goal: goal,
+      status: RETRY_PRIORITY_INHERITANCE_STATUSES
+    ).order(Arel.sql("COALESCE(completed_at, updated_at, created_at) DESC"), id: :desc).first
+
+    latest_unsuccessful_pr_run&.trigger_type == "manual" ? "manual" : "automatic"
+  end
 
   def runner_belongs_to_project_owner
     owner = project&.effective_owner

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -144,12 +144,10 @@ class User < ApplicationRecord
   end
 
   # Returns the user's settings, creating with defaults if not yet present.
-  # Handles concurrent creation attempts by rescuing unique constraint violations
-  # and reloading the association to return the existing record.
+  # create_or_find_by! uses a savepoint, so unique races do not poison an
+  # outer transaction before returning the existing settings row.
   def settings
-    user_setting || create_user_setting
-  rescue ActiveRecord::RecordNotUnique
-    reload_user_setting
+    user_setting || UserSetting.create_or_find_by!(user: self)
   end
 
   # Convenience method for getting account membership

--- a/app/temporal/activities/queue_agent_run_activity.rb
+++ b/app/temporal/activities/queue_agent_run_activity.rb
@@ -21,11 +21,14 @@ module Activities
 
       project = Project.find(project_id)
       goal ||= project.account.tenant_setting&.default_goal || "create_pr"
-      trigger_type ||= AgentRun.retry_trigger_type_for(
-        project: project,
-        source_pull_request_number: source_pull_request_number,
-        goal: goal
-      )
+      if trigger_type.nil? && goal == "create_pr" && source_pull_request_number.present?
+        trigger_type = AgentRun.retry_trigger_type_for(
+          project: project,
+          source_pull_request_number: source_pull_request_number,
+          goal: goal
+        )
+      end
+      trigger_type ||= "automatic"
       issue = issue_id ? Issue.find(issue_id) : nil
 
       # PR follow-up runs (source_pull_request_number present) intentionally do

--- a/app/temporal/activities/queue_agent_run_activity.rb
+++ b/app/temporal/activities/queue_agent_run_activity.rb
@@ -14,12 +14,18 @@ module Activities
       source_pull_request_number = input[:source_pull_request_number]
       goal = input[:goal]
       focus = input[:focus] || "general"
+      trigger_type = input[:trigger_type]
       auto_pick = input.fetch(:auto_pick, false)
       count_toward_draft_review_round = input.fetch(:count_toward_draft_review_round, false)
       expected_draft_review_count = input[:expected_draft_review_count]
 
       project = Project.find(project_id)
       goal ||= project.account.tenant_setting&.default_goal || "create_pr"
+      trigger_type ||= AgentRun.retry_trigger_type_for(
+        project: project,
+        source_pull_request_number: source_pull_request_number,
+        goal: goal
+      )
       issue = issue_id ? Issue.find(issue_id) : nil
 
       # PR follow-up runs (source_pull_request_number present) intentionally do
@@ -74,6 +80,7 @@ module Activities
             source_pull_request_number: source_pull_request_number,
             goal: goal,
             focus: focus,
+            trigger_type: trigger_type,
             auto_pick: auto_pick,
             count_toward_draft_review_round: count_toward_draft_review_round,
             expected_draft_review_count: expected_draft_review_count,

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -2378,6 +2378,59 @@ RSpec.describe AgentRun do
     end
   end
 
+  describe ".retry_trigger_type_for" do
+    let(:project) { create(:project) }
+
+    it "inherits manual priority from the latest unsuccessful PR run for the same goal" do
+      create(:agent_run, :timeout, :manual, project: project,
+        source_pull_request_number: 42,
+        goal: "create_pr",
+        completed_at: 5.minutes.ago)
+
+      trigger_type = described_class.retry_trigger_type_for(
+        project: project,
+        source_pull_request_number: 42,
+        goal: "create_pr"
+      )
+
+      expect(trigger_type).to eq("manual")
+    end
+
+    it "keeps automatic priority when a newer unsuccessful PR run was automatic" do
+      create(:agent_run, :timeout, :manual, project: project,
+        source_pull_request_number: 42,
+        goal: "create_pr",
+        completed_at: 10.minutes.ago)
+      create(:agent_run, :failed, :automatic, project: project,
+        source_pull_request_number: 42,
+        goal: "create_pr",
+        completed_at: 5.minutes.ago)
+
+      trigger_type = described_class.retry_trigger_type_for(
+        project: project,
+        source_pull_request_number: 42,
+        goal: "create_pr"
+      )
+
+      expect(trigger_type).to eq("automatic")
+    end
+
+    it "does not inherit priority from a successful PR run" do
+      create(:agent_run, :completed, :manual, project: project,
+        source_pull_request_number: 42,
+        goal: "create_pr",
+        completed_at: 5.minutes.ago)
+
+      trigger_type = described_class.retry_trigger_type_for(
+        project: project,
+        source_pull_request_number: 42,
+        goal: "create_pr"
+      )
+
+      expect(trigger_type).to eq("automatic")
+    end
+  end
+
   describe ".peek_next_queued_run" do
     def claim_peeked_run
       run = described_class.claim_next_queued_run(target_id: described_class.peek_next_queued_run.id)

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -2429,6 +2429,48 @@ RSpec.describe AgentRun do
 
       expect(trigger_type).to eq("automatic")
     end
+
+    it "treats a completed run as a reset boundary before an older manual failure" do
+      create(:agent_run, :timeout, :manual, project: project,
+        source_pull_request_number: 42,
+        goal: "create_pr",
+        completed_at: 10.minutes.ago)
+      create(:agent_run, :completed, :automatic, project: project,
+        source_pull_request_number: 42,
+        goal: "create_pr",
+        completed_at: 5.minutes.ago)
+
+      trigger_type = described_class.retry_trigger_type_for(
+        project: project,
+        source_pull_request_number: 42,
+        goal: "create_pr"
+      )
+
+      expect(trigger_type).to eq("automatic")
+    end
+
+    it "inherits manual priority again from a manual failure after a completed reset" do
+      create(:agent_run, :timeout, :manual, project: project,
+        source_pull_request_number: 42,
+        goal: "create_pr",
+        completed_at: 15.minutes.ago)
+      create(:agent_run, :completed, :automatic, project: project,
+        source_pull_request_number: 42,
+        goal: "create_pr",
+        completed_at: 10.minutes.ago)
+      create(:agent_run, :timeout, :manual, project: project,
+        source_pull_request_number: 42,
+        goal: "create_pr",
+        completed_at: 5.minutes.ago)
+
+      trigger_type = described_class.retry_trigger_type_for(
+        project: project,
+        source_pull_request_number: 42,
+        goal: "create_pr"
+      )
+
+      expect(trigger_type).to eq("manual")
+    end
   end
 
   describe ".peek_next_queued_run" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -257,4 +257,17 @@ RSpec.describe User do
       expect(ClaudeLoginSession.exists?(login_session.id)).to be(false)
     end
   end
+
+  describe "#settings" do
+    it "returns existing settings inside a transaction when the association cached nil" do
+      user = create(:user)
+      expect(user.user_setting).to be_nil
+
+      existing = create(:user_setting, user: user)
+
+      ActiveRecord::Base.transaction do
+        expect(user.settings).to eq(existing)
+      end
+    end
+  end
 end

--- a/spec/requests/agent_runs_spec.rb
+++ b/spec/requests/agent_runs_spec.rb
@@ -1990,6 +1990,24 @@ RSpec.describe "AgentRuns" do
         expect(run.trigger_type).to eq("automatic")
       end
 
+      it "inherits manual priority when resuming after a manual run timed out" do
+        pr.update!(auto_continue_paused: true)
+        create(:agent_run, :timeout, :manual, project: project,
+          source_pull_request_number: pr.github_number,
+          goal: "create_pr",
+          completed_at: 5.minutes.ago)
+
+        expect {
+          post toggle_auto_continue_pause_project_agent_runs_path(project), params: { pull_request_id: pr.id }
+        }.to change(AgentRun, :count).by(1)
+
+        run = AgentRun.last
+        expect(run.source_pull_request_number).to eq(pr.github_number)
+        expect(run.status).to eq("queued")
+        expect(run.goal).to eq("create_pr")
+        expect(run.trigger_type).to eq("manual")
+      end
+
       it "enqueues ProcessRunQueueJob when resuming" do
         pr.update!(auto_continue_paused: true)
 

--- a/spec/temporal/activities/queue_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/queue_agent_run_activity_spec.rb
@@ -191,6 +191,24 @@ RSpec.describe Activities::QueueAgentRunActivity do
       expect(agent_run.trigger_type).to eq("manual")
     end
 
+    it "does not inherit manual priority for review runs" do
+      create(:agent_run, :timeout,
+        project: project,
+        source_pull_request_number: 42,
+        goal: "review",
+        trigger_type: "manual",
+        completed_at: 5.minutes.ago)
+
+      result = activity.execute(
+        project_id: project.id,
+        source_pull_request_number: 42,
+        goal: "review"
+      )
+
+      agent_run = AgentRun.find(result[:agent_run_id])
+      expect(agent_run.trigger_type).to eq("automatic")
+    end
+
     it "does not inherit manual priority from a successful PR run" do
       create(:agent_run, :completed,
         project: project,

--- a/spec/temporal/activities/queue_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/queue_agent_run_activity_spec.rb
@@ -171,6 +171,46 @@ RSpec.describe Activities::QueueAgentRunActivity do
       expect(agent_run.goal).to eq("review")
     end
 
+    it "inherits manual priority from the latest unsuccessful PR run" do
+      create(:agent_run, :timeout,
+        project: project,
+        issue: issue,
+        source_pull_request_number: 42,
+        goal: "create_pr",
+        trigger_type: "manual",
+        completed_at: 5.minutes.ago)
+
+      result = activity.execute(
+        project_id: project.id,
+        issue_id: issue.id,
+        source_pull_request_number: 42,
+        goal: "create_pr"
+      )
+
+      agent_run = AgentRun.find(result[:agent_run_id])
+      expect(agent_run.trigger_type).to eq("manual")
+    end
+
+    it "does not inherit manual priority from a successful PR run" do
+      create(:agent_run, :completed,
+        project: project,
+        issue: issue,
+        source_pull_request_number: 42,
+        goal: "create_pr",
+        trigger_type: "manual",
+        completed_at: 5.minutes.ago)
+
+      result = activity.execute(
+        project_id: project.id,
+        issue_id: issue.id,
+        source_pull_request_number: 42,
+        goal: "create_pr"
+      )
+
+      agent_run = AgentRun.find(result[:agent_run_id])
+      expect(agent_run.trigger_type).to eq("automatic")
+    end
+
     it "stores the focus parameter on the created agent run" do
       result = activity.execute(
         project_id: project.id,


### PR DESCRIPTION
## Summary
- inherit manual trigger priority for replacement PR create runs when the latest unsuccessful run for that PR/goal was manual
- apply the same priority inheritance to Temporal queue activity and auto-continue resume paths
- harden `User#settings` so existing settings can be returned safely inside an outer transaction

## Root Cause
The PR retry/resume paths created fresh `create_pr` runs through automatic queueing code that either omitted `trigger_type` or hardcoded `automatic`, so a manually prioritized failed/timed-out run could come back as only label-prioritized work. While adding request coverage, the resume path also exposed that `User#settings` could poison an outer transaction on a stale association-cache unique race.

## Validation
- `bin/rspec spec/temporal/activities/queue_agent_run_activity_spec.rb spec/models/user_spec.rb:260 spec/models/agent_run_spec.rb:2365 spec/requests/agent_runs_spec.rb:1995`
- pre-commit RuboCop on staged files
- `git diff --check`