### PR TITLE
fix(specs): stop sleeping ~3s in DockerSnapshot slow-sampling test

### DIFF
--- a/spec/services/capacity/docker_snapshot_spec.rb
+++ b/spec/services/capacity/docker_snapshot_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Capacity::DockerSnapshot do
     end
 
     it "preserves classification of unrelated containers even with slow per-container sampling" do
-      threshold = described_class::DOCKER_SAMPLING_BUDGET - 0.05
+      stub_const("Capacity::DockerSnapshot::DOCKER_SAMPLING_BUDGET", 0.05)
       slow_backend = build_backend_double(
         identifier: "local",
         remote: false,
@@ -141,7 +141,7 @@ RSpec.describe Capacity::DockerSnapshot do
         containers: containers
       )
       allow(slow_backend).to receive(:container_stats) do |_container, **_opts|
-        sleep threshold
+        sleep 1
         {}
       end
 


### PR DESCRIPTION
## Summary
- The `Capacity::DockerSnapshot` spec's "preserves classification of unrelated containers even with slow per-container sampling" example (`spec/services/capacity/docker_snapshot_spec.rb:135`) used a real `sleep` (~2.95s) to simulate a slow `container_stats` call, making it the single slowest example in a recent CI run (3.17s).
- Fixed by shrinking `DOCKER_SAMPLING_BUDGET` via `stub_const` instead, so the same production `Timeout.timeout` short-circuits the sleep almost immediately — mirroring the identical technique already used for this exact scenario in `spec/services/accounts/operations/auto_capacity_observer_spec.rb:80`.
- Test now runs in ~0.4s (about 8x faster) with identical coverage and assertions.

## Other slow tests investigated (not changed)
Looked at the other top-5 slowest examples from the same CI run:
- `BootFile`, `SpecHelperCoverage`, `ProviderSmokeScript` specs spawn real `bundle exec ruby` subprocesses (one of which fully boots Rails via `config/environment`) to test actual process-boot behavior. No sleeps/timeouts involved — the cost is inherent to what's being verified (real subprocess + Rails boot), so left as-is.
- `TenantContext` spec (`spec/security/tenant_context_spec.rb`) re-runs ~15 migrations down/up plus `CREATE ROLE`/grants on every one of its 12 examples via a per-example `around` hook, which is real but avoidable overhead. Did not touch it here — it's security-critical RLS test coverage, and consolidating the per-example setup to run once per file needs careful verification against transactional-fixture/`SET ROLE` interactions to avoid weakening isolation coverage. Flagging as a candidate for a follow-up, not bundled into this fix.

## Test plan
- [x] `bundle exec rspec spec/services/capacity/docker_snapshot_spec.rb` — 19 examples, 0 failures, target example dropped from ~3.17s to ~0.4s
- [x] `bin/rubocop spec/services/capacity/docker_snapshot_spec.rb` — no offenses