### PR TITLE
fix(good-job): stagger maintenance cron bursts

### DIFF
--- a/bin/lib/dev_supervisor.sh
+++ b/bin/lib/dev_supervisor.sh
@@ -102,7 +102,7 @@ dev_supervisor_append_shell_context() {
       sh -c "pstree -aps $$ 2>&1 || ps -ef 2>&1"
   fi
   dev_supervisor_append_command "$file" "selected env" \
-    sh -c "env | sort | grep -E '^(TERM|TMUX|OVERMIND_SOCKET|PATH|SHELL|STARTUP_CLEANUP_GRACE_PERIOD|SKIP_DEV_CLEANUP)=' 2>&1 || true"
+    sh -c "env | sort | grep -E '^(TERM|TMUX|OVERMIND_SOCKET|OVERMIND_AUTO_RESTART|GOOD_JOB_DEV_MAX_THREADS|GOOD_JOB_MAX_THREADS|GOOD_JOB_EXECUTION_MODE|PATH|SHELL|STARTUP_CLEANUP_GRACE_PERIOD|SKIP_DEV_CLEANUP)=' 2>&1 || true"
   dev_supervisor_append_command "$file" "tty settings" \
     sh -c "stty -a < /dev/tty 2>&1 || true"
 }
@@ -182,7 +182,10 @@ dev_supervisor_snapshot_state() {
   dev_supervisor_append_command "$file" "overmind socket" sh -c "ls -la '${OVERMIND_SOCKET:-.overmind.sock}' 2>/dev/null"
   dev_supervisor_append_command "$file" "tmux sessions" sh -c "for socket in '$(dev_supervisor_tmux_socket_dir)'/overmind-$(dev_supervisor_app_name)-*; do [ -S \"\$socket\" ] || continue; echo \"-- \$socket --\"; tmux -S \"\$socket\" ls 2>&1 || true; done"
   dev_supervisor_append_tmux_details "$file"
-  dev_supervisor_append_command "$file" "processes" sh -c "if command -v rg >/dev/null 2>&1; then ps -ef | rg 'overmind|tmux|bin/dev|bin/rails server|bin/temporal_worker|yarn build --watch|build:css --watch|esbuild' -S; else ps -ef | grep -E 'overmind|tmux|bin/dev|bin/rails server|bin/temporal_worker|yarn build --watch|build:css --watch|esbuild' | grep -v grep; fi 2>&1 || true"
+  dev_supervisor_append_command "$file" "processes" sh -c "if command -v rg >/dev/null 2>&1; then ps -ef | rg 'overmind|tmux|bin/dev|bin/rails server|bin/jobs|bin/temporal_worker|yarn build --watch|build:css --watch|esbuild' -S; else ps -ef | grep -E 'overmind|tmux|bin/dev|bin/rails server|bin/jobs|bin/temporal_worker|yarn build --watch|build:css --watch|esbuild' | grep -v grep; fi 2>&1 || true"
+  dev_supervisor_append_command "$file" "memory summary" sh -c "free -h 2>&1 || true"
+  dev_supervisor_append_command "$file" "top rss processes" sh -c "ps -eo pid=,ppid=,etime=,stat=,rss=,vsz=,command= --sort=-rss | head -30 2>&1 || true"
+  dev_supervisor_append_command "$file" "cgroup memory" sh -c "for path in /sys/fs/cgroup/memory.current /sys/fs/cgroup/memory.max /sys/fs/cgroup/memory.peak /sys/fs/cgroup/memory.events /sys/fs/cgroup/memory.swap.current /sys/fs/cgroup/memory.swap.max; do [ -e \"\$path\" ] || continue; echo \"-- \$path --\"; cat \"\$path\"; done 2>&1 || true"
   dev_supervisor_append_command "$file" "overmind temp files" sh -c "ls -la /tmp/overmind-* 2>/dev/null || true"
 
   dev_supervisor_log_line "$(dev_supervisor_tmux_log)" "Wrote diagnostics snapshot to $file"

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -74,21 +74,25 @@ Rails.application.configure do
   config.x.good_job_enable_cron = Paid::GoodJobConfig.enable_cron
   config.good_job.enable_cron = config.x.good_job_enable_cron
 
+  # Keep frequent maintenance jobs staggered across the 5-minute window. Several
+  # of these jobs scan projects, containers, queues, or external services; if
+  # they all enqueue on :00/:05/:10 boundaries, the in-process async_server
+  # worker can see a short memory spike large enough to OOM the Rails process.
   config.good_job.cron = {
     worktree_cleanup: {
       cron: "0 */6 * * *",
       class: "WorktreeOrphanCleanupJob"
     },
     poll_workflow_health_check: {
-      cron: "*/5 * * * *",
+      cron: "1-59/5 * * * *",
       class: "PollWorkflowHealthCheckJob"
     },
     stale_run_detector: {
-      cron: "*/5 * * * *",
+      cron: "2-59/5 * * * *",
       class: "StaleRunDetectorJob"
     },
     docker_orphan_cleanup: {
-      cron: "*/5 * * * *",
+      cron: "3-59/5 * * * *",
       class: "DockerOrphanCleanupJob",
       description: "Remove orphaned Docker containers and volumes"
     },
@@ -124,7 +128,7 @@ Rails.application.configure do
       description: "Backfill eager auto-pick queue seeding for already-enabled projects"
     },
     auto_pick_eligibility_sweep: {
-      cron: "*/15 * * * *",
+      cron: "7-59/15 * * * *",
       class: "AutoPickEligibilitySweepJob",
       description: "Periodic re-evaluation of all open issues for auto-pick eligibility"
     },
@@ -134,12 +138,12 @@ Rails.application.configure do
       description: "Backfill follow-up runs for legacy analyzed issues"
     },
     service_container_reconciliation: {
-      cron: "*/5 * * * *",
+      cron: "1-59/5 * * * *",
       class: "ServiceContainerReconciliationJob",
       description: "Reconcile service container DB records against Docker state"
     },
     container_pool_replenishment: {
-      cron: "*/5 * * * *",
+      cron: "4-59/5 * * * *",
       class: "PoolReplenishmentJob",
       description: "Maintain warm agent container pool"
     },
@@ -177,12 +181,12 @@ Rails.application.configure do
       description: "Collect delayed human feedback (reactions, reviews) for recent agent runs"
     },
     queue_monitor: {
-      cron: "*/5 * * * *",
+      cron: "2-59/5 * * * *",
       class: "QueueMonitorJob",
       description: "Monitor queue depths and alert when thresholds are exceeded"
     },
     notifications_check_runner_quotas: {
-      cron: "*/5 * * * *",
+      cron: "3-59/5 * * * *",
       class: "Notifications::CheckRunnerQuotasJob",
       description: "Publish runner quota exhaustion notifications"
     },
@@ -207,7 +211,7 @@ Rails.application.configure do
       description: "Refresh host-forwarded Claude subscription credentials before expiry (RDR-041 Phase 3)"
     },
     chat_idle_reaper: {
-      cron: "*/5 * * * *",
+      cron: "4-59/5 * * * *",
       class: "ChatSessions::IdleReaperJob",
       description: "Close idle chat sessions past their timeout"
     },
@@ -217,12 +221,12 @@ Rails.application.configure do
       description: "Analyze knowledge gaps and recommend collector improvements (weekly)"
     },
     agent_run_pattern_detector: {
-      cron: "*/15 * * * *",
+      cron: "11-59/15 * * * *",
       class: "AgentRunPatternDetectorJob",
       description: "Detect goal-level failure patterns in agent runs and notify"
     },
     remediation_decision_outcomes: {
-      cron: "*/15 * * * *",
+      cron: "13-59/15 * * * *",
       class: "RemediationDecisionOutcomeJob",
       description: "Evaluate outcomes for auto-applied self-heal remediations"
     },
@@ -242,7 +246,7 @@ Rails.application.configure do
       description: "Run nightly full-suite mutation sweeps for opted-in Ruby projects"
     },
     dispatch_circuit_breaker_recovery: {
-      cron: "*/5 * * * *",
+      cron: "1-59/5 * * * *",
       class: "DispatchCircuitBreakerRecoveryJob",
       description: "Check open dispatch circuit breakers for recovery to half_open"
     }

--- a/spec/config/good_job_configuration_spec.rb
+++ b/spec/config/good_job_configuration_spec.rb
@@ -94,5 +94,29 @@ RSpec.describe GoodJob, :no_db do
         expect(cron).to have_key(job_key), "Expected cron job #{job_key} to be defined"
       end
     end
+
+    it "staggers frequent maintenance jobs across minute boundaries" do
+      expected_offsets = {
+        process_run_queue: "*/5 * * * *",
+        poll_workflow_health_check: "1-59/5 * * * *",
+        service_container_reconciliation: "1-59/5 * * * *",
+        dispatch_circuit_breaker_recovery: "1-59/5 * * * *",
+        stale_run_detector: "2-59/5 * * * *",
+        queue_monitor: "2-59/5 * * * *",
+        docker_orphan_cleanup: "3-59/5 * * * *",
+        notifications_check_runner_quotas: "3-59/5 * * * *",
+        container_pool_replenishment: "4-59/5 * * * *",
+        chat_idle_reaper: "4-59/5 * * * *",
+        auto_pick_eligibility_sweep: "7-59/15 * * * *",
+        agent_run_pattern_detector: "11-59/15 * * * *",
+        remediation_decision_outcomes: "13-59/15 * * * *"
+      }
+
+      aggregate_failures do
+        expected_offsets.each do |job_key, schedule|
+          expect(cron.dig(job_key, :cron)).to eq(schedule)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

This PR reduces the chance of dev/control-plane OOM stoppages caused by synchronized GoodJob maintenance bursts.

- Staggers frequent GoodJob cron jobs across the 5-minute window instead of enqueueing them all on `:00/:05/:10` boundaries.
- Moves 15-minute sweeps off the `:00/:15/:30/:45` boundary so they do not join the same maintenance spike.
- Adds dev supervisor memory diagnostics so future dead-pane snapshots include memory summary, top RSS processes, and cgroup OOM counters.
- Adds a regression spec for the intentional cron offsets.

## Root Cause

The investigated outage showed the Rails `web` process killed with exit 137 while in-process GoodJob maintenance jobs were active. Several scheduled jobs were aligned on the same minute boundary, creating avoidable short-lived memory pressure in `async_server` mode.

## Validation

- `bin/rspec spec/config/good_job_configuration_spec.rb spec/lib/paid/good_job_worker_spec.rb`
- `bash -n bin/lib/dev_supervisor.sh`
- `shellcheck bin/lib/dev_supervisor.sh`
- Pre-commit lint checks passed during commit
