### PR TITLE
feat: token optimization (rtk + codegraph) and concurrent Docker stats sampling

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -99,6 +99,32 @@ RUN set -eu; \
   unzip -j -o "$tmpdir/$asset" rathole -d "$tmpdir"; \
   install -m 0755 "$tmpdir/rathole" /usr/local/bin/rathole
 
+# Install rtk (Rust Token Killer) for compressed AI agent shell output.
+# rtk intercepts shell commands from AI agents and compresses the output 60-90%,
+# reducing context window consumption.
+# https://github.com/rtk-ai/rtk/releases
+ARG RTK_VERSION=0.43.0
+RUN set -eu; \
+  arch="$(dpkg --print-architecture)"; \
+  case "$arch" in \
+    amd64) asset="rtk-x86_64-unknown-linux-musl.tar.gz"; checksum="ff8a1e7766496e175291a85aeca1dc97c9ff6df33e51e5893d1fbc78fea2a609" ;; \
+    arm64) asset="rtk-aarch64-unknown-linux-gnu.tar.gz"; checksum="5519f7ca12e5c143a609f0d28a0a77b97413a8dce31c2681f1a41c24519a8731" ;; \
+    *) echo "Unsupported architecture: $arch" >&2; exit 1 ;; \
+  esac; \
+  tmpdir="$(mktemp -d)"; \
+  trap 'rm -rf "$tmpdir"' EXIT; \
+  curl -fsSL -o "$tmpdir/$asset" "https://github.com/rtk-ai/rtk/releases/download/v${RTK_VERSION}/${asset}"; \
+  echo "$checksum  $tmpdir/$asset" | sha256sum -c -; \
+  tar -xzf "$tmpdir/$asset" -C "$tmpdir"; \
+  install -m 0755 "$tmpdir/rtk" /usr/local/bin/rtk
+
+# Install CodeGraph for local-first code intelligence via MCP.
+# Builds a code knowledge graph that agents query instead of grepping/reading
+# files one at a time, reducing tool calls and tokens.
+# https://github.com/colbymchenry/codegraph
+ARG CODEGRAPH_VERSION=1.5.0
+RUN npm install -g @colbymchenry/codegraph@${CODEGRAPH_VERSION} --ignore-scripts
+
 # Install overmind process manager (requires tmux, installed above)
 RUN gem install overmind
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -115,7 +115,9 @@
     "oh-my-pi": "bash .devcontainer/install-oh-my-pi.sh",
     // Dev tools
     "markdownlint": "npm install -g --ignore-scripts markdownlint-cli",
-    "git-curate": "env PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH gem install git_curate"
+    "git-curate": "env PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH gem install git_curate",
+    // Token optimization tools (must run after agent CLIs are installed)
+    "token-optimization": "bash .devcontainer/setup-token-optimization.sh"
     // NOTE: Compound Engineering plugin install + configure-llm-tools.sh run at
     // the end of the "setup" chain above (ordering-sensitive), not here.
   },

--- a/.devcontainer/setup-token-optimization.sh
+++ b/.devcontainer/setup-token-optimization.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Initializes rtk (shell-output compression) and CodeGraph (code knowledge graph)
+# for all installed AI agent CLIs in the devcontainer.
+#
+# Non-fatal: failures are logged but do not block container creation.
+set -euo pipefail
+
+echo "=== Setting up rtk (Rust Token Killer) ==="
+
+# rtk init for each supported agent. Each call configures that agent's hook
+# mechanism independently. --hook-only avoids adding RTK.md to context.
+for flags in "" "--codex" "--gemini" "--opencode"; do
+  if rtk init -g --auto-patch --hook-only $flags 2>/dev/null; then
+    echo "  rtk initialized for: ${flags:-claude/copilot (default)}"
+  else
+    echo "  WARNING: rtk init failed for: ${flags:-default} (non-fatal)"
+  fi
+done
+
+echo ""
+echo "=== Setting up CodeGraph ==="
+
+# Initialize the code knowledge graph for this workspace.
+if codegraph init 2>/dev/null; then
+  echo "  CodeGraph graph built for workspace"
+else
+  echo "  WARNING: codegraph init failed (non-fatal)"
+fi
+
+# Configure codegraph as a global MCP server for all detected agents.
+# --location=global avoids modifying project files (CLAUDE.md/AGENTS.md).
+if codegraph install --yes --location=global --no-permissions 2>/dev/null; then
+  echo "  CodeGraph MCP configured for detected agents"
+else
+  echo "  WARNING: codegraph install failed (non-fatal)"
+fi
+
+echo ""
+echo "Token optimization setup complete."

--- a/.github/workflows/pr-artifact-check.yml
+++ b/.github/workflows/pr-artifact-check.yml
@@ -135,6 +135,7 @@ jobs:
             ".ruby_env.sh"
             ".aider*"
             ".paid-heartbeat"
+            ".codegraph/"
             "vendor/bundle/"
             "vendor/gems/"
             "node_modules/"

--- a/.gitignore
+++ b/.gitignore
@@ -212,6 +212,9 @@ __pycache__/
 # Paid heartbeat file (touched by agent CLI hooks during container execution)
 .paid-heartbeat
 
+# CodeGraph index (built per-run by Containers::TokenOptimization)
+.codegraph/
+
 # Claude Code plan files (local scratch; should not be committed)
 .claude/plans/
 

--- a/app/services/accounts/operations/auto_capacity_observer.rb
+++ b/app/services/accounts/operations/auto_capacity_observer.rb
@@ -129,23 +129,33 @@ module Accounts
         references = inventory.build_references
         containers = inventory.list_running_containers(timeout: DOCKER_LIST_TIMEOUT)
 
-        containers.each_with_index do |container, index|
-          if sampling_budget_exceeded?(deadline)
-            unsampled = containers.length - index
-            warnings << sampling_budget_warning(unsampled)
-            usage[:other][:container_count] += unsampled
-            break
+        results = Capacity::ConcurrentStatsSampler.call(
+          containers: containers,
+          monotonic_deadline: deadline,
+          per_container_timeout: DOCKER_CONTAINER_TIMEOUT
+        ) { |container| backend.container_stats(container, stream: false) }
+
+        unsampled = results.count(&:skipped)
+        if unsampled.positive?
+          warnings << sampling_budget_warning(unsampled)
+          usage[:other][:container_count] += unsampled
+        end
+
+        results.each do |result|
+          next if result.skipped
+
+          if result.error
+            warnings << sampling_warning(result.error)
+            next
           end
 
-          stats = Containers::DockerStatsParser.parse_stats(
-            with_timeout(per_container_timeout(deadline)) { backend.container_stats(container, stream: false) }
-          )
-          bucket = usage_bucket_for(inventory.classify_container(container:, references:))
+          stats = Containers::DockerStatsParser.parse_stats(result.raw_stats)
+          bucket = usage_bucket_for(inventory.classify_container(container: result.container, references:))
 
           usage[bucket][:container_count] += 1
           usage[bucket][:cpu_percent] += stats[:cpu_percent]
           usage[bucket][:memory_bytes] += stats[:memory_bytes]
-          running_agent_count += 1 if inventory.running_paid_agent_container?(container:, references:)
+          running_agent_count += 1 if inventory.running_paid_agent_container?(container: result.container, references:)
         rescue StandardError => error
           warnings << sampling_warning(error)
         end
@@ -185,14 +195,6 @@ module Accounts
 
       def monotonic_now
         Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      end
-
-      def sampling_budget_exceeded?(deadline)
-        monotonic_now >= deadline
-      end
-
-      def per_container_timeout(deadline)
-        [ DOCKER_CONTAINER_TIMEOUT, deadline - monotonic_now ].min
       end
 
       def sampling_warning(error)

--- a/app/services/capacity/concurrent_stats_sampler.rb
+++ b/app/services/capacity/concurrent_stats_sampler.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "timeout"
+
+module Capacity
+  # Fetches Docker stats for a batch of containers concurrently, bounded by a
+  # shared deadline and a per-container timeout.
+  #
+  # Docker's non-streaming stats endpoint samples two CPU counters across an
+  # interval, so a single call routinely takes close to a second regardless
+  # of load. Sampling containers one at a time therefore exhausts any
+  # reasonable budget once more than a handful are running. A small worker
+  # pool keeps total wall-clock time roughly flat instead of scaling
+  # linearly with container count.
+  class ConcurrentStatsSampler
+    MAX_THREADS = 8
+
+    Result = Struct.new(:container, :raw_stats, :error, :skipped, keyword_init: true) do
+      def success?
+        !skipped && error.nil?
+      end
+    end
+
+    def self.call(...)
+      new(...).call
+    end
+
+    # monotonic_deadline: must be a Process::CLOCK_MONOTONIC timestamp (e.g.
+    # Process.clock_gettime(Process::CLOCK_MONOTONIC) + budget), not a
+    # Time.now/Time.current-based value -- it is compared directly against
+    # this class's own monotonic clock reads.
+    def initialize(containers:, monotonic_deadline:, per_container_timeout:, max_threads: MAX_THREADS, &fetch)
+      @containers = containers
+      @deadline = monotonic_deadline
+      @per_container_timeout = per_container_timeout
+      @max_threads = max_threads
+      @fetch = fetch
+    end
+
+    def call
+      return [] if containers.empty?
+
+      results = Array.new(containers.size)
+      work = Queue.new
+      containers.each_with_index { |container, index| work << [ container, index ] }
+
+      worker_count = [ max_threads, containers.size ].min
+      threads = Array.new(worker_count) { Thread.new { drain(work, results) } }
+      threads.each(&:join)
+
+      results
+    end
+
+    private
+
+    attr_reader :containers, :deadline, :per_container_timeout, :max_threads, :fetch
+
+    def drain(work, results)
+      loop do
+        container, index = work.pop(true)
+        results[index] = sample(container)
+      end
+    rescue ThreadError
+      nil
+    end
+
+    def sample(container)
+      remaining = deadline - monotonic_now
+      return Result.new(container: container, skipped: true) if remaining <= 0
+
+      raw_stats = Timeout.timeout([ per_container_timeout, remaining ].min) { fetch.call(container) }
+      Result.new(container: container, raw_stats: raw_stats)
+    rescue StandardError => e
+      Result.new(container: container, error: e)
+    end
+
+    def monotonic_now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+  end
+end

--- a/app/services/capacity/docker_snapshot.rb
+++ b/app/services/capacity/docker_snapshot.rb
@@ -144,8 +144,14 @@ module Capacity
     STALE_CACHE_TTL = 2.minutes
     DOCKER_INFO_TIMEOUT = 2.seconds
     DOCKER_LIST_TIMEOUT = 2.seconds
-    DOCKER_CONTAINER_TIMEOUT = 1.second
-    DOCKER_SAMPLING_BUDGET = 3.seconds
+    # Docker's non-streaming stats endpoint samples two CPU counters across
+    # an interval, so a single call routinely takes 1-2s alone and measurably
+    # longer once several calls are in flight at once against the same
+    # daemon. Sampling runs concurrently (see ConcurrentStatsSampler) bounded
+    # by ConcurrentStatsSampler::MAX_THREADS, so this budget covers a couple
+    # of worker batches rather than scaling with total container count.
+    DOCKER_CONTAINER_TIMEOUT = 4.seconds
+    DOCKER_SAMPLING_BUDGET = 10.seconds
     PAID_COMPOSE_PROJECT = "paid"
 
     PAID_COMPOSE_SERVICES = %w[
@@ -305,28 +311,37 @@ module Capacity
       sampling_deadline = monotonic_now + DOCKER_SAMPLING_BUDGET
       running_containers = inventory.list_running_containers(timeout: DOCKER_LIST_TIMEOUT)
 
-      running_containers.each_with_index do |container, index|
-        if sampling_budget_exceeded?(sampling_deadline)
+      results = ConcurrentStatsSampler.call(
+        containers: running_containers,
+        monotonic_deadline: sampling_deadline,
+        per_container_timeout: DOCKER_CONTAINER_TIMEOUT
+      ) { |container| backend.container_stats(container, stream: false) }
+
+      results.each do |result|
+        if result.skipped
           degraded_reasons << "container_sampling_budget_exceeded"
-          classify_remaining_containers_as_other_docker(
-            containers: running_containers.drop(index),
-            bucket: buckets.fetch(:other_docker)
+          accumulate_bucket(buckets.fetch(:other_docker), memory_bytes: 0, cpu_percent: 0.0)
+          next
+        end
+
+        if result.error
+          Rails.logger.warn(
+            message: "container_manager.docker_stats_sample_failed",
+            backend_identifier: backend.identifier,
+            error_class: result.error.class.name,
+            error_message: result.error.message
           )
-          break
-        end
-
-        classification = inventory.classify_container(container:, references:)
-        stats = sample_container(container, deadline: sampling_deadline)
-
-        if stats.nil?
           degraded_reasons << "container_sample_failed"
-          classification = :other_docker
+          accumulate_bucket(buckets.fetch(:other_docker), memory_bytes: 0, cpu_percent: 0.0)
+          next
         end
 
+        classification = inventory.classify_container(container: result.container, references:)
+        parsed = Containers::DockerStatsParser.parse_stats(result.raw_stats)
         accumulate_bucket(
           buckets.fetch(classification),
-          memory_bytes: stats&.fetch(:memory_bytes, 0) || 0,
-          cpu_percent: stats&.fetch(:cpu_percent, 0.0) || 0.0
+          memory_bytes: parsed.fetch(:memory_bytes, 0).to_i,
+          cpu_percent: parsed.fetch(:cpu_percent, 0.0).to_f.round(2)
         )
       end
 
@@ -352,23 +367,6 @@ module Capacity
       with_timeout(DOCKER_INFO_TIMEOUT) { backend.system_info }
     end
 
-    def sample_container(container, deadline:)
-      remaining_budget = deadline - monotonic_now
-      return nil if remaining_budget <= 0
-
-      raw = with_timeout([ DOCKER_CONTAINER_TIMEOUT, remaining_budget ].min) do
-        backend.container_stats(container, stream: false)
-      end
-      parsed = Containers::DockerStatsParser.parse_stats(raw)
-
-      {
-        memory_bytes: parsed.fetch(:memory_bytes, 0).to_i,
-        cpu_percent: parsed.fetch(:cpu_percent, 0.0).to_f.round(2)
-      }
-    rescue Timeout::Error, Docker::Error::DockerError, Docker::Error::ExconError, Excon::Error
-      nil
-    end
-
     def docker_container_inventory
       @docker_container_inventory ||= DockerContainerInventory.new(backend: backend)
     end
@@ -377,12 +375,6 @@ module Capacity
       bucket.container_count += 1
       bucket.memory_bytes += memory_bytes
       bucket.cpu_percent = (bucket.cpu_percent + cpu_percent).round(2)
-    end
-
-    def classify_remaining_containers_as_other_docker(containers:, bucket:)
-      containers.each do |_container|
-        accumulate_bucket(bucket, memory_bytes: 0, cpu_percent: 0.0)
-      end
     end
 
     def remaining_memory(system_info:, buckets:)
@@ -447,10 +439,6 @@ module Capacity
 
     def monotonic_now
       Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    end
-
-    def sampling_budget_exceeded?(deadline)
-      monotonic_now >= deadline
     end
 
     def deep_dup_buckets

--- a/app/services/containers/git_operations.rb
+++ b/app/services/containers/git_operations.rb
@@ -145,6 +145,8 @@ module Containers
       backups/
       # Paid heartbeat file (touched by agent CLI hooks)
       .paid-heartbeat
+      # CodeGraph index (built per-run by Containers::TokenOptimization)
+      .codegraph/
     PATTERNS
 
     # Maximum number of files allowed in the auto-commit safety net.

--- a/app/services/containers/token_optimization.rb
+++ b/app/services/containers/token_optimization.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Containers
+  # Sets up rtk (shell-output compression) and CodeGraph (code knowledge graph)
+  # inside agent containers to reduce token consumption during agent runs.
+  #
+  # Both tools are non-fatal optimizations — a failure to initialize either one
+  # is logged as a warning and the agent run proceeds without the optimization.
+  module TokenOptimization
+    # Maps Paid runner keys to the extra flags rtk needs for that runner's
+    # hook mechanism. Runners not listed here are skipped (rtk stays inert).
+    # Claude/Copilot share the default init (no extra flags).
+    RTK_RUNNER_FLAGS = {
+      "claude" => %w[],
+      "claude_code" => %w[],
+      "copilot" => %w[],
+      "codex" => %w[--codex],
+      "gemini" => %w[--gemini],
+      "opencode" => %w[--opencode],
+      "cursor" => %w[--agent cursor]
+    }.freeze
+
+    CODEGRAPH_INIT_TIMEOUT = 120
+    CODEGRAPH_INSTALL_TIMEOUT = 30
+    RTK_INIT_TIMEOUT = 30
+
+    # Initializes rtk hooks for the specific runner inside an already-started
+    # container. Uses --hook-only to avoid injecting RTK.md into the agent's
+    # context (zero added tokens), and --auto-patch for non-interactive setup.
+    def self.rtk_init_for_runner(container_service:, runner_key:)
+      flags = RTK_RUNNER_FLAGS[runner_key.to_s]
+      return unless flags # runner not supported by rtk
+
+      command = [ "rtk", "init", "-g", "--auto-patch", "--hook-only", *flags ]
+      container_service.execute(command, timeout: RTK_INIT_TIMEOUT)
+      Rails.logger.info(message: "container_manager.rtk_initialized", runner: runner_key.to_s)
+    rescue => e
+      Rails.logger.warn(
+        message: "container_manager.rtk_init_failed",
+        runner: runner_key.to_s,
+        error: e.message
+      )
+    end
+
+    # Builds the CodeGraph knowledge graph inside the workspace and configures
+    # the MCP server for all detected agents. Should be called after the repo
+    # is cloned so the full tree is available for indexing.
+    def self.codegraph_setup(container_service:)
+      codegraph_init(container_service: container_service)
+      codegraph_install(container_service: container_service)
+    end
+
+    # Builds the graph in .codegraph/codegraph.db inside /workspace.
+    def self.codegraph_init(container_service:)
+      container_service.execute([ "codegraph", "init" ], timeout: CODEGRAPH_INIT_TIMEOUT)
+      Rails.logger.info(message: "container_manager.codegraph_initialized")
+    rescue => e
+      Rails.logger.warn(
+        message: "container_manager.codegraph_init_failed",
+        error: e.message
+      )
+    end
+
+    # Configures codegraph as a global MCP server for all detected agents.
+    # Uses --location=global so project files (CLAUDE.md/AGENTS.md) are not
+    # modified — the MCP config goes into each agent's global config on tmpfs.
+    def self.codegraph_install(container_service:)
+      container_service.execute(
+        [ "codegraph", "install", "--yes", "--location=global", "--no-permissions" ],
+        timeout: CODEGRAPH_INSTALL_TIMEOUT
+      )
+      Rails.logger.info(message: "container_manager.codegraph_mcp_configured")
+    rescue => e
+      Rails.logger.warn(
+        message: "container_manager.codegraph_install_failed",
+        error: e.message
+      )
+    end
+  end
+end

--- a/app/temporal/activities/clone_repo_activity.rb
+++ b/app/temporal/activities/clone_repo_activity.rb
@@ -39,6 +39,10 @@ module Activities
         git_ops.install_artifact_excludes
         install_quality_hooks(git_ops, agent_run)
         git_ops.install_co_author_hook
+
+        heartbeat("clone_repo.codegraph_setup", agent_run_id: agent_run_id)
+        Containers::TokenOptimization.codegraph_setup(container_service: container_service)
+
         create_worktree_record(agent_run)
 
         { agent_run_id: agent_run_id, branch_name: agent_run.branch_name }

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -1446,6 +1446,8 @@ module Activities
 
       raise RunnerExecutionError, "Agent run already finished with status #{agent_run.status}" if agent_run.finished?
 
+      Containers::TokenOptimization.rtk_init_for_runner(container_service: container_service, runner_key: runner)
+
       pre_agent_sha = capture_head_sha(container_service, agent_run)
 
       run_runner_preflight!(

--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -217,6 +217,33 @@ RUN RATHOLE_VERSION=0.5.0 \
     && chmod +x /usr/local/bin/rathole \
     && rm "${RATHOLE_ASSET}"
 
+# Install rtk (Rust Token Killer) for compressed AI agent shell output.
+# rtk intercepts shell commands from AI agents and compresses the output 60-90%,
+# reducing context window consumption.
+# https://github.com/rtk-ai/rtk/releases
+RUN RTK_VERSION=0.43.0 \
+    && DEB_ARCH="$(dpkg --print-architecture)" \
+    && case "$DEB_ARCH" in \
+        amd64) RTK_ASSET="rtk-x86_64-unknown-linux-musl.tar.gz"; EXPECTED_CHECKSUM="ff8a1e7766496e175291a85aeca1dc97c9ff6df33e51e5893d1fbc78fea2a609" ;; \
+        arm64) RTK_ASSET="rtk-aarch64-unknown-linux-gnu.tar.gz"; EXPECTED_CHECKSUM="5519f7ca12e5c143a609f0d28a0a77b97413a8dce31c2681f1a41c24519a8731" ;; \
+        *) echo "Unsupported architecture: $DEB_ARCH" >&2; exit 1 ;; \
+    esac \
+    && TARBALL="${RTK_ASSET}" \
+    && curl -fsSL -o "${TARBALL}" "https://github.com/rtk-ai/rtk/releases/download/v${RTK_VERSION}/${RTK_ASSET}" \
+    && echo "${EXPECTED_CHECKSUM}  ${TARBALL}" | sha256sum -c - \
+    && tar -xzf "${TARBALL}" -C /usr/local/bin rtk \
+    && chmod +x /usr/local/bin/rtk \
+    && rm "${TARBALL}"
+
+# Install CodeGraph for local-first code intelligence via MCP.
+# Builds a code knowledge graph that agents query instead of grepping/reading
+# files one at a time, reducing tool calls and tokens.
+# Supply-chain hardening: --ignore-scripts — the package has no lifecycle scripts;
+# platform-specific native binaries are resolved via npm optionalDependencies.
+# https://github.com/colbymchenry/codegraph
+RUN CODEGRAPH_VERSION=1.5.0 \
+    && npm install -g --ignore-scripts "@colbymchenry/codegraph@${CODEGRAPH_VERSION}"
+
 # Create non-root user for security before provider-specific setup. Keeping
 # this separate from any one provider narrows the blast radius of future edits.
 RUN useradd -m -s /bin/bash agent \

--- a/scripts/test-agent-image-inner.sh
+++ b/scripts/test-agent-image-inner.sh
@@ -50,6 +50,8 @@ check_tool "   Bundler" bundler --version
 check_tool "   Python" python3 --version
 check_tool "   ast-grep" ast-grep --version
 check_tool "   scc" scc --version
+check_tool "   rtk" rtk --version
+check_tool "   CodeGraph" codegraph --version
 
 echo ""
 echo "2. Agent CLIs (help should succeed without auth):"

--- a/spec/services/accounts/operations/auto_capacity_observer_spec.rb
+++ b/spec/services/accounts/operations/auto_capacity_observer_spec.rb
@@ -75,6 +75,25 @@ RSpec.describe Accounts::Operations::AutoCapacityObserver do
     expect(payload.dig(:usage, :agent, :memory_bytes)).to eq(1.gigabyte)
   end
 
+  it "isolates a per-container parse failure instead of losing data for the whole batch" do
+    create_recent_run_profile!
+    healthy_container = docker_container(labels: { "paid.agent_run_id" => "123" }, memory_bytes: 1.gigabyte, cpu_percent: 55.0)
+    malformed_container = instance_double(
+      Docker::Container,
+      id: SecureRandom.hex(6),
+      info: { "State" => "running", "Config" => { "Labels" => {} } }
+    )
+    allow(backend).to receive(:container_stats).with(malformed_container, stream: false).and_return(nil)
+
+    allow(backend).to receive(:list_containers).with(no_args).and_return([ healthy_container, malformed_container ])
+
+    payload = described_class.call(account: account, manual_limit: 5, backend: backend, cache: cache)
+
+    expect(payload[:status]).to eq(:degraded)
+    expect(payload[:warnings]).not_to be_empty
+    expect(payload.dig(:usage, :agent, :memory_bytes)).to eq(1.gigabyte)
+  end
+
   it "clears agent headroom when the sampling budget exhausts before every container is inspected" do
     create_recent_run_profile!
     stub_const("Accounts::Operations::AutoCapacityObserver::DOCKER_SAMPLING_BUDGET", 0)

--- a/spec/services/capacity/concurrent_stats_sampler_spec.rb
+++ b/spec/services/capacity/concurrent_stats_sampler_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Capacity::ConcurrentStatsSampler do
+  describe ".call" do
+    it "returns results in the same order as the input containers" do
+      containers = %w[a b c d e]
+
+      results = described_class.call(
+        containers: containers,
+        monotonic_deadline: monotonic_now + 5,
+        per_container_timeout: 1
+      ) { |container| container.upcase }
+
+      expect(results.map(&:container)).to eq(containers)
+      expect(results.map(&:raw_stats)).to eq(%w[A B C D E])
+      expect(results).to all(be_success)
+    end
+
+    it "samples containers concurrently instead of scaling linearly with count" do
+      containers = Array.new(6) { |i| i }
+      started_at = monotonic_now
+
+      results = described_class.call(
+        containers: containers,
+        monotonic_deadline: started_at + 5,
+        per_container_timeout: 2
+      ) { |_container| sleep 0.3; :ok }
+
+      elapsed = monotonic_now - started_at
+
+      expect(results).to all(be_success)
+      expect(elapsed).to be < (6 * 0.3)
+    end
+
+    it "marks a container as skipped without invoking the block when the deadline has already passed" do
+      results = described_class.call(
+        containers: [ :only ],
+        monotonic_deadline: monotonic_now - 1,
+        per_container_timeout: 1
+      ) { |_container| raise "should not be called" }
+
+      expect(results.first.skipped).to be(true)
+      expect(results.first).not_to be_success
+    end
+
+    it "captures a per-container error without aborting the other containers" do
+      results = described_class.call(
+        containers: [ :ok, :boom ],
+        monotonic_deadline: monotonic_now + 5,
+        per_container_timeout: 1
+      ) { |container| container == :boom ? raise("kaboom") : :fine }
+
+      ok_result = results.find { |r| r.container == :ok }
+      boom_result = results.find { |r| r.container == :boom }
+
+      expect(ok_result).to be_success
+      expect(boom_result.error).to be_a(RuntimeError)
+      expect(boom_result).not_to be_success
+    end
+
+    it "times out a slow container without blocking a fast one" do
+      results = described_class.call(
+        containers: [ :slow, :fast ],
+        monotonic_deadline: monotonic_now + 5,
+        per_container_timeout: 0.05,
+        max_threads: 2
+      ) { |container| container == :slow ? sleep(1) : :fine }
+
+      slow_result = results.find { |r| r.container == :slow }
+      fast_result = results.find { |r| r.container == :fast }
+
+      expect(slow_result.error).to be_a(Timeout::Error)
+      expect(fast_result).to be_success
+    end
+
+    it "bounds concurrency to max_threads" do
+      concurrent = 0
+      peak = 0
+      mutex = Mutex.new
+
+      described_class.call(
+        containers: Array.new(10) { |i| i },
+        monotonic_deadline: monotonic_now + 5,
+        per_container_timeout: 1,
+        max_threads: 3
+      ) do |_container|
+        mutex.synchronize { concurrent += 1; peak = [ peak, concurrent ].max }
+        sleep 0.05
+        mutex.synchronize { concurrent -= 1 }
+      end
+
+      expect(peak).to be <= 3
+    end
+
+    it "returns an empty array for no containers" do
+      results = described_class.call(
+        containers: [],
+        monotonic_deadline: monotonic_now + 1,
+        per_container_timeout: 1
+      ) { |container| container }
+
+      expect(results).to eq([])
+    end
+  end
+
+  def monotonic_now
+    Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  end
+end

--- a/spec/services/capacity/docker_snapshot_spec.rb
+++ b/spec/services/capacity/docker_snapshot_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe Capacity::DockerSnapshot do
       expect(snapshot.available_memory_bytes).to eq(0)
     end
 
-    it "preserves classification of unrelated containers even with slow per-container sampling" do
+    it "degrades safely when every container sample runs past the shared budget" do
       stub_const("Capacity::DockerSnapshot::DOCKER_SAMPLING_BUDGET", 0.05)
       slow_backend = build_backend_double(
         identifier: "local",
@@ -148,7 +148,34 @@ RSpec.describe Capacity::DockerSnapshot do
       snapshot = described_class.call(backend: slow_backend, now: now, cache: cache)
 
       expect(snapshot).to be_degraded
+      expect(snapshot.available_memory_bytes).to eq(0)
+      expect(snapshot.degraded_reasons).to include("container_sample_failed")
+      expect(snapshot.usage_buckets.values.sum(&:container_count)).to eq(container_rows.size)
+    end
+
+    it "cuts off remaining containers once the shared sampling budget is exhausted" do
+      stub_const("Capacity::DockerSnapshot::DOCKER_SAMPLING_BUDGET", 0.05)
+      stub_const("Capacity::ConcurrentStatsSampler::MAX_THREADS", 1)
+      slow_backend = build_backend_double(
+        identifier: "local",
+        remote: false,
+        host_identifiers: [ "local" ],
+        containers: containers
+      )
+      call_count = 0
+      allow(slow_backend).to receive(:container_stats) do |_container, **_opts|
+        call_count += 1
+        sleep 1
+        {}
+      end
+
+      snapshot = described_class.call(backend: slow_backend, now: now, cache: cache)
+
+      expect(snapshot).to be_degraded
+      expect(snapshot.available_memory_bytes).to eq(0)
       expect(snapshot.degraded_reasons).to include("container_sampling_budget_exceeded")
+      expect(call_count).to be < container_rows.size
+      expect(snapshot.usage_buckets.values.sum(&:container_count)).to eq(container_rows.size)
     end
 
     it "classifies containers from fixtures into paid buckets and aggregates unrelated usage" do
@@ -274,26 +301,6 @@ RSpec.describe Capacity::DockerSnapshot do
       expect(snapshot.bucket(:paid_agents)).to have_attributes(container_count: 2, memory_bytes: 3_500)
       expect(snapshot.bucket(:paid_service_containers)).to have_attributes(container_count: 1, memory_bytes: 1_200)
       expect(snapshot.bucket(:paid_control_plane)).to have_attributes(container_count: 3, memory_bytes: 3_400)
-    end
-
-    it "cuts off container sampling once the shared deadline is exhausted" do
-      monotonic_times = [
-        100.0,
-        100.0,
-        100.2,
-        100.4,
-        103.1
-      ]
-      snapshotter = described_class.new(backend: backend, now: now, cache: cache, force_refresh: true)
-      allow(snapshotter).to receive(:monotonic_now) { monotonic_times.shift || 103.1 }
-
-      snapshot = snapshotter.call
-
-      expect(snapshot).to be_degraded
-      expect(snapshot.available_memory_bytes).to eq(0)
-      expect(snapshot.degraded_reasons).to include("container_sampling_budget_exceeded")
-      expect(snapshot.bucket(:paid_agents)).to have_attributes(container_count: 1, memory_bytes: 3_000, cpu_percent: 22.0)
-      expect(snapshot.bucket(:other_docker)).to have_attributes(container_count: 6, memory_bytes: 0, cpu_percent: 0.0)
     end
 
     it "only treats compose workdirs with an exact paid basename as control plane containers" do

--- a/spec/services/containers/token_optimization_spec.rb
+++ b/spec/services/containers/token_optimization_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Containers::TokenOptimization do
+  let(:container_service) { instance_double(Containers::Provision) }
+  let(:exec_success) { Containers::Provision::Result.success(stdout: "ok", stderr: "", exit_code: 0) }
+
+  before do
+    allow(container_service).to receive(:execute).and_return(exec_success)
+    allow(Rails.logger).to receive(:info)
+    allow(Rails.logger).to receive(:warn)
+  end
+
+  describe ".rtk_init_for_runner" do
+    context "with supported runners" do
+      {
+        "claude" => [],
+        "claude_code" => [],
+        "copilot" => [],
+        "codex" => %w[--codex],
+        "gemini" => %w[--gemini],
+        "opencode" => %w[--opencode],
+        "cursor" => %w[--agent cursor]
+      }.each do |runner, extra_flags|
+        it "runs rtk init with correct flags for #{runner}" do
+          expected_command = [ "rtk", "init", "-g", "--auto-patch", "--hook-only", *extra_flags ]
+
+          expect(container_service).to receive(:execute)
+            .with(expected_command, timeout: described_class::RTK_INIT_TIMEOUT)
+
+          described_class.rtk_init_for_runner(container_service: container_service, runner_key: runner)
+        end
+      end
+
+      it "accepts symbol runner keys" do
+        expect(container_service).to receive(:execute)
+          .with([ "rtk", "init", "-g", "--auto-patch", "--hook-only", "--codex" ],
+              timeout: described_class::CODEGRAPH_INSTALL_TIMEOUT)
+
+        described_class.rtk_init_for_runner(container_service: container_service, runner_key: :codex)
+      end
+    end
+
+    context "with unsupported runners" do
+      %w[kilocode pi aider unknown_runner].each do |runner|
+        it "does not call execute for #{runner}" do
+          expect(container_service).not_to receive(:execute)
+
+          described_class.rtk_init_for_runner(container_service: container_service, runner_key: runner)
+        end
+      end
+    end
+
+    it "is non-fatal when execute raises" do
+      allow(container_service).to receive(:execute)
+        .and_raise(Containers::Provision::ExecutionError.new("boom"))
+
+      expect {
+        described_class.rtk_init_for_runner(container_service: container_service, runner_key: "claude")
+      }.not_to raise_error
+
+      expect(Rails.logger).to have_received(:warn).with(
+        hash_including(message: "container_manager.rtk_init_failed", runner: "claude")
+      )
+    end
+  end
+
+  describe ".codegraph_setup" do
+    it "calls codegraph_init and codegraph_install" do
+      expect(described_class).to receive(:codegraph_init).with(container_service: container_service)
+      expect(described_class).to receive(:codegraph_install).with(container_service: container_service)
+
+      described_class.codegraph_setup(container_service: container_service)
+    end
+
+    it "executes both commands through the container service" do
+      described_class.codegraph_setup(container_service: container_service)
+
+      expect(container_service).to have_received(:execute).with(
+        [ "codegraph", "init" ], timeout: described_class::CODEGRAPH_INIT_TIMEOUT
+      )
+      expect(container_service).to have_received(:execute).with(
+        [ "codegraph", "install", "--yes", "--location=global", "--no-permissions" ],
+        timeout: described_class::CODEGRAPH_INSTALL_TIMEOUT
+      )
+    end
+  end
+
+  describe ".codegraph_init" do
+    it "runs codegraph init in the workspace" do
+      expect(container_service).to receive(:execute)
+        .with([ "codegraph", "init" ], timeout: described_class::CODEGRAPH_INIT_TIMEOUT)
+
+      described_class.codegraph_init(container_service: container_service)
+    end
+
+    it "is non-fatal when execute raises" do
+      allow(container_service).to receive(:execute)
+        .and_raise(Containers::Provision::TimeoutError.new("timed out"))
+
+      expect {
+        described_class.codegraph_init(container_service: container_service)
+      }.not_to raise_error
+
+      expect(Rails.logger).to have_received(:warn).with(
+        hash_including(message: "container_manager.codegraph_init_failed")
+      )
+    end
+  end
+
+  describe ".codegraph_install" do
+    it "configures MCP globally without modifying project files" do
+      expect(container_service).to receive(:execute)
+        .with([ "codegraph", "install", "--yes", "--location=global", "--no-permissions" ],
+              timeout: described_class::RTK_INIT_TIMEOUT)
+
+      described_class.codegraph_install(container_service: container_service)
+    end
+
+    it "is non-fatal when execute raises" do
+      allow(container_service).to receive(:execute)
+        .and_raise(StandardError, "install failed")
+
+      expect {
+        described_class.codegraph_install(container_service: container_service)
+      }.not_to raise_error
+
+      expect(Rails.logger).to have_received(:warn).with(
+        hash_including(message: "container_manager.codegraph_install_failed")
+      )
+    end
+  end
+end

--- a/spec/temporal/activities/clone_repo_activity_spec.rb
+++ b/spec/temporal/activities/clone_repo_activity_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Activities::CloneRepoActivity do
       allow(git_ops).to receive(:install_artifact_excludes)
       allow(git_ops).to receive(:install_git_hooks)
       allow(git_ops).to receive(:install_co_author_hook)
+      allow(container_service).to receive(:execute)
 
       # Simulate what clone_and_setup_branch does to agent_run
       agent_run.update!(
@@ -61,6 +62,13 @@ RSpec.describe Activities::CloneRepoActivity do
       expect(git_ops).to receive(:install_artifact_excludes).ordered
       expect(git_ops).to receive(:install_git_hooks).ordered
       expect(git_ops).to receive(:install_co_author_hook).ordered
+
+      activity.execute(agent_run_id: agent_run.id)
+    end
+
+    it "sets up codegraph after clone and hooks" do
+      expect(Containers::TokenOptimization).to receive(:codegraph_setup)
+        .with(container_service: container_service)
 
       activity.execute(agent_run_id: agent_run.id)
     end
@@ -119,7 +127,8 @@ RSpec.describe Activities::CloneRepoActivity do
         allow(git_ops).to receive(:clone_and_checkout_branch)
         allow(git_ops).to receive(:install_artifact_excludes)
         allow(git_ops).to receive(:install_git_hooks)
-        allow(git_ops).to receive(:install_co_author_hook)
+      allow(git_ops).to receive(:install_co_author_hook)
+      allow(container_service).to receive(:execute)
 
         agent_run.update!(
           branch_name: "existing-feature-branch",

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -47,6 +47,9 @@ RSpec.describe Activities::RunAgentActivity do
     # about preflight behaviour aren't affected by the smoke exec call.
     # Tests that verify preflight paths override this stub.
     allow(activity).to receive(:run_runner_preflight!)
+
+    # Stub rtk init so existing execute-call counts aren't affected.
+    allow(Containers::TokenOptimization).to receive(:rtk_init_for_runner)
   end
 
   def create_ab_test_assignment(slug:, agent_run:, variant_template:, status: "running")
@@ -1940,6 +1943,15 @@ expect(container_service).to receive(:execute).with(
         allow(git_ops).to receive(:has_changes_since?).and_return(false)
 
         expect(git_ops).to receive(:head_sha).and_return("pre_agent_sha_abc123")
+
+        activity.execute(agent_run_id: agent_run.id)
+      end
+
+      it "initializes rtk for the runner before preflight" do
+        allow(git_ops).to receive(:has_changes_since?).and_return(false)
+
+        expect(Containers::TokenOptimization).to receive(:rtk_init_for_runner)
+          .with(container_service: container_service, runner_key: anything)
 
         activity.execute(agent_run_id: agent_run.id)
       end


### PR DESCRIPTION
## Summary

Agent runs now consume fewer tokens via two tools installed in both the devcontainer and agent container: **rtk** compresses shell command output 60–90% via transparent hooks, and **CodeGraph** lets agents query a local code knowledge graph instead of reading files one at a time. Separately, Docker container stats sampling — which feeds capacity observability — now runs concurrently instead of sequentially, preventing one slow `docker stats` call from timing out the entire batch.

## Changes

**Token optimization (rtk + CodeGraph)**

- Installed rtk v0.43.0 and CodeGraph v1.5.0 in both `.devcontainer/Dockerfile` and `docker/agent/Dockerfile` with SHA256 checksums and arch-aware asset selection
- `Containers::TokenOptimization` module orchestrates runtime init:
  - `CloneRepoActivity` calls `codegraph_setup` after clone+hooks (builds graph, configures MCP globally)
  - `RunAgentActivity` calls `rtk_init_for_runner` before preflight (sets up hooks for the active runner)
- Both tools are non-fatal — failures log warnings and the run proceeds normally
- `.codegraph/` added to all three artifact defense layers (`.gitignore`, `CONTAINER_ARTIFACT_EXCLUDES`, `pr-artifact-check.yml`)
- Includes `claude_code` runner key (API-key-backed Claude runners) and dedicated `CODEGRAPH_INSTALL_TIMEOUT` constant

**Concurrent Docker stats sampling**

- New `Capacity::ConcurrentStatsSampler` fetches container stats in parallel (bounded by `MAX_THREADS`)
- Both `DockerSnapshot` and `AutoCapacityObserver` use the shared sampler
- Per-container timeouts and errors are isolated — one slow or failing `docker stats` call no longer loses data for the entire remaining batch

## Test plan

- `spec/services/containers/token_optimization_spec.rb` — 19 tests covering all runner keys, codegraph init/install, and non-fatal error handling
- `spec/services/capacity/concurrent_stats_sampler_spec.rb` — concurrency bounds, timeout isolation, error isolation
- `spec/temporal/activities/clone_repo_activity_spec.rb` — 22 tests including new codegraph setup assertion
- `spec/temporal/activities/run_agent_activity_spec.rb` — 276 tests including new rtk init assertion
- All tests pass, `bin/lint --changed` clean

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/GLM_5.1-000000)
