### PR TITLE
chore(devcontainer): install oh-my-pi

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -23,6 +23,7 @@ services:
     - agent-kilocode:/home/vscode/.kilocode
     - agent-aider:/home/vscode/.aider
     - agent-cursor:/home/vscode/.cursor
+    - agent-omp:/home/vscode/.omp
 
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
@@ -122,3 +123,4 @@ volumes:
   agent-kilocode:
   agent-aider:
   agent-cursor:
+  agent-omp:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -49,7 +49,7 @@
     "AIDER_NO_BROWSER": "1",
     "GEMINI_API_KEY": "${localEnv:GEMINI_API_KEY}",
     "OVERMIND_SOCKET": "${containerWorkspaceFolder}/.overmind.sock",
-    "PATH": "${containerEnv:PATH}:/home/vscode/.local/bin"
+    "PATH": "${containerEnv:PATH}:/home/vscode/.local/bin:/home/vscode/.bun/bin"
   },
   // Agent CLI tool state (auth, config, plugins) is kept container-local in
   // named Docker volumes declared in compose.yaml, not bind-mounted from the
@@ -112,6 +112,7 @@
     "cursor-agent": "bash scripts/install-from-contract.sh cursor",
     "aider": "bash scripts/install-from-contract.sh aider",
     "opencode": "bash scripts/install-from-contract.sh opencode",
+    "oh-my-pi": "bash .devcontainer/install-oh-my-pi.sh",
     // Dev tools
     "markdownlint": "npm install -g --ignore-scripts markdownlint-cli",
     "git-curate": "env PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH gem install git_curate"

--- a/.devcontainer/init-agent-volumes.sh
+++ b/.devcontainer/init-agent-volumes.sh
@@ -24,6 +24,7 @@ AGENT_DIRS=(
   "$HOME/.kilocode"
   "$HOME/.aider"
   "$HOME/.cursor"
+  "$HOME/.omp"
 )
 
 for dir in "${AGENT_DIRS[@]}"; do

--- a/.devcontainer/install-oh-my-pi.sh
+++ b/.devcontainer/install-oh-my-pi.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Install Oh My Pi (omp) and its Bun runtime into the devcontainer user's home.
+
+set -euo pipefail
+
+BUN_VERSION="${BUN_VERSION:-1.3.14}"
+BUN_INSTALL="${BUN_INSTALL:-$HOME/.bun}"
+LOCAL_BIN_DIR="${LOCAL_BIN_DIR:-$HOME/.local/bin}"
+OMP_PACKAGE="${OMP_PACKAGE:-@oh-my-pi/pi-coding-agent@17.0.1}"
+BUN_RELEASE_BASE_URL="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}"
+
+export BUN_INSTALL
+export PATH="${BUN_INSTALL}/bin:${PATH}"
+
+install_bun() {
+  local arch
+  local asset
+  local checksum
+  local tmpdir
+
+  command -v unzip >/dev/null 2>&1 || {
+    echo "ERROR: unzip is required to install Bun." >&2
+    exit 1
+  }
+
+  arch="$(dpkg --print-architecture)"
+  case "$arch" in
+    amd64)
+      asset="bun-linux-x64.zip"
+      if ! grep -qm1 avx2 /proc/cpuinfo; then
+        asset="bun-linux-x64-baseline.zip"
+      fi
+      ;;
+    arm64)
+      asset="bun-linux-aarch64.zip"
+      ;;
+    *)
+      echo "ERROR: Unsupported architecture for Bun: $arch" >&2
+      exit 1
+      ;;
+  esac
+
+  tmpdir="$(mktemp -d)"
+
+  curl -fsSL "${BUN_RELEASE_BASE_URL}/SHASUMS256.txt" -o "${tmpdir}/SHASUMS256.txt"
+  checksum="$(awk -v asset="$asset" '$2 == asset { print $1 }' "${tmpdir}/SHASUMS256.txt")"
+  if [ -z "$checksum" ]; then
+    echo "ERROR: No Bun checksum found for ${asset}." >&2
+    exit 1
+  fi
+
+  curl -fsSL "${BUN_RELEASE_BASE_URL}/${asset}" -o "${tmpdir}/${asset}"
+  echo "${checksum}  ${tmpdir}/${asset}" | sha256sum -c -
+
+  mkdir -p "${BUN_INSTALL}/bin"
+  unzip -oq "${tmpdir}/${asset}" -d "${tmpdir}"
+  install -m 0755 "${tmpdir}/${asset%.zip}/bun" "${BUN_INSTALL}/bin/bun"
+  ln -sf "${BUN_INSTALL}/bin/bun" "${BUN_INSTALL}/bin/bunx"
+  rm -rf "$tmpdir"
+}
+
+if ! command -v bun >/dev/null 2>&1 || [ "$(bun --version)" != "$BUN_VERSION" ]; then
+  install_bun
+fi
+
+bun install -g "${OMP_PACKAGE}"
+mkdir -p "${LOCAL_BIN_DIR}"
+ln -sf "${BUN_INSTALL}/bin/bun" "${LOCAL_BIN_DIR}/bun"
+ln -sf "${BUN_INSTALL}/bin/bunx" "${LOCAL_BIN_DIR}/bunx"
+ln -sf "${BUN_INSTALL}/bin/omp" "${LOCAL_BIN_DIR}/omp"
+
+omp --version

--- a/spec/config/devcontainer_file_spec.rb
+++ b/spec/config/devcontainer_file_spec.rb
@@ -12,9 +12,26 @@ RSpec.describe DevcontainerFile, :no_db do
     JSON.parse(source.lines.reject { |line| line.lstrip.start_with?("//") }.join)
   end
 
+  let(:oh_my_pi_installer) { Rails.root.join(".devcontainer/install-oh-my-pi.sh").read }
+
   it "installs opencode through the shared contract wrapper" do
     command = devcontainer.fetch("postCreateCommand").fetch("opencode")
 
     expect(command).to eq("bash scripts/install-from-contract.sh opencode")
+  end
+
+  it "installs oh-my-pi through the devcontainer installer" do
+    command = devcontainer.fetch("postCreateCommand").fetch("oh-my-pi")
+    path = devcontainer.fetch("remoteEnv").fetch("PATH")
+
+    expect(command).to eq("bash .devcontainer/install-oh-my-pi.sh")
+    expect(path).to include("/home/vscode/.bun/bin")
+  end
+
+  it "pins and verifies the oh-my-pi Bun runtime install" do
+    expect(oh_my_pi_installer).to include('BUN_VERSION="${BUN_VERSION:-1.3.14}"')
+    expect(oh_my_pi_installer).to include("SHASUMS256.txt")
+    expect(oh_my_pi_installer).to include("sha256sum -c -")
+    expect(oh_my_pi_installer).not_to include("https://bun.sh/install")
   end
 end


### PR DESCRIPTION
## Summary
- install Oh My Pi (`omp`) in the devcontainer post-create flow
- install pinned Bun 1.3.14 from verified release assets for the `omp` runtime
- persist `~/.omp` in a named Docker volume and add focused devcontainer specs

## Why
This makes `omp` available consistently for Paid devcontainer users after rebuilds while avoiding a live `curl | bash` installer path for Bun.

## Validation
- `shellcheck .devcontainer/install-oh-my-pi.sh .devcontainer/init-agent-volumes.sh`
- `bin/rspec spec/config/devcontainer_file_spec.rb`
- `bash .devcontainer/install-oh-my-pi.sh && omp --version && bun --version`
- pre-commit lint hook