### PR TITLE
fix(agent-runs): prioritize review pickup ties

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -1116,6 +1116,10 @@ class AgentRun < ApplicationRecord
     END
   SQL
   GOAL_PRIORITY_SQL = Arel.sql(GOAL_PRIORITY_CASE_SQL).freeze
+  REVIEW_PICKUP_PRIORITY_CASE_SQL = <<~SQL.squish.freeze
+    CASE WHEN goal = 'review' THEN 0 ELSE 1 END
+  SQL
+  REVIEW_PICKUP_PRIORITY_SQL = Arel.sql(REVIEW_PICKUP_PRIORITY_CASE_SQL).freeze
   # Cross-project fair-share: a project's count of currently in-flight runs
   # (running + claimed-queued). Projects with fewer in-flight runs sort ahead
   # so a high-volume project cannot fully starve a low-volume one. This is
@@ -1124,7 +1128,7 @@ class AgentRun < ApplicationRecord
   PROJECT_ACTIVE_COUNT_EXPR_SQL = "COALESCE(project_active_counts.project_active_count, 0)"
   PROJECT_ACTIVE_COUNT_SQL = Arel.sql("#{PROJECT_ACTIVE_COUNT_EXPR_SQL} ASC").freeze
   USER_ACTIVE_COUNT_SQL = Arel.sql("COALESCE(user_active_counts.user_active_count, 0) ASC").freeze
-  # Sort key order:
+  # Visible queue sort key order:
   #   project_active_count → cross-project round-robin
   #   user_active_count    → cross-user fairness within a project tie
   #   queue_priority       → strict priority within a project
@@ -1140,6 +1144,18 @@ class AgentRun < ApplicationRecord
     GOAL_PRIORITY_SQL,
     { created_at: :asc, id: :asc }
   ].freeze
+  # Scheduler-only sort. Keep QUEUE_ORDER as the user-visible ordering; this
+  # adds only a hidden tiebreaker so short review runs drain before create_pr
+  # runs when all visible priority keys are otherwise tied.
+  SCHEDULER_QUEUE_ORDER = [
+    PROJECT_ACTIVE_COUNT_SQL,
+    USER_ACTIVE_COUNT_SQL,
+    QUEUE_PRIORITY_SQL,
+    IN_PROGRESS_SQL,
+    GOAL_PRIORITY_SQL,
+    REVIEW_PICKUP_PRIORITY_SQL,
+    { created_at: :asc, id: :asc }
+  ].freeze
   STATUS_ORDER_CASE_SQL = <<~SQL.squish.freeze
     CASE WHEN agent_runs.status = 'running' THEN 0
          WHEN agent_runs.status = 'queued' AND agent_runs.temporal_workflow_id IS NOT NULL THEN 1
@@ -1148,7 +1164,7 @@ class AgentRun < ApplicationRecord
   SQL
   STATUS_ORDER_SQL = Arel.sql("#{STATUS_ORDER_CASE_SQL} ASC").freeze
 
-  # Scope that adds the CTE and joins required by QUEUE_ORDER.
+  # Scope that adds the CTE and joins required by queue ordering.
   # All queue-ordering methods use this instead of bare `queued`.
   # Filters to unclaimed queued runs (temporal_workflow_id IS NULL) so
   # claimed-but-not-yet-running runs are excluded from peek results.
@@ -1175,7 +1191,7 @@ class AgentRun < ApplicationRecord
   # runs (temporal_workflow_id set) sort ahead of unclaimed ones at the same
   # tier; mirrors QUEUE_ORDER below STATUS_ORDER_SQL.
   scope :queue_order_display, -> {
-    unfinished
+    where(status: UNFINISHED_STATUSES)
       .with(
         project_active_counts: project_active_counts_cte,
         user_active_counts: user_active_counts_cte
@@ -1316,7 +1332,7 @@ class AgentRun < ApplicationRecord
   end
 
   def self.next_queued_run_from(scope)
-    scope.reorder(QUEUE_ORDER).first
+    scope.reorder(SCHEDULER_QUEUE_ORDER).first
   end
   private_class_method :next_queued_run_from
 

--- a/spec/jobs/process_run_queue_job_spec.rb
+++ b/spec/jobs/process_run_queue_job_spec.rb
@@ -290,6 +290,27 @@ RSpec.describe ProcessRunQueueJob do
       expect(auto_continue.reload.status).to eq("queued")
     end
 
+    it "starts review runs before create_pr runs when scheduler priorities tie" do
+      project = create(:project)
+      project.created_by.settings.update!(max_concurrent_runs: 1)
+      create_pr_run = create(:agent_run, :queued, :automatic, :existing_pr,
+        project: project, goal: "create_pr", source_pull_request_number: 42, created_at: 2.minutes.ago)
+      review_run = create(:agent_run, :queued, :automatic, :review_goal,
+        project: project, source_pull_request_number: 43, created_at: 1.minute.ago)
+
+      started_ids = []
+      allow(temporal_client).to receive(:start_workflow) do |_wf, input, **_opts|
+        started_ids << input[:agent_run_id]
+        workflow_handle
+      end
+
+      described_class.new.perform
+
+      expect(started_ids).to eq([ review_run.id ])
+      expect(review_run.reload.temporal_workflow_id).to be_present
+      expect(create_pr_run.reload.temporal_workflow_id).to be_nil
+    end
+
     it "does not start lower-priority work from the same project after claiming a manual run" do
       project = create(:project)
       project.created_by.settings.update!(max_concurrent_runs: 2)

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -2267,6 +2267,22 @@ RSpec.describe AgentRun do
       expect(described_class.next_queued_run).to eq(issue_run)
     end
 
+    it "picks review runs before create_pr runs without changing visible queue order" do
+      project = create(:project)
+      create_pr_run = create(:agent_run, :queued, :automatic, :existing_pr,
+        project: project, goal: "create_pr", source_pull_request_number: 42, created_at: 2.minutes.ago)
+      review_run = create(:agent_run, :queued, :automatic, :review_goal,
+        project: project, source_pull_request_number: 43, created_at: 1.minute.ago)
+
+      queue_preview_ids = described_class.queued_with_priority.order(described_class::QUEUE_ORDER).pluck(:id)
+      index_display_ids = described_class.queue_order_display.pluck(:id)
+
+      expect(described_class.next_queued_run).to eq(review_run)
+      expect(queue_preview_ids).to eq([ create_pr_run.id, review_run.id ])
+      expect(index_display_ids).to eq([ create_pr_run.id, review_run.id ])
+      expect(review_run.queue_priority_label).to eq(create_pr_run.queue_priority_label)
+    end
+
     it "uses FIFO within the same priority tier and goal type" do
       create(:agent_run, :queued, trigger_type: "manual", created_at: 1.minute.ago)
       older_manual = create(:agent_run, :queued, trigger_type: "manual", created_at: 2.minutes.ago)


### PR DESCRIPTION
## Summary
- add a scheduler-only tiebreaker so review agent runs are picked before create_pr runs when visible priority keys tie
- keep user-visible queue ordering and priority labels unchanged
- fix the queue display scope to use the existing unfinished status set explicitly

## Validation
- bin/rspec spec/models/agent_run_spec.rb spec/jobs/process_run_queue_job_spec.rb
- bin/rubocop app/models/agent_run.rb spec/models/agent_run_spec.rb spec/jobs/process_run_queue_job_spec.rb
- pre-commit lint hook