### PR TITLE
fix(mutation): disable SimpleCov during mutation sweeps

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -23,6 +23,10 @@ env:
   DB_USERNAME: postgres
   DB_PASSWORD: postgres
   MUTANT_OUTPUT_FILE: tmp/mutant.log
+  # Mutation sweeps only exercise the configured subjects, so whole-codebase
+  # line coverage is near zero. Disable SimpleCov so its minimum_coverage gate
+  # can't fail the run and its per-fork instrumentation can't stall workers.
+  COVERAGE: "false"
 
 jobs:
   incremental:

--- a/spec/paid/spec_helper_coverage_spec.rb
+++ b/spec/paid/spec_helper_coverage_spec.rb
@@ -7,10 +7,11 @@ class SpecHelperCoverage < Pathname
 end
 
 RSpec.describe SpecHelperCoverage, :no_db do
-  let(:probe_script) do
+  def probe_script(prelude: nil)
     <<~RUBY
       require "bundler/setup"
       require "rspec/core"
+      #{prelude}
       require_relative "spec/spec_helper"
       if Object.const_defined?(:SimpleCov)
         SimpleCov.command_name("spec_helper_coverage_probe-\#{Process.pid}")
@@ -55,6 +56,24 @@ RSpec.describe SpecHelperCoverage, :no_db do
         "COVERAGE" => "false"
       },
       "bundle", "exec", "ruby", "-e", probe_script,
+      chdir: Rails.root.to_s
+    )
+
+    expect(status.success?).to be(true), stderr
+    expect(stdout.lines.first.to_s.strip).to eq("false")
+  end
+
+  it "disables coverage during mutation sweeps, even when explicitly requested" do
+    # Mutant loads spec_helper in its main process via the rspec integration,
+    # so ::Mutant is defined at coverage-decision time. Whole-codebase line
+    # coverage is meaningless for a scoped mutation run and previously failed
+    # the job via the minimum_coverage gate, so SimpleCov must never start.
+    stdout, stderr, status = Open3.capture3(
+      {
+        "ALLOW_DBLESS_SPECS" => "true",
+        "COVERAGE" => "true"
+      },
+      "bundle", "exec", "ruby", "-e", probe_script(prelude: "Mutant = Module.new"),
       chdir: Rails.root.to_s
     )
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,15 @@ unless defined?(SpecRunMode)
   end
 end
 
-coverage_enabled = if ENV.key?("COVERAGE")
+coverage_enabled = if defined?(::Mutant)
+  # Mutant loads spec_helper in its main process (via the rspec integration),
+  # and each forked worker inherits that state. A mutation sweep only exercises
+  # a handful of subjects, so whole-codebase line coverage is near zero and
+  # would trip the minimum_coverage gate below — failing otherwise-healthy
+  # runs and adding per-fork coverage overhead that stalls the sweep. Line
+  # coverage is irrelevant to mutation testing, so never start SimpleCov here.
+  false
+elsif ENV.key?("COVERAGE")
   ENV["COVERAGE"] != "false"
 else
   # DB-less verification runs intentionally execute only a small subset of the


### PR DESCRIPTION
## Problem

The nightly **Mutation** workflow (`schedule`) has failed every run for 3+ weeks with one of two symptoms:

| Symptom | Cause |
|---|---|
| **exit 143** — runner shutdown mid-sweep | workers deadlock (killtime frozen, runtime ticking) until GitHub terminates the runner |
| **exit 2** — `SimpleCov failed … coverage related error` | SimpleCov's `minimum_coverage(80)` gate trips |

Example: [Mutation #1565](https://github.com/viamin/paid/actions/runs/30199105745) — killed at 80 min (before the 90-min timeout) at 268/370.

## Root cause

Both share one bug: **SimpleCov starts inside mutant's main process.**

Mutant's rspec integration loads `spec_helper` in the main process, so `SimpleCov.start` runs there and each forked worker inherits it. A scoped mutation sweep only exercises ~20 subjects, so whole-codebase line coverage is ~0% → the `minimum_coverage(80)` gate fails completed runs (exit 2).

The `simplecov` **0.22 → 1.0** bump (#2919, 2026-07-14) then turned this into a hard hang: 1.0's per-fork resultset merging contends across the 4 forking workers, deadlocking them (frozen killtime, ticking runtime) until GitHub shuts the runner down (exit 143). The failure mode shift lines up exactly with that bump.

`.mutant.yml`'s `COVERAGE: "false"` only sets the **fork** environment — it cannot undo a SimpleCov already started in the main process.

## Fix

- **`spec/spec_helper.rb`** — skip SimpleCov entirely when running under mutant (`defined?(::Mutant)`). This is the root-cause fix and covers every invocation path (CI full, CI incremental, local).
- **`.github/workflows/mutation.yml`** — set `COVERAGE: "false"` at the workflow level: a CI-hardened backup that doesn't depend on mutant internals, and explicit intent at the surface where the bug manifested.

Line coverage is irrelevant to mutation testing, so no signal is lost.

## Verification

- Probe with `::Mutant` defined → SimpleCov **not** loaded (`const_defined?(:SimpleCov) == false`).
- New regression test in `spec/paid/spec_helper_coverage_spec.rb` asserts SimpleCov stays unloaded under mutant **even with `COVERAGE=true`**; confirmed it **fails when the guard is removed** and passes with it.
- All 4 `spec_helper_coverage` cases green; RuboCop clean; existing env-var coverage behavior unchanged.
- The 7/12 run (pre-bump) proves the suite completes in ~5 min once SimpleCov isn't interfering → the 90-min timeout is ample.

## Notes

- This also fixes the latent same bug in the **incremental** (PR) mutation job, which would have failed exit-2 whenever a PR touched a tier-1 subject.
- Residual risk: I could not reproduce the *hang* delta locally (devcontainer too resource-contended for clean mutant benchmarks). The first nightly run post-merge is the final confirmation.
