### PR TITLE
fix(scan): dedup unresolved-threads fetches and widen stale-PR escape hatch

### DIFF
--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -699,14 +699,15 @@ module Activities
       end
 
       reviews = fetch_reviews(client, project, issue)
+      unresolved_threads = fetch_unresolved_threads(client, project, issue)
 
       if auto_merge_eligible?(project, client, issue,
-           pr_data: pr_data, checks: checks, reviews: reviews)
+           pr_data: pr_data, checks: checks, reviews: reviews, unresolved_threads: unresolved_threads)
         return owner_approved_trigger(issue)
       end
 
       triggers = detect_ready_triggers(project, client, issue,
-        pr_data: pr_data, checks: checks, reviews: reviews)
+        pr_data: pr_data, checks: checks, reviews: reviews, unresolved_threads: unresolved_threads)
       return :skipped if triggers.nil?
       return nil if triggers.empty?
 
@@ -768,26 +769,29 @@ module Activities
     def scan_escalated_pr(project, client, issue, pr_data: nil)
       pr_data ||= fetch_pr_data(client, project, issue)
 
+      bot_authored = third_party_bot_author?(project, issue.github_creator_login)
+      checks = fetch_check_runs(client, project, pr_data) if pr_data.present?
+      reviews = fetch_reviews(client, project, issue) if pr_data.present? && !bot_authored
+      unresolved_threads = fetch_unresolved_threads(client, project, issue) if pr_data.present?
+
       # Owner approval on an escalated PR unblocks auto-merge.
       if project.auto_merge_enabled? && pr_data.present?
-        checks = fetch_check_runs(client, project, pr_data)
-
-        if third_party_bot_author?(project, issue.github_creator_login)
+        if bot_authored
           if auto_merge_eligible_bot?(project, client, issue,
                checks: checks, mergeable: pr_data[:mergeable])
             return owner_approved_trigger(issue)
           end
         else
-          reviews = fetch_reviews(client, project, issue)
-
           if auto_merge_eligible?(project, client, issue,
-               pr_data: pr_data, checks: checks, reviews: reviews)
+               pr_data: pr_data, checks: checks, reviews: reviews,
+               unresolved_threads: unresolved_threads)
             return owner_approved_trigger(issue)
           end
         end
       end
 
-      triggers = detect_ready_triggers(project, client, issue, pr_data: pr_data)
+      triggers = detect_ready_triggers(project, client, issue,
+        pr_data: pr_data, checks: checks, reviews: reviews, unresolved_threads: unresolved_threads)
       return :skipped if triggers.nil?
       return nil if triggers.empty?
 
@@ -1057,24 +1061,21 @@ module Activities
     # `updated_at` on GitHub. Without this escape hatch the skip-unchanged
     # optimization prevents the scanner from ever reconsidering them.
     #
-    # Human-authored ready/escalated PRs with auto_merge_mode "all" face the
-    # same problem: CI transitions from pending to green do not update the
-    # PR's `updated_at` on GitHub. Owner approvals do update it, but if the
-    # owner approves before CI settles, the scan stamps `last_pr_scan_at`
-    # while CI is still pending, and the subsequent green transition never
-    # triggers a rescan. Restricted to auto_merge_mode "all" (not
-    # "dependabot_only") because only "all" enables auto-merge for
-    # non-Dependabot PRs.
+    # Human-authored ready/escalated PRs face the same problem regardless of
+    # auto_merge_mode: CI transitions from pending to green/red, review
+    # comments, and merge-conflict onset do not update the PR's `updated_at`
+    # on GitHub. Without this escape hatch a PR scanned while CI is pending
+    # is permanently skipped, blocking follow-up runs for CI failures, review
+    # feedback, or merge conflicts until someone pushes a commit.
     def scan_age_exceeds_ceiling?(project, issue)
       draft_or_restarted = issue.pr_review_phase.in?(%w[draft restarted])
       bot_ready_for_merge = issue.pr_review_phase == "ready" &&
         third_party_bot_author?(project, issue.github_creator_login) &&
         project.auto_merge_dependabot?
-      human_auto_merge = issue.pr_review_phase.in?(%w[ready escalated]) &&
-        !third_party_bot_author?(project, issue.github_creator_login) &&
-        project.auto_merge_mode == "all"
+      human_ready_or_escalated = issue.pr_review_phase.in?(%w[ready escalated]) &&
+        !third_party_bot_author?(project, issue.github_creator_login)
 
-      return false unless draft_or_restarted || bot_ready_for_merge || human_auto_merge
+      return false unless draft_or_restarted || bot_ready_for_merge || human_ready_or_escalated
 
       ceiling = SCAN_STALENESS_MULTIPLIER * project.poll_interval_seconds
       stale = issue.last_pr_scan_at < ceiling.seconds.ago
@@ -2451,9 +2452,10 @@ module Activities
     # non_bot_review_gate_triggers, causing ci_action_succeeded? to return
     # false — conservatively blocking auto-merge if ci_action is enabled.
     # Callers that have check data available should always pass it.
-    def no_outstanding_review_feedback?(project, client, issue, reviews, checks: nil, pr_data: nil)
+    def no_outstanding_review_feedback?(project, client, issue, reviews, checks: nil, pr_data: nil,
+      unresolved_threads: nil)
       last_run = last_completed_run(project, issue)
-      unresolved_threads = fetch_unresolved_threads(client, project, issue)
+      unresolved_threads ||= fetch_unresolved_threads(client, project, issue)
 
       return false if human_review_thread_triggers(project, unresolved_threads).any?
       return false if check_review_bot_status(reviews, unresolved_threads,
@@ -2915,14 +2917,15 @@ module Activities
     # Evaluates human-authored PR merge eligibility via the AutoMerge
     # strategy. Collects signals from provider data and delegates the
     # decision to {Automation::Strategies::AutoMerge}.
-    def auto_merge_eligible?(project, client, issue, pr_data:, checks:, reviews:)
+    def auto_merge_eligible?(project, client, issue, pr_data:, checks:, reviews:, unresolved_threads: nil)
       return false unless project.auto_merge_enabled? && pr_data.present?
 
       owner_approved = owner_approved_or_self_authored?(project, reviews, pr_data)
       checks_green = !checks.nil? && all_checks_green?(checks)
       mergeable = pr_data[:mergeable] == true
       review_feedback_clear = no_outstanding_review_feedback?(
-        project, client, issue, reviews, checks: checks, pr_data: pr_data
+        project, client, issue, reviews, checks: checks, pr_data: pr_data,
+        unresolved_threads: unresolved_threads
       )
       blocking_reviews_complete = all_blocking_review_methods_complete?(
         project, reviews, checks, pr_data: pr_data

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -7331,18 +7331,18 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         expect(unchanged_pr.reload.last_pr_scan_at).to be > 10.seconds.ago
       end
 
-      it "does not bypass skip for stale ready PRs authored by humans (preserves merge-conflict rescan path)" do
+      it "rescans stale ready PRs authored by humans regardless of auto-merge mode" do
         ceiling = described_class::SCAN_STALENESS_MULTIPLIER * project.poll_interval_seconds
         unchanged_pr.update!(pr_review_phase: "ready")
         unchanged_pr.update_columns(
           github_updated_at: (ceiling + 60).seconds.ago,
           last_pr_scan_at: (ceiling + 30).seconds.ago
         )
+        stub_github_for_pr
 
-        result = activity.execute(project_id: project.id)
+        activity.execute(project_id: project.id)
 
-        expect(automation_scan_results(result)).to eq([])
-        expect(unchanged_pr.reload.last_pr_scan_at).to be < ceiling.seconds.ago
+        expect(unchanged_pr.reload.last_pr_scan_at).to be > 10.seconds.ago
       end
 
       it "rescans stale bot-authored ready PRs when Dependabot auto-merge is enabled" do
@@ -7407,7 +7407,37 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         expect(unchanged_pr.reload.last_pr_scan_at).to be > 10.seconds.ago
       end
 
-      it "does not rescan stale human-authored ready PRs when auto-merge is dependabot_only" do
+      it "rescans stale human-authored escalated PRs when auto-merge is dependabot_only" do
+        ceiling = described_class::SCAN_STALENESS_MULTIPLIER * project.poll_interval_seconds
+        project.update!(auto_merge_mode: "dependabot_only")
+        unchanged_pr.update!(pr_review_phase: "escalated")
+        unchanged_pr.update_columns(
+          github_updated_at: (ceiling + 60).seconds.ago,
+          last_pr_scan_at: (ceiling + 30).seconds.ago
+        )
+        stub_github_for_pr
+
+        activity.execute(project_id: project.id)
+
+        expect(unchanged_pr.reload.last_pr_scan_at).to be > 10.seconds.ago
+      end
+
+      it "rescans stale human-authored escalated PRs when auto-merge is off" do
+        ceiling = described_class::SCAN_STALENESS_MULTIPLIER * project.poll_interval_seconds
+        project.update!(auto_merge_mode: "off")
+        unchanged_pr.update!(pr_review_phase: "escalated")
+        unchanged_pr.update_columns(
+          github_updated_at: (ceiling + 60).seconds.ago,
+          last_pr_scan_at: (ceiling + 30).seconds.ago
+        )
+        stub_github_for_pr
+
+        activity.execute(project_id: project.id)
+
+        expect(unchanged_pr.reload.last_pr_scan_at).to be > 10.seconds.ago
+      end
+
+      it "rescans stale human-authored ready PRs when auto-merge is dependabot_only" do
         ceiling = described_class::SCAN_STALENESS_MULTIPLIER * project.poll_interval_seconds
         project.update!(auto_merge_mode: "dependabot_only")
         unchanged_pr.update!(pr_review_phase: "ready")
@@ -7415,14 +7445,14 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           github_updated_at: (ceiling + 60).seconds.ago,
           last_pr_scan_at: (ceiling + 30).seconds.ago
         )
+        stub_github_for_pr
 
-        result = activity.execute(project_id: project.id)
+        activity.execute(project_id: project.id)
 
-        expect(automation_scan_results(result)).to eq([])
-        expect(unchanged_pr.reload.last_pr_scan_at).to be < ceiling.seconds.ago
+        expect(unchanged_pr.reload.last_pr_scan_at).to be > 10.seconds.ago
       end
 
-      it "does not rescan stale human-authored ready PRs when auto-merge is off" do
+      it "rescans stale human-authored ready PRs when auto-merge is off" do
         ceiling = described_class::SCAN_STALENESS_MULTIPLIER * project.poll_interval_seconds
         project.update!(auto_merge_mode: "off")
         unchanged_pr.update!(pr_review_phase: "ready")
@@ -7430,11 +7460,11 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           github_updated_at: (ceiling + 60).seconds.ago,
           last_pr_scan_at: (ceiling + 30).seconds.ago
         )
+        stub_github_for_pr
 
-        result = activity.execute(project_id: project.id)
+        activity.execute(project_id: project.id)
 
-        expect(automation_scan_results(result)).to eq([])
-        expect(unchanged_pr.reload.last_pr_scan_at).to be < ceiling.seconds.ago
+        expect(unchanged_pr.reload.last_pr_scan_at).to be > 10.seconds.ago
       end
 
       it "scans ready PRs for merge conflicts when auto-fix is enabled" do


### PR DESCRIPTION
## Summary

Human-authored PRs in ready/escalated phase were permanently skipped by the scanner when `auto_merge_mode` was not `"all"`. CI status transitions, review comments, and merge-conflict onset don't update a PR's `updated_at` on GitHub, so the `skip_unchanged_pr?` optimization meant these PRs never got rescanned — blocking follow-up runs for CI failures, review feedback, or merge conflicts until someone manually pushed a commit.

Two related fixes to the scan path:

**1. Widen the stale-PR escape hatch** — Removed the `auto_merge_mode == "all"` gate from `scan_age_exceeds_ceiling?`. All human-authored ready/escalated PRs now qualify for rescan once they exceed the staleness ceiling (`SCAN_STALENESS_MULTIPLIER * poll_interval`), regardless of auto-merge configuration. Previously only `auto_merge_mode: "all"` PRs escaped; `dependabot_only` and `off` PRs were stuck forever.

**2. Dedup unresolved-threads API calls** — To offset the additional rescans from the wider pool, `fetch_unresolved_threads` is now pre-fetched once per PR in `scan_ready_pr` and `scan_escalated_pr`, then threaded through `no_outstanding_review_feedback?`, `auto_merge_eligible?`, and `detect_ready_triggers`. Previously each downstream call independently fetched threads, causing 2–3 duplicate API calls per PR per scan.

### Test plan

- 389 specs pass, RuboCop clean
- Updated 3 existing tests that asserted the old "does not rescan" behavior to assert rescans now happen for `off` and `dependabot_only` modes
- Added 2 new tests covering escalated phase with `dependabot_only` and `off` auto-merge modes (previously only `all` was tested for escalated)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/GLM_5.1-6366f1?logo=claude&logoColor=white)
