### PR TITLE
feat(auto-merge): scan Dependabot PRs without automation label

### DIFF
--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -33,6 +33,7 @@ module Activities
     SCAN_STALENESS_MULTIPLIER = 3
     KNOWN_BOT_PREFIXES = %w[dependabot renovate github-actions].freeze
     DEPENDENCY_UPDATE_BOT_AUTHORS = Project::DEPENDENCY_UPDATE_BOT_AUTHORS
+    DEPENDABOT_AUTO_MERGE_AUTHORS = DependabotAutoMergeJob::DEPENDABOT_AUTHORS
     REVIEW_BOT_CLEAN_PATTERN = /generated no (?:new )?comments/i
     # Body-only review bots (currently Codex) signal "no findings" by posting
     # an *issue comment* — not a review — with text like
@@ -310,25 +311,40 @@ module Activities
     end
 
     def find_paid_prs(project)
-      labeled_prs = project.issues
+      candidate_prs = project.issues
         .pull_requests_only
         .auto_continue_active
         .where(github_state: "open")
-        .where("labels @> ?", [ project.automation_label_name ].to_json)
+
+      labeled_prs = automation_labeled_prs(project, candidate_prs)
+      dependabot_prs = if project.auto_merge_dependabot?
+        dependabot_auto_merge_prs(candidate_prs)
+      else
+        candidate_prs.none
+      end
+      scannable_prs = labeled_prs.or(dependabot_prs)
 
       trusted_creator_logins = trusted_creator_logins_for(project)
       trusted_prs = if trusted_creator_logins.any?
-        labeled_prs.where("LOWER(github_creator_login) IN (?)", trusted_creator_logins).to_a
+        scannable_prs.where("LOWER(github_creator_login) IN (?)", trusted_creator_logins).to_a
       else
         []
       end
       untrusted_prs = if trusted_creator_logins.any?
-        labeled_prs.where("LOWER(github_creator_login) NOT IN (?)", trusted_creator_logins)
+        scannable_prs.where("LOWER(github_creator_login) NOT IN (?)", trusted_creator_logins)
       else
-        labeled_prs
+        scannable_prs
       end
 
       trusted_prs + untrusted_prs.select { |issue| authorized_for_automation_scan?(project, issue) }
+    end
+
+    def automation_labeled_prs(project, candidate_prs)
+      candidate_prs.where("labels @> ?", [ project.automation_label_name ].to_json)
+    end
+
+    def dependabot_auto_merge_prs(candidate_prs)
+      candidate_prs.where("LOWER(github_creator_login) IN (?)", DEPENDABOT_AUTO_MERGE_AUTHORS.map(&:downcase))
     end
 
     def authorized_for_automation_scan?(project, issue)

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -792,7 +792,8 @@
               </div>
               <p class="mt-1 text-xs text-gray-500">
                 Automatically merge PRs when CI passes and all checks are green.
-                "Dependabot Only" merges bot-authored dependency update PRs (review requirements skipped).
+                In "Dependabot Only" and "All PRs" modes, Paid may run agents on Dependabot PRs when CI or merge conflicts need fixes.
+                Dependabot PRs use a dependency-update merge path; GitHub branch protection rules still apply.
                 "All PRs" merges any paid-ready PR, including Paid-generated and Dependabot PRs.
               </p>
               <% if @project.errors[:auto_merge_mode].any? %>

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -4999,6 +4999,65 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         expect(automation_scan_results(result).first[:triggers].map { |t| t[:type] }).to include("ci_failure")
       end
 
+      it "triggers ci_failure without the automation label when Dependabot auto-merge is enabled" do
+        project.update!(auto_merge_mode: "dependabot_only")
+        Issue.find_by!(project: project, github_number: 42).update!(labels: %w[dependencies ruby])
+        expect(github_client).not_to receive(:issue_events)
+        stub_github_for_pr(
+          draft: true,
+          author_login: "dependabot[bot]",
+          checks: [ { name: "ci", conclusion: "failure" } ],
+          review_threads: [],
+          reviews: []
+        )
+
+        result = activity.execute(project_id: project.id)
+
+        expect(automation_scan_results(result).size).to eq(1)
+        expect(automation_scan_results(result).first[:triggers].map { |t| t[:type] }).to include("ci_failure")
+      end
+
+      it "triggers ci_failure without the automation label when all PR auto-merge is enabled" do
+        project.update!(auto_merge_mode: "all")
+        Issue.find_by!(project: project, github_number: 42).update!(labels: %w[dependencies ruby])
+        expect(github_client).not_to receive(:issue_events)
+        stub_github_for_pr(
+          draft: true,
+          author_login: "dependabot[bot]",
+          checks: [ { name: "ci", conclusion: "failure" } ],
+          review_threads: [],
+          reviews: []
+        )
+
+        result = activity.execute(project_id: project.id)
+
+        expect(automation_scan_results(result).size).to eq(1)
+        expect(automation_scan_results(result).first[:triggers].map { |t| t[:type] }).to include("ci_failure")
+      end
+
+      it "ignores unlabeled Dependabot PRs when Dependabot auto-merge is disabled" do
+        project.update!(auto_merge_mode: "off")
+        Issue.find_by!(project: project, github_number: 42).update!(labels: %w[dependencies ruby])
+        expect(github_client).not_to receive(:pull_request)
+
+        result = activity.execute(project_id: project.id)
+
+        expect(automation_scan_results(result)).to be_empty
+      end
+
+      it "does not auto-enroll unlabeled Renovate PRs through Dependabot auto-merge" do
+        project.update!(auto_merge_mode: "dependabot_only")
+        Issue.find_by!(project: project, github_number: 42).update!(
+          github_creator_login: "renovate[bot]",
+          labels: %w[dependencies ruby]
+        )
+        expect(github_client).not_to receive(:pull_request)
+
+        result = activity.execute(project_id: project.id)
+
+        expect(automation_scan_results(result)).to be_empty
+      end
+
       it "does not grant the dependency-update bypass to bot-name lookalikes" do
         issue = Issue.find_by!(project: project, github_number: 42)
         issue.update!(github_creator_login: "dependabot-maintainer")


### PR DESCRIPTION
## Summary
- Include Dependabot PRs in PR scanning when Dependabot auto-merge is enabled, even without the Paid automation label.
- Keep unlabeled auto-enrollment limited to Dependabot authors supported by the auto-merge job.
- Clarify auto-merge settings copy so users know Paid may run agents on Dependabot PRs while GitHub branch protection still applies.

## Validation
- bin/rspec spec/temporal/activities/scan_paid_prs_activity_spec.rb
- bin/lint --changed
