### PR TITLE
fix(agent-runs): allow agents to inspect bundle cache

### DIFF
--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -434,7 +434,12 @@ class Runner < ApplicationRecord
           }
         }
       },
-      model: kilocode_qualified_model(kilocode_provider_id, model_id)
+      model: kilocode_qualified_model(kilocode_provider_id, model_id),
+      permission: {
+        external_directory: {
+          "/tmp/**": "allow"
+        }
+      }
     }.to_json
   end
 

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -2488,9 +2488,10 @@ module Activities
         )
       end
 
-      @harness_plan_cache[cache_key] = disable_codex_apps_for_review_goal?(runner_key, agent_run) ?
-        disable_codex_apps(plan) :
-        plan
+      plan = allow_codex_bundle_dir(runner_key, plan)
+      plan = disable_codex_apps(plan) if disable_codex_apps_for_review_goal?(runner_key, agent_run)
+
+      @harness_plan_cache[cache_key] = plan
     end
 
     def disable_codex_apps_for_review_goal?(runner_key, agent_run)
@@ -2499,6 +2500,24 @@ module Activities
       RunnerSupport.runner_key_for_agent_type(runner_key) == "codex"
     rescue ArgumentError
       false
+    end
+
+    def allow_codex_bundle_dir(runner_key, plan)
+      return plan unless RunnerSupport.runner_key_for_agent_type(runner_key) == "codex"
+      return plan if plan.command.each_cons(2).any? { |left, right| left == "--add-dir" && right == "/tmp/bundle" }
+
+      prompt = plan.command.last
+      command = plan.command[0..-2]
+      exec_index = command.index("exec") || 0
+      command.insert(exec_index + 1, "--add-dir", "/tmp/bundle")
+
+      Runners::HarnessExecutionPlan::Result.new(
+        command: command + [ prompt ],
+        env: plan.env,
+        preparation: plan.preparation
+      )
+    rescue ArgumentError
+      plan
     end
 
     def disable_codex_apps(plan)

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -2506,13 +2506,12 @@ module Activities
       return plan unless RunnerSupport.runner_key_for_agent_type(runner_key) == "codex"
       return plan if plan.command.each_cons(2).any? { |left, right| left == "--add-dir" && right == "/tmp/bundle" }
 
-      prompt = plan.command.last
-      command = plan.command[0..-2]
+      command = plan.command.dup
       exec_index = command.index("exec") || 0
       command.insert(exec_index + 1, "--add-dir", "/tmp/bundle")
 
       Runners::HarnessExecutionPlan::Result.new(
-        command: command + [ prompt ],
+        command: command,
         env: plan.env,
         preparation: plan.preparation
       )
@@ -2523,14 +2522,12 @@ module Activities
     def disable_codex_apps(plan)
       return plan if plan.command.include?("--disable") && plan.command.each_cons(2).any? { |left, right| left == "--disable" && right == "apps" }
 
-      prompt = plan.command.last
-      command_prefix = plan.command[0..-2]
-      disable_index = command_prefix.index("exec") || 0
-      command = command_prefix.dup
+      command = plan.command.dup
+      disable_index = command.index("exec") || 0
       command.insert(disable_index + 1, "--disable", "apps")
 
       Runners::HarnessExecutionPlan::Result.new(
-        command: command + [ prompt ],
+        command: command,
         env: plan.env,
         preparation: plan.preparation
       )

--- a/spec/models/runner_spec.rb
+++ b/spec/models/runner_spec.rb
@@ -1024,6 +1024,11 @@ RSpec.describe Runner do
         }
       })
       expect(config["model"]).to eq("anthropic/claude-sonnet-4-20250514")
+      expect(config["permission"]).to eq({
+        "external_directory" => {
+          "/tmp/**" => "allow"
+        }
+      })
     end
 
     it "does not double-prefix already-qualified model ids" do

--- a/spec/services/runners/test_agent_spec.rb
+++ b/spec/services/runners/test_agent_spec.rb
@@ -74,7 +74,12 @@ RSpec.describe Runners::TestAgent do
           }
         }
       },
-      "model" => "anthropic/claude-sonnet-4-20250514"
+      "model" => "anthropic/claude-sonnet-4-20250514",
+      "permission" => {
+        "external_directory" => {
+          "/tmp/**" => "allow"
+        }
+      }
     }
   end
 

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -565,6 +565,38 @@ RSpec.describe Activities::RunAgentActivity do
       expect(command.last).to eq("say 'hi'")
     end
 
+    it "preserves trailing Codex harness args when adding bundle access and review disables" do
+      plan = Runners::HarnessExecutionPlan::Result.new(
+        command: [ "codex", "exec", "--json", "review prompt", "--extra-output" ],
+        env: {},
+        preparation: AgentHarness::ExecutionPreparation.new(file_writes: [])
+      )
+      review_run = create(:agent_run, :running, project: project, goal: "review", source_pull_request_number: 42)
+
+      allow(Runners::HarnessExecutionPlan).to receive(:for_runner_key).and_return(plan)
+
+      result = activity.send(:harness_execution_plan_for, "codex", "review prompt", agent_run: review_run)
+
+      expect(result.command).to eq(
+        [ "codex", "exec", "--disable", "apps", "--add-dir", "/tmp/bundle", "--json", "review prompt", "--extra-output" ]
+      )
+    end
+
+    it "does not duplicate existing Codex bundle access or review disables" do
+      plan = Runners::HarnessExecutionPlan::Result.new(
+        command: [ "codex", "exec", "--disable", "apps", "--add-dir", "/tmp/bundle", "review prompt" ],
+        env: {},
+        preparation: AgentHarness::ExecutionPreparation.new(file_writes: [])
+      )
+      review_run = create(:agent_run, :running, project: project, goal: "review", source_pull_request_number: 42)
+
+      allow(Runners::HarnessExecutionPlan).to receive(:for_runner_key).and_return(plan)
+
+      result = activity.send(:harness_execution_plan_for, "codex", "review prompt", agent_run: review_run)
+
+      expect(result.command).to eq(plan.command)
+    end
+
     it "builds a sh -c wrapper for Gemini subscription auth" do
       context = described_class::CommandContext.new(
         runner_candidate: "gemini",

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -528,7 +528,9 @@ RSpec.describe Activities::RunAgentActivity do
 
       expect(script).to include("--disable")
       expect(script).to include("apps")
-      expect(command[4]).to eq("review prompt")
+      expect(script).to include("--add-dir")
+      expect(script).to include("/tmp/bundle")
+      expect(command.last).to eq("review prompt")
     end
 
     it "keeps Codex app connectors enabled for non-review runs" do
@@ -543,6 +545,24 @@ RSpec.describe Activities::RunAgentActivity do
 
       expect(script).not_to include("--disable")
       expect(script).not_to include("apps")
+      expect(script).to include("--add-dir")
+      expect(script).to include("/tmp/bundle")
+    end
+
+    it "allows Codex to inspect the container Bundler path" do
+      context = described_class::CommandContext.new(
+        runner_candidate: "codex",
+        runner: "codex",
+        user: nil
+      )
+
+      command = activity.send(:build_command, context, "say 'hi'", agent_run: agent_run)
+      script = command[2]
+
+      expect(script).to include("codex")
+      expect(script).to include("--add-dir")
+      expect(script).to include("/tmp/bundle")
+      expect(command.last).to eq("say 'hi'")
     end
 
     it "builds a sh -c wrapper for Gemini subscription auth" do
@@ -572,7 +592,7 @@ RSpec.describe Activities::RunAgentActivity do
       )
       command = activity.send(:build_command, context, multiline_prompt)
 
-      expect(command[4]).to eq(multiline_prompt)
+      expect(command.last).to eq(multiline_prompt)
       expect(command[2]).not_to include("\n")
     end
 
@@ -713,7 +733,9 @@ RSpec.describe Activities::RunAgentActivity do
         expect(command).to eq([ "env", "-u", "OPENAI_HEADER_X_AGENT_RUN_ID", "-u", "OPENAI_HEADER_X_PROXY_TOKEN", "opencode", "run", "ping" ])
         expect(env).to include("OPENROUTER_API_KEY" => "sk-openrouter-secret", "OPENAI_BASE_URL" => "https://openrouter.ai/api/v1")
         expect(preparation.file_writes.first.path).to eq("~/.config/opencode/opencode.json")
-        expect(preparation.file_writes.first.content).to include("\"model\": \"openrouter/moonshotai/kimi-k2-0905\"")
+        config = JSON.parse(preparation.file_writes.first.content)
+        expect(config["model"]).to eq("openrouter/moonshotai/kimi-k2-0905")
+        expect(config.dig("permission", "external_directory")).to include("/tmp/**" => "allow")
       end
 
       it "preserves multi-line prompts when wrapping the harness runtime command" do
@@ -755,6 +777,16 @@ RSpec.describe Activities::RunAgentActivity do
         config_json = JSON.parse(Base64.strict_decode64(env["PAID_KILOCODE_CONFIG_B64"]))
         expect(config_json["model"]).to eq("anthropic/claude-sonnet-4-20250514")
         expect(config_json["provider"]).to eq(expected_kilocode_model_config)
+      end
+
+      it "allows Kilocode to inspect container support paths" do
+        context = build_kilocode_context(user)
+
+        env = activity.send(:command_env_for, context, "ping")
+        config_json = JSON.parse(Base64.strict_decode64(env.fetch("PAID_KILOCODE_CONFIG_B64")))
+
+        expect(config_json.dig("permission", "external_directory")).to include("/tmp/**" => "allow")
+        expect(config_json.dig("permission", "external_directory")).not_to have_key("/home/agent/**")
       end
 
       it "does not include PAID_KILOCODE_CONFIG_B64 for subscription kilocode runners" do


### PR DESCRIPTION
## Summary

- allow Codex container runs to inspect Paid's Bundler cache at `/tmp/bundle`
- allow direct-outbound Kilocode runs to inspect `/tmp/**`, which includes `/tmp/bundle`
- add regression coverage for Codex, OpenCode, and Kilocode permission behavior

## Why

Review agents can need to inspect installed gem sources when validating framework behavior. Paid sets `BUNDLE_PATH=/tmp/bundle` inside agent containers, but Codex treated that path as an external directory and auto-rejected the file read, causing review runs to fail before posting a review.

## Validation

- `bin/rspec spec/models/runner_spec.rb spec/temporal/activities/run_agent_activity_spec.rb`
- `bin/lint --changed`