### PR TITLE
fix(dev-update): run migrations before restarting dev

### DIFF
--- a/app/services/prompts/service_container_sections.rb
+++ b/app/services/prompts/service_container_sections.rb
@@ -68,6 +68,9 @@ module Prompts
           to match a new migration — running the migration is what catches
           `strong_migrations` violations (unsafe index adds, blocking column
           rewrites, etc.) and keeps the schema dump in sync.
+        - Make migrations safe to rerun after a partial failure. Use defensive
+          guards such as `table_exists?`, `column_exists?`, and `index_exists?`
+          where rerunning against a partially changed database could otherwise fail.
         - Commit the migration file and the regenerated `db/schema.rb` together.
       SECTION
     end

--- a/bin/dev-update
+++ b/bin/dev-update
@@ -85,6 +85,33 @@ restart_required_from_trigger_context() {
   return 1
 }
 
+migrations_changed_in() {
+  local files="$1"
+  local file
+
+  while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    case "$file" in
+      db/migrate/*)
+        return 0
+        ;;
+    esac
+  done <<< "$files"
+
+  return 1
+}
+
+migrations_changed() {
+  migrations_changed_in "${DEV_UPDATE_RESTART_TRIGGER_FILES:-}" ||
+    migrations_changed_in "${DEV_UPDATE_CHANGED_FILES:-}" ||
+    migrations_changed_in "$PULL_CHANGED_FILES"
+}
+
+migrations_changed_in_trigger_context() {
+  migrations_changed_in "${DEV_UPDATE_RESTART_TRIGGER_FILES:-}" ||
+    migrations_changed_in "${DEV_UPDATE_CHANGED_FILES:-}"
+}
+
 log() {
   echo "$LOG_PREFIX $(date '+%Y-%m-%d %H:%M:%S') $*"
 }
@@ -309,7 +336,8 @@ ensure_on_main() {
     # feature-branch edits onto main when unstash_dirty_tree runs later.
     if tree_is_dirty; then
       record_failure "dirty-non-main"
-      fail "Working tree on '$current_branch' has uncommitted changes. Commit or stash them before running dev-update."
+      log "ERROR: Working tree on '$current_branch' has uncommitted changes. Commit or stash them before running dev-update."
+      return 1
     fi
     log "Switching to main branch (currently on $current_branch)..."
     git checkout main
@@ -328,7 +356,8 @@ pull_latest() {
   if ! git pull --ff-only origin main; then
     record_failure "git-pull"
     unstash_dirty_tree
-    fail "git pull --ff-only failed. Check for diverged history or upstream issues."
+    log "ERROR: git pull --ff-only failed. Check for diverged history or upstream issues."
+    return 1
   fi
 
   local post_head
@@ -424,14 +453,42 @@ prune_worktree_databases() {
 }
 
 run_setup() {
-  log "Running bin/setup --skip-server..."
+  local setup_args=(--skip-server)
+  if migrations_changed; then
+    setup_args+=(--skip-database)
+  fi
+
+  log "Running bin/setup ${setup_args[*]}..."
   local status=0
   STARTUP_CLEANUP_KILL_ALL="$STARTUP_CLEANUP_KILL_ALL" \
-    dev_supervisor_run_clean bin/setup --skip-server || status=$?
+    dev_supervisor_run_clean bin/setup "${setup_args[@]}" || status=$?
   # Mirror bin/setup's worktree-database creation by reaping orphans, but only
   # after a clean setup — the DB is in a known-good state and Ruby is available.
-  [ "$status" -eq 0 ] && prune_worktree_databases
+  [ "$status" -eq 0 ] && ! migrations_changed && prune_worktree_databases
   return "$status"
+}
+
+run_migrations_if_needed() {
+  migrations_changed || return 0
+
+  log "Migration files changed; running bin/rails db:migrate before restart..."
+  local output
+  if output="$(dev_supervisor_run_clean bin/ensure-worktree-databases 2>&1)"; then
+    log_command_output "ensure-worktree-databases" "$output"
+  else
+    log_command_output "ensure-worktree-databases" "$output"
+    fail "bin/ensure-worktree-databases failed. Fix database setup and rerun bin/dev-update --full."
+  fi
+
+  if output="$(dev_supervisor_run_clean bin/rails db:migrate 2>&1)"; then
+    log_command_output "db:migrate" "$output"
+    log "Database migrations are current."
+  else
+    log_command_output "db:migrate" "$output"
+    fail "bin/rails db:migrate failed. Fix the migration and rerun bin/dev-update --full."
+  fi
+
+  prune_worktree_databases
 }
 
 wait_for_overmind_health() {
@@ -505,8 +562,19 @@ recover_dev_if_needed() {
 
 run_full_restart() {
   log "Starting full restart update..."
-  ensure_on_main
-  pull_latest
+  if migrations_changed_in_trigger_context; then
+    log "Migration files are in the trigger context; stopping Overmind before pulling to avoid Rails pending-migration errors."
+    stop_overmind
+  fi
+
+  if ! ensure_on_main; then
+    recover_dev_if_needed
+    fail "Cannot update while the current branch has uncommitted changes."
+  fi
+  if ! pull_latest; then
+    recover_dev_if_needed
+    fail "git pull --ff-only failed. Check for diverged history or upstream issues."
+  fi
   stop_overmind
 
   if ! run_setup; then
@@ -514,6 +582,7 @@ run_full_restart() {
     recover_dev_if_needed
     fail "Full restart aborted because bin/setup --skip-server failed."
   fi
+  run_migrations_if_needed
 
   if ! start_dev; then
     fail "Full restart completed setup but failed to restore a healthy Overmind session."
@@ -533,8 +602,12 @@ case "$MODE" in
       exit 0
     fi
     log "Starting lightweight update..."
-    ensure_on_main
-    pull_latest
+    if ! ensure_on_main; then
+      fail "Cannot update while the current branch has uncommitted changes."
+    fi
+    if ! pull_latest; then
+      fail "git pull --ff-only failed. Check for diverged history or upstream issues."
+    fi
     if restart_required_from_pull; then
       log "Pull included restart-worthy files outside the trigger context; upgrading to full restart."
       stop_overmind
@@ -542,6 +615,7 @@ case "$MODE" in
         recover_dev_if_needed
         fail "Full restart aborted because bin/setup --skip-server failed."
       fi
+      run_migrations_if_needed
       if ! start_dev; then
         fail "Full restart completed setup but failed to restore a healthy Overmind session."
       fi

--- a/bin/setup
+++ b/bin/setup
@@ -37,6 +37,7 @@ FileUtils.chdir APP_ROOT do
   # This script is a way to set up or update your development environment automatically.
   # This script is idempotent, so that you can run it at any time and get an expectable outcome.
   # Add necessary setup steps to this file.
+  skip_database = ARGV.include?("--skip-database")
 
   puts "== Setting up git hooks =="
   system! "git config core.hooksPath .githooks"
@@ -59,13 +60,17 @@ FileUtils.chdir APP_ROOT do
     system("sudo mkdir -p #{workspace_root}/runs && sudo chown -R $(whoami) /var/paid")
   end
 
-  puts "\n== Preparing database =="
-  system! "bin/ensure-worktree-databases"
-  system! "bin/rails db:prepare"
-  system! "bin/rails db:reset" if ARGV.include?("--reset")
+  unless skip_database
+    puts "\n== Preparing database =="
+    system! "bin/ensure-worktree-databases"
+    system! "bin/rails db:prepare"
+    system! "bin/rails db:reset" if ARGV.include?("--reset")
+  end
 
-  puts "\n== Checking Qdrant connectivity =="
-  system "bin/rails qdrant:check"
+  unless skip_database
+    puts "\n== Checking Qdrant connectivity =="
+    system "bin/rails qdrant:check"
+  end
 
   puts "\n== Building agent container image =="
   system! "scripts/build-agent-image.sh"

--- a/db/seeds/prompts.rb
+++ b/db/seeds/prompts.rb
@@ -252,6 +252,9 @@ upsert_global_prompt.call(
       to match a new migration — running the migration is what catches
       `strong_migrations` violations (unsafe index adds, blocking column
       rewrites, etc.) and keeps the schema dump in sync.
+    - Make migrations safe to rerun after a partial failure. Use defensive
+      guards such as `table_exists?`, `column_exists?`, and `index_exists?`
+      where rerunning against a partially changed database could otherwise fail.
     - Commit the migration file and the regenerated `db/schema.rb` together.
   TEMPLATE
   variables: []

--- a/spec/lib/dev_update_spec.rb
+++ b/spec/lib/dev_update_spec.rb
@@ -241,6 +241,96 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
     end
   end
 
+  it "runs migrations before restarting when trigger context includes migration files" do
+    Dir.mktmpdir("dev-update-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir, start_overmind_running: true)
+      create_stale_socket(dir)
+
+      stdout, stderr, status = run_with_migration_trigger(dir, script_path, "--full")
+
+      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect_calls(dir, migration_restart_calls("overmind quit"))
+
+      updater_log = read_updater_log(dir)
+      expect(updater_log).to include("stopping Overmind before pulling")
+      expect(updater_log).to include("Migration files changed; running bin/rails db:migrate before restart...")
+      expect(updater_log).to include("Database migrations are current.")
+    end
+  end
+
+  it "runs migrations before restarting when pull brings in migration files" do
+    Dir.mktmpdir("dev-update-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir, pull_diff_files: %w[
+        app/models/user.rb
+        db/migrate/20260722000000_add_widgets.rb
+      ])
+
+      result = Open3.capture3(
+        trigger_context_env(dir,
+          "DEV_UPDATE_TRIGGER_MODE" => "lightweight",
+          "DEV_UPDATE_CHANGED_FILES" => "app/models/user.rb"),
+        script_path,
+        "--lightweight",
+        chdir: dir
+      )
+      stdout, stderr, status = result
+
+      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect_calls(dir, migration_restart_calls)
+    end
+  end
+
+  it "fails before restart when explicit migration run fails" do
+    Dir.mktmpdir("dev-update-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir, rails_migrate_exit_status: 1)
+
+      stdout, stderr, status = run_with_migration_trigger(dir, script_path, "--full")
+
+      expect(status.success?).to be(false), -> { "expected failure but got success\nstdout: #{stdout}\nstderr: #{stderr}" }
+      expect_calls(dir, migration_restart_calls[0...-1])
+
+      updater_log = read_updater_log(dir)
+      expect(updater_log).to include("db:migrate: migration failed")
+      expect(updater_log).to include("ERROR: bin/rails db:migrate failed. Fix the migration and rerun bin/dev-update --full.")
+    end
+  end
+
+  it "recovers Overmind when a migration-triggered update stops before a failed pull" do
+    Dir.mktmpdir("dev-update-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir, start_overmind_running: true, pull_exit_status: 1)
+      create_stale_socket(dir)
+
+      stdout, stderr, status = Open3.capture3(
+        trigger_context_env(dir,
+          "DEV_UPDATE_TRIGGER_MODE" => "full",
+          "DEV_UPDATE_CHANGED_FILES" => "db/migrate/20260722000000_add_widgets.rb",
+          "DEV_UPDATE_RESTART_TRIGGER_FILES" => "db/migrate/20260722000000_add_widgets.rb"),
+        script_path,
+        "--full",
+        chdir: dir
+      )
+
+      expect(status.success?).to be(false), -> { "expected failure but got success\nstdout: #{stdout}\nstderr: #{stderr}" }
+      expect(File.exist?(File.join(dir, "dev-ran"))).to be(true)
+      expect(read_updater_log(dir)).to include("Recovery start succeeded.")
+      expect(read_updater_log(dir)).to include("ERROR: git pull --ff-only failed.")
+    end
+  end
+
+  it "recovers Overmind when a migration-triggered update stops before a dirty branch abort" do
+    Dir.mktmpdir("dev-update-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir, start_overmind_running: true, current_branch: "feature/fix", dirty_tree: true)
+      create_stale_socket(dir)
+
+      stdout, stderr, status = run_with_migration_trigger(dir, script_path, "--full")
+
+      expect(status.success?).to be(false), -> { "expected failure but got success\nstdout: #{stdout}\nstderr: #{stderr}" }
+      expect(File.exist?(File.join(dir, "dev-ran"))).to be(true)
+      expect(read_updater_log(dir)).to include("Recovery start succeeded.")
+      expect(read_updater_log(dir)).to include("ERROR: Cannot update while the current branch has uncommitted changes.")
+    end
+  end
+
   it "stays lightweight when pull brings in only autoloadable files" do
     Dir.mktmpdir("dev-update-spec", exec_tmpdir) do |dir|
       script_path = prepare_script_fixture(dir, pull_diff_files: %w[
@@ -557,6 +647,10 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
     File.read(File.join(dir, "log", "dev-update", "dev-update.log"))
   end
 
+  def expect_calls(dir, expected)
+    expect(File.read(File.join(dir, "calls.log")).lines.map(&:chomp)).to eq(expected)
+  end
+
   def expect_trigger_context_log(dir)
     updater_log = read_updater_log(dir)
     expect(updater_log).to include("Trigger source: Activities::TriggerDevEnvironmentUpdateActivity")
@@ -575,6 +669,28 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
         "DEV_UPDATE_TRIGGER_SOURCE" => "Activities::TriggerDevEnvironmentUpdateActivity"
       }.merge(overrides)
     )
+  end
+
+  def migration_trigger_env(dir)
+    trigger_context_env(dir,
+      "DEV_UPDATE_TRIGGER_MODE" => "full",
+      "DEV_UPDATE_CHANGED_FILES" => "db/migrate/20260722000000_add_widgets.rb",
+      "DEV_UPDATE_RESTART_TRIGGER_FILES" => "db/migrate/20260722000000_add_widgets.rb")
+  end
+
+  def run_with_migration_trigger(dir, script_path, mode)
+    Open3.capture3(migration_trigger_env(dir), script_path, mode, chdir: dir)
+  end
+
+  def migration_restart_calls(*prefix)
+    [
+      *prefix,
+      "git pull",
+      "setup --skip-server --skip-database",
+      "ensure-worktree-databases",
+      "rails db:migrate",
+      "dev"
+    ]
   end
 
   def failure_lock_env(dir)
@@ -632,6 +748,7 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
     stash_pop_exit_status: 0,
     stash_pop_output: "Applied stash",
     pull_diff_files: [],
+    rails_migrate_exit_status: 0,
     status_successes_after_start: nil
   )
     FileUtils.mkdir_p(File.join(dir, "bin"))
@@ -660,9 +777,36 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
       <<~BASH
         #!/usr/bin/env bash
         touch "#{dir}/setup-ran"
+        printf 'setup %s\\n' "$*" >> "#{dir}/calls.log"
         printf '%s\n' "${STARTUP_CLEANUP_KILL_ALL:-}" > "#{dir}/setup-env.log"
         #{capture_setup_bundler_line}
         exit #{setup_exit_status}
+      BASH
+    )
+
+    write_executable(
+      File.join(dir, "bin", "ensure-worktree-databases"),
+      <<~BASH
+        #!/usr/bin/env bash
+        printf 'ensure-worktree-databases\\n' >> "#{dir}/calls.log"
+        exit 0
+      BASH
+    )
+
+    write_executable(
+      File.join(dir, "bin", "rails"),
+      <<~BASH
+        #!/usr/bin/env bash
+        printf 'rails %s\\n' "$*" >> "#{dir}/calls.log"
+        if [ "$*" = "db:migrate" ]; then
+          if [ "#{rails_migrate_exit_status}" -eq 0 ]; then
+            echo "migrated"
+          else
+            echo "migration failed" >&2
+          fi
+          exit #{rails_migrate_exit_status}
+        fi
+        exit 0
       BASH
     )
 
@@ -671,6 +815,7 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
       <<~BASH
         #!/usr/bin/env bash
         touch "#{dir}/dev-ran"
+        printf 'dev\\n' >> "#{dir}/calls.log"
         #{capture_port_line}
         #{capture_kill_all_line}
         #{capture_dev_bundler_line}
@@ -719,6 +864,7 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
             ;;
           pull)
             touch "#{dir}/pull-ran"
+            printf 'git pull\\n' >> "#{dir}/calls.log"
             exit #{pull_exit_status}
             ;;
           diff)
@@ -767,6 +913,7 @@ RSpec.describe "bin/dev-update" do # rubocop:disable RSpec/DescribeClass
             exit 0
             ;;
           quit)
+            printf 'overmind quit\\n' >> "#{dir}/calls.log"
             touch "#{dir}/overmind-quit-ran"
             rm -f "#{dir}/overmind-running"
             exit 0

--- a/spec/lib/setup_script_spec.rb
+++ b/spec/lib/setup_script_spec.rb
@@ -38,6 +38,23 @@ RSpec.describe "bin/setup" do # rubocop:disable RSpec/DescribeClass
     end
   end
 
+  it "skips database preparation when --skip-database is provided" do
+    Dir.mktmpdir("setup-script-spec", exec_tmpdir) do |dir|
+      script_path = prepare_script_fixture(dir)
+      env = setup_script_env(dir)
+
+      stdout, stderr, status = Open3.capture3(env, script_path, "--skip-server", "--skip-database", chdir: dir)
+
+      expect(status.success?).to be(true), -> { "stdout: #{stdout}\nstderr: #{stderr}" }
+      expect(stdout).not_to include("== Preparing database ==")
+      database_log = File.join(dir, "database-calls.log")
+      database_calls = File.exist?(database_log) ? File.read(database_log) : ""
+      expect(database_calls).not_to include("ensure-worktree-databases")
+      expect(database_calls).not_to include("rails db:prepare")
+      expect(database_calls).not_to include("rails qdrant:check")
+    end
+  end
+
   it "installs the lockfile Bundler version before running bundle when missing" do
     Dir.mktmpdir("setup-script-spec", exec_tmpdir) do |dir|
       script_path = prepare_script_fixture(dir, installed_bundler_versions: [])
@@ -69,6 +86,7 @@ RSpec.describe "bin/setup" do # rubocop:disable RSpec/DescribeClass
       File.join(dir, "bin", "ensure-worktree-databases"),
       <<~BASH
         #!/usr/bin/env bash
+        printf 'ensure-worktree-databases\\n' >> "#{dir}/database-calls.log"
         exit 0
       BASH
     )
@@ -94,6 +112,7 @@ RSpec.describe "bin/setup" do # rubocop:disable RSpec/DescribeClass
       File.join(dir, "bin", "rails"),
       <<~BASH
         #!/usr/bin/env bash
+        printf 'rails %s\\n' "$*" >> "#{dir}/database-calls.log"
         exit 0
       BASH
     )


### PR DESCRIPTION
## Summary

- stop Overmind before pulling migration-triggered self-updates so Rails cannot reload into a pending-migration error
- add `bin/setup --skip-database` and have `bin/dev-update` run an explicit `bin/rails db:migrate` gate before restart
- add migration prompt guidance for rerunnable/partial-failure-safe migrations

## Validation

- `bin/rspec spec/lib/dev_update_spec.rb spec/lib/setup_script_spec.rb spec/services/prompts/build_for_issue_spec.rb spec/services/prompts/build_for_pr_spec.rb spec/services/prompts/service_container_sections_spec.rb spec/db/prompt_seeds_spec.rb`
- `bin/rubocop spec/lib/dev_update_spec.rb spec/lib/setup_script_spec.rb bin/setup app/services/prompts/service_container_sections.rb db/seeds/prompts.rb`
- `shellcheck -x bin/dev-update`
- `git diff --check`