### PR TITLE
docs: add multi-host Docker backend RDR

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ docker compose up --build
 # before using the app. `bin/setup` already runs `bin/rails db:prepare`.
 ```
 
-> **Note**: By default, the checked-in `docker-compose.yml` starts `postgres`, `redis`, `temporal`, `temporal-admin-tools`, `temporal-ui`, `qdrant`, `web`, and `worker` when you run `docker compose up --build`. The compose file wires `DATABASE_URL`, `REDIS_URL`, Temporal, and Qdrant for the app so development-only dashboards such as `rails_performance` work out of the box. The `agent-image` and `agent-test` services are profile-gated, so they only start when their profiles are explicitly enabled. `ANTHROPIC_API_KEY` is passed through today; if you want proxy-based OpenAI or Google auth in Compose, add `OPENAI_API_KEY` and/or `GOOGLE_API_KEY` to the `web` service, and to `worker` as well if you want worker-side flows to see them.
+> **Note**: By default, the checked-in `docker-compose.yml` starts `postgres`, `redis`, `temporal`, `temporal-admin-tools`, `temporal-ui`, `qdrant`, `web`, and `worker` when you run `docker compose up --build`. The compose file wires `DATABASE_URL`, `REDIS_URL`, Temporal, and Qdrant for the app so development-only dashboards such as `rails_performance` work out of the box. The `agent-test` service is profile-gated, so it only starts when its profile is explicitly enabled. Build `paid-agent:latest` with `./scripts/build-agent-image.sh`; that script extracts the Dockerfile build args from `Gemfile.lock` and `agent-harness`. `ANTHROPIC_API_KEY` is passed through today; if you want proxy-based OpenAI or Google auth in Compose, add `OPENAI_API_KEY` and/or `GOOGLE_API_KEY` to the `web` service, and to `worker` as well if you want worker-side flows to see them.
 
 **Database role note**: Compose creates the Rails `paid` role separately from the PostgreSQL admin role so tenant row-level security cannot be bypassed by a superuser connection. If you have an older `postgres-data` volume where `paid` was the bootstrap superuser, recreate that volume before running this branch.
 
@@ -260,7 +260,7 @@ OpenCode and KiloCode direct-outbound API-key entries are the exception: Paid wr
 | `qdrant` | 6333 | Vector database for semantic knowledge search |
 | `temporal-admin-tools` | - | CLI tools for Temporal administration |
 | `worker` | - | Temporal worker process (executes workflows) |
-| `agent-image` | - | Builds the `paid-agent:latest` image (`setup` profile, exits immediately) |
+| `agent-image` | - | Legacy setup profile; use `./scripts/build-agent-image.sh` for supported agent image builds |
 | `agent-test` | - | Agent container for testing the image (`test` profile only) |
 
 ### Networks

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -209,8 +209,8 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/paid/workspaces:/var/paid/workspaces
 
-  # Builds the paid-agent:latest image used by Containers::Provision.
-  # This service exits immediately; it exists only to ensure the image is built.
+  # Legacy setup profile for paid-agent:latest. Prefer scripts/build-agent-image.sh,
+  # which extracts required build args from Gemfile.lock and agent-harness.
   agent-image:
     build:
       context: ./docker/agent

--- a/docs/guides/remote-docker-setup.md
+++ b/docs/guides/remote-docker-setup.md
@@ -4,6 +4,8 @@ This guide configures Paid to run agent containers on one remote Docker host ove
 
 The most practical self-hosted case is a laptop or devcontainer running the Paid control plane while a QNAP NAS runs the agent containers over Tailscale. That setup moves container CPU and memory pressure off the development machine without changing Paid's runtime model.
 
+This is a single-host remote backend. `CONTAINER_BACKEND=remote` switches agent provisioning to the configured remote Docker daemon; it does not add the remote host as extra capacity alongside local Docker. Multi-host scheduling is future work.
+
 ## Overview
 
 Paid keeps the existing named-volume plus in-container clone workflow. The only runtime difference is that Docker API calls go to a remote daemon instead of `/var/run/docker.sock`.
@@ -22,19 +24,50 @@ For the QNAP/NAS scenario, Tailscale is a good fit because it gives both machine
 
 ```text
 Laptop / devcontainer                    QNAP NAS (Tailscale)
-┌─────────────────────┐                 ┌──────────────────────┐
-│ Paid Rails app      │                 │ Container Station    │
-│ Temporal workers    │── Tailscale ──▶│ dockerd :2376 (mTLS) │
-│ GoodJob             │   TCP 2376     │                      │
-│                     │◀── Tailscale ──│ Agent containers     │
-│ :3000 (proxy)       │   HTTP :3000   │ clone, build, run    │
-└─────────────────────┘                 └──────────────────────┘
++---------------------+                 +----------------------+
+| Paid Rails app      |                 | Container Station    |
+| Temporal workers    |-- Tailscale --->| dockerd :2376 (mTLS) |
+| GoodJob             |   TCP 2376      |                      |
+|                     |<-- Tailscale ---| Agent containers     |
+| :3000 (proxy)       |   HTTP :3000    | clone, build, run    |
++---------------------+                 +----------------------+
 ```
 
 Two directions matter:
 
 - Paid -> NAS on TCP `2376`: Docker API calls to create, start, exec, inspect, and stop containers
 - NAS containers -> Paid on HTTP `:3000`: secrets-proxy traffic for LLM access and proxy-issued credentials
+
+Walkthrough topology:
+
+- Paid runs inside a devcontainer on a laptop or workstation
+- The Paid host has a stable Tailscale IP, shown below as `<paid-host-tailscale-ip>`
+- The QNAP has a stable Tailscale IP, shown below as `<qnap-tailscale-ip>`
+- The QNAP may also have a LAN IP, shown below as `<qnap-lan-ip>`
+- The QNAP may use a nonstandard SSH port, shown below as `<qnap-ssh-port>`
+
+Before troubleshooting Docker connectivity, confirm the configured QNAP SSH port in Control Panel > Network & File Services > Telnet / SSH. Then verify SSH reachability on LAN and Tailscale:
+
+```bash
+nc -vz <qnap-lan-ip> <qnap-ssh-port>
+nc -vz <qnap-tailscale-ip> <qnap-ssh-port>
+ssh -p <qnap-ssh-port> <qnap-user>@<qnap-tailscale-ip>
+```
+
+## Host vs. Devcontainer Commands
+
+Run host-network and Docker CLI transfer commands on the laptop or machine that can reach both Tailscale and the Docker socket:
+
+- `ssh`, `scp`, `nc`, and Tailscale CLI checks
+- `docker save paid-agent:latest | gzip > /tmp/paid-agent.tgz`
+- `docker load` against `DOCKER_HOST=tcp://<qnap-tailscale-ip>:2376`
+
+Run Paid/Rails commands inside the devcontainer:
+
+- `bundle exec rake remote_docker:test_connection`
+- `bundle exec rake remote_docker:generate_certs[...]`
+- `bin/rails runner ...`
+- Environment verification for `CONTAINER_BACKEND`, `REMOTE_DOCKER_*`, and `PAID_PROXY_EXTERNAL_URL`
 
 ## 1. Configure the QNAP Docker Host
 
@@ -68,13 +101,44 @@ If your QNAP uses a JSON daemon config instead of CLI flags, the equivalent fiel
 }
 ```
 
+In the verified QNAP setup, Container Station already had Docker listening on `tcp://0.0.0.0:2376` with mTLS enabled:
+
+```text
+--tlscacert=/etc/docker/tls/ca.pem
+--tlscert=/etc/docker/tls/server.pem
+--tlskey=/etc/docker/tls/server-key.pem
+```
+
+The QNAP TLS directory included:
+
+```text
+/etc/docker/tls/ca.pem
+/etc/docker/tls/ca-key.pem
+/etc/docker/tls/server.pem
+/etc/docker/tls/server-cert.pem
+/etc/docker/tls/server-key.pem
+/etc/docker/tls/cert.pem
+/etc/docker/tls/key.pem
+```
+
+The existing `/etc/docker/tls/cert.pem` client certificate had `TLS Web Client Authentication`, and `/etc/docker/tls/key.pem` matched it, so we reused the QNAP-provided client cert instead of generating a new client bundle.
+
 Lock TCP `2376` down to Tailscale-only access. Do not expose it on the public LAN or internet.
 
 Create the two Docker networks Paid expects:
 
 ```bash
-docker network create paid_agent
-docker network create paid_internal
+docker network create \
+  --driver bridge \
+  --internal \
+  --subnet 172.28.0.0/16 \
+  --opt com.docker.network.bridge.enable_ip_masquerade=false \
+  paid_agent
+
+docker network create \
+  --driver bridge \
+  --subnet 172.29.8.0/22 \
+  paid_internal
 ```
 
 `paid_agent` is the restricted proxy-mode network. `paid_internal` is the unrestricted network used for direct-outbound and subscription-auth cases.
@@ -91,6 +155,29 @@ ping <laptop-tailscale-ip>
 ```
 
 Tailscale IPs are stable enough to use directly in the remote Docker and proxy environment variables.
+
+### QNAP QuFirewall
+
+If Tailscale ping works but the SSH port or Docker TCP `2376` times out, add a QuFirewall allow rule:
+
+- Permission: Allow
+- Interface: `tailscale0` if shown, otherwise All
+- Source: the Paid host Tailscale IP as `/32`, for example `<paid-host-tailscale-ip>/32`
+- Protocol: TCP
+- Ports: `2376,<qnap-ssh-port>`
+
+QuFirewall created an effective rule like:
+
+```text
+ACCEPT tcp -- <paid-host-tailscale-ip> 0.0.0.0/0 multiport dports 2376,<qnap-ssh-port>
+```
+
+Then verify both ports over Tailscale:
+
+```bash
+nc -vz -G 5 <qnap-tailscale-ip> <qnap-ssh-port>
+nc -vz -G 5 <qnap-tailscale-ip> 2376
+```
 
 ## 3. Generate and Distribute TLS Certificates
 
@@ -117,24 +204,64 @@ Distribution model:
 
 At a minimum, the NAS daemon must trust `ca.pem`, and the Paid host must present the client cert pair referenced by `REMOTE_DOCKER_CERT` and `REMOTE_DOCKER_KEY`.
 
+If the QNAP already has a working client certificate, copy it into the Paid workspace instead:
+
+```text
+tmp/remote-docker-certs/ca.pem
+tmp/remote-docker-certs/client-cert.pem
+tmp/remote-docker-certs/client-key.pem
+```
+
+For Docker CLI compatibility, also keep copies named exactly:
+
+```text
+tmp/remote-docker-certs/cert.pem
+tmp/remote-docker-certs/key.pem
+```
+
+Docker CLI requires `ca.pem`, `cert.pem`, and `key.pem` under `DOCKER_CERT_PATH`. Paid's env vars can point directly at `client-cert.pem`, `client-key.pem`, and `ca.pem`.
+
+QNAP `scp` may fail because modern `scp` uses SFTP by default and some QNAP SSH setups do not provide the expected SFTP subsystem. Use legacy SCP mode or stream over SSH:
+
+```bash
+scp -O -P <qnap-ssh-port> <qnap-user>@<qnap-tailscale-ip>:/etc/docker/tls/cert.pem tmp/remote-docker-certs/client-cert.pem
+ssh -p <qnap-ssh-port> <qnap-user>@<qnap-tailscale-ip> 'cat /etc/docker/tls/key.pem' > tmp/remote-docker-certs/client-key.pem
+ssh -p <qnap-ssh-port> <qnap-user>@<qnap-tailscale-ip> 'cat /etc/docker/tls/ca.pem' > tmp/remote-docker-certs/ca.pem
+cp tmp/remote-docker-certs/client-cert.pem tmp/remote-docker-certs/cert.pem
+cp tmp/remote-docker-certs/client-key.pem tmp/remote-docker-certs/key.pem
+```
+
 ## 4. Make the Agent Image Available on the NAS
 
 The remote daemon must have the `paid-agent:latest` image available before Paid can start runs there.
 
-Options:
+The supported local build path is:
+
+```bash
+./scripts/build-agent-image.sh
+```
+
+Do not use `docker compose --profile setup build agent-image` for this flow. The agent Dockerfile now requires build arguments extracted from `Gemfile.lock` and `agent-harness`; `scripts/build-agent-image.sh` is the maintained path that computes and passes those values.
+
+Options for getting the image onto the NAS:
 
 - Save and transfer manually:
 
 ```bash
 docker save paid-agent:latest | gzip > /tmp/paid-agent.tgz
-scp /tmp/paid-agent.tgz <qnap-user>@<qnap-tailscale-ip>:/tmp/
-ssh <qnap-user>@<qnap-tailscale-ip> 'gunzip -c /tmp/paid-agent.tgz | docker load'
+gunzip -c /tmp/paid-agent.tgz | \
+  DOCKER_HOST=tcp://<qnap-tailscale-ip>:2376 \
+  DOCKER_TLS_VERIFY=1 \
+  DOCKER_CERT_PATH="$PWD/tmp/remote-docker-certs" \
+  docker load
 ```
 
 - Push to a registry the NAS can pull from, such as Docker Hub, GHCR, or a private registry
 - Set up a cron job or deploy hook on the NAS to keep `paid-agent:latest` current
 
 If the image is missing, remote provisioning will fail even if the TLS connection itself is healthy.
+
+For the verified walkthrough, the image was built inside the Paid devcontainer, saved from the laptop Docker context, loaded into the QNAP Docker daemon over mTLS, and verified as `linux/amd64` on both sides. The QNAP was `x86_64`, so no cross-architecture build was needed.
 
 ## 5. Configure Paid
 
@@ -144,10 +271,10 @@ Set these environment variables on the Paid control plane:
 CONTAINER_BACKEND=remote
 REMOTE_DOCKER_HOST=<qnap-tailscale-ip>:2376
 REMOTE_DOCKER_IDENTIFIER=qnap-nas
-REMOTE_DOCKER_CERT=/path/to/client-cert.pem
-REMOTE_DOCKER_KEY=/path/to/client-key.pem
-REMOTE_DOCKER_CA=/path/to/ca.pem
-PAID_PROXY_EXTERNAL_URL=http://<laptop-tailscale-ip>:3000
+REMOTE_DOCKER_CERT=/workspaces/paid/tmp/remote-docker-certs/client-cert.pem
+REMOTE_DOCKER_KEY=/workspaces/paid/tmp/remote-docker-certs/client-key.pem
+REMOTE_DOCKER_CA=/workspaces/paid/tmp/remote-docker-certs/ca.pem
+PAID_PROXY_EXTERNAL_URL=http://<paid-host-tailscale-ip>:3000
 ```
 
 What each variable does:
@@ -164,6 +291,8 @@ What each variable does:
 
 Use the laptop's Tailscale IP in `PAID_PROXY_EXTERNAL_URL` so containers running on the NAS can call back into the Paid app.
 
+Replace `<qnap-tailscale-ip>` with the remote Docker host's Tailscale IP and `<paid-host-tailscale-ip>` with the Paid control-plane host's Tailscale IP.
+
 ## 6. Verify Connectivity
 
 First, test raw Docker API connectivity:
@@ -174,12 +303,35 @@ bundle exec rake remote_docker:test_connection
 
 Expected output is an `OK` ping from the configured remote backend.
 
+Verified walkthrough output:
+
+```text
+Remote backend qnap-nas responded with "OK"
+```
+
+You can also test Docker CLI connectivity from the host:
+
+```bash
+DOCKER_HOST=tcp://<qnap-tailscale-ip>:2376 \
+DOCKER_TLS_VERIFY=1 \
+DOCKER_CERT_PATH="$PWD/tmp/remote-docker-certs" \
+docker version
+```
+
 Then verify an actual run:
 
 1. Start Paid with the remote env vars.
 2. Queue a test agent run.
 3. Confirm the created container appears on the QNAP, not on the local Docker daemon.
 4. Confirm the agent can still reach the secrets proxy through `PAID_PROXY_EXTERNAL_URL`.
+
+The walkthrough smoke test created a QNAP container from `paid-agent:latest`, then exec'd:
+
+```bash
+curl -I --max-time 10 http://<paid-host-tailscale-ip>:3000
+```
+
+The request returned `HTTP/1.1 302 Found` with exit status `0`, and container cleanup succeeded.
 
 Operational checks worth doing after the first successful run:
 

--- a/docs/rdrs/RDR-048-multi-host-docker-backend-support.md
+++ b/docs/rdrs/RDR-048-multi-host-docker-backend-support.md
@@ -1,0 +1,578 @@
+# RDR-048: Multi-Host Docker Backend Support
+
+> Revise during planning; lock at implementation. If wrong, abandon code and iterate RDR.
+
+## Metadata
+
+- **Date**: 2026-07-16
+- **Status**: Draft
+- **Type**: Operations + Architecture
+- **Priority**: P1
+- **Related Issues**: #2944 (tracking), #2945 (backend configuration and registry), #2946 (scheduler and manual placement), #2947 (per-host concurrency), #2948 (multi-host lifecycle operations), #2949 (readiness checks), #2950 (management UI), #2951 (setup guide and automation helpers), #2952 (optional capacity-aware placement), #2953 (implementation audit and RDR closeout)
+- **Related RDRs**: RDR-019 (Remote Container Execution), RDR-020 (Service Container Architecture), RDR-033 (Worker Pool Scaling Algorithm), RDR-043 (Zero-Config Docker Capacity Autoscaling)
+- **Related Tests**: Docker backend resolver tests, container provisioning tests, process queue admission tests, orphan cleanup tests, container metrics tests, capacity snapshot tests, operations dashboard system tests, host setup wizard tests
+
+## Implementation Status
+
+Not implemented. Paid currently supports selecting exactly one active Docker backend for new paid-agent provisioning:
+
+- `CONTAINER_BACKEND=local` provisions paid-agent containers on local Docker.
+- `CONTAINER_BACKEND=remote` provisions paid-agent containers on one configured remote Docker daemon.
+- `CONTAINER_BACKEND=swarm` provisions paid-agent containers through the Swarm backend.
+
+The current remote Docker backend has been verified against the QNAP host `elguapo` at `100.113.201.1:2376` using mTLS, with `paid-agent:latest` and the required Docker networks present. In that mode, however, `elguapo` replaces local Docker for new agent containers; it is not additional capacity beside local Docker on `barts-macbook-pro`.
+
+Paid already has several primitives needed for multi-host operation:
+
+- `agent_runs.container_host` persists the host/backend selected for a run.
+- `container_pool_entries.container_host` persists the backend used for warm pool entries.
+- `Containers::Backends::Resolver` can register named backends.
+- `Containers.backend_for(host)` can reconnect to a backend by persisted `container_host`.
+- `Containers.all_backends` lets orphan cleanup scan more than the active backend in some modes.
+- Metrics collection uses `Containers.backend_for(agent_run.container_host)`.
+- Backend interfaces already expose `identifier`, `remote?`, `supports_host_paths?`, `owns_host?`, `all_host_identifiers`, and `container_host_for(container)`.
+
+Paid still assumes one active backend for placement and admission:
+
+- `config/initializers/container_backend.rb` resolves one `Rails.application.config.x.container_backend` from `CONTAINER_BACKEND`.
+- Fresh provisioning defaults to `Containers.backend`.
+- Warm pool replenishment creates entries with `Containers.backend.identifier`.
+- `ProcessRunQueueJob` fetches one Docker capacity policy/snapshot per pass.
+- `Capacity::RunAdmission#active_local_agent_reserved_bytes` only accounts for local-style hosts (`nil`, blank, and `local`).
+- `ServiceContainerReconciliationJob` checks running service containers through `Containers.backend`.
+- Network and proxy readiness are evaluated for the backend passed to provisioning, but no scheduler chooses among several backend candidates.
+- The account operations dashboard can already surface capacity state, but there is no UI for adding Docker hosts, setting per-host concurrency limits, checking readiness, or guiding remote-host setup.
+
+## Issue Plan
+
+Implementation is tracked by a dependency-ordered issue chain. No issue in this chain should be labeled higher than `P2`.
+
+| Issue | Priority | Scope | Dependency |
+|-------|----------|-------|------------|
+| #2944 | P2 | Umbrella tracking issue for RDR-048 | None |
+| #2945 | P2 | Multi-host backend configuration and registry | Depends on #2944 |
+| #2946 | P2 | Conservative scheduler and manual host placement | Depends on #2945 |
+| #2947 | P2 | Independent per-host Docker concurrency limits | Depends on #2946 |
+| #2948 | P2 | Multi-host lifecycle operations for cleanup, metrics, warm pools, and service containers | Depends on #2947 |
+| #2949 | P2 | Per-host Docker readiness checks | Depends on #2948 |
+| #2950 | P2 | Docker Hosts management UI | Depends on #2949 |
+| #2951 | P2 | Remote Docker setup guide and automation helpers | Depends on #2950 |
+| #2952 | P3 | Optional capacity-aware host placement | Depends on #2951 |
+| #2953 | P2 | Final implementation audit, gap filing, and RDR status update | Depends on #2952 |
+
+The final issue (#2953) should update this RDR to `Implemented` only after auditing that the shipped implementation matches the plan. If any acceptance criteria are missing or intentionally deferred, #2953 should create specific follow-up issues and reference them from this RDR instead of marking the RDR implemented prematurely.
+
+## Problem Statement
+
+Paid can target local Docker or one remote Docker host, but it cannot use multiple Docker hosts at once. This is limiting for developers and self-hosted operators who have useful capacity split across machines, such as:
+
+- local Docker on `barts-macbook-pro`;
+- a QNAP/NAS Docker daemon such as `elguapo`;
+- a remote workstation available over Tailscale or another private network.
+
+Switching `CONTAINER_BACKEND=remote` is operationally useful, but it changes all new paid-agent provisioning to the remote daemon. Operators cannot keep local Docker as the default while manually placing selected runs on a remote host, nor can Paid fall back from one healthy host to another without changing environment configuration and restarting the app.
+
+The current configuration path is also too opaque for self-hosted operators. Adding a remote Docker host requires leaving Paid, generating certificates, copying files, preparing networks, building or loading images, setting environment variables, and then inferring from logs whether the host is ready. Paid should automate the parts it can safely automate, provide copyable host-specific commands for the rest, and make readiness failures visible in the UI.
+
+The first version should not attempt a full cluster scheduler. The core need is to register several Docker backends, manage per-host capacity limits, select one explicitly or conservatively, persist that selection, and make lifecycle operations follow the persisted host.
+
+## Context
+
+### Verified Remote Host Facts
+
+- QNAP `elguapo` Docker is reachable at `100.113.201.1:2376` with mTLS.
+- The Paid devcontainer host is `barts-macbook-pro`, Tailscale IP `100.114.20.109`.
+- Containers on `elguapo` can call back to Paid at `http://100.114.20.109:3000`.
+- `elguapo` has the required Docker networks and `paid-agent:latest`.
+- `paid_agent` is the restricted/internal agent network.
+- `paid_internal` is the unrestricted infrastructure network.
+- The remote backend does not support host bind mounts.
+
+### Current Backend Model
+
+The backend interface is already close to the right abstraction. `LocalDocker`, `RemoteDocker`, and `Swarm` provide a shared set of container, network, volume, stats, image, and host-identity operations. This RDR should extend that model rather than introducing a separate Docker client layer.
+
+The key missing distinction is:
+
+```text
+active backend = default backend used by singleton-era callers
+configured backends = all Docker hosts available for scheduler placement
+selected backend = backend chosen for a specific run/container lifecycle
+```
+
+Today those collapse into `Containers.backend` for most provisioning paths.
+
+### Host Identity
+
+The selected backend should continue to be recorded in `agent_runs.container_host`. For local and single remote Docker backends, this is already the backend identifier. For Swarm, it may be a node hostname returned by `container_host_for(container)`.
+
+Multi-host mode should treat host identifiers as operator-facing stable names, not raw URLs, so logs, UI, and retry decisions can say `local` or `elguapo` instead of only `tcp://100.113.201.1:2376`.
+
+## Recommendation
+
+Introduce a multi-host Docker scheduler and management UI that can register several Docker backends, configure independent host capacity limits, and choose one backend for each paid-agent run.
+
+Core decision:
+
+> Keep `local`, `remote`, and `swarm` as backward-compatible single-backend modes. Add an explicit multi-host mode that registers named backends, performs conservative placement, and persists the selected backend through the existing `agent_runs.container_host` field.
+
+V1 should prioritize correctness and operator control:
+
+- explicit preferred host from global/account/project configuration;
+- independent per-host concurrency limits;
+- optional first-healthy fallback among configured hosts;
+- no automatic capacity balancing unless later implementation proves it can reuse existing capacity code safely;
+- no implicit activation from existing `REMOTE_DOCKER_*` variables.
+
+The account operations UI should become the primary operator surface for multi-host configuration. Environment variables remain the bootstrap/backward-compatible path, but once multi-host mode is enabled, Paid should let an admin add hosts, validate readiness, view capacity, generate setup assets where safe, and copy exact remaining setup commands.
+
+## Proposed Design
+
+### Backend Registry
+
+Extend backend registration so Paid can distinguish the active singleton backend from all configured schedulable Docker hosts.
+
+In single-backend modes:
+
+- `CONTAINER_BACKEND=local` keeps today’s behavior.
+- `CONTAINER_BACKEND=remote` keeps today’s behavior with one remote backend from `REMOTE_DOCKER_*`.
+- `CONTAINER_BACKEND=swarm` keeps today’s behavior.
+- `Containers.backend` continues to return the selected singleton backend.
+
+In multi-host mode:
+
+- `CONTAINER_BACKEND=multi` enables the scheduler.
+- `Containers.backend` may return a compatibility/default backend, but new paid-agent provisioning must ask the scheduler for a selected backend.
+- `Containers.backend_for(container_host)` must resolve any configured named backend.
+- `Containers.all_backends` must return every configured backend so cleanup and metrics can iterate all hosts.
+
+The scheduler itself can be a small service, tentatively `Containers::BackendScheduler`, with inputs:
+
+```text
+agent_run
+project/account/global host preference
+allowed fallback hosts
+required backend capabilities
+health/readiness snapshot
+```
+
+Output:
+
+```text
+selected backend
+selection reason
+fallback chain considered
+```
+
+### Proposed V1 Configuration
+
+Existing environment variables continue to work unchanged for single-backend modes.
+
+For multi-host mode, prefer a structured config payload over unbounded indexed environment variables. This fits better than inventing `REMOTE_DOCKER_HOST_1`, `REMOTE_DOCKER_HOST_2`, `REMOTE_DOCKER_CERT_1`, and so on, and it leaves room for per-host settings.
+
+Example:
+
+```yaml
+CONTAINER_BACKEND: multi
+CONTAINER_BACKENDS_CONFIG: |
+  default_host: local
+  fallback: first_healthy
+  hosts:
+    local:
+      type: local
+      concurrency:
+        mode: manual
+        max_concurrent_runs: 2
+    elguapo:
+      type: remote
+      host: tcp://100.113.201.1:2376
+      tls:
+        ca_file: /workspaces/paid/config/docker/elguapo/ca.pem
+        client_cert: /workspaces/paid/config/docker/elguapo/cert.pem
+        client_key: /workspaces/paid/config/docker/elguapo/key.pem
+      proxy_external_url: http://100.114.20.109:3000
+      supports_host_paths: false
+      concurrency:
+        mode: manual
+        max_concurrent_runs: 4
+    aws-runner-1:
+      type: remote
+      host: tcp://10.0.10.25:2376
+      tls:
+        ca_file: /var/paid/docker-hosts/aws-runner-1/ca.pem
+        client_cert: /var/paid/docker-hosts/aws-runner-1/cert.pem
+        client_key: /var/paid/docker-hosts/aws-runner-1/key.pem
+      proxy_external_url: https://paid.example.com
+      supports_host_paths: false
+      concurrency:
+        mode: manual
+        max_concurrent_runs: 8
+```
+
+If Rails credentials or another existing structured settings surface becomes the preferred home during implementation, this shape should be mapped there rather than forcing all host definitions into process environment. For operator-managed deployments, prefer persisted host records or a structured tenant setting edited through the UI, with secret material stored through the existing credential/encrypted settings pattern rather than plaintext JSON.
+
+Per-host config should support at least:
+
+- stable host identifier;
+- backend type (`local` or `remote` in v1; `swarm` can remain its own singleton mode unless explicitly added later);
+- Docker endpoint and TLS settings for remote hosts;
+- per-host `PAID_PROXY_EXTERNAL_URL` or equivalent callback URL;
+- image name/tag override only if needed;
+- whether host bind mounts are supported;
+- whether the host is enabled for automatic fallback.
+- concurrency mode (`manual` in v1, `auto` later when per-host capacity admission is proven);
+- hard per-host max concurrent runs;
+- optional per-host project/account overrides or eligibility tags in a later phase;
+- setup status and last readiness error.
+
+### Management UI
+
+Add a Docker Hosts area to the account operations/admin interface. It should be designed as an operational control plane, not a marketing page: dense, scannable, and centered on host state, capacity, and setup progress.
+
+The host index should show:
+
+- host name and backend type;
+- enabled/disabled state;
+- health/readiness state with the failing check named;
+- Docker endpoint or local indicator;
+- configured proxy callback URL;
+- architecture and Docker daemon summary when available;
+- image status for `paid-agent:latest`;
+- required network status;
+- current active paid-agent runs;
+- per-host concurrency limit and available slots;
+- whether fallback placement may use the host;
+- last successful check and last error.
+
+The host detail page should let an admin:
+
+- edit display name, identifier, endpoint, callback URL, image tag, fallback eligibility, and manual concurrency limit;
+- run readiness checks on demand;
+- view recent runs placed on the host;
+- view recent provisioning, cleanup, metrics, and readiness errors scoped to the host;
+- copy setup commands for the host;
+- disable a host without deleting its historical run ownership;
+- delete only hosts with no active containers, or otherwise require an explicit drain path.
+
+The project/account/global placement settings should expose:
+
+- default preferred host;
+- fallback behavior (`disabled`, `first_healthy`);
+- optional per-project preferred host;
+- optional manual run placement override when starting or retrying a run;
+- validation that selected hosts are enabled and compatible with the run requirements.
+
+### Setup Guide and Automation
+
+The UI should include a setup guide/wizard for adding a remote Docker host. The guide should be host-specific and preserve progress across steps.
+
+For a QNAP/NAS or Linux remote host, the wizard should cover:
+
+1. Name the host and choose a stable identifier such as `elguapo`.
+2. Enter the host/IP and expected Docker TLS port.
+3. Generate or upload Docker mTLS client/server certificate material.
+4. Show the commands or QNAP UI steps needed to install server certificates and enable the TLS Docker endpoint.
+5. Validate that Paid can ping Docker over TLS.
+6. Configure the callback/proxy URL reachable from containers on that host.
+7. Validate callback reachability from a short-lived test container when possible.
+8. Verify or create required Docker networks.
+9. Verify `paid-agent:latest` is present and architecture-compatible.
+10. Build, pull, load, or copy the image using the best available method.
+11. Set the host concurrency limit.
+12. Run a dry-run provisioning check that creates and removes a disposable container.
+
+Paid should automate what it can do from the control plane:
+
+- generate a local certificate authority and Docker client certificate/key for a named host;
+- generate a server certificate signing request or self-signed server certificate when the operator supplies hostnames/IP SANs;
+- store client certificate material securely for the backend connection;
+- test TLS connectivity;
+- create missing Docker networks on the remote daemon when authorized;
+- inspect Docker architecture and daemon resources;
+- check image presence and labels/digest;
+- run a disposable readiness container;
+- generate exact shell commands for remote setup;
+- generate `docker save` / `docker load`, registry push/pull, or remote `docker build` instructions for `paid-agent:latest`.
+
+Paid should clearly document what it cannot safely automate from inside the app:
+
+- changing NAS vendor settings that require QNAP admin UI access;
+- opening firewall/router ports;
+- installing Docker or enabling daemon TLS when SSH/admin access is unavailable;
+- copying server certificates to a host unless an explicit remote access mechanism is configured;
+- guaranteeing Tailscale or VPN routing outside the container network;
+- distributing subscription-auth host credentials to remote Docker hosts without an explicit credential design.
+
+For non-QNAP remote hosts such as AWS instances, the same wizard should provide a generic Linux path. Later implementations may add provider-specific helpers, but v1 should keep the core contract Docker-over-mTLS plus reachable Paid callback URL.
+
+### Placement Policy
+
+V1 placement order:
+
+1. Use an explicit host requested for the run when present and authorized by configuration.
+2. Otherwise use project preference.
+3. Otherwise use account preference.
+4. Otherwise use global/default host.
+5. If the preferred host is unavailable and fallback is enabled, choose the first healthy compatible host in configured order.
+6. If no compatible host is available, leave the run queued and log a host-specific capacity/readiness reason.
+
+This deliberately avoids automatic load balancing in v1. Capacity-aware placement can come later after the per-host capacity snapshots, admission accounting, and UI/debugging story are proven.
+
+Manual concurrency limits are still enforced in v1. A host with `max_concurrent_runs: 2` may run two paid-agent containers even if another configured host has room; fallback only chooses another compatible host when policy allows it. This lets `local`, `elguapo`, and an AWS runner each have independent ceilings.
+
+The scheduler must filter hosts by hard capability requirements before health fallback:
+
+- worktree bind mounts require `supports_host_paths?`;
+- subscription-auth runs that rely on host-backed credentials require a backend that supports the selected auth material;
+- restricted proxy-mode runs require a reachable proxy callback URL;
+- service-container dependencies require network reachability on the same backend or an explicitly supported cross-host service strategy.
+
+### Health and Readiness
+
+Each configured backend should have a health/readiness check that can be evaluated independently and cached briefly:
+
+- Docker ping succeeds.
+- Docker daemon architecture is compatible with `paid-agent:latest`.
+- Required networks exist:
+  - `paid_agent`;
+  - `paid_internal`.
+- `paid-agent:latest` exists locally on that Docker host or can be pulled/created according to configured policy.
+- Remote containers can reach that host’s configured Paid callback/proxy URL.
+- Backend supports the selected run’s mount/auth/network requirements.
+- TLS credentials for remote Docker are present and valid enough to connect.
+
+Readiness failure should be host-specific. One unhealthy remote host must not make a healthy local host unusable.
+
+### Operational Behavior
+
+#### Image Distribution
+
+Images are per-host state. Multi-host mode must treat `paid-agent:latest` on `local`, `elguapo`, and any AWS host as separate artifacts. V1 can require operators to pre-build or pre-load the image on every configured host, but the UI should still help:
+
+- detect whether the image exists on each host;
+- show architecture compatibility;
+- show digest/tag drift when available;
+- generate copyable build/load/pull commands;
+- optionally trigger an image pull/build where the Docker API and deployment policy allow it.
+
+A later phase may add full reconciliation that builds, pushes, pulls, or verifies digests per host.
+
+#### Network Reconciliation
+
+Networks are per-host state. `NetworkPolicy.ensure_network!` already accepts a backend argument; multi-host mode should call it for the selected backend during provisioning and expose readiness for missing networks. Optional reconciliation can create missing networks on each configured host when policy allows.
+
+#### Proxy and Callback URLs
+
+Remote backends need a URL reachable from containers on that host. The current global `PAID_PROXY_EXTERNAL_URL` is sufficient for one remote host, but multi-host mode needs per-host callback configuration because different hosts may reach Paid through different addresses.
+
+For the verified QNAP setup:
+
+```text
+elguapo containers -> http://100.114.20.109:3000
+```
+
+Local Docker can continue to use the in-compose proxy host where applicable.
+
+#### Host-Specific Errors and Retry
+
+Provisioning failures should record the backend identifier and failure class. Retry behavior should distinguish:
+
+- selected host transient failure: retry the same host first when the run has an explicit host;
+- fallback-enabled preference failure: try the next healthy compatible host;
+- capability mismatch: do not retry on incompatible hosts;
+- authentication or TLS misconfiguration: surface as operator action, not queue churn.
+
+If a retry chooses a different host after a failed pre-container attempt, `agent_runs.container_host` should be updated only when a container is actually created or successfully selected for lifecycle ownership. Avoid recording a host too early if no resources exist there.
+
+#### Cleanup and Orphan Scanning
+
+`DockerOrphanCleanupJob` already iterates `Containers.all_backends`; multi-host mode should make that method return every configured backend. The existing persisted `container_host` and `backend.all_host_identifiers` strategy should remain the ownership boundary for active-run and warm-pool filtering.
+
+`AgentRunResourceJanitorJob`, `AgentRun#cleanup_orphaned_workspace_volume`, and metrics collection already resolve by `container_host`; these paths should continue to be the model for lifecycle operations.
+
+`ServiceContainerReconciliationJob` currently checks service containers through `Containers.backend`. Multi-host support must either persist service container host identity or keep service containers scoped to one backend until a cross-host service-container design exists.
+
+#### Metrics and Capacity
+
+Metrics collection for a running agent container should continue to use `Containers.backend_for(agent_run.container_host)`.
+
+Capacity snapshots should become per-backend, using the existing `Capacity::DockerSnapshot.cache_key(backend_identifier)` shape. Queue admission currently fetches one snapshot/policy per pass; multi-host mode needs per-host admission.
+
+V1 should support manual per-host concurrency limits:
+
+```text
+local: max_concurrent_runs = 2
+elguapo: max_concurrent_runs = 4
+aws-runner-1: max_concurrent_runs = 8
+```
+
+Admission should count only active paid-agent runs on the selected host when applying that host's limit. User/account/project guardrails still apply across all hosts unless a later RDR deliberately changes fairness semantics. In other words, host limits are execution-capacity ceilings, not a bypass for tenant/account/user concurrency policy.
+
+When the selected host has no slots, behavior depends on placement policy:
+
+- explicit host selection: leave the run queued for that host and explain the host limit;
+- preferred host with fallback disabled: leave the run queued for the preferred host;
+- preferred host with first-healthy fallback: choose the first compatible healthy host that also has an available host slot.
+
+Capacity-aware scheduling should be a later phase unless implementation can safely extend `Capacity::RunAdmission` to account for active/reserved memory per selected backend.
+
+#### Remote Host Bind Mounts and Auth
+
+The remote backend does not support host bind mounts. Multi-host placement must reject remote hosts for runs requiring `worktree_path` bind mounts and should favor named-volume/in-container clone flows for remote execution.
+
+Subscription-auth behavior also differs by backend:
+
+- host-backed credential mounts are natural on local Docker;
+- remote Docker cannot mount local credential paths;
+- provider proxy mode works on restricted networks if the remote container can reach Paid’s proxy URL;
+- subscription-auth/direct-outbound mode requires a deliberate host-specific credential story before remote placement is allowed.
+
+## Consequences
+
+### Benefits
+
+- Operators can use local Docker and remote NAS/workstation capacity at the same time.
+- Developers can offload expensive agent runs to QNAP/NAS hardware without losing local Docker as a fallback.
+- Operators can set conservative, independent concurrency ceilings per Docker host.
+- The UI makes remote host setup observable and repeatable instead of relying on environment variables and logs.
+- `agent_runs.container_host` becomes a complete lifecycle routing key for multi-host operations.
+- The backend interface remains the central abstraction instead of adding a parallel orchestration system.
+- Later capacity-aware placement can build on per-host health, metrics, and readiness snapshots.
+
+### Costs
+
+- Configuration becomes more complex, especially TLS and per-host callback URLs.
+- The operations UI must handle secrets, setup progress, validation errors, and destructive actions carefully.
+- Operators must manage image and network drift across hosts unless reconciliation is added.
+- Debugging requires every log/UI surface to identify the selected host.
+- Warm pools and service containers need host-specific behavior.
+- Capacity calculations become per-host instead of deployment-global.
+
+### Risks
+
+- A partially healthy host may pass Docker ping but fail at network, image, proxy, architecture, or auth readiness.
+- Remote credential differences can cause a run to work locally and fail remotely.
+- Cleanup can miss resources if a host identifier changes after containers are created.
+- First-healthy fallback can surprise operators if it silently moves work to a remote host with different cost/performance/security properties.
+- Capacity-aware scheduling could over-admit if it mixes memory accounting across hosts.
+- Certificate generation can create a false sense of completion if server-side installation and firewall changes remain manual.
+- Per-host concurrency limits can interact confusingly with existing user/account/project guardrails unless the UI explains which limit is binding.
+
+Mitigations:
+
+- require explicit `CONTAINER_BACKEND=multi`;
+- keep v1 placement manual/preference-driven;
+- log selected host and selection reason;
+- cache and expose per-host readiness;
+- show the binding concurrency limit in queue/admission explanations;
+- make setup guides explicit about automated vs manual steps;
+- preserve single-backend behavior exactly;
+- make host identifiers stable and operator-controlled.
+
+## Alternatives Considered
+
+### Alternative 1: Keep Single Backend Only
+
+Continue requiring operators to choose `local`, `remote`, or `swarm` at process start.
+
+Rejected. This preserves simplicity, but it forces remote QNAP to be a replacement for local Docker rather than additional capacity. It also wastes existing `container_host` and backend lookup infrastructure that already points toward multi-host lifecycle support.
+
+### Alternative 2: Use Docker Swarm Only
+
+Tell operators who need multiple hosts to use the existing Swarm backend.
+
+Rejected for v1. Swarm is useful when operators want a Docker-native cluster, but it is a heavier operational commitment than "local Docker plus one QNAP over mTLS." It also changes scheduling, networking, service semantics, and image distribution in ways that are unnecessary for manual local-plus-remote placement.
+
+### Alternative 3: Require Kubernetes or an External Orchestrator
+
+Move multi-host scheduling outside Paid entirely.
+
+Rejected. This may be appropriate for managed platform deployments later, but it is too heavy for the self-hosted/developer use case. The verified `elguapo` setup already works through the Docker backend abstraction.
+
+### Alternative 4: Treat Remote QNAP as Replacement Capacity
+
+Keep the current `CONTAINER_BACKEND=remote` behavior and document that operators can switch the whole deployment to QNAP when needed.
+
+Rejected. This is today’s behavior and does not satisfy simultaneous use, explicit host placement, fallback, or per-host lifecycle visibility.
+
+### Alternative 5: Capacity-Balanced Scheduler in V1
+
+Immediately choose the host with the most available CPU/memory.
+
+Rejected for v1. Paid has Docker capacity primitives from RDR-043, but they are currently oriented around one active backend and local auto capacity. Balancing across hosts before per-host accounting, UI, and fallback semantics are stable would increase risk.
+
+### Alternative 6: Configuration-Only Multi-Host Support
+
+Support multi-host definitions only through environment variables or YAML, without a UI.
+
+Rejected. This would technically enable multiple Docker hosts, but it would keep the hardest parts of the workflow hidden: certificate setup, image readiness, network drift, callback reachability, and per-host concurrency. The target operator needs Paid to make setup and troubleshooting visible.
+
+## Implementation Outline
+
+### Phase 1: Registry, Config, and Manual Placement
+
+- Add structured multi-host config parsing.
+- Register named local/remote backends.
+- Add `Containers::BackendScheduler`.
+- Add explicit global/account/project preferred-host setting or equivalent configuration surface.
+- Add manual per-host concurrency limits and enforce them during queue admission.
+- Select a backend before provisioning and pass it into `Containers::Provision`.
+- Persist selected host through existing `agent_runs.container_host`.
+- Keep `CONTAINER_BACKEND=local`, `remote`, and `swarm` behavior unchanged.
+
+### Phase 2: Management UI and Setup Guide
+
+- Add Docker Hosts management under the account operations/admin interface.
+- Add host index, host detail, edit form, and disable/drain affordances.
+- Add setup wizard for local, QNAP/NAS, and generic remote Linux Docker hosts.
+- Add helpers to generate certificate material or setup commands where safe.
+- Add image/network/proxy readiness panels with copyable remediation commands.
+- Add UI explanations showing host concurrency limits separately from account/user/project guardrails.
+
+### Phase 3: Health Checks and Visibility
+
+- Add per-backend readiness checks and short-lived cache.
+- Surface host health, network/image/proxy readiness, and recent errors in admin/status UI.
+- Log selection reason and fallback chain.
+- Ensure remote proxy callback validation is per host.
+
+### Phase 4: Lifecycle Coverage
+
+- Make `Containers.all_backends` return all configured multi-host backends.
+- Ensure cleanup, janitor, metrics, warm pool, and service-container reconciliation use persisted host identity.
+- Decide whether service containers remain single-host or gain host persistence.
+- Add tests for cleanup and metrics across local plus `elguapo`.
+
+### Phase 5: Capacity-Aware Placement
+
+- Extend `Capacity::DockerSnapshot` and `Capacity::RunAdmission` to operate per backend.
+- Account for active and reserved agent memory by selected host.
+- Add capacity-aware selection as an opt-in policy after manual placement is stable.
+- Preserve first-healthy/manual placement as the conservative fallback.
+
+### Phase 6: Optional Image and Network Reconciliation
+
+- Verify or reconcile required networks on each host.
+- Verify image presence and compatible architecture.
+- Optionally pull/build/distribute images per host.
+- Optionally compare image digests and report drift.
+
+## Acceptance Criteria
+
+- Existing `CONTAINER_BACKEND=local` behavior is unchanged.
+- Existing single `CONTAINER_BACKEND=remote` behavior is unchanged.
+- Existing `CONTAINER_BACKEND=swarm` behavior is unchanged.
+- Multi-host config can register local Docker plus `elguapo`.
+- The operations/admin UI can add, edit, disable, and inspect Docker hosts.
+- The UI exposes independent manual concurrency limits per host.
+- Queue admission enforces host-level concurrency separately from existing user/account/project guardrails.
+- A run can be explicitly placed on either `local` or `elguapo`.
+- First-healthy fallback can be enabled or disabled by configuration.
+- `agent_runs.container_host` records the chosen backend/host for every provisioned run.
+- Cleanup scans all configured hosts in multi-host mode.
+- Metrics collection reads from the persisted host for each running container.
+- Remote hosts are rejected for runs that require unsupported host bind mounts.
+- Remote proxy readiness validates that containers can reach the configured Paid callback URL.
+- The setup guide can generate or accept certificate material, test Docker TLS connectivity, and show copyable remaining setup commands.
+- The setup guide can verify or guide image availability and required networks per host.
+- Tests cover backward compatibility, host selection, fallback, host concurrency, persisted host lookup, setup wizard behavior, cleanup, and metrics.

--- a/docs/rdrs/README.md
+++ b/docs/rdrs/README.md
@@ -95,6 +95,7 @@ For more information, see the [RDR methodology](https://github.com/cwensel/rdr).
 | [RDR-019](RDR-019-remote-container-execution.md) | Remote Container Execution | Implemented | Medium |
 | [RDR-033](RDR-033-worker-pool-scaling-algorithm.md) | Worker Pool Scaling Algorithm | Implemented | Medium |
 | [RDR-043](RDR-043-zero-config-docker-capacity-autoscaling.md) | Zero-Config Docker Capacity Autoscaling | Draft | Medium |
+| [RDR-048](RDR-048-multi-host-docker-backend-support.md) | Multi-Host Docker Backend Support | Draft | P1 |
 
 ### Quality & Automation
 


### PR DESCRIPTION
## Summary

Adds RDR-048 for multi-host Docker backend support in Paid, building on the remote Docker/QNAP documentation already on this branch.

This RDR covers:

- explicit multi-host mode while preserving `local`, `remote`, and `swarm` single-backend modes;
- local Docker plus remote hosts such as QNAP `elguapo` and future AWS/Linux Docker hosts;
- conservative manual/preferred-host placement;
- independent per-host Docker concurrency limits;
- multi-host lifecycle behavior for cleanup, metrics, pools, and service containers;
- Docker Hosts management UI;
- setup guide and automation helpers for certificates, networks, proxy callback checks, and images;
- dependency-ordered implementation issues #2944 through #2953.

## Issue Chain

- #2944: tracking
- #2945: backend configuration and registry
- #2946: scheduler and manual placement
- #2947: per-host concurrency
- #2948: multi-host lifecycle operations
- #2949: readiness checks
- #2950: management UI
- #2951: setup guide and automation helpers
- #2952: optional capacity-aware placement
- #2953: implementation audit and RDR closeout

## Auto-Merge

Do not auto-merge this PR. This is a planning/RDR PR that should receive human review before merging.

## Validation

- `npx markdownlint docs/rdrs/RDR-048-multi-host-docker-backend-support.md docs/rdrs/README.md`
- pre-commit hook ran successfully during commit