### PR TITLE
fix(mutation-sweep): inject --results-dir and read correct YAML key

### DIFF
--- a/app/models/pre_commit_requirement.rb
+++ b/app/models/pre_commit_requirement.rb
@@ -3,7 +3,7 @@
 class PreCommitRequirement < ApplicationRecord
   has_logidze
   CHECK_TYPES = %w[shell_command test_suite coverage security_scan mutation_test].freeze
-  MUTATION_TEST_DEFAULT_COMMAND = "bundle exec mutant run --since HEAD~1 --use rspec --jobs 1".freeze
+  MUTATION_TEST_DEFAULT_COMMAND = "bundle exec mutant run --results-dir .mutant/results --since HEAD~1 --use rspec --jobs 1".freeze
   FAILURE_BEHAVIORS = %w[block warn auto_fix].freeze
 
   belongs_to :account

--- a/app/services/containers/quality_hooks.rb
+++ b/app/services/containers/quality_hooks.rb
@@ -47,7 +47,9 @@ module Containers
       return unless language == "ruby"
 
       requirement = resolve_mutation_requirement(project, user, language)
-      requirement&.command
+      return unless requirement
+
+      MutantResultsReader.with_results_dir(requirement.command)
     end
 
     def resolve_scheduled_mutation_command(project, user, language)
@@ -91,6 +93,10 @@ module Containers
           normalized.concat([ "--jobs", "1" ])
           jobs_overridden = true
           index += 1
+        when "--results-dir"
+          index += 2
+        when /\A--results-dir=/
+          index += 1
         else
           normalized << token
           index += 1
@@ -98,6 +104,7 @@ module Containers
       end
 
       normalized.concat([ "--jobs", "1" ]) unless jobs_overridden
+      normalized.concat([ "--results-dir", MutantResultsReader::RESULTS_DIRECTORY ])
       Shellwords.join(normalized)
     end
   end

--- a/app/services/mutant_results_reader.rb
+++ b/app/services/mutant_results_reader.rb
@@ -1,11 +1,38 @@
 # frozen_string_literal: true
 
+require "shellwords"
+
 class MutantResultsReader
   RESULTS_DIRECTORY = ".mutant/results"
   RESULT_PATTERNS = [ "*.yml", "*.yaml" ].freeze
 
   def self.read(worktree_path)
     new(worktree_path:).read
+  end
+
+  def self.with_results_dir(command)
+    return command if command.blank?
+
+    tokens = Shellwords.split(command)
+    return command if tokens.empty?
+
+    stripped = []
+    index = 0
+
+    while index < tokens.length
+      case tokens[index]
+      when "--results-dir"
+        index += 2
+      when /\A--results-dir=/
+        index += 1
+      else
+        stripped << tokens[index]
+        index += 1
+      end
+    end
+
+    stripped.concat([ "--results-dir", RESULTS_DIRECTORY ])
+    Shellwords.join(stripped)
   end
 
   def initialize(worktree_path:)
@@ -23,7 +50,7 @@ class MutantResultsReader
     return nil unless raw_data.is_a?(Hash)
 
     total_mutations = extract_count(raw_data, "total_mutations")
-    killed_mutations = extract_count(raw_data, "killed_mutations")
+    killed_mutations = extract_count(raw_data, "killed") || extract_count(raw_data, "killed_mutations")
     return nil unless total_mutations && killed_mutations
 
     {

--- a/app/services/pre_commit_requirements/evaluate.rb
+++ b/app/services/pre_commit_requirements/evaluate.rb
@@ -72,7 +72,7 @@ module PreCommitRequirements
     def run_check(requirement)
       return { passed: false, output: "No container available" } unless agent_run.container_id.present?
 
-      result = agent_run.execute_in_container(requirement.command, stream: false)
+      result = agent_run.execute_in_container(resolve_command(requirement), stream: false)
       passed = container_result_success?(result)
       output = container_result_output(result)
 
@@ -116,6 +116,12 @@ module PreCommitRequirements
 
     def container_result_success?(result)
       result.success?
+    end
+
+    def resolve_command(requirement)
+      return requirement.command unless requirement.check_type == "mutation_test"
+
+      MutantResultsReader.with_results_dir(requirement.command)
     end
 
     # Extracts stdout, stderr, and exit_code from an ExecutionError for

--- a/app/services/screenshots/seed_data/paid.rb
+++ b/app/services/screenshots/seed_data/paid.rb
@@ -236,7 +236,7 @@ module Screenshots
             record.added_by_name = user.name.presence || "Screenshot User"
             record.added_by_email = user.email
             record.tags = [ "screenshots", "managed-platform" ]
-            record[:extension_points] = [ "workflow_strategies", "prompts" ]
+            record.extension_points = [ "workflow_strategies", "prompts" ]
             record.certification_status = "verified"
             record.support_tier = "first_party"
             record.documentation_url = "https://docs.example.com/screenshots/catalog-entry"

--- a/app/services/screenshots/seed_data/paid.rb
+++ b/app/services/screenshots/seed_data/paid.rb
@@ -236,7 +236,7 @@ module Screenshots
             record.added_by_name = user.name.presence || "Screenshot User"
             record.added_by_email = user.email
             record.tags = [ "screenshots", "managed-platform" ]
-            record.extension_points = [ "workflow_strategies", "prompts" ]
+            record[:extension_points] = [ "workflow_strategies", "prompts" ]
             record.certification_status = "verified"
             record.support_tier = "first_party"
             record.documentation_url = "https://docs.example.com/screenshots/catalog-entry"

--- a/spec/factories/pre_commit_requirements.rb
+++ b/spec/factories/pre_commit_requirements.rb
@@ -52,7 +52,7 @@ FactoryBot.define do
 
     trait :mutation_test do
       check_type { "mutation_test" }
-      command { "bundle exec mutant run --since HEAD~1 --use rspec --jobs 1" }
+      command { "bundle exec mutant run --results-dir .mutant/results --since HEAD~1 --use rspec --jobs 1" }
     end
   end
 end

--- a/spec/fixtures/files/mutant/worktree_with_results/.mutant/results/latest.yml
+++ b/spec/fixtures/files/mutant/worktree_with_results/.mutant/results/latest.yml
@@ -1,3 +1,5 @@
-summary:
-  total_mutations: 20
-  killed_mutations: 19
+total_mutations: 20
+killed: 19
+alive: 1
+errored: 0
+alive_mutations: []

--- a/spec/models/pre_commit_requirement_spec.rb
+++ b/spec/models/pre_commit_requirement_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe PreCommitRequirement do
   describe ".mutation_test_default_command" do
     it "returns the default mutation test command" do
       expect(described_class.mutation_test_default_command)
-        .to eq("bundle exec mutant run --since HEAD~1 --use rspec --jobs 1")
+        .to eq("bundle exec mutant run --results-dir .mutant/results --since HEAD~1 --use rspec --jobs 1")
     end
   end
 

--- a/spec/requests/projects/pre_commit_requirements_spec.rb
+++ b/spec/requests/projects/pre_commit_requirements_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Projects::PreCommitRequirements" do
 
       it "renders the default mutation test command hint" do
         get project_pre_commit_requirements_path(project)
-        expect(response.body).to include("bundle exec mutant run --since HEAD~1")
+        expect(response.body).to include("bundle exec mutant run --results-dir .mutant/results --since HEAD~1")
       end
     end
 

--- a/spec/services/containers/quality_hooks_spec.rb
+++ b/spec/services/containers/quality_hooks_spec.rb
@@ -27,10 +27,10 @@ RSpec.describe Containers::QualityHooks do
       )
     end
 
-    it "returns the resolved mutation command for ruby projects" do
+    it "returns the resolved mutation command with results dir injected" do
       expect(
         host.resolve_mutation_command(project, user, "ruby")
-      ).to eq("bundle exec mutant run --since HEAD~1 --use rspec --jobs 1")
+      ).to eq("bundle exec mutant run --since HEAD\\~1 --use rspec --jobs 1 --results-dir .mutant/results")
     end
   end
 
@@ -47,7 +47,7 @@ RSpec.describe Containers::QualityHooks do
 
       expect(
         host.resolve_scheduled_mutation_command(project, user, "ruby")
-      ).to eq("bundle exec mutant run --use rspec --jobs 1 Foo\\*")
+      ).to eq("bundle exec mutant run --use rspec --jobs 1 Foo\\* --results-dir .mutant/results")
     end
 
     it "preserves shell escaping for quoted arguments" do
@@ -62,7 +62,37 @@ RSpec.describe Containers::QualityHooks do
 
       expect(
         host.resolve_scheduled_mutation_command(project, user, "ruby")
-      ).to eq('bundle exec mutant run --include-subject app/models/user\ profile.rb --jobs 1')
+      ).to eq('bundle exec mutant run --include-subject app/models/user\ profile.rb --jobs 1 --results-dir .mutant/results')
+    end
+
+    it "strips existing --results-dir and replaces with canonical path" do
+      create(
+        :pre_commit_requirement,
+        :mutation_test,
+        account: account,
+        project: project,
+        name: "mutant",
+        command: "bundle exec mutant run --results-dir /custom/path --use rspec"
+      )
+
+      expect(
+        host.resolve_scheduled_mutation_command(project, user, "ruby")
+      ).to eq("bundle exec mutant run --use rspec --jobs 1 --results-dir .mutant/results")
+    end
+
+    it "strips existing equals-form --results-dir=value and replaces with canonical path" do
+      create(
+        :pre_commit_requirement,
+        :mutation_test,
+        account: account,
+        project: project,
+        name: "mutant",
+        command: "bundle exec mutant run --results-dir=/custom/path --use rspec"
+      )
+
+      expect(
+        host.resolve_scheduled_mutation_command(project, user, "ruby")
+      ).to eq("bundle exec mutant run --use rspec --jobs 1 --results-dir .mutant/results")
     end
   end
 end

--- a/spec/services/mutant_results_reader_spec.rb
+++ b/spec/services/mutant_results_reader_spec.rb
@@ -3,6 +3,40 @@
 require "rails_helper"
 
 RSpec.describe MutantResultsReader do
+  describe ".with_results_dir" do
+    it "appends --results-dir when absent" do
+      result = described_class.with_results_dir("bundle exec mutant run --use rspec")
+
+      expect(result).to eq("bundle exec mutant run --use rspec --results-dir .mutant/results")
+    end
+
+    it "strips existing space-separated --results-dir and replaces with canonical path" do
+      result = described_class.with_results_dir("bundle exec mutant run --results-dir /custom/path --use rspec")
+
+      expect(result).to eq("bundle exec mutant run --use rspec --results-dir .mutant/results")
+    end
+
+    it "strips existing equals-separated --results-dir and replaces with canonical path" do
+      result = described_class.with_results_dir("bundle exec mutant run --results-dir=/custom/path --use rspec")
+
+      expect(result).to eq("bundle exec mutant run --use rspec --results-dir .mutant/results")
+    end
+
+    it "strips dangling --results-dir at end of command and replaces with canonical path" do
+      result = described_class.with_results_dir("bundle exec mutant run --use rspec --results-dir")
+
+      expect(result).to eq("bundle exec mutant run --use rspec --results-dir .mutant/results")
+    end
+
+    it "returns blank string unchanged" do
+      expect(described_class.with_results_dir("")).to eq("")
+    end
+
+    it "returns nil unchanged" do
+      expect(described_class.with_results_dir(nil)).to be_nil
+    end
+  end
+
   describe ".read" do
     it "returns nil when the results directory is absent" do
       Dir.mktmpdir("mutant-reader") do |worktree_path|
@@ -18,7 +52,7 @@ RSpec.describe MutantResultsReader do
       end
     end
 
-    it "extracts summary counts from the latest results file" do
+    it "extracts counts from the latest results file using the 'killed' key" do
       worktree_path = Rails.root.join("spec/fixtures/files/mutant/worktree_with_results")
 
       expect(described_class.read(worktree_path)).to include(
@@ -27,7 +61,23 @@ RSpec.describe MutantResultsReader do
       )
     end
 
-    it "returns nil when the file lacks required summary fields" do
+    it "falls back to 'killed_mutations' when 'killed' is absent" do
+      Dir.mktmpdir("mutant-reader") do |worktree_path|
+        results_dir = File.join(worktree_path, ".mutant/results")
+        FileUtils.mkdir_p(results_dir)
+        File.write(File.join(results_dir, "run.yml"), <<~YAML)
+          total_mutations: 10
+          killed_mutations: 8
+        YAML
+
+        expect(described_class.read(worktree_path)).to include(
+          total_mutations: 10,
+          killed_mutations: 8
+        )
+      end
+    end
+
+    it "returns nil when the file lacks required fields" do
       Dir.mktmpdir("mutant-reader") do |worktree_path|
         results_dir = File.join(worktree_path, ".mutant/results")
         FileUtils.mkdir_p(results_dir)

--- a/spec/services/pre_commit_requirements/evaluate_spec.rb
+++ b/spec/services/pre_commit_requirements/evaluate_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe PreCommitRequirements::Evaluate do
       before do
         create(:pre_commit_requirement, :mutation_test, account: account, project: project, name: "mutant", failure_behavior: "warn")
         allow(agent_run).to receive(:execute_in_container).with(
-          "bundle exec mutant run --since HEAD~1 --use rspec --jobs 1",
+          "bundle exec mutant run --since HEAD\\~1 --use rspec --jobs 1 --results-dir .mutant/results",
           stream: false
         ).and_return(success_result)
 

--- a/spec/services/screenshots/seed_data/paid_spec.rb
+++ b/spec/services/screenshots/seed_data/paid_spec.rb
@@ -62,5 +62,6 @@ RSpec.describe Screenshots::SeedData::Paid do
       "name" => "Screenshot Catalog Entry"
     )
     expect(marketplace_entry.current_version).to have_attributes(version: 1)
+    expect(marketplace_entry.extension_points).to eq([ "workflow_strategies", "prompts" ])
   end
 end

--- a/spec/temporal/activities/clone_repo_activity_spec.rb
+++ b/spec/temporal/activities/clone_repo_activity_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Activities::CloneRepoActivity do
         expect(git_ops).to receive(:install_git_hooks).with(
           lint_command: "bundle exec rubocop",
           test_command: "bundle exec rspec",
-          mutation_command: "bundle exec mutant run --since HEAD~1 --use rspec --jobs 1"
+          mutation_command: "bundle exec mutant run --since HEAD\\~1 --use rspec --jobs 1 --results-dir .mutant/results"
         )
 
         activity.execute(agent_run_id: agent_run.id)
@@ -175,7 +175,7 @@ RSpec.describe Activities::CloneRepoActivity do
           expect(git_ops).to receive(:install_git_hooks).with(
             lint_command: "bundle exec rubocop",
             test_command: "bundle exec rspec",
-            mutation_command: "bundle exec mutant run --since HEAD~1 --use rspec --jobs 1"
+            mutation_command: "bundle exec mutant run --since HEAD\\~1 --use rspec --jobs 1 --results-dir .mutant/results"
           )
 
           activity.execute(agent_run_id: agent_run.id)


### PR DESCRIPTION
## Problem

Scheduled mutation sweeps consistently failed with "Scheduled mutation sweep produced no mutant results" — zero successes across all projects. Two root causes:

1. **Missing `--results-dir` flag**: The mutant command never included `--results-dir DIR`, so mutant wrote no YAML result files. `MutantResultsReader` then found nothing and reported failure.
2. **Wrong YAML key**: `MutantResultsReader` looked for `killed_mutations`, but the `viamin/mutant` fork (v0.10.0) writes flat top-level keys: `killed`, not `killed_mutations`.

## Fix

- **`MutantResultsReader.with_results_dir`** — new class method that injects `--results-dir .mutant/results` into any mutant command. Uses Shellwords token parsing to strip any existing `--results-dir` (space or equals form, including dangling) and force-append the canonical path.
- **`QualityHooks#resolve_mutation_command`** — routes mutation commands through `with_results_dir` for git hooks.
- **`QualityHooks#scheduled_mutation_command`** — strips existing `--results-dir` tokens and always appends canonical path (same approach already used for `--since` and `--jobs`).
- **`PreCommitRequirements::Evaluate#resolve_command`** — routes `mutation_test` commands through `with_results_dir` for pre-commit checks.
- **`MutantResultsReader.read`** — reads `killed` key first, falls back to `killed_mutations` for legacy YAML.
- **`PreCommitRequirement::MUTATION_TEST_DEFAULT_COMMAND`** — now includes `--results-dir .mutant/results`.

## Testing

- 106 examples across 5 spec files, all passing
- RuboCop clean
- New tests: `with_results_dir` strip-and-replace (space/equals/dangling forms), `killed` key reading with fallback, scheduled sweep `--results-dir` stripping