### PR TITLE
docs(rdr): track managed subscription auth issue tree

### DIFF
--- a/docs/rdrs/RDR-041-subscription-runner-auth-lifecycle.md
+++ b/docs/rdrs/RDR-041-subscription-runner-auth-lifecycle.md
@@ -1,217 +1,366 @@
-# RDR-041: Subscription Runner Auth Lifecycle (Detection, Long-Lived Tokens, Self-Heal)
+# RDR-041: Subscription Runner Managed Auth Lifecycle
 
 > Revise during planning; lock at implementation. If wrong, abandon code and iterate RDR.
 
 ## Metadata
 
-- **Status**: Accepted
+- **Status**: Partially Implemented
 - **Date**: 2026-06-26
+- **Revised**: 2026-07-16
 - **Priority**: P1
-- **Related Issues**: #2690, #2683, #2685, #2684, #2686, #2687, #2688, #2689
-- **Related RDRs**: RDR-004 (Container Isolation), RDR-006 (Secrets Proxy Architecture), RDR-007 (Agent CLI Abstraction), RDR-010 (Multi-Tenancy and RBAC), RDR-025 (Runner Quota Tracking), RDR-040 (Runner Model Compatibility Contracts)
+- **Related Issues**: [#2690](https://github.com/viamin/paid/issues/2690), [#2683](https://github.com/viamin/paid/issues/2683), [#2685](https://github.com/viamin/paid/issues/2685), [#2684](https://github.com/viamin/paid/issues/2684), [#2686](https://github.com/viamin/paid/issues/2686), [#2687](https://github.com/viamin/paid/issues/2687), [#2688](https://github.com/viamin/paid/issues/2688), [#2689](https://github.com/viamin/paid/issues/2689), [#2958](https://github.com/viamin/paid/issues/2958), [#2959](https://github.com/viamin/paid/issues/2959), [#2960](https://github.com/viamin/paid/issues/2960), [#2961](https://github.com/viamin/paid/issues/2961), [#2962](https://github.com/viamin/paid/issues/2962), [#2963](https://github.com/viamin/paid/issues/2963), [#2964](https://github.com/viamin/paid/issues/2964), [#2965](https://github.com/viamin/paid/issues/2965), [#2966](https://github.com/viamin/paid/issues/2966)
+- **Related RDRs**: RDR-004 (Container Isolation), RDR-006 (Secrets Proxy Architecture), RDR-007 (Agent CLI Abstraction), RDR-010 (Multi-Tenancy and RBAC), RDR-025 (Runner Quota Tracking), RDR-040 (Runner Model Compatibility Contracts), RDR-048 (Multi-Host Docker Backend Support)
 
 ## Implementation Status
 
-Accepted and tracked, not materially implemented yet. Existing pre-RDR plumbing includes the `auth_expired` run status and non-zero auth classification, but the exit-0/preflight auth gap, proactive auth health, managed runner credentials, Claude long-lived token injection, and self-heal flows remain open work tracked by the related phase issues.
+RDR-041 is partially implemented, but only Claude Code has a remote-safe managed credential path today.
+
+Shipped:
+
+- Exit-0 and preflight auth-error classification now route subscription auth failures to `auth_expired`.
+- `Runners::AuthHealth`, dashboard auth-health UI, and `ClaudeAuthHealthCheckJob` provide proactive Claude health checks.
+- `RunnerCredential` exists as an encrypted, account-scoped credential store with logidze audit, runner scoping, revocation, and UI.
+- Managed Claude setup tokens are injected as `CLAUDE_CODE_OAUTH_TOKEN`; when present, provisioning skips host `.credentials.json` seeding.
+- Browser-completed Claude login captures native `.credentials.json` into a `RunnerCredential`.
+- Claude keep-warm can refresh host-forwarded native credentials and write the rotated credential back under a lock.
+
+The original Claude-focused issue chain (#2690, #2683, #2685, #2684, #2686, #2687, #2688, #2689) is closed/completed. This RDR remains **Partially Implemented** because the revised scope now covers provider-neutral managed auth and RDR-048 remote-host eligibility, not only Claude.
+
+Still open:
+
+- Provider-neutral managed auth for Codex, Gemini, and Copilot.
+- Remote-safe Codex subscription auth. Codex still depends on a Docker-host-bind-mountable `auth.json` and cannot run on a backend where `supports_host_paths? == false` unless it uses API-key/proxy mode.
+- A canonical materialization contract that says how each provider turns an encrypted `RunnerCredential` into container runtime state.
+- Refresh ownership for providers whose CLI may rotate credentials during a run.
+- Feature-flagged rollout is not implemented; `FeatureFlags::DEFINITIONS` does not yet include `managed_subscription_runner_auth`.
+- Production-style auth-attempt telemetry is not implemented, so managed auth cannot yet be compared against legacy host-mounted local auth by provider and Docker host.
+- RDR-048 scheduler/readiness integration is not implemented, so remote hosts are not yet selected/rejected by provider auth capability.
+
+## Issue Plan
+
+The original Claude-focused issue chain ([#2690](https://github.com/viamin/paid/issues/2690), [#2683](https://github.com/viamin/paid/issues/2683), [#2685](https://github.com/viamin/paid/issues/2685), [#2684](https://github.com/viamin/paid/issues/2684), [#2686](https://github.com/viamin/paid/issues/2686), [#2687](https://github.com/viamin/paid/issues/2687), [#2688](https://github.com/viamin/paid/issues/2688), [#2689](https://github.com/viamin/paid/issues/2689)) is complete. The revised provider-neutral and RDR-048-compatible work is tracked by this dependency-ordered issue chain. These issues are auth-related and should remain `P1`.
+
+| Issue | Priority | Scope | Dependency |
+|-------|----------|-------|------------|
+| [#2958](https://github.com/viamin/paid/issues/2958) | P1 | Umbrella tracking issue for the revised managed subscription auth lifecycle | None |
+| [#2959](https://github.com/viamin/paid/issues/2959) | P1 | Gate managed subscription auth rollout and add runtime auth-source metadata | Depends on [#2958](https://github.com/viamin/paid/issues/2958) |
+| [#2960](https://github.com/viamin/paid/issues/2960) | P1 | Add runner auth attempt telemetry for managed versus host auth | Depends on [#2959](https://github.com/viamin/paid/issues/2959) |
+| [#2961](https://github.com/viamin/paid/issues/2961) | P1 | Extract subscription auth provider adapter/materializer contract | Depends on [#2959](https://github.com/viamin/paid/issues/2959), [#2960](https://github.com/viamin/paid/issues/2960) |
+| [#2962](https://github.com/viamin/paid/issues/2962) | P1 | Implement remote-safe Codex managed subscription auth | Depends on [#2961](https://github.com/viamin/paid/issues/2961), [#2960](https://github.com/viamin/paid/issues/2960) |
+| [#2963](https://github.com/viamin/paid/issues/2963) | P1 | Enforce subscription auth host eligibility in RDR-048 scheduler and readiness | Depends on [#2961](https://github.com/viamin/paid/issues/2961), [#2962](https://github.com/viamin/paid/issues/2962) |
+| [#2964](https://github.com/viamin/paid/issues/2964) | P1 | Add Gemini and Copilot managed subscription auth materializers | Depends on [#2962](https://github.com/viamin/paid/issues/2962), [#2963](https://github.com/viamin/paid/issues/2963) |
+| [#2965](https://github.com/viamin/paid/issues/2965) | P1 | Cut over managed subscription auth after telemetry proves reliability | Depends on [#2960](https://github.com/viamin/paid/issues/2960), [#2963](https://github.com/viamin/paid/issues/2963), [#2964](https://github.com/viamin/paid/issues/2964) |
+| [#2966](https://github.com/viamin/paid/issues/2966) | P1 | Final implementation audit, gap filing, and RDR status update | Depends on [#2965](https://github.com/viamin/paid/issues/2965) |
+
+The final issue ([#2966](https://github.com/viamin/paid/issues/2966)) should update this RDR to `Implemented` only after auditing that the shipped implementation matches the plan. If any acceptance criteria are missing or intentionally deferred, #2966 should create specific follow-up issues and reference them from this RDR instead of marking the RDR implemented prematurely.
 
 ## Problem Statement
 
-Subscription-auth runners (Claude Code, Codex, Gemini, Copilot) execute inside agent containers using OAuth credentials **forwarded from the host/devcontainer**, not API keys. When the upstream credential expires, the forwarded credential expires with it, and every container inherits the same dead token. Today this is a **silent breakage**: Paid has no proactive signal that the source credential is stale, the only path that classifies an auth failure requires a non-zero runner exit, and there is no way to re-authorize without shell access to the host/devcontainer.
+Subscription-auth runners (Claude Code, Codex, Gemini, Copilot) run paid local CLIs inside Paid-managed containers. Their credentials are OAuth/session artifacts for the user's subscription plan, not normal provider API keys.
 
-Claude Code's interactive OAuth access token has a short (~24h) lifetime and does not auto-refresh on headless machines, so the forwarded Claude credential goes stale frequently and quietly. This blocks subscription Claude runs and is invisible until a human notices runs failing — or, worse, until a run is recorded as successful while the runner actually never authenticated.
+The original implementation forwarded host/devcontainer credential directories into agent containers. That has two hard limits:
 
-Two outcomes are required:
+1. **Availability.** A remote Docker daemon cannot mount a credential directory from the Paid control-plane host.
+2. **Refresh ownership.** For rotating credentials, the important state is not just the initial token; it is where the refreshed credential lands. If a container refreshes a copied credential and exits, Paid keeps a stale parent credential and future runs fail.
 
-1. **Detect** the expired/expiring state and surface it loudly, before runs start failing.
-2. **Re-authorize** a runner without requiring a human to open a terminal on the host/devcontainer — including cloud deployments where no terminal exists.
+RDR-048 makes this urgent. Multi-host Docker placement can only send a subscription runner to a remote backend when the runner has a remote-safe credential source. Host-mounted local auth must remain supported for local Docker, but it cannot be the only path.
 
-## Context
+## Goals
 
-### Current Forwarding Pipeline
+1. Let a Paid user initiate subscription auth from the Runners UI and store the result in Paid.
+2. Use that auth for both local and remote Docker containers.
+3. Keep refresh/rotation state owned by Paid, not by an ephemeral container.
+4. Preserve the existing local host-mounted path while the new path rolls out.
+5. Measure managed-auth success rates against legacy local-container auth before forcing cutover.
+6. Keep provider-specific OAuth behavior isolated in provider adapters or agent-harness, not scattered across provisioning code.
 
-Subscription auth is detected and forwarded at container provision time in `app/services/containers/provision.rb`:
+## Current Provider Matrix
 
-- **Detection is existence-only.** `claude_subscription_auth?` (≈`provision.rb:2259`) returns true iff a `.credentials.json` file exists at `claude_config_host_path` or `claude_local_config_path`. Codex/Gemini/Copilot use the analogous `auth.json` / `oauth_creds.json` / `config.json` checks. No expiry, validity, or token shape is inspected.
-- **Mount + seed.** The host config dir is mounted read-only at a staging path (`provision.rb:1851-1879`) and credentials are copied into a writable `/home/agent/.<provider>` tmpfs after start (`seed_claude_credentials!`, `seed_codex_credentials!`, …). A `PAID_<PROVIDER>_SUBSCRIPTION_AUTH=1` env var signals mode, and subscription containers run on the unrestricted `paid_internal` network instead of the firewalled `paid_agent` network (`app/services/network_policy.rb`).
+| Provider | Current local behavior | Current remote behavior | Managed-auth status | Required next step |
+|----------|------------------------|--------------------------|---------------------|--------------------|
+| Claude Code | Host `.credentials.json`, managed `CLAUDE_CODE_OAUTH_TOKEN`, or captured native credential | Works when managed `RunnerCredential` exists; host file is not required | Partially implemented | Keep, harden, and place behind the same provider-neutral contract as other providers |
+| Codex | Host `auth.json` bind mount with lock/writeback | Not supported unless that auth file exists on the remote Docker host or the runner uses API-key/proxy mode | Not implemented | Add Codex login, refresh/writeback, and native `auth.json` materialization from `RunnerCredential` |
+| Gemini | Host `oauth_creds.json`/config copy | Local-copy only; no DB-managed credential | Not implemented | Add managed credential shape and native config materializer |
+| Copilot | Host `config.json`/local config copy | Local-copy only; no DB-managed credential | Not implemented | Add managed credential shape and native config materializer |
 
-### Claude/Codex Asymmetry (root cause of the silent breakage)
+## External Prior Art: Oh My Pi
 
-- **Codex self-heals.** `auth.json` is mounted **read-write** with a serializing lock (`provision.rb:1861`, `with_codex_auth_lock` at `provision.rb:1272`). The Codex CLI refreshes headlessly and writes the rotated token back to the host file, so the source stays warm.
-- **Claude cannot self-heal the same way.** `.credentials.json` is mounted **read-only** and copied into ephemeral tmpfs. Any in-container refresh dies with the container. And the `claude` CLI does **not** auto-refresh on headless machines (upstream bug), its refresh tokens are **single-use/rotating** (concurrent-refresh race), and its access tokens are ~24h. So the host copy only stays valid if something keeps it warm — and nothing does.
+The Oh My Pi `@oh-my-pi/ai` package is MIT licensed and provides useful source material:
 
-### Detection Gaps in the Run Path
+- Provider OAuth login flows for Anthropic/Claude, OpenAI Codex, Gemini, and GitHub Copilot.
+- A provider registry with `login`, `refreshToken`, `storeCredentialsAs`, and provider-specific credential metadata.
+- A Codex device-code flow (`loginOpenAICodexDevice`) that maps well to a Paid "Connect Codex" button because it avoids localhost callback assumptions.
+- An auth broker/gateway architecture where a server owns refresh tokens, exposes redacted snapshots, performs refresh centrally, and only gives clients resolved credentials or API responses.
 
-In `app/temporal/activities/run_agent_activity.rb`:
+It is not a drop-in replacement for Paid:
 
-- `auth_expired_error?(runner, output)` (≈`:1799`) pattern-matches runner output against agent-harness `:auth_expired` patterns, but is **only called on non-zero exit** (≈`:1541`).
-- The **success path (exit 0)** checks rate-limits, credits, and model-not-found but **not** auth (`:1490-1531`); the preflight path has the same omission (≈`:1672-1706`). A runner that prints an auth error and exits 0 is recorded as a successful run.
-- `auth_expired` is a real terminal `AgentRun` status with full plumbing (model status/scope, failure-recovery mapping to `auth_failure`, dashboard stats coloring/label), but nothing surfaces it as an actionable "re-authenticate" prompt. The new dashboard retry-limited widget (`dashboard_controller.rb:32`, `_retry_limited_issues.html.erb`) covers retry-cap/push-blocked abandonment, not auth.
+- Oh My Pi primarily serves its own clients and provider gateway flows; Paid runs external CLIs inside Docker containers.
+- Claude in Paid already has an official-CLI capture path. Replacing it with a custom Anthropic PKCE flow would increase ToS and maintenance risk.
+- Codex/Gemini/Copilot still need native CLI config files or an equivalent provider-specific runtime materializer; an API gateway alone does not make those CLIs authenticated.
 
-### agent-harness Already Has Auth Scaffolding (and a Gap)
-
-`AgentHarness::Authentication` (agent-harness 0.23.0, `lib/agent_harness/authentication.rb`) already exposes:
-
-- `auth_status(provider)` → `{valid:, expires_at:, error:}`
-- `auth_capabilities(provider)` / `auth_url(provider)` (returns `https://claude.ai/oauth/authorize`) / `refresh_auth(provider, token:)` (stores a **pre-exchanged** token under a file lock; explicitly does not perform code exchange).
-
-**Critical gap:** the module reads/writes a **top-level** `oauth_token` / `expiresAt` shape, but a real Claude CLI `.credentials.json` nests everything under `claudeAiOauth` (`{"claudeAiOauth": {"accessToken", "refreshToken", "expiresAt", …}}`). As written, `auth_status(:claude)` reports a genuine host credential as "No authentication token found", and `refresh_auth` writes a shape the container CLI will not read. This is a provider-specific correctness gap that belongs upstream.
-
-## Research Findings
-
-Claude Code subscription auth mechanics (verified against Claude Code docs and tracked issues):
-
-- **`claude setup-token`** produces a ~1-year, **non-rotating** OAuth token (prefix `sk-ant-oat01-`) intended for headless/CI use via the `CLAUDE_CODE_OAUTH_TOKEN` env var. Generating it requires an interactive browser once, on **any** machine — not necessarily the deployment host. As a static bearer, it is **not** refreshed by the CLI.
-- **Interactive `/login`** uses OAuth 2.0 authorization-code + PKCE: local callback server, browser consent at `console.anthropic.com`, code exchanged server-to-server for access + refresh tokens. This flow can in principle be re-implemented by a web app (generate auth URL + PKCE verifier server-side, user authorizes, paste code back, exchange), but it is undocumented and a mild ToS gray area since it reuses Claude Code's OAuth client.
-- **`.credentials.json`** stores `claudeAiOauth.{accessToken, refreshToken, expiresAt, scopes, subscriptionType}`; access token ~24h; **refresh tokens are single-use** (concurrent refresh → one wins, others get 401 / `refresh_token_reused`).
-- **Headless refresh is broken upstream**: the CLI does not use the stored refresh token on headless machines and instead prompts for `/login`.
-- **`CLAUDE_CODE_OAUTH_TOKEN`** is honored as a static bearer and is **not** stripped by agent-harness's Anthropic provider (`subscription_unset_vars` / `api_key_unset_vars` cover only `ANTHROPIC_*`), so it passes through to the container CLI unmodified.
-
-Implication: for Claude, "self-heal via the refresh token" is **not** "mount RW and let the CLI refresh" (that only works for Codex). It requires Paid or agent-harness to perform the refresh-token→access-token exchange itself. The simpler, more reliable near-term unblock is a long-lived `setup-token` injected via `CLAUDE_CODE_OAUTH_TOKEN`.
-
-### Login CLI surface (for a Paid-initiated, browser-completed login)
-
-We investigated whether Paid could drive the **official** `claude` CLI's login semi-interactively (Paid runs the CLI, the CLI emits an OAuth URL, the user authorizes in their own browser, a code is fed back) — a TOS-clean alternative to re-implementing Claude's OAuth client. Findings (documented behavior unless noted):
-
-- **Subcommands.** `claude auth login` (`--email`, `--sso`, `--console`), `claude auth logout`, `claude auth status` (JSON, or `--text`; exits 0 logged in / 1 not), and `claude setup-token` (prints `sk-ant-oat01-…` to stdout, saves nothing). The interactive REPL also has `/login` and `/logout`.
-- **No orchestratable manual mode on the subcommands.** Neither `claude auth login` nor `claude setup-token` documents a `--no-browser`, `--manual`, `--code`, or `--code-file` flag. `--no-browser` (print URL, paste redirect back) exists only for `claude mcp login`, not for Claude Code's own auth.
-- **`setup-token` is not headless-bridgeable.** It starts a localhost callback server and auto-opens a browser on the initiating machine; it has no print-URL-and-paste-code fallback. It is designed to be run on a machine that already has a browser, with the resulting token copied elsewhere.
-- **Naive stdin relay is blocked by PKCE binding.** The OAuth code is bound to the PKCE challenge of the session that generated the URL. Piping a code into a fresh `claude auth login` opens a *new* flow with a *new* challenge, invalidating the code (`echo code | claude auth login` does not work; tracked upstream in claude-code#47994, closed-as-duplicate, no flag shipped). Requested-but-unshipped flags there include `--code`, `--code-file`, `--no-browser`, and a device-code flow.
-- **Code-paste fallback exists only inside the interactive `/login`.** In WSL2/SSH/container sessions the CLI detects the unreachable callback and prints a code for the user to paste at the `Paste code here if prompted` prompt — but only within an already-running interactive session, where the PKCE challenge is held in the same process.
-- **Credential landing.** `setup-token` → stdout only (capturable). `/login` and `auth login` → `~/.claude/.credentials.json` (or macOS Keychain), not stdout.
-- **Supported headless pattern** per Anthropic docs: a user runs `claude setup-token` locally and supplies the resulting `CLAUDE_CODE_OAUTH_TOKEN` to the orchestrator — which is exactly Phase 2.
+Decision: borrow the architecture and provider-flow code where useful, especially Codex device auth and broker-owned refresh semantics, but keep the Paid abstraction explicit: encrypted `RunnerCredential` records plus provider-specific materializers for CLI runtime state.
 
 ## Recommendation
 
-Adopt a phased lifecycle, with a clean ownership boundary consistent with RDR-007: **agent-harness owns provider-specific OAuth/auth facts and flows; Paid owns credential storage, multi-tenancy, container injection, detection surfacing, and UX.**
+Promote `RunnerCredential` from "Claude credential storage" to the canonical account-scoped credential store for all subscription runners. Add a provider-neutral lifecycle around it:
 
-- **Phase 1 — Detection (fix-agnostic, no new OAuth code).** Turn the silent breakage into a loud, actionable signal: close the exit-0 auth gap, add a proactive source-credential check, surface an "auth expired / expiring — re-authenticate" dashboard banner, and run a periodic health job.
-- **Phase 2 — Long-lived token management (primary near-term unblock).** UI-managed, encrypted, account-scoped storage for a long-lived Claude `CLAUDE_CODE_OAUTH_TOKEN`, injected into the container as an env var, with a "mark as long-lived" flag. Removes the host dependency and the refresh problem for ~1 year, and works in cloud/headless deployments.
-- **Phase 3 — Self-heal via upstream refresh.** Add refresh-token exchange to agent-harness and a Paid keep-warm path that writes the rotated credential back to the source under a lock. Validates the original refresh hypothesis, and becomes the durability enabler for the Phase 4 interactive login (whose captured credential is short-lived).
-- **Phase 4 — Browser-completed real login (full host-independence).** A real, TOS-clean login the user completes in their own browser from the Paid UI, by surfacing the official `claude` interactive login over a server-side PTY (form-bridged, or a full xterm.js terminal). Falls back to a headless CLI drive if an upstream `--code`/device-code flag ships (claude-code#47994), or a re-implemented PKCE flow only as a last resort.
+```text
+Connect in Paid UI
+  -> encrypted RunnerCredential
+  -> server-side refresh/lease before run
+  -> container-specific materialization
+  -> optional rotated credential harvest
+  -> success/failure telemetry
+```
 
-Phases 1 and 2 are the committed near-term scope. Phases 3 and 4 are sequenced behind them and tracked upstream.
+Host bind mounts become a legacy/local fallback, not the primary subscription-auth story.
 
 ## Proposed Design
 
-### Ownership boundary (agent-harness vs Paid)
-
-agent-harness owns, per provider:
-
-- Correct native credential parsing for `auth_status` (fix the `claudeAiOauth` shape gap).
-- `auth_url` / code-exchange (PKCE) and refresh-token exchange APIs.
-- Auth error classification patterns (already consumed via `RunnerSupport.error_classification_patterns_for`).
+### Ownership Boundary
 
 Paid owns:
 
-- Encrypted, account-scoped credential storage and its UI.
-- Resolving and injecting credentials into containers.
-- Detection surfacing (banner, job, run-path classification).
+- account-scoped encrypted credential storage;
+- auth/connect UI and authorization;
+- credential leases and refresh orchestration;
+- materializing credentials into the selected container;
+- run-level telemetry and RDR-048 host eligibility decisions.
 
-Where Phase 1 needs correct expiry parsing before the upstream `auth_status` fix ships, Paid uses a narrow native-shape parser guarded by `TODO(#<agent-harness-issue>)` and switches to `AgentHarness::Authentication.auth_status` once upstream is correct.
+Provider adapters or agent-harness own:
 
-### Phase 1 — Detection
+- provider-specific login flows;
+- provider-specific refresh-token exchange;
+- native credential parsing and validation;
+- native CLI file generation;
+- auth error classification patterns.
 
-1. **Exit-0 auth check.** In `run_agent_activity.rb`, add `auth_expired_error?(runner, sanitized_output)` to the `result.success?` branch (`:1490-1531`) and the preflight path (≈`:1672-1706`), mirroring the existing rate-limit/credits checks, raising `RunnerAuthExpiredError`.
-2. **Auth-health service.** `Runners::AuthHealth` reports, per account and subscription runner: `{ valid, expires_at, source: :managed_token | :host_forwarded, error }`. For managed tokens it reads stored metadata. For host-forwarded credentials, prefer the **supported** `claude auth status` CLI primitive (JSON output, exit 0 valid / 1 not) over parsing the credential file; fall back to a native `claudeAiOauth.expiresAt` parse (interim) and switch to a fixed `AgentHarness::Authentication.auth_status` once the upstream shape gap is resolved.
-3. **Dashboard banner.** Load `@auth_health` in `DashboardController#show` and render `dashboard/_auth_health_banner`, mirroring the `_retry_limited_issues` wiring (`show.html.erb:60`). Banner links to the credential UI from Phase 2.
-4. **Periodic job.** `ClaudeAuthHealthCheckJob` mirroring `app/jobs/github_token_health_check_job.rb`, registered in `config/initializers/good_job.rb` (≈ every 4h), flagging expired/expiring credentials.
+Provider-specific facts may live in Paid while upstream support is missing, but each interim adapter must be narrow, tested with fixtures, and removable once agent-harness exposes the same contract.
 
-### Phase 2 — Long-lived token management
+### Credential Record
 
-1. **Storage — `RunnerCredential` model.** Account-scoped, mirroring `IntegrationCredential`:
-   - `encrypts :token` (Rails 7+), `has_logidze`, `belongs_to :account`, `belongs_to :created_by` (User, optional).
-   - Columns: `runner_key`, `name`, `auth_kind` (default `oauth_token`), `long_lived` (boolean), `expires_at`, `last_used_at`, `revoked_at`, `metadata` jsonb.
-   - Unique on `(account_id, runner_key, name)`; created via `rails generate migration` + `rails generate logidze:model`; table/column comments per project convention.
-   - `long_lived = true` ⇒ skip expiry-tracking and refresh; treat as a static bearer.
-2. **Runtime resolution (no hard FK on `runners`).** Resolve the active `RunnerCredential` by `(account, runner_key)` at provision time. This avoids modifying the subscription check constraint (`auth_type != 'subscription' OR provider_api_key_id IS NULL AND integration_credential_id IS NULL …`) and keeps runners user-scoped while credentials are shareable account-wide.
-3. **Injection.** In `provision.rb`:
-   - Make `claude_subscription_auth?` also return true when a managed token exists for the run's account+runner.
-   - In the `claude_subscription_auth?` branch (≈`:2103`), append `CLAUDE_CODE_OAUTH_TOKEN=<token>` to the container env.
-   - When a managed token is used, **skip seeding the host `.credentials.json`** so the env token is the unambiguous source (avoids precedence conflicts).
-4. **UI.** `RunnerCredentialsController` + views mirroring `IntegrationCredentialsController`, with an entry point from the runner edit form (`app/views/runners/_form.html.erb`). A single labeled field ("paste your `claude setup-token` value") plus a "long-lived" checkbox — never raw JSON. Pundit policy and account scoping consistent with other credential models.
+Extend `RunnerCredential` conceptually without replacing the shipped table:
 
-### Phase 3 — Self-heal via upstream refresh (experimental)
+- `runner_key`: `claude`, `codex`, `gemini`, `copilot`.
+- `auth_kind`: `oauth_token`, `api_key`, `signing_token`, or provider-specific OAuth session.
+- `token`: encrypted primary secret. For structured OAuth sessions, this may be an encrypted serialized payload rather than a single bearer string.
+- `expires_at`, `long_lived`, `last_used_at`, `revoked_at`: existing lifecycle fields.
+- `metadata`: provider account identity, scopes, source flow, native format version, and non-secret diagnostics.
 
-- Upstream: add a refresh-token exchange API to `AgentHarness::Authentication` and fix the native credential shape so a refreshed credential is written back in a form the CLI reads.
-- Paid: a keep-warm path (provision preflight and/or periodic job) that, for host-forwarded Claude credentials, calls the exchange, persists the rotated credential to the source under a lock (the Codex `with_codex_auth_lock` pattern), and re-seeds. Classify `refresh_token_reused` as `auth_expired`.
+Do not store raw native files as opaque permanent truth when a normalized provider credential is available. Native files are runtime artifacts generated from the canonical credential and provider metadata. Exception: short-term Claude native capture may continue storing the captured JSON until the provider adapter can normalize it losslessly.
 
-### Phase 4 — Browser-completed real login (full host-independence)
+### Provider Adapter Contract
 
-Goal: a user authorizes a real Claude login from the Paid UI using only their browser — no terminal, SSH, or shell on the host/devcontainer, and nothing installed locally. The OAuth code is PKCE-bound to the session that generated the URL (claude-code#47994), so the reliable, TOS-clean way to do this is to keep the **official `claude` login running as one live process** and let the human complete the browser step against it. Three routes, in preference order:
+Introduce a small contract per subscription provider:
 
-- **4a — Real interactive login over a server-side PTY (preferred).** Paid spawns the official interactive `claude` `/login` (or `claude auth login`) inside an ephemeral, single-tenant container with an isolated `CLAUDE_CONFIG_DIR`. In a headless container the CLI falls back to the documented "open this URL, paste the code here" mode (WSL/SSH/containers). The user opens the URL in their own browser tab, authorizes with their Anthropic account, and returns the code; Paid feeds it to the **same** live process, so the PKCE challenge matches. On success Paid reads the resulting `.credentials.json` (access + **refresh** token) from the isolated config dir, stores it as a `RunnerCredential`, and tears down the container. Two UI variants:
-  - **(i) Form-bridged (lighter, smaller surface).** Paid drives the login; the UI shows only the authorize URL and a "paste your code" field, and Paid writes the code to the process stdin. No general terminal is exposed. Fragility: parsing the CLI's prompt/URL from TUI output (version-dependent).
-  - **(ii) Full browser terminal (xterm.js + PTY over WebSocket).** The live session is surfaced to the browser via xterm.js so the human reads and drives the real terminal — robust to CLI TUI changes, at the cost of more infrastructure and a larger surface. (Terminalwire is an adjacent model but streams a server-side CLI to a *native thin client the user installs locally*, reintroducing a local-install requirement; xterm.js keeps it browser-only.)
+```text
+provider_key
+supported_connect_flows
+credential_status(credential)
+refresh_if_needed(credential)
+materialize_for_container(credential, target)
+harvest_after_run(target)
+rotation_risk
+remote_safe?
+```
 
-  This is the pattern cloud IDEs and bastions already use (Codespaces, Gitpod, Coder, Teleport web terminals): the official tool, run by a human, surfaced over the web — no OAuth reimplementation. It yields the short-lived interactive credential (~24h) plus a refresh token, so it **depends on Phase 3** (Paid-side refresh) to stay durable; `setup-token`'s 1-year token is not obtainable here because it relies on a localhost callback with no cross-host paste fallback.
-- **4b — Headless CLI drive without a live session (pending upstream).** If `claude auth login` gains a `--code`/`--code-file`/`--no-browser` or device-code flag (requested in claude-code#47994), the live-process requirement disappears and a simple URL→code exchange suffices. Watch that issue; adopt if it ships.
-- **4c — Re-implement the PKCE flow in Paid (TOS gray area, last resort).** Generate the authorize URL + verifier (agent-harness `auth_url` + an upstream code-exchange API), accept the code, exchange it, store a `RunnerCredential`. Reuses Claude Code's OAuth client ourselves rather than the CLI, so only if 4a/4b are infeasible.
+`materialize_for_container` returns one of:
 
-All routes land their credential in the Phase 2 `RunnerCredential` store and reuse the Phase 2 injection path. **Security is the dominant cost of 4a:** a browser→process→container bridge is effectively web-exposed command execution, so it must be authenticated to the Paid user, authorized via Pundit to their own account, run a *constrained* session (an auto-launched login-only wrapper, not a general shell), use an ephemeral single-tenant container on a restricted network, time-box the WebSocket/session token, capture-then-destroy the credential, and audit the action.
+- environment variables, such as `CLAUDE_CODE_OAUTH_TOKEN`;
+- native file writes into `/home/agent/.<provider>/...`;
+- a broker/proxy configuration when the CLI can use one;
+- an explicit unsupported result with a reason safe to show in the UI.
+
+`rotation_risk` tells orchestration whether the credential can be shared concurrently:
+
+- `none`: non-rotating setup token or API key;
+- `server_refresh_only`: Paid refreshes before the run and containers should not rotate;
+- `container_may_rotate`: the CLI may mutate the native file during the run, so the run needs a credential lease and post-run harvest;
+- `unsupported`: do not schedule without a different auth mode.
+
+### Refresh and Lease Rule
+
+For every managed subscription credential:
+
+1. Before provisioning, acquire a per-credential lease.
+2. Refresh if the credential is near expiry and the provider supports server-side refresh.
+3. Materialize only a fresh credential into the container.
+4. If the provider may rotate in-container, keep the lease for the run and harvest the native file afterward.
+5. Persist any rotated credential before releasing the lease.
+6. Mark the credential `auth_expired` if refresh fails with an invalid/reused refresh token.
+
+This intentionally favors correctness over concurrency for rotating OAuth sessions. Higher concurrency is only allowed when the provider can use a non-rotating token, broker-owned refresh, or access-token-only runtime.
+
+### Provider-Specific Paths
+
+#### Claude Code
+
+Keep the shipped managed setup-token path as the default remote-safe Claude path:
+
+- user provides or captures a credential through Paid UI;
+- Paid stores it as `RunnerCredential`;
+- provisioning injects `CLAUDE_CODE_OAUTH_TOKEN` or writes native `.credentials.json`;
+- remote Docker is eligible because no host bind mount is required.
+
+For browser-completed native Claude login, durability depends on server-side keep-warm refresh. Continue using the official CLI capture path unless upstream ships a supported device-code/manual-code flow. Do not replace it with custom Anthropic PKCE unless the official path remains too brittle and the ToS risk is accepted explicitly.
+
+#### Codex
+
+Codex is the first missing provider to implement because it directly blocks RDR-048 remote subscription auth.
+
+Recommended path:
+
+1. Add a "Connect Codex" flow using a device-code login modeled on Oh My Pi's Codex provider.
+2. Store access token, refresh token, expiry, account identity, and native-format metadata in `RunnerCredential`.
+3. Before provisioning, refresh under a per-credential lease if near expiry.
+4. Generate a valid `/home/agent/.codex/auth.json` in the container from the canonical credential.
+5. If the Codex CLI may rotate `auth.json` during execution, keep the lease through the run and copy the resulting file or parsed token state back into `RunnerCredential`.
+6. Until post-run harvest is proven, serialize runs that share the same Codex credential or force API-key/proxy mode for remote Docker.
+
+Do not claim "Codex works remotely" merely because Paid can copy an initial `auth.json`. The acceptance criterion is that refresh state remains valid after the run.
+
+#### Gemini and Copilot
+
+Implement after Codex unless a customer need prioritizes them:
+
+- add provider login adapters or documented setup-token ingestion;
+- normalize credential state in `RunnerCredential`;
+- generate only the minimal native CLI config in the container;
+- reject remote scheduling when the provider cannot be materialized without host files.
+
+### RDR-048 Host Eligibility Contract
+
+Scheduler and readiness decisions must evaluate provider/auth capability, not just backend type:
+
+```text
+if runner uses managed RunnerCredential and materializer.remote_safe?
+  local and remote Docker are eligible
+else if runner uses host-forwarded subscription auth
+  only backends with supports_host_paths? are eligible
+else if runner uses API-key/proxy auth
+  any backend with proxy/network readiness is eligible
+else
+  reject with "runner is not authenticated"
+```
+
+Host readiness should surface auth incompatibility as a named reason, for example:
+
+- `requires_host_bind_mount`;
+- `managed_auth_missing`;
+- `provider_materializer_missing`;
+- `credential_expired`;
+- `credential_refresh_failed`;
+- `remote_proxy_unreachable`.
+
+RDR-048 setup docs should not instruct users to copy local subscription credential directories to remote hosts. They should direct users to managed `RunnerCredential` flows where supported, and clearly mark provider gaps where remote placement is intentionally blocked.
+
+### Feature Flag and Rollout
+
+Add a tenant-scoped feature flag, tentatively `managed_subscription_runner_auth`, following `FeatureFlags` and `tenant_settings.features` conventions.
+
+Rollout stages:
+
+1. **Shadow/read-only.** Keep legacy host-mounted auth active. For runs with a managed credential available, compute the materialization plan and record whether it would have been remote-safe, without using it.
+2. **Opt-in per tenant/provider.** Use managed auth for selected providers and accounts. Fall back to host-mounted auth only when no managed credential exists.
+3. **Remote enforcement.** Allow remote Docker placement only when managed auth or API-key/proxy auth is available.
+4. **Default-on.** Prefer managed auth everywhere; host-mounted subscription auth remains a local-only escape hatch.
+5. **Cleanup.** Remove provider-specific legacy code only after success metrics show managed auth is at least as reliable as legacy local auth for the same provider.
+
+### Success Metrics and Telemetry
+
+Add a durable way to compare new and old auth paths. Existing `agent_runs.status`, `agent_runs.container_host`, `agent_runs.auth_provider`, `agent_runs.final_runner`, `agent_run_logs`, and `orchestration_decisions` are useful but not specific enough for credential materialization outcomes.
+
+Recommended: add a small `runner_auth_attempts` table or equivalent structured event stream keyed to `agent_run_id` and `runner_credential_id`.
+
+Record:
+
+- `runner_key`;
+- `container_host`;
+- backend capability (`supports_host_paths?`, `remote?`);
+- auth source (`managed`, `host_forwarded`, `api_key_proxy`);
+- materialization mode (`env`, `native_file`, `broker`, `host_mount`);
+- feature flag state;
+- refresh state (`not_needed`, `refreshed`, `refresh_failed`, `expired`);
+- lease state (`none`, `acquired`, `waited`, `timeout`);
+- result (`materialized`, `skipped`, `failed`, `harvested`, `harvest_failed`);
+- failure reason safe for UI;
+- timing and retry counts.
+
+Use these events to report:
+
+- success rate by provider/auth source/container host;
+- auth-expired rate before and after managed auth;
+- refresh failure rate;
+- remote placement rejection reasons;
+- managed-vs-legacy local run outcomes for the same runner family.
+
+Do not log plaintext tokens, native credential files, authorization codes, or refresh tokens.
 
 ## Alternatives Considered
 
-- **Raw `.credentials.json` paste (original "option 1").** Rejected as the primary UX: obtaining and pasting the nested OAuth JSON (including the refresh token) is a power-user operation. The encrypted store is retained as the substrate; only the ingestion UX changes (long-lived token paste, later in-app OAuth).
-- **Mount Claude `.credentials.json` read-write like Codex.** Rejected: the Claude CLI does not refresh headlessly, so an RW mount would not self-heal; it would also expose more of `~/.claude` to container writes and hit single-use refresh-token races without serialization.
-- **Force subscription Claude onto API-key/proxy mode.** Rejected: defeats the purpose of subscription runners (using the user's plan) and changes the cost/billing model; orthogonal to the auth-resilience problem.
-- **User-scoped credentials (like `ProviderApiKey`).** Rejected in favor of account scoping (like `IntegrationCredential` / `GithubToken`) for team sharing and a consistent audit trail; runners remain user-scoped and resolve a shared credential at runtime.
-- **Refresh-token self-heal first (user's initial instinct).** Deferred to Phase 3: it is net-new OAuth-exchange code with real uncertainty (headless-refresh bug, rotation race, undocumented endpoint), whereas long-lived tokens are a faster and more reliable unblock.
-- **Paid-orchestrated `setup-token` to capture a 1-year token automatically.** Rejected as infeasible today: `setup-token` requires a browser + localhost callback on the initiating machine and has no headless/manual mode, so an orchestrator cannot bridge it. Captured under Phase 4 as a "watch upstream" item rather than a current option.
-- **Naive stdin relay of `claude auth login` (URL out, code in via pipe).** Rejected: the code is PKCE-bound to the originating session, so feeding it to a fresh process fails (claude-code#47994). Only a same-process flow (PTY-driven `/login`, or a future `--code` flag) can work; folded into Phase 4a.
-
-## Trade-offs
-
-**Positive**
-
-- Eliminates the silent failure: expired auth becomes a loud, actionable dashboard signal and a correctly classified run outcome.
-- Decouples runner auth from host/devcontainer state; enables cloud/headless deployments (Phase 2 onward).
-- Keeps provider-specific OAuth logic upstream in agent-harness, consistent with RDR-007 and the "no provider-specific behavior scattered in Paid" rule.
-- Reuses proven encryption/audit/multi-tenancy patterns (`IntegrationCredential`, `GithubToken`, logidze).
-
-**Negative / Risks**
-
-- Long-lived tokens are higher-value secrets with a ~1-year blast radius; mitigated by `encrypts`, account scoping, revoke, logidze audit, and `last_used_at`.
-- Generating a `setup-token` still requires one interactive browser session somewhere until Phase 4 ships.
-- agent-harness's current `auth_status`/`refresh_auth` shape gap requires an interim Paid-side parser; carries `TODO` debt until the upstream fix lands.
-- Phases 3/4 depend on undocumented Claude OAuth endpoints and an agent-harness release; treat as experimental and gate behind validation.
-- Phase 4a adds a browser→process→container bridge — effectively web-exposed command execution. It is the highest-risk surface in this RDR and must be tightly scoped (constrained login-only session, ephemeral single-tenant container, Pundit authz, time-boxed session, audit) per RDR-004/RDR-010; a full xterm.js terminal is riskier than the form-bridged variant.
-- Phase 4's captured credential is short-lived (~24h), so a durable Phase 4 requires Phase 3; the two ship together for a complete host-independent story.
+- **Keep host bind mounts and document remote copying.** Rejected. Copying secrets to remote Docker hosts multiplies credential sprawl and still fails the refresh ownership problem unless the remote host can write back to the canonical source.
+- **Only support Claude remotely.** Rejected as a temporary state, not an architecture. RDR-048 needs an explicit eligibility contract for all subscription runners so the scheduler does not place unsupported providers on remote hosts.
+- **Use Oh My Pi wholesale.** Rejected. Its provider flows and broker are valuable, but Paid's execution model is Dockerized external CLIs, not only brokered API calls. Paid needs a native CLI materialization layer.
+- **Let containers own refresh.** Rejected for rotating credentials unless the refreshed state is harvested before the lease is released. Otherwise every successful in-container refresh creates a stale parent credential.
+- **Serialize all subscription runs forever.** Rejected as the default. It is acceptable during rollout for rotation-risk providers, but the target is broker-owned refresh, non-rotating setup tokens, or access-token-only runtime where providers allow it.
+- **Force subscription runners into provider API-key mode.** Rejected. That changes user billing and defeats the purpose of subscription runners.
 
 ## Implementation Plan
 
-**Phase 1 (detection) — small, low risk, immediate value**
+### Phase 1: Gate Existing Runtime State
 
-1. Add exit-0 + preflight auth classification in `run_agent_activity.rb`.
-2. Add `Runners::AuthHealth` (prefer `claude auth status`; interim native-shape parser as fallback).
-3. Add `DashboardController#show` loader + `_auth_health_banner` partial.
-4. Add `ClaudeAuthHealthCheckJob` + GoodJob cron registration.
-5. Specs: exit-0 auth classification; auth-health service for valid/expired/missing; banner rendering; job flagging.
+- Add `managed_subscription_runner_auth` to `FeatureFlags::DEFINITIONS`.
+- Add explicit auth-source metadata to provisioning logs for Claude's current managed path and legacy host-mounted paths.
+- Add scheduler-facing helper methods that answer whether a runner/auth mode requires host paths.
 
-**Phase 2 (long-lived token) — migration + UI + injection**
+### Phase 2: Auth Attempt Telemetry
 
-1. `RunnerCredential` model + migration + logidze; schema dump.
-2. Runtime resolution by `(account, runner_key)`.
-3. `provision.rb`: detection + `CLAUDE_CODE_OAUTH_TOKEN` injection + skip host seed when managed token present.
-4. `RunnerCredentialsController` + views + Pundit policy + runner-form entry point.
-5. Specs: model (encryption, scoping, revoke, validation); injection (env var present, host seed skipped, detection true); request specs for the credentials UI/policy.
+- Add `runner_auth_attempts` or structured orchestration events for materialization, refresh, lease, and harvest outcomes.
+- Add query/UI reporting for success rate by provider, auth source, and container host.
+- Backfill no secrets; only start collecting new events.
+- Use these metrics during rollout to compare managed local auth with legacy host-mounted local auth before broadening remote placement.
 
-**Phase 3 / Phase 4 — sequenced behind Phases 1–2**
+### Phase 3: Provider Adapter Interface
 
-- File agent-harness issues: (a) `auth_status`/`refresh_auth` native `claudeAiOauth` shape; (b) refresh-token exchange API; (c) code-exchange API for the 4c fallback.
-- Phase 3: refresh-token exchange (upstream) + Paid keep-warm writeback under a lock (the Codex `with_codex_auth_lock` pattern); classify `refresh_token_reused` as `auth_expired`.
-- Phase 4a: server-side PTY login in an ephemeral, constrained, single-tenant container; credential capture from the isolated `CLAUDE_CONFIG_DIR` + teardown; start with the form-bridged variant before the xterm.js terminal. Scope the bridge per RDR-004/RDR-010 (authn, Pundit authz, login-only wrapper, time-boxed session, audit).
-- Watch claude-code#47994 for a headless/`--code`/device-code flag on `claude auth login`; if it ships, implement Phase 4b and skip the 4c PKCE re-implementation.
-- Reference these with `TODO(#…)` at the interim Paid parser and any injection seams.
+- Extract Claude's current managed-token and native-credential behavior behind the provider adapter contract.
+- Keep existing Claude runtime behavior unchanged while moving decisions out of `Containers::Provision` branches.
+- Add contract specs with fixture credentials and redaction checks.
 
-**Cross-cutting**
+### Phase 4: Codex Managed Auth
 
-- Feature branch + PR; no direct commits to `main`. Conventional Commits. No `--no-verify`.
-- Update this RDR's status to Final before implementation; Implemented after.
+- Add the Codex connect flow, preferably device-code based.
+- Store Codex OAuth state in `RunnerCredential`.
+- Generate native `auth.json` inside the agent container.
+- Implement refresh-before-run and, if needed, lease-through-run plus post-run harvest.
+- Keep remote placement disabled for Codex until refresh/writeback is proven by tests and telemetry.
+
+### Phase 5: RDR-048 Scheduler Integration
+
+- Teach host selection to reject remote hosts for host-forwarded subscription auth.
+- Allow remote hosts when managed materialization is remote-safe.
+- Surface auth incompatibility in readiness, queue explanations, and setup guide output.
+- Update RDR-048 remote setup docs to point to managed credential flows instead of remote secret copying.
+
+### Phase 6: Gemini and Copilot
+
+- Add provider adapters and connect/materialization flows.
+- Start in shadow mode, then opt-in per tenant/provider.
+- Use telemetry gates before allowing remote placement.
+
+### Phase 7: Cutover and Cleanup
+
+- Make managed auth the default when a credential exists.
+- Keep host-mounted subscription auth local-only.
+- Remove obsolete provider-specific provisioning branches only after metrics prove managed auth reliability and every provider has a maintained adapter.
 
 ## Validation
 
-- **Detection.** Simulate an expired host credential (past `expiresAt`) and a missing credential; assert `Runners::AuthHealth` reports invalid with the right `source`, the banner renders, and the job flags it. Simulate a runner exit-0 with an auth-error body; assert it is classified `auth_expired` rather than recorded as success.
-- **Long-lived token.** With a stored `RunnerCredential`, assert `claude_subscription_auth?` is true with no host file, `CLAUDE_CODE_OAUTH_TOKEN` is present in the container env, the host `.credentials.json` seed is skipped, and a real subscription Claude run authenticates end-to-end.
-- **Security.** Token is encrypted at rest, scoped to account, revocable, audit-tracked (logidze), and never logged in plaintext or placed on a command line.
-- **Interactive login (Phase 4a).** A user with only a browser completes `claude` login end-to-end: the URL is surfaced, the pasted code reaches the same live process, and the captured credential (with refresh token) is stored as a `RunnerCredential` and then refreshed by Phase 3. The bridge rejects unauthenticated/cross-account access, exposes only the login-only session (no arbitrary shell), and the container is torn down after capture.
-- **Regression.** Existing host-forwarded Claude and Codex (RW self-heal) paths remain unchanged when no managed credential is present.
+- **Credential storage.** `RunnerCredential` remains encrypted, account-scoped, revocable, logidze-tracked, and never exposes plaintext secrets in logs, events, or UI.
+- **Provider contract.** Each adapter has fixture-based tests for valid, expired, malformed, refreshable, and unrefreshable credentials.
+- **Materialization.** Claude env-token and Codex native-file materializers produce exactly the runtime state the CLI expects without host bind mounts.
+- **Refresh ownership.** A rotating provider updates `RunnerCredential` after refresh; a simulated stale parent credential cannot survive a successful run.
+- **Lease behavior.** Concurrent runs sharing a rotation-risk credential serialize, wait, or fail with a safe reason instead of racing refresh tokens.
+- **RDR-048 compatibility.** Remote Docker placement is allowed for managed remote-safe auth and rejected for host-forwarded auth on `supports_host_paths? == false` backends.
+- **Feature flag.** Disabling `managed_subscription_runner_auth` preserves the legacy local host-mounted path.
+- **Telemetry.** Managed and legacy auth attempts can be compared by provider, host, auth source, and outcome without exposing secrets.
+- **End-to-end smoke.** In development, run the same subscription runner through local Docker with legacy host auth, local Docker with managed auth, and remote Docker with managed auth; compare recorded success rates and failure reasons.

--- a/docs/rdrs/RDR-048-multi-host-docker-backend-support.md
+++ b/docs/rdrs/RDR-048-multi-host-docker-backend-support.md
@@ -8,8 +8,8 @@
 - **Status**: Draft
 - **Type**: Operations + Architecture
 - **Priority**: P1
-- **Related Issues**: #2944 (tracking), #2945 (backend configuration and registry), #2946 (scheduler and manual placement), #2947 (per-host concurrency), #2948 (multi-host lifecycle operations), #2949 (readiness checks), #2950 (management UI), #2951 (setup guide and automation helpers), #2952 (optional capacity-aware placement), #2953 (implementation audit and RDR closeout)
-- **Related RDRs**: RDR-019 (Remote Container Execution), RDR-020 (Service Container Architecture), RDR-033 (Worker Pool Scaling Algorithm), RDR-043 (Zero-Config Docker Capacity Autoscaling)
+- **Related Issues**: [#2944](https://github.com/viamin/paid/issues/2944) (tracking), [#2945](https://github.com/viamin/paid/issues/2945) (backend configuration and registry), [#2946](https://github.com/viamin/paid/issues/2946) (scheduler and manual placement), [#2947](https://github.com/viamin/paid/issues/2947) (per-host concurrency), [#2948](https://github.com/viamin/paid/issues/2948) (multi-host lifecycle operations), [#2949](https://github.com/viamin/paid/issues/2949) (readiness checks), [#2950](https://github.com/viamin/paid/issues/2950) (management UI), [#2951](https://github.com/viamin/paid/issues/2951) (setup guide and automation helpers), [#2952](https://github.com/viamin/paid/issues/2952) (optional capacity-aware placement), [#2953](https://github.com/viamin/paid/issues/2953) (implementation audit and RDR closeout), [#2963](https://github.com/viamin/paid/issues/2963) (subscription auth host eligibility)
+- **Related RDRs**: RDR-019 (Remote Container Execution), RDR-020 (Service Container Architecture), RDR-033 (Worker Pool Scaling Algorithm), RDR-041 (Subscription Runner Managed Auth Lifecycle), RDR-043 (Zero-Config Docker Capacity Autoscaling)
 - **Related Tests**: Docker backend resolver tests, container provisioning tests, process queue admission tests, orphan cleanup tests, container metrics tests, capacity snapshot tests, operations dashboard system tests, host setup wizard tests
 
 ## Implementation Status
@@ -43,24 +43,26 @@ Paid still assumes one active backend for placement and admission:
 - Network and proxy readiness are evaluated for the backend passed to provisioning, but no scheduler chooses among several backend candidates.
 - The account operations dashboard can already surface capacity state, but there is no UI for adding Docker hosts, setting per-host concurrency limits, checking readiness, or guiding remote-host setup.
 
+Subscription-runner auth is also not multi-host aware yet. RDR-041 now defines the required auth eligibility contract: managed provider materializers can make a subscription runner remote-safe, but legacy host-mounted subscription credentials remain local-only unless the selected backend supports host paths.
+
 ## Issue Plan
 
-Implementation is tracked by a dependency-ordered issue chain. No issue in this chain should be labeled higher than `P2`.
+Implementation is tracked by a dependency-ordered core issue chain. No issue in the core multi-host chain should be labeled higher than `P2`; the cross-cutting subscription-auth eligibility work is tracked as the `P1` RDR-041 issue [#2963](https://github.com/viamin/paid/issues/2963).
 
 | Issue | Priority | Scope | Dependency |
 |-------|----------|-------|------------|
-| #2944 | P2 | Umbrella tracking issue for RDR-048 | None |
-| #2945 | P2 | Multi-host backend configuration and registry | Depends on #2944 |
-| #2946 | P2 | Conservative scheduler and manual host placement | Depends on #2945 |
-| #2947 | P2 | Independent per-host Docker concurrency limits | Depends on #2946 |
-| #2948 | P2 | Multi-host lifecycle operations for cleanup, metrics, warm pools, and service containers | Depends on #2947 |
-| #2949 | P2 | Per-host Docker readiness checks | Depends on #2948 |
-| #2950 | P2 | Docker Hosts management UI | Depends on #2949 |
-| #2951 | P2 | Remote Docker setup guide and automation helpers | Depends on #2950 |
-| #2952 | P3 | Optional capacity-aware host placement | Depends on #2951 |
-| #2953 | P2 | Final implementation audit, gap filing, and RDR status update | Depends on #2952 |
+| [#2944](https://github.com/viamin/paid/issues/2944) | P2 | Umbrella tracking issue for RDR-048 | None |
+| [#2945](https://github.com/viamin/paid/issues/2945) | P2 | Multi-host backend configuration and registry | Depends on [#2944](https://github.com/viamin/paid/issues/2944) |
+| [#2946](https://github.com/viamin/paid/issues/2946) | P2 | Conservative scheduler and manual host placement | Depends on [#2945](https://github.com/viamin/paid/issues/2945) |
+| [#2947](https://github.com/viamin/paid/issues/2947) | P2 | Independent per-host Docker concurrency limits | Depends on [#2946](https://github.com/viamin/paid/issues/2946) |
+| [#2948](https://github.com/viamin/paid/issues/2948) | P2 | Multi-host lifecycle operations for cleanup, metrics, warm pools, and service containers | Depends on [#2947](https://github.com/viamin/paid/issues/2947) |
+| [#2949](https://github.com/viamin/paid/issues/2949) | P2 | Per-host Docker readiness checks | Depends on [#2948](https://github.com/viamin/paid/issues/2948) |
+| [#2950](https://github.com/viamin/paid/issues/2950) | P2 | Docker Hosts management UI | Depends on [#2949](https://github.com/viamin/paid/issues/2949) |
+| [#2951](https://github.com/viamin/paid/issues/2951) | P2 | Remote Docker setup guide and automation helpers | Depends on [#2950](https://github.com/viamin/paid/issues/2950) |
+| [#2952](https://github.com/viamin/paid/issues/2952) | P3 | Optional capacity-aware host placement | Depends on [#2951](https://github.com/viamin/paid/issues/2951) |
+| [#2953](https://github.com/viamin/paid/issues/2953) | P2 | Final implementation audit, gap filing, and RDR status update | Depends on [#2952](https://github.com/viamin/paid/issues/2952), [#2963](https://github.com/viamin/paid/issues/2963) |
 
-The final issue (#2953) should update this RDR to `Implemented` only after auditing that the shipped implementation matches the plan. If any acceptance criteria are missing or intentionally deferred, #2953 should create specific follow-up issues and reference them from this RDR instead of marking the RDR implemented prematurely.
+The final issue ([#2953](https://github.com/viamin/paid/issues/2953)) should update this RDR to `Implemented` only after auditing that the shipped implementation matches the plan. If any acceptance criteria are missing or intentionally deferred, #2953 should create specific follow-up issues and reference them from this RDR instead of marking the RDR implemented prematurely.
 
 ## Problem Statement
 
@@ -420,12 +422,12 @@ Capacity-aware scheduling should be a later phase unless implementation can safe
 
 The remote backend does not support host bind mounts. Multi-host placement must reject remote hosts for runs requiring `worktree_path` bind mounts and should favor named-volume/in-container clone flows for remote execution.
 
-Subscription-auth behavior also differs by backend:
+Subscription-auth behavior is selected per runner/provider/auth mode, not by backend alone:
 
-- host-backed credential mounts are natural on local Docker;
-- remote Docker cannot mount local credential paths;
-- provider proxy mode works on restricted networks if the remote container can reach Paid’s proxy URL;
-- subscription-auth/direct-outbound mode requires a deliberate host-specific credential story before remote placement is allowed.
+- managed `RunnerCredential` auth is remote-safe only when the provider materializer can produce the required env vars or native CLI files inside the container;
+- host-backed credential mounts are allowed only on backends where `supports_host_paths?` is true;
+- provider proxy/API-key mode works on restricted networks if the remote container can reach Paid's proxy URL;
+- remote placement must be rejected with a named reason when a subscription runner still depends on host-mounted credentials, a missing managed credential, or a provider materializer that has not been implemented.
 
 ## Consequences
 

--- a/docs/rdrs/README.md
+++ b/docs/rdrs/README.md
@@ -39,7 +39,7 @@ For more information, see the [RDR methodology](https://github.com/cwensel/rdr).
 | [RDR-004](RDR-004-container-isolation.md) | Container Isolation Strategy | Implemented | High |
 | [RDR-005](RDR-005-git-worktree-management.md) | Git Worktree Management | Superseded | High |
 | [RDR-006](RDR-006-secrets-proxy.md) | Secrets Proxy Architecture | Implemented | High |
-| [RDR-041](RDR-041-subscription-runner-auth-lifecycle.md) | Subscription Runner Auth Lifecycle (Detection, Long-Lived Tokens, Self-Heal) | Accepted | P1 |
+| [RDR-041](RDR-041-subscription-runner-auth-lifecycle.md) | Subscription Runner Managed Auth Lifecycle | Partially Implemented | P1 |
 
 ### Agent System
 
@@ -187,7 +187,8 @@ For more information, see the [RDR methodology](https://github.com/cwensel/rdr).
 2. **Research**: Investigation, findings integration, alternative exploration
 3. **Finalize**: Lock before development; status becomes "Final"
 4. **Implement**: Use as specification; no modifications during coding
-5. **Post-Mortem**: Update status; create addendum for lessons learned
+5. **Close Out**: Use a final audit issue that depends on the implementation chain. That issue updates the RDR and README statuses to "Implemented" only after validating the shipped implementation against the RDR plan and acceptance criteria. If gaps are found, it creates specific dependent follow-up issues and leaves the RDR status unchanged or "Partially Implemented".
+6. **Post-Mortem**: Add lessons learned after implementation, when useful.
 
 **Critical Rule**: If implementation exposes fundamental flaws in an RDR, abandon the code, incorporate learnings back into the RDR, and restart.
 


### PR DESCRIPTION
## Summary

RDR-041 now has a concrete, dependency-ordered issue tree for the remaining managed subscription auth work, and RDR-048 explicitly depends on that auth eligibility work before final closeout.

## What changed

- Links the revised RDR-041 work to new P1 issues #2958-#2966.
- Links RDR-048 to the cross-cutting P1 auth eligibility issue #2963 while keeping the core multi-host chain P2/P3.
- Adds the RDR closeout convention: final audit issue validates implementation against the RDR before marking it implemented, and files dependent follow-ups for any gaps.

## Verification

- `bin/lint --changed`
