### PR TITLE
fix: let scheduler use spare project capacity

### DIFF
--- a/app/jobs/process_run_queue_job.rb
+++ b/app/jobs/process_run_queue_job.rb
@@ -80,7 +80,6 @@ class ProcessRunQueueJob < ApplicationJob
       reroute_cache = {}
       blocked_account_create_pr_ids = Set.new
       blocked_account_dispatch_ids = Set.new
-      started_priority_by_project = {}
       docker_snapshot = nil
       base_reserved_agent_memory_bytes = nil
       started_reserved_agent_memory_bytes = 0
@@ -110,11 +109,6 @@ class ProcessRunQueueJob < ApplicationJob
         # don't consume expensive admission work.
         if AgentRuns::RecheckIssueEligibility.call(next_run)
           skipped_ids.add(next_run.id)
-          next
-        end
-
-        if lower_priority_than_inflight_or_started_project_run?(next_run, started_priority_by_project)
-          blocked_project_ids.add(next_run.project_id)
           next
         end
 
@@ -274,7 +268,6 @@ class ProcessRunQueueJob < ApplicationJob
           consecutive_failures = 0
           starts_count += 1
           started_reserved_agent_memory_bytes += admission[:estimated_memory_per_run_bytes].to_i if docker_snapshot&.[](:available)
-          record_started_project_priority(next_run, started_priority_by_project)
           break if starts_count >= MAX_STARTS_PER_PERFORM
         else
           consecutive_failures += 1
@@ -496,36 +489,6 @@ class ProcessRunQueueJob < ApplicationJob
     ::AgentRuns::DispatchCircuitBreaker
       .new(agent_run.project.account)
       .mark_probe_dispatched!(agent_run_id: agent_run.id)
-  end
-
-  def record_started_project_priority(agent_run, started_priority_by_project)
-    priority = queue_priority_for(agent_run)
-    existing = started_priority_by_project[agent_run.project_id]
-    started_priority_by_project[agent_run.project_id] = priority if existing.nil? || priority < existing
-  end
-
-  # Blocks a queued run from starting when the same project still has
-  # higher-priority work in flight — whether already running or merely
-  # claimed-but-not-yet-started — or started higher-priority work earlier in
-  # this pass. This keeps priority strict within a project: e.g. a P2 must
-  # wait while any P1 for the project is running or queued-and-claimed.
-  def lower_priority_than_inflight_or_started_project_run?(agent_run, started_priority_by_project)
-    current_priority = queue_priority_for(agent_run)
-    started_priority = started_priority_by_project[agent_run.project_id]
-    return true if started_priority && current_priority > started_priority
-
-    AgentRun
-      .inflight_with_priority
-      .where(project_id: agent_run.project_id)
-      .where("#{AgentRun::QUEUE_PRIORITY_CASE_SQL} < ?", current_priority)
-      .exists?
-  end
-
-  def queue_priority_for(agent_run)
-    value = agent_run.read_attribute(:queue_priority)
-    return value.to_i unless value.nil?
-
-    AgentRun::QUEUE_PRIORITIES.keys.index(agent_run.queue_priority_tier) || AgentRun::QUEUE_PRIORITIES.size
   end
 
   def start_claimed_run(agent_run)

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -1242,16 +1242,6 @@ class AgentRun < ApplicationRecord
       )
   }
 
-  # Scope over in-flight runs (running + claimed-queued) exposing the same
-  # queue_priority expression as queued_with_priority via QUEUE_LATERAL_JOIN.
-  # Used by the queue processor to keep a lower-priority run from starting
-  # while a higher-priority run for the same project is still in flight —
-  # whether merely claimed or already running. No fair-share CTEs are joined
-  # because callers filter on queue_priority alone (not the full QUEUE_ORDER).
-  scope :inflight_with_priority, -> {
-    capacity_inflight.joins(QUEUE_LATERAL_JOIN)
-  }
-
   def self.project_active_counts_cte
     capacity_inflight
       .select("project_id, COUNT(*) AS project_active_count")

--- a/spec/jobs/process_run_queue_job_spec.rb
+++ b/spec/jobs/process_run_queue_job_spec.rb
@@ -311,7 +311,7 @@ RSpec.describe ProcessRunQueueJob do
       expect(create_pr_run.reload.temporal_workflow_id).to be_nil
     end
 
-    it "does not start lower-priority work from the same project after claiming a manual run" do
+    it "uses spare capacity for lower-priority work after claiming a manual run" do
       project = create(:project)
       project.created_by.settings.update!(max_concurrent_runs: 2)
       manual = create(:agent_run, :queued, :manual, project: project, goal: "review", source_pull_request_number: 42,
@@ -327,12 +327,12 @@ RSpec.describe ProcessRunQueueJob do
 
       described_class.new.perform
 
-      expect(started_ids).to eq([ manual.id ])
+      expect(started_ids).to eq([ manual.id, p1_run.id ])
       expect(manual.reload.temporal_workflow_id).to be_present
-      expect(p1_run.reload.temporal_workflow_id).to be_nil
+      expect(p1_run.reload.temporal_workflow_id).to be_present
     end
 
-    it "does not start lower-priority work while a manual run from the same project is claimed" do
+    it "uses spare capacity while higher-priority work from the same project is claimed" do
       project = create(:project)
       project.created_by.settings.update!(max_concurrent_runs: 2)
       create(:agent_run, :queued, :manual, project: project, goal: "review", source_pull_request_number: 42,
@@ -340,17 +340,42 @@ RSpec.describe ProcessRunQueueJob do
       p1_issue = create(:issue, project: project, labels: [ "P1" ])
       p1_run = create(:agent_run, :queued, :automatic, project: project, issue: p1_issue)
 
-      expect(temporal_client).not_to receive(:start_workflow)
+      expect(temporal_client).to receive(:start_workflow).with(
+        Workflows::AgentExecutionWorkflow,
+        hash_including(agent_run_id: p1_run.id),
+        hash_including(task_queue: "paid-agent-tasks")
+      ).and_return(workflow_handle)
 
       described_class.new.perform
 
-      expect(p1_run.reload.temporal_workflow_id).to be_nil
+      expect(p1_run.reload.temporal_workflow_id).to be_present
     end
 
-    it "does not start lower-priority work while higher-priority work from the same project is running" do
+    it "uses spare capacity for lower-priority work while higher-priority work from the same project is running" do
       project = create(:project)
       user = project.created_by
       user.settings.update!(max_concurrent_runs: 10)
+
+      p1_issue = create(:issue, project: project, github_number: 100, labels: [ "P1" ])
+      create(:agent_run, :running, project: project, trigger_type: "automatic", issue: p1_issue)
+      p2_issue = create(:issue, project: project, github_number: 200, labels: [ "P2" ])
+      p2_run = create(:agent_run, :queued, project: project, trigger_type: "automatic", issue: p2_issue)
+
+      expect(temporal_client).to receive(:start_workflow).with(
+        Workflows::AgentExecutionWorkflow,
+        hash_including(agent_run_id: p2_run.id),
+        hash_including(task_queue: "paid-agent-tasks")
+      ).and_return(workflow_handle)
+
+      described_class.new.perform
+
+      expect(p2_run.reload.temporal_workflow_id).to be_present
+    end
+
+    it "does not start lower-priority work when the same project is at its concurrency cap" do
+      project = create(:project)
+      user = project.created_by
+      user.settings.update!(max_concurrent_runs: 10, max_parallel_agents_per_project: 3)
 
       3.times do |i|
         p1_issue = create(:issue, project: project, github_number: 100 + i, labels: [ "P1" ])
@@ -414,14 +439,11 @@ RSpec.describe ProcessRunQueueJob do
       expect(p2_run.reload.temporal_workflow_id).to be_present
     end
 
-    it "does not block equal-priority queued work (a running P1 allows another queued P1 to start)" do
+    it "uses spare capacity for equal-priority queued work from the same project" do
       project = create(:project)
       user = project.created_by
       user.settings.update!(max_concurrent_runs: 10)
 
-      # The guard blocks only STRICTLY higher-priority in-flight work (`<`), so
-      # a second P1 must still be allowed to start alongside a running P1 —
-      # otherwise a project could never run two same-tier items concurrently.
       running_p1 = create(:issue, project: project, github_number: 10, labels: [ "P1" ])
       create(:agent_run, :running, project: project, trigger_type: "automatic", issue: running_p1)
       queued_p1 = create(:issue, project: project, github_number: 11, labels: [ "P1" ])


### PR DESCRIPTION
## Summary

Queued work now fills spare scheduler capacity instead of waiting behind a higher-priority run from the same project. The scheduler still respects the existing user, account, project, create_pr, Docker, runner, and dispatch-circuit gates, so a project can use only the capacity it is allowed to use.

This removes the old strict same-project priority blocker and the now-unused priority scope that supported it. Priority ordering still chooses the next candidate; it no longer acts as an extra capacity denial after the real admission checks pass.

## Verification

- `bin/rspec spec/jobs/process_run_queue_job_spec.rb --format progress`
- `bin/rubocop app/jobs/process_run_queue_job.rb app/models/agent_run.rb spec/jobs/process_run_queue_job_spec.rb`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenAI_Codex_GPT--5.5](https://img.shields.io/badge/OpenAI_Codex_GPT--5.5-000000)
