### PR TITLE
fix(db): remove nonexistent trigger_exists? guard from docker_hosts logidze migration

### DIFF
--- a/db/migrate/20260723042956_add_logidze_to_docker_hosts.rb
+++ b/db/migrate/20260723042956_add_logidze_to_docker_hosts.rb
@@ -6,8 +6,6 @@ class AddLogidzeToDockerHosts < ActiveRecord::Migration[8.1]
 
     reversible do |dir|
       dir.up do
-        next if trigger_exists?(:docker_hosts, :logidze_on_docker_hosts)
-
         create_trigger :logidze_on_docker_hosts, on: :docker_hosts
       end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -3996,6 +3996,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_24_035127) do
       CREATE TRIGGER logidze_on_cost_budgets BEFORE INSERT OR UPDATE ON public.cost_budgets FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
 
+  create_trigger :logidze_on_docker_hosts, sql_definition: <<-SQL
+      CREATE TRIGGER logidze_on_docker_hosts BEFORE INSERT OR UPDATE ON public.docker_hosts FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
+  SQL
+
   create_trigger :logidze_on_exception_incidents, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_exception_incidents BEFORE INSERT OR UPDATE ON public.exception_incidents FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{occurrence_count,last_occurred_at,backtrace,context}')
   SQL
@@ -4090,9 +4094,5 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_24_035127) do
 
   create_trigger :logidze_on_users, sql_definition: <<-SQL
       CREATE TRIGGER logidze_on_users BEFORE INSERT OR UPDATE ON public.users FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at', '{encrypted_password,reset_password_token,reset_password_sent_at,remember_created_at}')
-  SQL
-
-  create_trigger :logidze_on_docker_hosts, sql_definition: <<-SQL
-      CREATE TRIGGER logidze_on_docker_hosts BEFORE INSERT OR UPDATE ON public.docker_hosts FOR EACH ROW WHEN ((COALESCE(current_setting('logidze.disabled'::text, true), ''::text) <> 'on'::text)) EXECUTE FUNCTION logidze_logger('null', 'updated_at')
   SQL
 end


### PR DESCRIPTION
## Summary
- `db/migrate/20260723042956_add_logidze_to_docker_hosts.rb` called `trigger_exists?`, a method that does not exist on the `fx` gem (0.11.0) or in Rails migrations — it only exposes `create_trigger`/`drop_trigger`/`update_trigger`. This broke `bin/rails db:prepare`/`bin/setup` for anyone running migrations from scratch (`NoMethodError: undefined method 'trigger_exists?'`).
- Removed the bogus guard so the migration matches every other logidze migration in the repo (e.g. `add_logidze_to_runner_credentials.rb`), which calls `create_trigger` unconditionally.
- Regenerated `db/schema.rb` from a clean `db:schema:dump` — the only change is the `logidze_on_docker_hosts` trigger definition moving to its alphabetically-sorted position, matching fx's standard dump order.

## Test plan
- [x] `bin/rails db:migrate` runs the migration cleanly against a fresh DB
- [x] `bin/setup` completes end-to-end without error
- [x] `git diff db/schema.rb` shows only trigger reordering, no content changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)