### PR TITLE
chore: update node to 24 lts

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 ruby 3.4.8
-nodejs 22.13.0
+nodejs 24.18.0
 golang 1.25.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Install JavaScript dependencies
-ARG NODE_VERSION=22.12.0
+ARG NODE_VERSION=24.18.0
 ARG YARN_VERSION=1.22.22
 ENV PATH=/usr/local/node/bin:$PATH
 # Pin node-build to a specific release for supply chain security


### PR DESCRIPTION
## Summary

- Update the shared Node runtime pin in `.tool-versions` from 22.13.0 to 24.18.0.
- Update the production Docker build Node pin from 22.12.0 to 24.18.0 so image builds stay aligned with CI.

## Why

PR #2932 exposed that the current Node 22 pin is too old for newer transitive JavaScript dependencies. `ini@7.0.0` requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`, causing every workflow job that runs `yarn install --frozen-lockfile` to fail before tests run.

Node 24 is the current LTS line, so this moves the project to a supported major version instead of only patching the Node 22 line.

## Validation

- `node --version` -> `v24.18.0`
- `yarn install --frozen-lockfile && bin/yarn-postinstall`
- pre-commit checks during commit