### PR TITLE
fix(previews): tolerate legacy preview sessions table

### DIFF
--- a/db/migrate/20260710151421_create_preview_sessions.rb
+++ b/db/migrate/20260710151421_create_preview_sessions.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 class CreatePreviewSessions < ActiveRecord::Migration[8.1]
-  def change
+  def up
+    if table_exists?(:preview_sessions)
+      enable_preview_sessions_rls if column_exists?(:preview_sessions, :account_id)
+      return
+    end
+
     create_table :preview_sessions,
       comment: "Live web-app preview sessions exposed to reviewers via the same-origin " \
                "/previews/:token reverse proxy (RDR-045)." do |t|
@@ -41,30 +46,40 @@ class CreatePreviewSessions < ActiveRecord::Migration[8.1]
     add_index :preview_sessions, [ :account_id, :status, :expires_at ],
       name: "idx_preview_sessions_on_account_status_expires"
 
-    reversible do |dir|
-      dir.up do
-        safety_assured do
-          execute <<~SQL
-            ALTER TABLE preview_sessions ENABLE ROW LEVEL SECURITY;
-            ALTER TABLE preview_sessions FORCE ROW LEVEL SECURITY;
-            CREATE POLICY tenant_isolation ON preview_sessions
-              USING (
-                paid_tenant_bypass() OR preview_sessions.account_id = paid_current_account_id()
-              )
-              WITH CHECK (
-                paid_tenant_bypass() OR preview_sessions.account_id = paid_current_account_id()
-              );
-          SQL
-        end
-      end
+    enable_preview_sessions_rls
+  end
 
-      dir.down do
-        safety_assured do
-          execute "DROP POLICY IF EXISTS tenant_isolation ON preview_sessions"
-          execute "ALTER TABLE preview_sessions NO FORCE ROW LEVEL SECURITY"
-          execute "ALTER TABLE preview_sessions DISABLE ROW LEVEL SECURITY"
-        end
-      end
+  def down
+    if table_exists?(:preview_sessions)
+      disable_preview_sessions_rls
+      drop_table :preview_sessions
+    end
+  end
+
+  private
+
+  def enable_preview_sessions_rls
+    safety_assured do
+      execute <<~SQL
+        ALTER TABLE preview_sessions ENABLE ROW LEVEL SECURITY;
+        ALTER TABLE preview_sessions FORCE ROW LEVEL SECURITY;
+        DROP POLICY IF EXISTS tenant_isolation ON preview_sessions;
+        CREATE POLICY tenant_isolation ON preview_sessions
+          USING (
+            paid_tenant_bypass() OR preview_sessions.account_id = paid_current_account_id()
+          )
+          WITH CHECK (
+            paid_tenant_bypass() OR preview_sessions.account_id = paid_current_account_id()
+          );
+      SQL
+    end
+  end
+
+  def disable_preview_sessions_rls
+    safety_assured do
+      execute "DROP POLICY IF EXISTS tenant_isolation ON preview_sessions"
+      execute "ALTER TABLE preview_sessions NO FORCE ROW LEVEL SECURITY"
+      execute "ALTER TABLE preview_sessions DISABLE ROW LEVEL SECURITY"
     end
   end
 end

--- a/db/migrate/20260710151421_create_preview_sessions.rb
+++ b/db/migrate/20260710151421_create_preview_sessions.rb
@@ -50,10 +50,19 @@ class CreatePreviewSessions < ActiveRecord::Migration[8.1]
   end
 
   def down
-    if table_exists?(:preview_sessions)
-      disable_preview_sessions_rls
-      drop_table :preview_sessions
-    end
+    return unless table_exists?(:preview_sessions)
+
+    # If the named index we create in `up` is absent, the table predated this
+    # migration record (legacy-table path). Dropping it would destroy data that
+    # this migration never created, so treat the rollback as a no-op in that case.
+    return unless index_exists?(
+      :preview_sessions,
+      %i[account_id status expires_at],
+      name: "idx_preview_sessions_on_account_status_expires"
+    )
+
+    disable_preview_sessions_rls
+    drop_table :preview_sessions
   end
 
   private

--- a/db/migrate/20260710151421_create_preview_sessions.rb
+++ b/db/migrate/20260710151421_create_preview_sessions.rb
@@ -50,19 +50,13 @@ class CreatePreviewSessions < ActiveRecord::Migration[8.1]
   end
 
   def down
-    return unless table_exists?(:preview_sessions)
-
-    # If the named index we create in `up` is absent, the table predated this
-    # migration record (legacy-table path). Dropping it would destroy data that
-    # this migration never created, so treat the rollback as a no-op in that case.
-    return unless index_exists?(
-      :preview_sessions,
-      %i[account_id status expires_at],
-      name: "idx_preview_sessions_on_account_status_expires"
-    )
-
-    disable_preview_sessions_rls
-    drop_table :preview_sessions
+    # Always a no-op. `20260722102221_add_extended_fields_to_preview_sessions`
+    # creates the same `idx_preview_sessions_on_account_status_expires` index on
+    # the legacy-table upgrade path, so that index cannot reliably distinguish
+    # a table this migration created from a pre-existing legacy table. Dropping
+    # the table during rollback would destroy legacy data, so we leave the table
+    # in place regardless. The `up` path is idempotent and handles a
+    # pre-existing table gracefully.
   end
 
   private
@@ -81,14 +75,6 @@ class CreatePreviewSessions < ActiveRecord::Migration[8.1]
             paid_tenant_bypass() OR preview_sessions.account_id = paid_current_account_id()
           );
       SQL
-    end
-  end
-
-  def disable_preview_sessions_rls
-    safety_assured do
-      execute "DROP POLICY IF EXISTS tenant_isolation ON preview_sessions"
-      execute "ALTER TABLE preview_sessions NO FORCE ROW LEVEL SECURITY"
-      execute "ALTER TABLE preview_sessions DISABLE ROW LEVEL SECURITY"
     end
   end
 end

--- a/db/migrate/20260722102430_enforce_preview_session_constraints.rb
+++ b/db/migrate/20260722102430_enforce_preview_session_constraints.rb
@@ -14,6 +14,19 @@ class EnforcePreviewSessionConstraints < ActiveRecord::Migration[8.1]
       unless foreign_key_exists?(:preview_sessions, :users, column: :created_by_id)
         add_foreign_key :preview_sessions, :users, column: :created_by_id, on_delete: :nullify
       end
+
+      execute <<~SQL
+        ALTER TABLE preview_sessions ENABLE ROW LEVEL SECURITY;
+        ALTER TABLE preview_sessions FORCE ROW LEVEL SECURITY;
+        DROP POLICY IF EXISTS tenant_isolation ON preview_sessions;
+        CREATE POLICY tenant_isolation ON preview_sessions
+          USING (
+            paid_tenant_bypass() OR preview_sessions.account_id = paid_current_account_id()
+          )
+          WITH CHECK (
+            paid_tenant_bypass() OR preview_sessions.account_id = paid_current_account_id()
+          );
+      SQL
     end
   end
 

--- a/db/migrate/20260722102430_enforce_preview_session_constraints.rb
+++ b/db/migrate/20260722102430_enforce_preview_session_constraints.rb
@@ -32,9 +32,11 @@ class EnforcePreviewSessionConstraints < ActiveRecord::Migration[8.1]
 
   def down
     safety_assured do
-      execute "DROP POLICY IF EXISTS tenant_isolation ON preview_sessions"
-      execute "ALTER TABLE preview_sessions NO FORCE ROW LEVEL SECURITY"
-      execute "ALTER TABLE preview_sessions DISABLE ROW LEVEL SECURITY"
+      # Do not disable RLS here — CreatePreviewSessions already established the
+      # tenant_isolation policy and RLS on this table. Rolling back only this
+      # migration must leave the prior state (RLS enabled + forced + policy)
+      # intact so that db:rollback STEP=1 on a normal install does not remove
+      # tenant isolation that the preceding migration version still relies on.
 
       if foreign_key_exists?(:preview_sessions, :users, column: :created_by_id)
         remove_foreign_key :preview_sessions, :users, column: :created_by_id

--- a/db/migrate/20260722102430_enforce_preview_session_constraints.rb
+++ b/db/migrate/20260722102430_enforce_preview_session_constraints.rb
@@ -32,11 +32,19 @@ class EnforcePreviewSessionConstraints < ActiveRecord::Migration[8.1]
 
   def down
     safety_assured do
-      # Do not disable RLS here — CreatePreviewSessions already established the
-      # tenant_isolation policy and RLS on this table. Rolling back only this
-      # migration must leave the prior state (RLS enabled + forced + policy)
-      # intact so that db:rollback STEP=1 on a normal install does not remove
-      # tenant isolation that the preceding migration version still relies on.
+      # On the legacy-table upgrade path, CreatePreviewSessions#up returned early
+      # (account_id did not exist yet), so THIS migration was the first to
+      # establish RLS on that database. We must tear it down here so that
+      # `db:rollback STEP=1` restores the true pre-EnforcePreviewSessionConstraints
+      # state (no RLS, no policy). On the normal (fresh-table) path, the same
+      # policy was installed by CreatePreviewSessions; dropping it here is safe
+      # because re-running db:migrate re-applies EnforcePreviewSessionConstraints
+      # and restores full tenant isolation.
+      execute <<~SQL
+        DROP POLICY IF EXISTS tenant_isolation ON preview_sessions;
+        ALTER TABLE preview_sessions NO FORCE ROW LEVEL SECURITY;
+        ALTER TABLE preview_sessions DISABLE ROW LEVEL SECURITY;
+      SQL
 
       if foreign_key_exists?(:preview_sessions, :users, column: :created_by_id)
         remove_foreign_key :preview_sessions, :users, column: :created_by_id

--- a/db/migrate/20260722102430_enforce_preview_session_constraints.rb
+++ b/db/migrate/20260722102430_enforce_preview_session_constraints.rb
@@ -32,6 +32,10 @@ class EnforcePreviewSessionConstraints < ActiveRecord::Migration[8.1]
 
   def down
     safety_assured do
+      execute "DROP POLICY IF EXISTS tenant_isolation ON preview_sessions"
+      execute "ALTER TABLE preview_sessions NO FORCE ROW LEVEL SECURITY"
+      execute "ALTER TABLE preview_sessions DISABLE ROW LEVEL SECURITY"
+
       if foreign_key_exists?(:preview_sessions, :users, column: :created_by_id)
         remove_foreign_key :preview_sessions, :users, column: :created_by_id
       end


### PR DESCRIPTION
## Summary

- Make the preview sessions create migration tolerate local databases where a legacy `preview_sessions` table already exists but the migration version was not recorded.
- Reapply tenant RLS after the legacy table has been upgraded with `account_id`.

## Root Cause

Some local worktree databases already had the old `preview_sessions` table shape, so `db:prepare` failed on `PG::DuplicateTable` before the later normalization migrations could run.

## Validation

- `bin/rails db:prepare`
- `bin/rubocop db/migrate/20260710151421_create_preview_sessions.rb db/migrate/20260722102430_enforce_preview_session_constraints.rb`
- `git diff --check`