### PR TITLE
feat: remove Aider runner support

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -21,7 +21,6 @@ services:
     - agent-opencode-data:/home/vscode/.local/share/opencode
     - agent-copilot:/home/vscode/.copilot
     - agent-kilocode:/home/vscode/.kilocode
-    - agent-aider:/home/vscode/.aider
     - agent-cursor:/home/vscode/.cursor
     - agent-omp:/home/vscode/.omp
 
@@ -121,6 +120,5 @@ volumes:
   agent-opencode-data:
   agent-copilot:
   agent-kilocode:
-  agent-aider:
   agent-cursor:
   agent-omp:

--- a/.devcontainer/configure-llm-tools.sh
+++ b/.devcontainer/configure-llm-tools.sh
@@ -92,41 +92,6 @@ if [ -f "/usr/local/bin/codex" ] && [ ! -f "/usr/local/bin/codex.real" ]; then
 fi
 
 # ============================================================================
-# Aider
-# ============================================================================
-
-# Create Aider path shim (resolves install location; does not add auto-approval flags
-# since Aider does not have a global auto-approve mode)
-echo "[DEBUG] Creating Aider path shim..."
-cat << 'EOF' | sudo tee "$WRAPPER_DIR/aider" > /dev/null
-#!/bin/bash
-# Aider path shim for devcontainer
-# Prefer user-local installation if present
-if [ -f "$HOME/.local/bin/aider" ]; then
-  exec "$HOME/.local/bin/aider" "$@"
-fi
-
-# Resolve this shim's canonical path to avoid recursion
-SELF_PATH="$(readlink -f "$0" 2>/dev/null || echo "$0")"
-AIDER_CMD="$(command -v aider 2>/dev/null || true)"
-if [ -n "$AIDER_CMD" ]; then
-  AIDER_REAL="$(readlink -f "$AIDER_CMD" 2>/dev/null || echo "$AIDER_CMD")"
-  if [ "$AIDER_REAL" != "$SELF_PATH" ]; then
-    exec "$AIDER_CMD" "$@"
-  fi
-fi
-
-echo "Error: could not locate a real 'aider' binary." >&2
-exit 1
-EOF
-sudo chmod +x "$WRAPPER_DIR/aider"
-
-# Link to /usr/local/bin if not already present
-if [ ! -f "/usr/local/bin/aider" ]; then
-  sudo ln -sf "$WRAPPER_DIR/aider" /usr/local/bin/aider
-fi
-
-# ============================================================================
 # Gemini CLI
 # ============================================================================
 
@@ -248,7 +213,6 @@ echo "  - Claude: Dangerous mode (--dangerously-skip-permissions)"
 echo "  - Codex: Auto-approve mode (approval_policy=never, sandbox=danger-full-access)"
 echo "  - Gemini CLI: Auto-accept mode (autoAccept=true)"
 echo "  - KiloCode: Auto-approve mode (permission=allow, container-specific config)"
-echo "  - Aider: Path shim (no global auto-approve mode available)"
 echo "  - Cursor: Config mounted from host (~/.cursor)"
 echo "  - OpenCode: Auto-approve mode (permission=allow, container-specific config)"
 echo "  - GitHub Copilot CLI: Config mounted from host (~/.copilot)"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -46,7 +46,6 @@
     "GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}"
   },
   "remoteEnv": {
-    "AIDER_NO_BROWSER": "1",
     "GEMINI_API_KEY": "${localEnv:GEMINI_API_KEY}",
     "OVERMIND_SOCKET": "${containerWorkspaceFolder}/.overmind.sock",
     "PATH": "${containerEnv:PATH}:/home/vscode/.local/bin:/home/vscode/.bun/bin"
@@ -110,7 +109,6 @@
     "github-copilot-cli": "bash scripts/install-from-contract.sh copilot",
     "kilocode": "bash scripts/install-from-contract.sh kilocode",
     "cursor-agent": "bash scripts/install-from-contract.sh cursor",
-    "aider": "bash scripts/install-from-contract.sh aider",
     "opencode": "bash scripts/install-from-contract.sh opencode",
     "oh-my-pi": "bash .devcontainer/install-oh-my-pi.sh",
     // Dev tools

--- a/.devcontainer/init-agent-volumes.sh
+++ b/.devcontainer/init-agent-volumes.sh
@@ -22,7 +22,6 @@ AGENT_DIRS=(
   "$HOME/.local/share/opencode"
   "$HOME/.copilot"
   "$HOME/.kilocode"
-  "$HOME/.aider"
   "$HOME/.cursor"
   "$HOME/.omp"
 )

--- a/.github/workflows/agent-image.yml
+++ b/.github/workflows/agent-image.yml
@@ -351,20 +351,6 @@ jobs:
           echo "$install_command" >> "$GITHUB_OUTPUT"
           echo "PAID_EOF" >> "$GITHUB_OUTPUT"
 
-      - name: Extract Aider CLI install contract from agent-harness
-        if: steps.changes.outputs.image_relevant == 'true'
-        id: aider-contract
-        run: |
-          contract=$(bundle exec ruby scripts/extract-runner-install-contract.rb aider)
-          install_command=$(echo "$contract" | sed -n 's/^INSTALL_COMMAND=//p')
-          if [ -z "$install_command" ]; then
-            echo "Failed to extract Aider CLI install command from agent-harness" >&2
-            exit 1
-          fi
-          echo "install_command<<PAID_EOF" >> "$GITHUB_OUTPUT"
-          echo "$install_command" >> "$GITHUB_OUTPUT"
-          echo "PAID_EOF" >> "$GITHUB_OUTPUT"
-
       - name: Extract Copilot CLI install contract from agent-harness
         if: steps.changes.outputs.image_relevant == 'true'
         id: copilot-contract
@@ -404,7 +390,6 @@ jobs:
             PI_PACKAGE=${{ steps.pi-contract.outputs.package }}
             KILOCODE_INSTALL_COMMAND=${{ steps.kilocode-contract.outputs.install_command }}
             GEMINI_CLI_INSTALL_COMMAND=${{ steps.gemini-contract.outputs.install_command }}
-            AIDER_INSTALL_COMMAND=${{ steps.aider-contract.outputs.install_command }}
             COPILOT_INSTALL_COMMAND=${{ steps.copilot-contract.outputs.install_command }}
           cache-from: type=gha,scope=paid-agent
           cache-to: type=gha,mode=max,scope=paid-agent

--- a/.github/workflows/pr-artifact-check.yml
+++ b/.github/workflows/pr-artifact-check.yml
@@ -133,7 +133,6 @@ jobs:
             "backups/"
             ".pg_log.txt"
             ".ruby_env.sh"
-            ".aider*"
             ".paid-heartbeat"
             ".codegraph/"
             "vendor/bundle/"

--- a/.gitignore
+++ b/.gitignore
@@ -206,8 +206,6 @@ __pycache__/
 /.yarn-cache-v2/
 /.yarn-local-cache/
 
-# Aider tool artifacts
-.aider*
 
 # Paid heartbeat file (touched by agent CLI hooks during container execution)
 .paid-heartbeat

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Paid stores every decision point as data—prompts, model preferences, workflow 
 - **GitHub Integration**: Add projects via PAT, watch for labeled issues
 - **Temporal Workflows**: Durable, observable orchestration of agent activities
 - **Container Isolation**: Agents run in sandboxed Docker containers. Proxy-mode runs use the restricted `paid_agent` network with no default internet access; subscription-auth and direct-outbound provider runs use `paid_internal` so provider CLIs can reach upstream APIs directly.
-- **Multiple Agents and Providers**: Support for Claude Code, Codex, Cursor, Gemini, Aider, OpenCode, Kilocode, Pi, and Copilot when the runtime is both supported by `agent-harness` and installed in `paid-agent`
+- **Multiple Agents and Providers**: Support for Claude Code, Codex, Cursor, Gemini, OpenCode, Kilocode, Pi, and Copilot when the runtime is both supported by `agent-harness` and installed in `paid-agent`
   - Gap: broader runtime parity is tracked by provider metadata and smoke-test refactors ([#798](https://github.com/viamin/paid/issues/798), [#796](https://github.com/viamin/paid/issues/796)) plus agent-image install delegation work ([#789](https://github.com/viamin/paid/issues/789)-[#795](https://github.com/viamin/paid/issues/795)).
 - **Secrets Proxy**: Git credentials, default platform LLM keys, and stored provider API-key auth for proxy-compatible agent CLIs are proxied through authenticated endpoints
   - Caveat: subscription auth intentionally copies CLI login state into the agent runtime, and direct-outbound OpenCode/KiloCode API-key providers still place provider credentials in runtime config because they can target non-proxied upstream APIs. Knowledge-side direct key usage is tracked by [#1043](https://github.com/viamin/paid/issues/1043) and [#1044](https://github.com/viamin/paid/issues/1044).
@@ -214,7 +214,7 @@ bin/dev                 # Start Rails, JS/CSS watchers, GoodJob, and the split T
 By default, provider tests and real agent runs use the same containerized auth path. For Codex and Gemini, when a Paid-managed proxy key is configured on the `web` service, Test Agent can instead use the agent-harness auth path for faster validation. Each provider can usually be configured in one of two ways:
 
 1. Paid-managed proxy auth using an API key on the `web` service.
-2. Stored provider API-key auth using an API key saved in Paid. For Claude, Codex, Gemini, Cursor, and Aider agent runs, Paid keeps the stored key server-side and routes provider calls through the secrets proxy.
+2. Stored provider API-key auth using an API key saved in Paid. For Claude, Codex, Gemini, and Cursor agent runs, Paid keeps the stored key server-side and routes provider calls through the secrets proxy.
 3. Subscription auth using local CLI login state that Paid copies into the agent container.
 
 OpenCode and KiloCode direct-outbound API-key entries are the exception: Paid writes their runtime provider config inside the agent container because those tools can target upstream APIs that the secrets proxy does not cover.
@@ -340,7 +340,7 @@ bin/ci                       # Runs setup, lint, and security audit
                              │
 ┌────────────────────────────▼────────────────────────────────────┐
 │        Docker Containers (paid_agent or paid_internal)           │
-│   Agent CLI (Claude, Codex, Cursor, Gemini, Aider, ...)         │
+│   Agent CLI (Claude, Codex, Cursor, Gemini, ...)                 │
 │   ── Proxy mode: Secrets Proxy ──► Provider APIs                │
 │   ── Subscription/direct outbound: HTTPS to Provider APIs        │
 │   ── Git Credential Proxy ──► GitHub                            │

--- a/app/controllers/runners_controller.rb
+++ b/app/controllers/runners_controller.rb
@@ -232,7 +232,7 @@ class RunnersController < ApplicationController
     end
     attrs = raw_params.permit(
       *permitted,
-      config: { opencode: [ :api_provider, :model ], kilocode: [ :api_provider, :model, :preflight_timeout_seconds ], aider: [ :api_provider, :model ],
+      config: { opencode: [ :api_provider, :model ], kilocode: [ :api_provider, :model, :preflight_timeout_seconds ],
                 pi: [ :api_provider, :model ] },
       tier_model_ids: LlmModel::TIERS,
       complexity_thresholds: Runner::COMPLEXITY_THRESHOLD_KEYS
@@ -277,7 +277,7 @@ class RunnersController < ApplicationController
     addable_keys = resource_addable_keys
     existing_subscription_keys = resource_records.kept_only.subscription.pluck(:runner_key)
     # Only single-instance api_key runners (e.g. openrouter_free) are hidden
-    # once added. Other api_key runners (opencode, kilocode, aider, pi) allow
+    # once added. Other api_key runners (opencode, kilocode, pi) allow
     # legitimate duplicates when the API key or name differs, so they must
     # keep appearing in the "Add Runner" options.
     existing_single_instance_keys = resource_records.kept_only.api_key.pluck(:runner_key)
@@ -685,7 +685,7 @@ class RunnersController < ApplicationController
   def compatible_api_key_for_runner?(api_key:, runner_key:)
     # Direct-outbound runners support multiple API key types depending on the
     # selected api_provider, so check against all compatible service types.
-    if %w[opencode kilocode aider].include?(runner_key)
+    if %w[opencode kilocode].include?(runner_key)
       return resource_model_class::DIRECT_OUTBOUND_SERVICE_TYPES.include?(api_key.api_service_type)
     end
     if runner_key == "pi"

--- a/app/javascript/controllers/runner_form_controller.js
+++ b/app/javascript/controllers/runner_form_controller.js
@@ -18,7 +18,6 @@ function loadRunnerApiServiceType() {
     claude: "anthropic",
     cursor: "anthropic",
     codex: "openai",
-    aider: "anthropic",
     gemini: "google",
     openrouter_free: "openrouter",
     openrouter_pareto: "openrouter",
@@ -27,7 +26,7 @@ function loadRunnerApiServiceType() {
 
 const RUNNER_API_SERVICE_TYPE = loadRunnerApiServiceType()
 
-// OpenCode, KiloCode, Aider, and Pi support multiple upstream API providers, each with its
+// OpenCode, KiloCode, and Pi support multiple upstream API providers, each with its
 // own API key type. The mapping is derived from data-service-type attributes on
 // the <option> elements rendered by the backend (Runner::DIRECT_OUTBOUND_API_PROVIDERS),
 // keeping the backend as the single source of truth.
@@ -53,7 +52,7 @@ function loadDirectOutboundApiProviderServiceTypes() {
 }
 
 // Runner keys that use dynamic api_provider selection.
-const DYNAMIC_API_RUNNER_KEYS = new Set(["opencode", "kilocode", "aider", "pi"])
+const DYNAMIC_API_RUNNER_KEYS = new Set(["opencode", "kilocode", "pi"])
 
 export default class extends Controller {
   static values = {
@@ -70,7 +69,6 @@ export default class extends Controller {
     "apiKeyOption",
     "opencodeSettings",
     "kilocodeSettings",
-    "aiderSettings",
     "piSettings",
     "directOutboundApiProviderSelect",
     "tierSettings",
@@ -122,7 +120,6 @@ export default class extends Controller {
     const isApiKey = this.runnerApiKeyMode()
     const showOpenCodeSettings = isApiKey && runnerKey === "opencode"
     const showKiloCodeSettings = isApiKey && runnerKey === "kilocode"
-    const showAiderSettings = isApiKey && runnerKey === "aider"
     const showPiSettings = isApiKey && runnerKey === "pi"
 
     this.opencodeSettingsTargets.forEach((el) => {
@@ -136,13 +133,6 @@ export default class extends Controller {
       el.hidden = !showKiloCodeSettings
       el.querySelectorAll("select, input").forEach((control) => {
         control.disabled = !showKiloCodeSettings
-      })
-    })
-
-    this.aiderSettingsTargets.forEach((el) => {
-      el.hidden = !showAiderSettings
-      el.querySelectorAll("select, input").forEach((control) => {
-        control.disabled = !showAiderSettings
       })
     })
 
@@ -209,7 +199,7 @@ export default class extends Controller {
   requiredApiServiceTypeFor(runnerKey) {
     if (!runnerKey) return null
 
-    // OpenCode, KiloCode, Aider, and Pi determine their required API key type from
+    // OpenCode, KiloCode, and Pi determine their required API key type from
     // the selected api_provider dropdown.
     if (DYNAMIC_API_RUNNER_KEYS.has(runnerKey)) {
       const apiProvider = this.currentDirectOutboundApiProvider(runnerKey)

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -15,7 +15,7 @@ class AgentRun < ApplicationRecord
     [ /(Bearer\s)[A-Za-z0-9\-._~+\/]+=*/i, "\\1[REDACTED]" ]
   ].freeze
   STATUSES = %w[queued running paused completed no_output failed cancelled timeout token_budget_exceeded retried auth_expired rate_limited].freeze
-  AGENT_TYPES = %w[claude_code cursor codex copilot aider gemini opencode kilocode pi api devin factory internal_agent].freeze
+  AGENT_TYPES = %w[claude_code cursor codex copilot gemini opencode kilocode pi api devin factory internal_agent].freeze
   FOCUSES = %w[general ci_fix review_feedback merge_conflict conversation issue_implementation label_action].freeze
   # analyze_issue is automation-only (triggered via Automation::Decision), not exposed in the manual run form.
   GOALS = %w[create_pr create_issue review enhance_issue analyze_issue].freeze

--- a/app/models/provider_api_key.rb
+++ b/app/models/provider_api_key.rb
@@ -25,9 +25,9 @@ class ProviderApiKey < ApplicationRecord
   # Returns true when this API key's service type is compatible with the
   # given provider. Providers with a fixed service type (claude → anthropic)
   # are checked against ProviderSupport::PROVIDER_API_SERVICE_TYPE. Providers
-  # that support multiple upstream API providers (opencode, kilocode, aider, pi)
+  # that support multiple upstream API providers (opencode, kilocode, pi)
   # resolve compatibility from their provider-specific service-type sets.
-  DYNAMIC_API_PROVIDER_KEYS = %w[opencode kilocode aider pi].to_set.freeze
+  DYNAMIC_API_PROVIDER_KEYS = %w[opencode kilocode pi].to_set.freeze
 
   def compatible_with?(provider_key)
     if DYNAMIC_API_PROVIDER_KEYS.include?(provider_key.to_s)

--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -94,9 +94,6 @@ class Runner < ApplicationRecord
   }.freeze
   MIN_PREFLIGHT_TIMEOUT_SECONDS = 1
 
-  AIDER_API_PROVIDER_KEYS = DIRECT_OUTBOUND_API_PROVIDERS.keys.freeze
-  AIDER_DEFAULT_API_PROVIDER = "openrouter"
-
   # Pi supports multiple upstream API-key providers selected via --provider.
   # Keep this list aligned to providers Paid can represent as ProviderApiKey
   # records and that Pi documents as built-in API-key auth targets.
@@ -184,7 +181,6 @@ class Runner < ApplicationRecord
   validate :api_key_entry_must_be_unique
   validate :opencode_api_key_config_must_be_valid
   validate :kilocode_api_key_config_must_be_valid
-  validate :aider_api_key_config_must_be_valid
   validate :pi_api_key_config_must_be_valid
   validate :direct_outbound_config_models_must_exist_in_catalog
   validate :openrouter_free_requires_api_key_auth
@@ -234,7 +230,6 @@ class Runner < ApplicationRecord
     model_id = case runner_key
     when "opencode" then opencode_model_id
     when "kilocode" then kilocode_model_id
-    when "aider" then aider_model_id
     when "pi" then pi_model_id
     end
     label += " #{model_id}" if model_id.present?
@@ -379,22 +374,6 @@ class Runner < ApplicationRecord
     DIRECT_OUTBOUND_API_PROVIDERS.dig(kilocode_api_provider, :service_type)
   end
 
-  def aider_config
-    config.is_a?(Hash) ? config.fetch("aider", {}) : {}
-  end
-
-  def aider_api_provider
-    return nil unless runner_key == "aider"
-
-    aider_config["api_provider"].presence || AIDER_DEFAULT_API_PROVIDER
-  end
-
-  def aider_model_id
-    return nil unless runner_key == "aider"
-
-    aider_config["model"].to_s.presence
-  end
-
   def pi_config
     config.is_a?(Hash) ? config.fetch("pi", {}) : {}
   end
@@ -417,17 +396,6 @@ class Runner < ApplicationRecord
     PI_API_PROVIDERS.dig(pi_api_provider, :service_type)
   end
 
-  def aider_required_api_service_type
-    return nil unless runner_key == "aider"
-
-    DIRECT_OUTBOUND_API_PROVIDERS.dig(aider_api_provider, :service_type)
-  end
-
-  # NOTE: Aider is excluded here because the execution path does not yet have
-  # direct-outbound plumbing (no agent_harness_runner_runtime, no
-  # direct_outbound_exec_env/exec_command support). The config infrastructure
-  # (aider_config, aider_api_provider, aider_model_id) exists as prep work;
-  # add aider_direct_outbound? here once the runtime path is implemented.
   def requires_direct_outbound?
     opencode_direct_outbound? || kilocode_direct_outbound? || pi_direct_outbound? || openrouter_free_direct_outbound? || openrouter_pareto_direct_outbound?
   end
@@ -596,7 +564,6 @@ class Runner < ApplicationRecord
     case runner_key
     when "kilocode" then kilocode_model_id
     when "opencode" then opencode_model_id
-    when "aider" then aider_model_id
     when "pi" then pi_model_id
     end
   end
@@ -605,7 +572,6 @@ class Runner < ApplicationRecord
     case runner_key
     when "kilocode" then kilocode_required_api_service_type
     when "opencode" then opencode_required_api_service_type
-    when "aider" then aider_required_api_service_type
     when "pi" then pi_required_api_service_type
     end
   end
@@ -721,7 +687,7 @@ class Runner < ApplicationRecord
   # instance of. Such keys are hidden from the "Add Runner" UI once the user
   # already has one, and free-model rotation is scoped to them. Today only
   # the openrouter_free runner is single-instance; other api_key runners
-  # (opencode, kilocode, aider, pi) legitimately allow duplicates when their
+  # (opencode, kilocode, pi) legitimately allow duplicates when their
   # API key or name differs.
   def self.single_instance_runner_key?(runner_key)
     runner_key.to_s == OPENROUTER_FREE_RUNNER_KEY
@@ -903,10 +869,6 @@ class Runner < ApplicationRecord
   end
 
   def direct_outbound_capable_runner?
-    # NOTE: Aider is intentionally excluded — it is still mapped as a standard
-    # Anthropic runner in DefaultTierModelIds::RUNNER_KEY_TO_MODEL_PROVIDER,
-    # so including it here would cause clear_stale_direct_outbound_tier_models
-    # to erase its valid standard tier mappings on every save.
     %w[kilocode opencode openrouter_free openrouter_pareto pi].include?(runner_key)
   end
 
@@ -1012,8 +974,6 @@ class Runner < ApplicationRecord
       config.dig("opencode", "model")
     when "kilocode"
       config.dig("kilocode", "model")
-    when "aider"
-      config.dig("aider", "model")
     when "pi"
       config.dig("pi", "model")
     end
@@ -1427,27 +1387,6 @@ class Runner < ApplicationRecord
     end
   end
 
-  # NOTE: The runner UI/controller does not yet permit nested aider config
-  # keys (api_provider, model). This validation is prep work for when the
-  # controller is updated to support Aider API-key runners.
-  #
-  # Guard: RunnerResolver#tenant_api_key_runner auto-materializes api_key
-  # runners without config. Those tenant-key entries must remain valid —
-  # only enforce config requirements when aider-specific config is present.
-  def aider_api_key_config_must_be_valid
-    return unless runner_key == "aider"
-    return unless api_key?
-    return unless config.is_a?(Hash) && config.key?("aider")
-
-    unless AIDER_API_PROVIDER_KEYS.include?(aider_api_provider)
-      errors.add(:config, "must include a supported Aider API provider")
-    end
-
-    if aider_model_id.blank?
-      errors.add(:config, "must include an Aider model id")
-    end
-  end
-
   def pi_api_key_config_must_be_valid
     return unless runner_key == "pi"
     return unless api_key?
@@ -1482,7 +1421,6 @@ class Runner < ApplicationRecord
   def required_api_service_type
     return opencode_required_api_service_type if runner_key == "opencode"
     return kilocode_required_api_service_type if runner_key == "kilocode"
-    return aider_required_api_service_type if runner_key == "aider"
     return pi_required_api_service_type if runner_key == "pi"
 
     self.class.api_service_type_for(runner_key)
@@ -1501,13 +1439,6 @@ class Runner < ApplicationRecord
       api_key? &&
       KILOCODE_API_PROVIDER_KEYS.include?(kilocode_api_provider) &&
       kilocode_model_id.present?
-  end
-
-  def aider_direct_outbound?
-    runner_key == "aider" &&
-      api_key? &&
-      AIDER_API_PROVIDER_KEYS.include?(aider_api_provider) &&
-      aider_model_id.present?
   end
 
   def pi_direct_outbound?
@@ -1537,11 +1468,6 @@ class Runner < ApplicationRecord
       required_api_service_type == "openrouter"
   end
 
-  # NOTE: Aider is intentionally absent — only direct_outbound_capable_runner?
-  # runners (kilocode/opencode/openrouter_free/pi) reach this method via
-  # direct_outbound_config_models_must_exist_in_catalog. If aider joins that
-  # set in the future, add the case branch back so the validation error names
-  # "Aider" instead of the raw runner_key.
   def direct_outbound_runner_label
     case runner_key
     when "opencode" then "OpenCode"

--- a/app/services/agent_runs/runner_resolver.rb
+++ b/app/services/agent_runs/runner_resolver.rb
@@ -286,7 +286,6 @@ module AgentRuns
     end
 
     def account_credential_service_type_for(base_runner)
-      return base_runner.aider_required_api_service_type if base_runner.runner_key == "aider"
       return base_runner.pi_required_api_service_type if base_runner.runner_key == "pi"
 
       static = support_module.api_service_type_for(base_runner.runner_key)
@@ -310,13 +309,6 @@ module AgentRuns
       api_service_type = credential.provider_api_key&.api_service_type || account_credential_service_type_for(base_runner)
 
       case base_runner.runner_key
-      when "aider"
-        {
-          "aider" => {
-            "api_provider" => api_service_type,
-            "model" => base_runner.aider_model_id
-          }.compact
-        }
       when "pi"
         config = {
           "pi" => {

--- a/app/services/containers/git_operations.rb
+++ b/app/services/containers/git_operations.rb
@@ -140,7 +140,6 @@ module Containers
       .cache-rubocop/
       .rubocop-cache/
       .rubocop_cache/
-      .aider*
       # Database backups
       backups/
       # Paid heartbeat file (touched by agent CLI hooks)
@@ -246,7 +245,6 @@ module Containers
       backups/
       .pg_log.txt
       .ruby_env.sh
-      .aider*
       .paid-heartbeat
       vendor/bundle/
       vendor/gems/

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -1972,8 +1972,7 @@ module Containers
         "/home/agent/.local/share/kilo",
         "/home/agent/.config/opencode",
         "/home/agent/.local/share/opencode",
-        "/home/agent/.copilot",
-        "/home/agent/.aider"
+        "/home/agent/.copilot"
       ]
 
       # ~/.codex gets non-recursive chown to preserve host-backed file ownership
@@ -2003,7 +2002,6 @@ module Containers
       fix_opencode_config_tmpfs_ownership!
       fix_opencode_data_tmpfs_ownership!
       fix_copilot_tmpfs_ownership!
-      fix_aider_tmpfs_ownership!
     end
 
     # Ensures the bind-mounted /workspace is writable by the non-root agent user.
@@ -2092,12 +2090,6 @@ module Containers
     # agent user can write to it. Tmpfs mounts are created as root-owned.
     def fix_copilot_tmpfs_ownership!
       fix_tmpfs_ownership!(".copilot")
-    end
-
-    # Fixes ownership of the ~/.aider tmpfs so the non-root agent user can
-    # write to it. Tmpfs mounts are created as root-owned.
-    def fix_aider_tmpfs_ownership!
-      fix_tmpfs_ownership!(".aider")
     end
 
     # Fixes ownership of a tmpfs mount under /home/agent so the non-root
@@ -2376,7 +2368,6 @@ module Containers
     #   /home/agent/.config/opencode         - tmpfs (64MB, for OpenCode CLI config)
     #   /home/agent/.local/share/opencode    - tmpfs (64MB, for OpenCode CLI data)
     #   /home/agent/.copilot                 - tmpfs (64MB, for GitHub Copilot CLI config)
-    #   /home/agent/.aider                   - tmpfs (64MB, for Aider CLI config/session data)
     # All other paths are read-only via ReadonlyRootfs.
     def container_config
       {
@@ -2504,10 +2495,6 @@ module Containers
       # GitHub Copilot CLI stores config and auth state under ~/.copilot.
       # Ownership is fixed by fix_copilot_tmpfs_ownership! after container start.
       tmpfs["/home/agent/.copilot"] = "size=#{64 * 1024 * 1024},mode=0700"
-
-      # Aider CLI stores config and session data under ~/.aider.
-      # Ownership is fixed by fix_aider_tmpfs_ownership! after container start.
-      tmpfs["/home/agent/.aider"] = "size=#{64 * 1024 * 1024},mode=0700"
 
       {
         "Memory" => options[:memory_bytes],

--- a/app/services/providers/default_tier_model_ids.rb
+++ b/app/services/providers/default_tier_model_ids.rb
@@ -5,13 +5,10 @@ module Providers
     PROVIDER_KEY_TO_MODEL_PROVIDER = {
       "claude" => "anthropic",
       "cursor" => "anthropic",
-      "aider" => "anthropic",
       "codex" => "openai",
       "gemini" => "google"
     }.freeze
 
-    # Aider is excluded until its execution path supports direct-outbound
-    # plumbing (see Provider#requires_direct_outbound? for details).
     DIRECT_OUTBOUND_PROVIDER_KEYS = %w[kilocode opencode].freeze
 
     def self.call(provider_key:)

--- a/app/services/runners/default_tier_model_ids.rb
+++ b/app/services/runners/default_tier_model_ids.rb
@@ -5,7 +5,6 @@ module Runners
     RUNNER_KEY_TO_MODEL_PROVIDER = {
       "claude" => "anthropic",
       "cursor" => "anthropic",
-      "aider" => "anthropic",
       "codex" => "openai",
       "gemini" => "google"
     }.freeze

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -2936,7 +2936,7 @@ module Activities
         ]
       when "codex"
         [ %(OPENAI_HEADER_X_PAID_PROVIDER_ID="$PAID_PROVIDER_ID") ]
-      when "claude", "cursor", "aider"
+      when "claude", "cursor"
         [
           %(ANTHROPIC_BASE_URL="$PAID_PROXY_URL/api/proxy/anthropic"),
           %(ANTHROPIC_HEADER_X_AGENT_RUN_ID="$AGENT_RUN_ID"),

--- a/app/views/runners/_form.html.erb
+++ b/app/views/runners/_form.html.erb
@@ -241,43 +241,6 @@
     </div>
   </div>
 
-  <% aider_settings_enabled = is_api_key && runner.runner_key == "aider" %>
-  <% aider_api_provider = runner.aider_api_provider || Runner::AIDER_DEFAULT_API_PROVIDER %>
-  <div data-runner-form-target="aiderSettings" <% unless aider_settings_enabled %>hidden<% end %>>
-    <div class="rounded-lg border border-gray-200 p-4">
-      <h3 class="text-sm font-semibold text-gray-900">Aider Model Settings</h3>
-      <p class="mt-1 text-xs text-gray-500">Configure the upstream API provider and model for this Aider entry.</p>
-
-      <div class="mt-4">
-        <label for="runner_config_aider_api_provider" class="block text-sm font-medium text-gray-900">API Provider</label>
-        <select id="runner_config_aider_api_provider"
-                name="runner[config][aider][api_provider]"
-                <% unless aider_settings_enabled %>disabled<% end %>
-                class="mt-2 block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
-                data-runner-form-target="directOutboundApiProviderSelect"
-                data-runner-key="aider"
-                data-action="change->runner-form#refreshRunnerSpecificFields">
-          <% Runner::DIRECT_OUTBOUND_API_PROVIDERS.each do |slug, cfg| %>
-            <option value="<%= slug %>" data-service-type="<%= cfg[:service_type] %>" <% if aider_api_provider == slug %>selected<% end %>><%= cfg[:label] %></option>
-          <% end %>
-        </select>
-      </div>
-
-      <div class="mt-4">
-        <label for="runner_config_aider_model" class="block text-sm font-medium text-gray-900">Model ID</label>
-        <input id="runner_config_aider_model"
-               name="runner[config][aider][model]"
-               type="text"
-               value="<%= runner.aider_model_id %>"
-               placeholder="glm-5.1"
-               autocomplete="off"
-                <% unless aider_settings_enabled %>disabled<% end %>
-               class="mt-2 block w-full rounded-md border-0 px-3 py-1.5 font-mono text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
-        <p class="mt-1 text-xs text-gray-500">Required for API-key Aider entries. The model identifier for the selected API provider.</p>
-      </div>
-    </div>
-  </div>
-
   <% pi_settings_enabled = is_api_key && runner.runner_key == "pi" %>
   <% pi_api_provider = runner.pi_api_provider || Runner::PI_DEFAULT_API_PROVIDER %>
   <div data-runner-form-target="piSettings" <% unless pi_settings_enabled %>hidden<% end %>>

--- a/config/initializers/agent_harness.rb
+++ b/config/initializers/agent_harness.rb
@@ -355,7 +355,7 @@ AgentHarness.configure do |config|
   end
 
   config.default_provider = default_key if default_key
-  config.fallback_providers = %w[cursor aider].filter_map do |runner_key|
+  config.fallback_providers = %w[cursor].filter_map do |runner_key|
     next unless supported_runner_keys.include?(runner_key)
 
     harness_runner_key = RunnerSupport.harness_runner_key_for(runner_key).to_sym

--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -450,17 +450,6 @@ RUN if [ -z "${CURSOR_ARTIFACT_URL}" ]; then echo "ERROR: CURSOR_ARTIFACT_URL bu
     && ln -sf "/opt/cursor-agent/${CURSOR_BINARY_NAME}" "${CURSOR_GLOBAL_PATH}" \
     && rm -rf /tmp/cursor-artifact.tar.gz /tmp/dist-package
 
-# Install Aider CLI via agent-harness install contract.
-# agent-harness owns the Aider install recipe, uv bootstrap, and version pin.
-# The install command is extracted at build time by
-# scripts/build-agent-image.sh / agent-image.yml — Paid no longer pins these versions.
-ARG AIDER_INSTALL_COMMAND
-RUN if [ -z "${AIDER_INSTALL_COMMAND}" ]; then \
-        echo "ERROR: AIDER_INSTALL_COMMAND build-arg is required (sourced from agent-harness)" >&2; \
-        exit 1; \
-    fi \
-    && eval "${AIDER_INSTALL_COMMAND}"
-
 # Install git credential helper for proxy-based authentication.
 # This allows git clone/push inside the container without exposing GitHub tokens.
 COPY scripts/git-credential-paid /usr/local/bin/git-credential-paid

--- a/docs/AGENT_SYSTEM.md
+++ b/docs/AGENT_SYSTEM.md
@@ -31,7 +31,7 @@ The agent system has four layers:
 │  ┌────────────────────────────────────────────────────────────────────────┐ │
 │  │ 4. AGENT LAYER (agent-harness gem)                                       │ │
 │  │    Unified interface to CLI agents (Claude Code, Cursor, Gemini CLI,   │ │
-│  │    GitHub Copilot, Codex, Aider, OpenCode, Kilocode)                   │ │
+│  │    GitHub Copilot, Codex, OpenCode, Kilocode)                          │ │
 │  └────────────────────────────────────────────────────────────────────────┘ │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
@@ -618,7 +618,7 @@ Paid adopts the existing `agent-harness` gem for CLI agent orchestration and pro
 
 ### Provider Registry
 
-Built-in providers include Claude Code, Cursor, Gemini CLI, GitHub Copilot, Codex, Aider, OpenCode, and Kilocode. Providers expose capabilities (streaming, file_upload, vision, tool_use, json_mode, mcp, dangerous_mode), firewall requirements, and instruction file paths. The registry also supports aliases (e.g., `:anthropic` → `:claude`, `:copilot` → `:github_copilot`).
+Built-in providers include Claude Code, Cursor, Gemini CLI, GitHub Copilot, Codex, OpenCode, and Kilocode. Providers expose capabilities (streaming, file_upload, vision, tool_use, json_mode, mcp, dangerous_mode), firewall requirements, and instruction file paths. The registry also supports aliases (e.g., `:anthropic` → `:claude`, `:copilot` → `:github_copilot`).
 
 ### Response Shape
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -76,7 +76,7 @@ Paid is composed of four main subsystems that work together to orchestrate AI-dr
 | Component | Technology | Rationale |
 |-----------|------------|-----------|
 | Containers | Docker | Industry standard, aidp compatibility |
-| Agent CLIs | Claude Code, Cursor, Gemini CLI, GitHub Copilot, Codex, Aider, OpenCode, Kilocode, MistralVibe | Extracted to shared gem |
+| Agent CLIs | Claude Code, Cursor, Gemini CLI, GitHub Copilot, Codex, OpenCode, Kilocode, MistralVibe | Extracted to shared gem |
 | API Calls | agent-harness gem | Unified LLM interface, model registry |
 | Isolation | Git worktrees | Parallel work without conflicts |
 
@@ -212,7 +212,7 @@ Each agent runs in an isolated Docker container with:
 Based on aidp's devcontainer approach:
 
 - Base: Ruby + Node + common dev tools
-- Pre-installed: Agent CLIs (Claude Code, Cursor, Gemini CLI, GitHub Copilot, Codex, Aider, OpenCode, Kilocode, MistralVibe)
+- Pre-installed: Agent CLIs (Claude Code, Cursor, Gemini CLI, GitHub Copilot, Codex, OpenCode, Kilocode, MistralVibe)
 - Firewall: Allowlist-only network access
 - No secrets: API keys not passed to container
 
@@ -331,7 +331,7 @@ Two modes of agent execution:
 
 **CLI Mode** (via agent-harness gem):
 
-- Claude Code, Cursor, Gemini CLI, GitHub Copilot, Codex, Aider, OpenCode, Kilocode, MistralVibe
+- Claude Code, Cursor, Gemini CLI, GitHub Copilot, Codex, OpenCode, Kilocode, MistralVibe
 - Runs in container with proxied API access
 - Orchestration handles fallbacks, rate limits, and health checks
 - Output and token usage captured via `AgentHarness::Response`/token tracker

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -10,7 +10,7 @@ This glossary defines terms specific to the Paid platform that are not industry-
 |------|-----------|
 | **Agent Run** | A single execution of a runner against a task (issue, PR review, etc.). Tracks lifecycle from queued to running to completed/failed. Core domain object (`AgentRun` model). |
 | **Focused Agent Run** | An agent run scoped to a single, narrow problem class (e.g., CI fix, review response) rather than all PR problems at once. See RDR-031. |
-| **Runner** | A code execution backend (e.g., Claude Code, Copilot, Aider, OpenCode, Kilocode) that performs agent work. Formerly called "Provider" in code. Renamed in #1950. NOT the same as an LLM provider. |
+| **Runner** | A code execution backend (e.g., Claude Code, Copilot, OpenCode, Kilocode) that performs agent work. Formerly called "Provider" in code. Renamed in #1950. NOT the same as an LLM provider. |
 | **Runner State** | The operational status record for a runner (healthy, degraded, circuit-open, etc.). This remains implemented through legacy `ProviderState` / `provider_states` identifiers even though the domain concept is runner health. |
 | **Runner Key** | The unique identifier string for a specific runner (e.g., `claude_code`, `copilot`). Formerly `provider_key`. Renamed in #1950. |
 | **Agent Harness** | The shared execution framework (`agent_harness` gem) that wraps individual runners, providing plan-only APIs, heartbeats, and lifecycle management. All LLM calls must go through this gem. |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -443,8 +443,8 @@ Agent-run provider auth modes have the following runtime secret contract:
 
 | Auth mode | Providers | Runtime material | Notes |
 | --- | --- | --- | --- |
-| Paid-managed proxy key | Claude, Codex, Gemini, Cursor, Aider | Run id, proxy token, provider proxy base URL | Provider key stays on the Rails service and is added by the secrets proxy. |
-| Stored provider API key | Claude, Codex, Gemini, Cursor, Aider | Run-scoped proxy credential plus provider entry id | Provider key stays server-side; the proxy validates the provider belongs to the run owner before forwarding. |
+| Paid-managed proxy key | Claude, Codex, Gemini, Cursor | Run id, proxy token, provider proxy base URL | Provider key stays on the Rails service and is added by the secrets proxy. |
+| Stored provider API key | Claude, Codex, Gemini, Cursor | Run-scoped proxy credential plus provider entry id | Provider key stays server-side; the proxy validates the provider belongs to the run owner before forwarding. |
 | Subscription auth | Claude, Codex, Gemini, Copilot | CLI login state mounted or copied into the runtime | Explicit exception: the CLI needs native account session files. |
 | Direct-outbound API key | OpenCode, KiloCode | Provider API key in runtime env or config | Explicit exception: these entries can target upstream APIs outside the proxy coverage. |
 

--- a/docs/rdrs/README.md
+++ b/docs/rdrs/README.md
@@ -157,7 +157,7 @@ For more information, see the [RDR methodology](https://github.com/cwensel/rdr).
 
 ### Agent Execution
 
-- **CLI Abstraction**: agent-harness gem with providers for Claude Code, Cursor, Gemini CLI, GitHub Copilot, Codex, Aider, OpenCode, Kilocode, Pi
+- **CLI Abstraction**: agent-harness gem with providers for Claude Code, Cursor, Gemini CLI, GitHub Copilot, Codex, OpenCode, Kilocode, Pi
 - **Model Selection**: LLM-based meta-agent with rules fallback
 - **Prompts**: Database-stored with A/B testing and automated evolution
 

--- a/lib/provider_support.rb
+++ b/lib/provider_support.rb
@@ -11,13 +11,13 @@ module ProviderSupport
   #
   # NOTE: Inclusion here does NOT mean the provider's CLI is installed in the
   # agent Docker container. For container execution, see CONTAINER_EXECUTABLE_PROVIDER_KEYS.
-  APP_PROVIDER_KEYS = %w[claude cursor codex copilot aider gemini opencode kilocode pi].freeze
+  APP_PROVIDER_KEYS = %w[claude cursor codex copilot gemini opencode kilocode pi].freeze
 
   # Provider keys whose CLIs are actually installed in the agent Docker container
   # and can execute repository-changing agent tasks. GitHub Copilot CLI is
   # included via its --autopilot mode which enables fully autonomous,
   # non-interactive agent execution.
-  CONTAINER_EXECUTABLE_PROVIDER_KEYS = Set.new(%w[aider claude codex copilot cursor gemini kilocode opencode pi]).freeze
+  CONTAINER_EXECUTABLE_PROVIDER_KEYS = Set.new(%w[claude codex copilot cursor gemini kilocode opencode pi]).freeze
 
   # Upper bound on how far in the future a parsed rate-limit reset is trusted.
   #
@@ -207,7 +207,6 @@ module ProviderSupport
     "claude" => "anthropic",
     "cursor" => "anthropic",
     "codex" => "openai",
-    "aider" => "anthropic",
     "gemini" => "google"
   }.freeze
 

--- a/lib/runner_support.rb
+++ b/lib/runner_support.rb
@@ -11,13 +11,13 @@ module RunnerSupport
   #
   # NOTE: Inclusion here does NOT mean the runner's CLI is installed in the
   # agent Docker container. For container execution, see CONTAINER_EXECUTABLE_RUNNER_KEYS.
-  APP_RUNNER_KEYS = %w[claude cursor codex copilot aider gemini opencode openrouter_free openrouter_pareto kilocode pi].freeze
+  APP_RUNNER_KEYS = %w[claude cursor codex copilot gemini opencode openrouter_free openrouter_pareto kilocode pi].freeze
 
   # Runner keys whose CLIs are actually installed in the agent Docker container
   # and can execute repository-changing agent tasks. GitHub Copilot CLI is
   # included via its --autopilot mode which enables fully autonomous,
   # non-interactive agent execution.
-  CONTAINER_EXECUTABLE_RUNNER_KEYS = Set.new(%w[aider claude codex copilot cursor gemini kilocode opencode openrouter_free openrouter_pareto pi]).freeze
+  CONTAINER_EXECUTABLE_RUNNER_KEYS = Set.new(%w[claude codex copilot cursor gemini kilocode opencode openrouter_free openrouter_pareto pi]).freeze
 
   APP_RUNNER_TO_HARNESS_KEY = {
     "openrouter_free" => "opencode",
@@ -233,7 +233,6 @@ module RunnerSupport
     "claude" => "anthropic",
     "cursor" => "anthropic",
     "codex" => "openai",
-    "aider" => "anthropic",
     "gemini" => "google",
     "openrouter_free" => "openrouter",
     "openrouter_pareto" => "openrouter"

--- a/scripts/build-agent-image.sh
+++ b/scripts/build-agent-image.sh
@@ -168,16 +168,6 @@ if [ -z "${GEMINI_CLI_INSTALL_COMMAND}" ]; then
     exit 1
 fi
 
-# Extract Aider CLI install command from agent-harness (single source of truth).
-# agent-harness owns the uv bootstrap, aider-chat version pin, and install recipe.
-AIDER_CONTRACT=$(bundle exec ruby "${PROJECT_ROOT}/scripts/extract-runner-install-contract.rb" aider)
-AIDER_INSTALL_COMMAND=$(echo "${AIDER_CONTRACT}" | sed -n 's/^INSTALL_COMMAND=//p')
-
-if [ -z "${AIDER_INSTALL_COMMAND}" ]; then
-    echo "ERROR: Could not extract Aider CLI install command from agent-harness" >&2
-    exit 1
-fi
-
 # Extract Copilot CLI install command from agent-harness (single source of truth).
 COPILOT_CONTRACT=$(bundle exec ruby "${PROJECT_ROOT}/scripts/extract-runner-install-contract.rb" copilot)
 COPILOT_INSTALL_COMMAND=$(echo "${COPILOT_CONTRACT}" | sed -n 's/^INSTALL_COMMAND=//p')
@@ -203,7 +193,6 @@ echo "  opencode: via agent-harness contract"
 echo "  pi: ${PI_PACKAGE}"
 echo "  kilocode-cli: ${KILOCODE_INSTALL_COMMAND}"
 echo "  gemini-cli: ${GEMINI_CLI_INSTALL_COMMAND}"
-echo "  aider-cli: via agent-harness contract"
 echo "  copilot-cli: ${COPILOT_INSTALL_COMMAND}"
 
 "${DOCKER_BUILD_ENV[@]}" docker build \
@@ -224,7 +213,6 @@ echo "  copilot-cli: ${COPILOT_INSTALL_COMMAND}"
     --build-arg "PI_PACKAGE=${PI_PACKAGE}" \
     --build-arg "KILOCODE_INSTALL_COMMAND=${KILOCODE_INSTALL_COMMAND}" \
     --build-arg "GEMINI_CLI_INSTALL_COMMAND=${GEMINI_CLI_INSTALL_COMMAND}" \
-    --build-arg "AIDER_INSTALL_COMMAND=${AIDER_INSTALL_COMMAND}" \
     --build-arg "COPILOT_INSTALL_COMMAND=${COPILOT_INSTALL_COMMAND}" \
     "${PROJECT_ROOT}/docker/agent/"
 

--- a/scripts/extract-provider-install-contract.rb
+++ b/scripts/extract-provider-install-contract.rb
@@ -77,7 +77,7 @@ end
 # - npm-based (Codex):    {source: :npm, package:, install_command: [...], version:}
 # - npm-nested (Kilocode): {source: {type: :npm, package:}, install_command: [...], default_version:}
 # - Flat (Gemini):        {install_command_string:, default_version:}
-# - uv-tool (Aider):      {source: :uv_tool, bootstrap_commands: [...], install_environment: {...},
+# - uv-tool:              {source: :uv_tool, bootstrap_commands: [...], install_environment: {...},
 #                           install_command: [...], package:, version:}
 source = contract[:source]
 is_npm = source == :npm || (source.is_a?(Hash) && source[:type] == :npm)
@@ -85,7 +85,7 @@ if source == :uv_tool
   # Compose a single install command string from the structured contract:
   #   1. Create directories referenced by install_environment
   #   2. Run bootstrap commands (e.g., install uv via pip)
-  #   3. Run the install command (e.g., uv tool install aider-chat)
+  #   3. Run the install command (e.g., uv tool install <package>)
   # Environment variables are inlined per-command so no persistent ENV is needed.
   env_hash = contract[:install_environment] || {}
   env_prefix = env_hash.map { |k, v| "#{k}=#{v}" }.join(" ")

--- a/scripts/extract-runner-install-contract.rb
+++ b/scripts/extract-runner-install-contract.rb
@@ -77,7 +77,7 @@ end
 # - npm-based (Codex):    {source: :npm, package:, install_command: [...], version:}
 # - npm-nested (Kilocode): {source: {type: :npm, package:}, install_command: [...], default_version:}
 # - Flat (Gemini):        {install_command_string:, default_version:}
-# - uv-tool (Aider):      {source: :uv_tool, bootstrap_commands: [...], install_environment: {...},
+# - uv-tool:              {source: :uv_tool, bootstrap_commands: [...], install_environment: {...},
 #                           install_command: [...], package:, version:}
 source = contract[:source]
 is_npm = source == :npm || (source.is_a?(Hash) && source[:type] == :npm)
@@ -85,7 +85,7 @@ if source == :uv_tool
   # Compose a single install command string from the structured contract:
   #   1. Create directories referenced by install_environment
   #   2. Run bootstrap commands (e.g., install uv via pip)
-  #   3. Run the install command (e.g., uv tool install aider-chat)
+  #   3. Run the install command (e.g., uv tool install <package>)
   # Environment variables are inlined per-command so no persistent ENV is needed.
   env_hash = contract[:install_environment] || {}
   env_prefix = env_hash.map { |k, v| "#{k}=#{v}" }.join(" ")

--- a/scripts/install-from-contract.sh
+++ b/scripts/install-from-contract.sh
@@ -10,7 +10,7 @@
 # Usage:
 #   scripts/install-from-contract.sh <provider>
 #
-# Supported providers: codex, gemini, copilot, kilocode, cursor, aider, opencode
+# Supported providers: codex, gemini, copilot, kilocode, cursor, opencode
 
 set -e
 
@@ -148,7 +148,7 @@ done
 PROVIDER="${1:-}"
 if [ -z "$PROVIDER" ]; then
   echo "Usage: $0 <provider>" >&2
-  echo "Supported providers: codex, gemini, copilot, kilocode, cursor, aider, opencode" >&2
+  echo "Supported providers: codex, gemini, copilot, kilocode, cursor, opencode" >&2
   exit 1
 fi
 

--- a/scripts/test-agent-image-inner.sh
+++ b/scripts/test-agent-image-inner.sh
@@ -61,7 +61,6 @@ check_tool "   Gemini CLI" gemini --help
 check_tool "   Kilocode CLI" kilo --help
 check_tool "   Pi CLI" pi --help
 check_tool "   Cursor agent CLI" cursor-agent --version
-check_tool "   Aider CLI" aider --help
 
 echo ""
 echo "3. User check (should be agent, not root):"

--- a/scripts/test-agent-provider-contracts-inner.sh
+++ b/scripts/test-agent-provider-contracts-inner.sh
@@ -9,7 +9,7 @@
 # Usage (called by test-agent-provider-contracts.sh):
 #   docker run --rm \
 #     -v ./scripts/test-agent-provider-contracts-inner.sh:/tmp/contract-test.sh:ro \
-#     -e CONTAINER_EXECUTABLE_KEYS="aider claude codex cursor gemini kilocode opencode pi" \
+#     -e CONTAINER_EXECUTABLE_KEYS="claude codex cursor gemini kilocode opencode pi" \
 #     -e CODEX_NOTIFY_LINE='notify = ["sh", "-lc", "date +%s > /workspace/.paid-heartbeat"]' \
 #     -e CODEX_CONFIG_TOML_BODY='[chatgpt]...' \
 #     paid-agent:latest bash /tmp/contract-test.sh
@@ -33,7 +33,6 @@ pass() {
 # This mapping must stay in sync with docker/agent/Dockerfile installs.
 declare -A PROVIDER_CLI_BINARY
 PROVIDER_CLI_BINARY=(
-    [aider]=aider
     [claude]=claude
     [codex]=codex
     [copilot]=copilot

--- a/scripts/test-agent-runner-contracts-inner.sh
+++ b/scripts/test-agent-runner-contracts-inner.sh
@@ -9,7 +9,7 @@
 # Usage (called by test-agent-runner-contracts.sh):
 #   docker run --rm \
 #     -v ./scripts/test-agent-runner-contracts-inner.sh:/tmp/contract-test.sh:ro \
-#     -e CONTAINER_EXECUTABLE_KEYS="aider claude codex cursor gemini kilocode opencode openrouter_free pi" \
+#     -e CONTAINER_EXECUTABLE_KEYS="claude codex cursor gemini kilocode opencode openrouter_free pi" \
 #     -e CODEX_NOTIFY_LINE='notify = ["sh", "-lc", "date +%s > /workspace/.paid-heartbeat"]' \
 #     -e CODEX_CONFIG_TOML_BODY='[chatgpt]...' \
 #     paid-agent:latest bash /tmp/contract-test.sh
@@ -33,7 +33,6 @@ pass() {
 # This mapping must stay in sync with docker/agent/Dockerfile installs.
 declare -A RUNNER_CLI_BINARY
 RUNNER_CLI_BINARY=(
-    [aider]=aider
     [claude]=claude
     [codex]=codex
     [copilot]=copilot

--- a/spec/factories/agent_runs.rb
+++ b/spec/factories/agent_runs.rb
@@ -139,10 +139,6 @@ FactoryBot.define do
       agent_type { "copilot" }
     end
 
-    trait :aider do
-      agent_type { "aider" }
-    end
-
     trait :gemini do
       agent_type { "gemini" }
     end

--- a/spec/lib/provider_support_spec.rb
+++ b/spec/lib/provider_support_spec.rb
@@ -37,10 +37,6 @@ RSpec.describe ProviderSupport do
       expect(described_class::CONTAINER_EXECUTABLE_PROVIDER_KEYS).to include("copilot")
     end
 
-    it "includes aider" do
-      expect(described_class::CONTAINER_EXECUTABLE_PROVIDER_KEYS).to include("aider")
-    end
-
     it "includes pi" do
       expect(described_class::CONTAINER_EXECUTABLE_PROVIDER_KEYS).to include("pi")
     end
@@ -73,11 +69,6 @@ RSpec.describe ProviderSupport do
       expect(keys).to include("copilot")
     end
 
-    it "includes aider when backed by the agent harness registry" do
-      keys = described_class.container_executable_provider_keys
-      expect(keys).to include("aider")
-    end
-
     it "includes pi when backed by the agent harness registry" do
       keys = described_class.container_executable_provider_keys
       expect(keys).to include("pi")
@@ -107,10 +98,6 @@ RSpec.describe ProviderSupport do
 
     it "returns true for copilot" do
       expect(described_class.container_executable_provider_key?("copilot")).to be true
-    end
-
-    it "returns true for aider" do
-      expect(described_class.container_executable_provider_key?("aider")).to be true
     end
 
     it "returns true for pi" do
@@ -346,7 +333,6 @@ RSpec.describe ProviderSupport do
     describe "CLI binary mapping completeness" do
       it "has a CLI binary mapping for every container-executable provider" do
         cli_binary_for = {
-          "aider" => "aider",
           "claude" => "claude",
           "codex" => "codex",
           "copilot" => "copilot",

--- a/spec/lib/runner_support_spec.rb
+++ b/spec/lib/runner_support_spec.rb
@@ -41,10 +41,6 @@ RSpec.describe RunnerSupport do
       expect(described_class::CONTAINER_EXECUTABLE_RUNNER_KEYS).to include("copilot")
     end
 
-    it "includes aider" do
-      expect(described_class::CONTAINER_EXECUTABLE_RUNNER_KEYS).to include("aider")
-    end
-
     it "includes pi" do
       expect(described_class::CONTAINER_EXECUTABLE_RUNNER_KEYS).to include("pi")
     end
@@ -82,11 +78,6 @@ RSpec.describe RunnerSupport do
       expect(keys).to include("copilot")
     end
 
-    it "includes aider when backed by the agent harness registry" do
-      keys = described_class.container_executable_runner_keys
-      expect(keys).to include("aider")
-    end
-
     it "includes pi when backed by the agent harness registry" do
       keys = described_class.container_executable_runner_keys
       expect(keys).to include("pi")
@@ -120,10 +111,6 @@ RSpec.describe RunnerSupport do
 
     it "returns true for copilot" do
       expect(described_class.container_executable_runner_key?("copilot")).to be true
-    end
-
-    it "returns true for aider" do
-      expect(described_class.container_executable_runner_key?("aider")).to be true
     end
 
     it "returns true for pi" do
@@ -355,7 +342,6 @@ RSpec.describe RunnerSupport do
     describe "CLI binary mapping completeness" do
       it "has a CLI binary mapping for every container-executable provider" do
         cli_binary_for = {
-          "aider" => "aider",
           "claude" => "claude",
           "codex" => "codex",
           "copilot" => "copilot",

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -3017,7 +3017,7 @@ RSpec.describe AgentRun do
     end
 
     it "defines valid AGENT_TYPES" do
-      expect(described_class::AGENT_TYPES).to eq(%w[claude_code cursor codex copilot aider gemini opencode kilocode pi api devin factory internal_agent])
+      expect(described_class::AGENT_TYPES).to eq(%w[claude_code cursor codex copilot gemini opencode kilocode pi api devin factory internal_agent])
     end
 
     it "defines valid GOALS" do

--- a/spec/models/provider_api_key_spec.rb
+++ b/spec/models/provider_api_key_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe ProviderApiKey do
           key = build(:provider_api_key, api_service_type: service_type)
           expect(key.compatible_with?("opencode")).to be(true), "expected #{service_type} to be compatible with opencode"
           expect(key.compatible_with?("kilocode")).to be(true), "expected #{service_type} to be compatible with kilocode"
-          expect(key.compatible_with?("aider")).to be(true), "expected #{service_type} to be compatible with aider"
         end
       end
 
@@ -74,7 +73,6 @@ RSpec.describe ProviderApiKey do
         key = build(:provider_api_key, api_service_type: "google")
         expect(key.compatible_with?("opencode")).to be(false)
         expect(key.compatible_with?("kilocode")).to be(false)
-        expect(key.compatible_with?("aider")).to be(false)
       end
 
       it "returns false for Pi-unsupported service types" do

--- a/spec/models/runner_spec.rb
+++ b/spec/models/runner_spec.rb
@@ -1123,118 +1123,6 @@ RSpec.describe Runner do
     end
   end
 
-  describe "Aider config infrastructure" do
-    let(:account) { create(:account, slug: "runner-aider-#{SecureRandom.hex(6)}") }
-    let(:user) { create(:user, account: account, email: "runner-aider-#{SecureRandom.hex(6)}@example.com") }
-    let(:api_key) { create(:provider_api_key, user: user, api_service_type: "zai") }
-
-    it "reads aider config accessors from the config hash" do
-      runner = build(
-        :runner,
-        user: user,
-        runner_key: "aider",
-        auth_type: "api_key",
-        provider_api_key: api_key,
-        config: { "aider" => { "api_provider" => "zai", "model" => "glm-5.1" } }
-      )
-
-      expect(runner.aider_api_provider).to eq("zai")
-      expect(runner.aider_model_id).to eq("glm-5.1")
-      expect(runner.aider_required_api_service_type).to eq("zai")
-    end
-
-    it "defaults api_provider to openrouter when unset" do
-      runner = build(:runner, runner_key: "aider", auth_type: "api_key",
-        user: user, provider_api_key: api_key, config: { "aider" => { "model" => "glm-5.1" } })
-
-      expect(runner.aider_api_provider).to eq("openrouter")
-    end
-
-    it "returns nil accessors for non-aider providers" do
-      runner = build(:runner, runner_key: "claude")
-
-      expect(runner.aider_api_provider).to be_nil
-      expect(runner.aider_model_id).to be_nil
-    end
-
-    it "is not direct-outbound even when fully configured (no execution plumbing yet)" do
-      runner = build(
-        :runner,
-        user: user,
-        runner_key: "aider",
-        auth_type: "api_key",
-        provider_api_key: api_key,
-        config: { "aider" => { "api_provider" => "zai", "model" => "glm-5.1" } }
-      )
-
-      expect(runner.requires_direct_outbound?).to be(false)
-    end
-
-    it "validates model presence for API-key aider providers when api_provider is set" do
-      runner = build(
-        :runner,
-        user: user,
-        runner_key: "aider",
-        auth_type: "api_key",
-        provider_api_key: api_key,
-        config: { "aider" => { "api_provider" => "zai" } }
-      )
-
-      expect(runner).not_to be_valid
-      expect(runner.errors[:config].join).to include("Aider model id")
-    end
-
-    it "validates model presence for API-key aider providers" do
-      runner = build(
-        :runner,
-        user: user,
-        runner_key: "aider",
-        auth_type: "api_key",
-        provider_api_key: api_key,
-        config: { "aider" => {} }
-      )
-
-      expect(runner).not_to be_valid
-      expect(runner.errors[:config].join).to include("Aider model id")
-    end
-
-    it "accepts a fully configured API-key aider runner" do
-      runner = build(
-        :runner,
-        user: user,
-        runner_key: "aider",
-        auth_type: "api_key",
-        provider_api_key: api_key,
-        config: { "aider" => { "api_provider" => "zai", "model" => "glm-5.1" } }
-      )
-
-      expect(runner).to be_valid
-    end
-
-    it "skips aider config validation for subscription runners" do
-      runner = build(:runner, runner_key: "aider", auth_type: "subscription")
-
-      runner.valid?
-      expect(runner.errors[:config]).to be_empty
-    end
-
-    it "skips aider config validation for tenant-key providers with no config" do
-      user = create(:user)
-      api_key = create(:provider_api_key, user: user, api_service_type: "anthropic")
-      runner = build(
-        :runner,
-        user: user,
-        runner_key: "aider",
-        auth_type: "api_key",
-        provider_api_key: api_key,
-        config: nil
-      )
-
-      runner.valid?
-      expect(runner.errors[:config]).to be_empty
-    end
-  end
-
   describe "sync_direct_outbound_tier_models callback" do
     let(:account) { create(:account, slug: "sync-tier-#{SecureRandom.hex(6)}") }
     let(:user) { create(:user, account: account, email: "sync-tier-#{SecureRandom.hex(6)}@example.com") }
@@ -1799,7 +1687,7 @@ RSpec.describe Runner do
     end
 
     it "returns false for runners that allow duplicates" do
-      %w[opencode kilocode aider pi claude cursor].each do |key|
+      %w[opencode kilocode pi claude cursor].each do |key|
         expect(described_class.single_instance_runner_key?(key)).to be false
       end
     end

--- a/spec/models/user_setting_spec.rb
+++ b/spec/models/user_setting_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe UserSetting do
     it "returns user-configured run-enabled runners filtered to container-executable" do
       allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor])
       user.runners.create!(runner_key: "cursor", enabled_for_agent_runs: true)
-      user.runners.create!(runner_key: "aider", enabled_for_agent_runs: true)
+      user.runners.create!(runner_key: "codex", enabled_for_agent_runs: true)
 
       expect(described_class.enabled_agent_runners(user)).to contain_exactly("claude", "cursor")
     end
@@ -194,7 +194,7 @@ RSpec.describe UserSetting do
     it "returns configured fallback runners filtered to container-executable" do
       allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor])
       user.runners.create!(runner_key: "cursor", enabled_for_agent_runs: false, enabled_for_fallback: true)
-      user.runners.create!(runner_key: "aider", enabled_for_agent_runs: false, enabled_for_fallback: true)
+      user.runners.create!(runner_key: "codex", enabled_for_agent_runs: false, enabled_for_fallback: true)
 
       expect(described_class.fallback_candidate_providers(user)).to contain_exactly("claude", "cursor")
     end
@@ -529,36 +529,36 @@ RSpec.describe UserSetting do
     let(:user) { create(:user) }
 
     before do
-      allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor aider])
+      allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor codex])
       user.runners.create!(runner_key: "cursor")
-      user.runners.create!(runner_key: "aider")
+      user.runners.create!(runner_key: "codex")
     end
 
     it "returns default runner first, then fallbacks" do
-      setting = build(:user_setting, user: user, default_agent_runner: "claude", fallback_runners: %w[cursor aider])
-      expect(setting.provider_priority).to eq(%w[claude cursor aider])
+      setting = build(:user_setting, user: user, default_agent_runner: "claude", fallback_runners: %w[cursor codex])
+      expect(setting.provider_priority).to eq(%w[claude cursor codex])
     end
 
     it "excludes the default runner from fallback list" do
       setting = build(:user_setting, user: user, default_agent_runner: "claude", fallback_runners: %w[claude cursor])
-      expect(setting.provider_priority).to eq(%w[claude cursor aider])
+      expect(setting.provider_priority).to eq(%w[claude cursor codex])
     end
 
     it "handles empty fallback_runners" do
       setting = build(:user_setting, user: user, default_agent_runner: "claude", fallback_runners: [])
-      expect(setting.provider_priority).to eq(%w[claude aider cursor])
+      expect(setting.provider_priority).to eq(%w[claude codex cursor])
     end
 
     it "handles nil fallback_runners" do
       setting = build(:user_setting, user: user, default_agent_runner: "claude")
       setting.fallback_runners = nil
-      expect(setting.provider_priority).to eq(%w[claude aider cursor])
+      expect(setting.provider_priority).to eq(%w[claude codex cursor])
     end
 
     it "appends configured fallback runners missing from saved order" do
       setting = build(:user_setting, user: user, default_agent_runner: "claude", fallback_runners: [ "cursor" ])
 
-      expect(setting.provider_priority).to eq(%w[claude cursor aider])
+      expect(setting.provider_priority).to eq(%w[claude cursor codex])
     end
 
     it "includes fallback-only runners in the runtime priority" do
@@ -569,7 +569,7 @@ RSpec.describe UserSetting do
 
       setting = build(:user_setting, user: user, default_agent_runner: "claude", fallback_runners: [])
 
-      expect(setting.provider_priority).to eq(%w[claude aider cursor])
+      expect(setting.provider_priority).to eq(%w[claude codex cursor])
     end
   end
 
@@ -577,11 +577,11 @@ RSpec.describe UserSetting do
     let(:user) { create(:user) }
     let(:claude) { user.runners.find_by!(runner_key: "claude") }
     let!(:cursor) { user.runners.create!(runner_key: "cursor", enabled_for_agent_runs: true) }
-    let!(:aider) { user.runners.create!(runner_key: "aider", enabled_for_agent_runs: true) }
+    let!(:codex) { user.runners.create!(runner_key: "codex", enabled_for_agent_runs: true) }
     let(:settings) { user.settings }
 
     before do
-      allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor aider])
+      allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor codex])
     end
 
     it "returns the goal-specific default in single mode" do
@@ -591,7 +591,7 @@ RSpec.describe UserSetting do
 
     it "returns the only enabled runner when fewer than two are enabled" do
       cursor.update!(enabled_for_agent_runs: false)
-      aider.update!(enabled_for_agent_runs: false)
+      codex.update!(enabled_for_agent_runs: false)
       settings.update!(runner_selection_mode: "round_robin")
 
       expect(settings.select_automated_provider_identifier).to eq(claude.routing_key)
@@ -600,46 +600,46 @@ RSpec.describe UserSetting do
     describe "round_robin mode" do
       it "cycles through runners in alphabetical-key order, repeating each weight times" do
         # Providers iterate in `ordered` scope (provider_key ASC):
-        # aider, claude, cursor.
-        aider.update!(weight: 1)
-        claude.update!(weight: 3)
+        # claude, codex, cursor.
+        claude.update!(weight: 1)
+        codex.update!(weight: 3)
         cursor.update!(weight: 1)
         settings.update!(runner_selection_mode: "round_robin")
 
         sequence = Array.new(10) { settings.select_automated_provider_identifier }
         expected_cycle = [
-          aider.routing_key,
-          claude.routing_key, claude.routing_key, claude.routing_key,
+          claude.routing_key,
+          codex.routing_key, codex.routing_key, codex.routing_key,
           cursor.routing_key
         ]
         expect(sequence).to eq(expected_cycle + expected_cycle)
       end
 
       it "resets the cursor when runner weights change" do
-        aider.update!(weight: 5)
+        claude.update!(weight: 5)
         settings.update!(runner_selection_mode: "round_robin")
 
         2.times { settings.select_automated_provider_identifier }
-        aider.update!(weight: 1)
+        claude.update!(weight: 1)
 
         first_after_change = settings.select_automated_provider_identifier
-        expect(first_after_change).to eq(aider.routing_key)
+        expect(first_after_change).to eq(claude.routing_key)
       end
     end
 
     describe "random mode" do
       it "respects weights when picking a runner" do
-        # Ordered candidates: aider (1), claude (3), cursor (1)
-        # Cumulative weights: aider [0..0], claude [1..3], cursor [4..4]
-        aider.update!(weight: 1)
-        claude.update!(weight: 3)
+        # Ordered candidates: claude (1), codex (3), cursor (1)
+        # Cumulative weights: claude [0..0], codex [1..3], cursor [4..4]
+        claude.update!(weight: 1)
+        codex.update!(weight: 3)
         cursor.update!(weight: 1)
         settings.update!(runner_selection_mode: "random")
 
         allow(SecureRandom).to receive(:random_number).with(5).and_return(0, 1, 3, 4)
 
         results = Array.new(4) { settings.select_automated_provider_identifier }
-        expect(results).to eq([ aider.routing_key, claude.routing_key, claude.routing_key, cursor.routing_key ])
+        expect(results).to eq([ claude.routing_key, codex.routing_key, codex.routing_key, cursor.routing_key ])
       end
     end
   end
@@ -648,51 +648,51 @@ RSpec.describe UserSetting do
     let(:user) { create(:user) }
 
     before do
-      allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor aider])
+      allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor codex])
       user.runners.create!(runner_key: "cursor")
-      user.runners.create!(runner_key: "aider")
+      user.runners.create!(runner_key: "codex")
     end
 
     it "respects saved order before appending remaining configured runners" do
-      setting = build(:user_setting, user: user, fallback_runners: [ "aider" ])
+      setting = build(:user_setting, user: user, fallback_runners: [ "codex" ])
 
-      expect(setting.fallback_priority_for(primary_provider: "claude")).to eq(%w[aider cursor])
+      expect(setting.fallback_priority_for(primary_provider: "claude")).to eq(%w[codex cursor])
     end
 
     it "wraps configured order after the current primary runner" do
-      setting = build(:user_setting, user: user, fallback_runners: %w[claude cursor aider])
+      setting = build(:user_setting, user: user, fallback_runners: %w[claude cursor codex])
 
-      expect(setting.fallback_priority_for(primary_provider: "cursor")).to eq(%w[aider claude])
+      expect(setting.fallback_priority_for(primary_provider: "cursor")).to eq(%w[codex claude])
     end
   end
 
   describe "#available_providers" do
     let(:user) { create(:user) }
-    let(:setting) { create(:user_setting, user: user, fallback_runners: %w[cursor aider]) }
+    let(:setting) { create(:user_setting, user: user, fallback_runners: %w[cursor codex]) }
 
     before do
-      allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor aider])
+      allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor codex])
       user.runners.create!(runner_key: "cursor")
-      user.runners.create!(runner_key: "aider")
+      user.runners.create!(runner_key: "codex")
     end
 
     it "returns all runners when none are unavailable" do
-      expect(setting.available_providers).to eq(%w[claude cursor aider])
+      expect(setting.available_providers).to eq(%w[claude cursor codex])
     end
 
     it "excludes rate-limited runners" do
       create(:runner_state, user: user, runner_name: "cursor", rate_limited_until: 1.hour.from_now)
-      expect(setting.available_providers).to eq(%w[claude aider])
+      expect(setting.available_providers).to eq(%w[claude codex])
     end
 
     it "excludes runners with open circuits" do
       create(:runner_state, :circuit_open, user: user, runner_name: "claude")
-      expect(setting.available_providers).to eq(%w[cursor aider])
+      expect(setting.available_providers).to eq(%w[cursor codex])
     end
 
     it "includes runners with half-open circuits" do
       create(:runner_state, :circuit_half_open, user: user, runner_name: "cursor")
-      expect(setting.available_providers).to eq(%w[claude cursor aider])
+      expect(setting.available_providers).to eq(%w[claude cursor codex])
     end
   end
 
@@ -733,7 +733,7 @@ RSpec.describe UserSetting do
     let(:user) { create(:user) }
 
     before do
-      allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor aider])
+      allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor codex])
     end
 
     it "is valid with known runners" do
@@ -823,16 +823,16 @@ RSpec.describe UserSetting do
     let(:setting) { build(:user_setting, user: user) }
 
     before do
-      allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor aider])
+      allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor codex])
     end
 
     it "resolves runner-key tokens without calling Runner.for_identifier per candidate" do
       cursor = user.runners.create!(runner_key: "cursor", enabled_for_agent_runs: true, enabled_for_fallback: true)
-      aider = user.runners.create!(runner_key: "aider", enabled_for_agent_runs: true, enabled_for_fallback: true)
+      codex = user.runners.create!(runner_key: "codex", enabled_for_agent_runs: true, enabled_for_fallback: true)
 
       expect(Runner).not_to receive(:for_identifier)
 
-      result = setting.send(:identifiers_for_provider_token, "cursor", candidates: [ cursor.routing_key, aider.routing_key ])
+      result = setting.send(:identifiers_for_provider_token, "cursor", candidates: [ cursor.routing_key, codex.routing_key ])
 
       expect(result).to eq([ cursor.routing_key ])
     end
@@ -884,21 +884,21 @@ RSpec.describe UserSetting do
 
   describe "new-record runner availability" do
     before do
-      allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor aider])
+      allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor codex])
     end
 
     it "uses the new user when resolving agent-run runners" do
       new_user = build(:user)
       setting = build(:user_setting, user: new_user)
 
-      expect(setting.send(:allowed_runner_identifiers_for_agent_runs)).to match_array(%w[claude cursor aider])
+      expect(setting.send(:allowed_runner_identifiers_for_agent_runs)).to match_array(%w[claude cursor codex])
     end
 
     it "uses the new user when resolving fallback runners" do
       new_user = build(:user)
       setting = build(:user_setting, user: new_user)
 
-      expect(setting.send(:allowed_runner_identifiers_for_fallback)).to match_array(%w[claude cursor aider])
+      expect(setting.send(:allowed_runner_identifiers_for_fallback)).to match_array(%w[claude cursor codex])
     end
   end
 end

--- a/spec/requests/runners_spec.rb
+++ b/spec/requests/runners_spec.rb
@@ -256,12 +256,12 @@ RSpec.describe "Runners" do
   describe "PATCH /runners/settings" do
     before do
       sign_in user
-      allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor aider])
+      allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor codex])
     end
 
     it "updates runner priority settings from the providers page" do
       cursor = user.runners.create!(runner_key: "cursor", enabled_for_agent_runs: true, enabled_for_fallback: true)
-      aider = user.runners.create!(runner_key: "aider", enabled_for_agent_runs: false, enabled_for_fallback: true)
+      codex = user.runners.create!(runner_key: "codex", enabled_for_agent_runs: false, enabled_for_fallback: true)
       claude = user.runners.find_by!(runner_key: "claude")
 
       patch settings_runners_path, params: {
@@ -269,7 +269,7 @@ RSpec.describe "Runners" do
           default_agent_runner: "cursor",
           default_agent_runners_by_goal: { create_pr: "cursor", review: "claude" },
           fallback_enabled: true,
-          fallback_runners: %w[claude aider].to_json
+          fallback_runners: %w[claude codex].to_json
         }
       }
 
@@ -278,7 +278,7 @@ RSpec.describe "Runners" do
       expect(settings.default_agent_runner).to eq(cursor.routing_key)
       expect(settings.default_agent_runners_by_goal).to eq("create_pr" => cursor.routing_key, "review" => claude.routing_key)
       expect(settings.fallback_enabled).to be(true)
-      expect(settings.fallback_runners).to eq([ claude.routing_key, aider.routing_key ])
+      expect(settings.fallback_runners).to eq([ claude.routing_key, codex.routing_key ])
     end
 
     it "drops goal-specific defaults whose providers are no longer enabled during reconciliation" do
@@ -331,7 +331,7 @@ RSpec.describe "Runners" do
 
     it "disables fallback for providers not in enabled_fallback_runner_keys" do
       user.runners.create!(runner_key: "cursor", enabled_for_agent_runs: true, enabled_for_fallback: true)
-      user.runners.create!(runner_key: "aider", enabled_for_agent_runs: true, enabled_for_fallback: true)
+      user.runners.create!(runner_key: "codex", enabled_for_agent_runs: true, enabled_for_fallback: true)
 
       patch settings_runners_path, params: {
         user_setting: {
@@ -345,7 +345,7 @@ RSpec.describe "Runners" do
       expect(response).to redirect_to(runners_path)
       expect(user.runners.find_by(runner_key: "claude").enabled_for_fallback).to be(true)
       expect(user.runners.find_by(runner_key: "cursor").enabled_for_fallback).to be(true)
-      expect(user.runners.find_by(runner_key: "aider").enabled_for_fallback).to be(false)
+      expect(user.runners.find_by(runner_key: "codex").enabled_for_fallback).to be(false)
     end
 
     it "enables fallback for providers in enabled_fallback_runner_keys" do
@@ -522,7 +522,7 @@ RSpec.describe "Runners" do
       allow(UserSetting).to receive(:enabled_agent_runners).with(user).and_return([], [ "claude" ])
       allow(RunnerSupport).to receive(:addable_runner_key?).and_return(true)
 
-      post runners_path, params: { runner: { runner_key: "aider", enabled_for_agent_runs: true, enabled_for_fallback: true } }
+      post runners_path, params: { runner: { runner_key: "codex", enabled_for_agent_runs: true, enabled_for_fallback: true } }
 
       expect(response).to redirect_to(runners_path)
     end
@@ -759,13 +759,6 @@ RSpec.describe "Runners" do
       expect(response).to have_http_status(:unprocessable_content)
       expect(response.body).to include("must include an OpenCode model id")
     end
-
-    it "creates an aider runner successfully" do
-      post runners_path, params: { runner: { runner_key: "aider", enabled_for_agent_runs: true, enabled_for_fallback: true } }
-
-      expect(response).to redirect_to(runners_path)
-      expect(user.runners.find_by(runner_key: "aider")).to be_present
-    end
   end
 
   describe "GET /runners/new" do
@@ -792,16 +785,16 @@ RSpec.describe "Runners" do
       expect(response.body).to include("No additional runners are installed in paid-agent yet")
     end
 
-    it "offers aider in the API-key runner list when a compatible key exists" do
+    it "offers kilocode in the API-key runner list when a compatible key exists" do
       create(:provider_api_key, user: user, api_service_type: "openrouter", name: "OpenRouter")
-      allow(RunnerSupport).to receive(:addable_runner_keys).and_return(%w[claude aider])
+      allow(RunnerSupport).to receive(:addable_runner_keys).and_return(%w[claude kilocode])
 
       get new_runner_path(form_variant: "api_key")
 
       expect(response).to have_http_status(:ok)
       expect(response.body).to include('value="api_key"')
       expect(response.body).to include('id="runner_runner_key_api_key"')
-      expect(response.body).to include('option value="aider"')
+      expect(response.body).to include('option value="kilocode"')
     end
 
     it "defaults back to subscription when the requested runner already has an active managed credential" do
@@ -825,7 +818,7 @@ RSpec.describe "Runners" do
         provider_api_key: user.provider_api_keys.first,
         tier_model_ids: LlmModel::TIERS.index_with { free_model.model_id }
       )
-      allow(RunnerSupport).to receive(:addable_runner_keys).and_return(%w[claude openrouter_free aider])
+      allow(RunnerSupport).to receive(:addable_runner_keys).and_return(%w[claude openrouter_free kilocode])
 
       get new_runner_path(form_variant: "api_key")
 
@@ -833,7 +826,7 @@ RSpec.describe "Runners" do
       # Single-instance runner is hidden once added...
       expect(response.body).not_to include('option value="openrouter_free"')
       # ...but other API-key runners remain available.
-      expect(response.body).to include('option value="aider"')
+      expect(response.body).to include('option value="kilocode"')
     end
 
     it "keeps offering duplicate-capable API-key runners after one is added" do
@@ -866,10 +859,10 @@ RSpec.describe "Runners" do
         provider_api_key: user.provider_api_keys.first,
         tier_model_ids: LlmModel::TIERS.index_with { free_model.model_id }
       )
-      # openrouter_free is hidden (single-instance, already added) but aider
+      # openrouter_free is hidden (single-instance, already added) but kilocode
       # is a duplicate-capable API-key runner with a compatible key, so the
       # "Add Runner" CTA must remain instead of showing "No More Runners Yet".
-      allow(RunnerSupport).to receive(:addable_runner_keys).and_return(%w[claude openrouter_free aider])
+      allow(RunnerSupport).to receive(:addable_runner_keys).and_return(%w[claude openrouter_free kilocode])
 
       get runners_path
 

--- a/spec/services/agent_runs/execute_spec.rb
+++ b/spec/services/agent_runs/execute_spec.rb
@@ -167,47 +167,6 @@ RSpec.describe AgentRuns::Execute do
       end
     end
 
-    context "when aider returns normalized token usage" do
-      let(:agent_run) { create(:agent_run, :aider, project: project) }
-
-      before do
-        allow(AgentHarness).to receive(:send_message).and_return(response)
-      end
-
-      %w[gpt-4o claude-3-5-sonnet-20241022 gemini-2.5-pro].each do |backend_model|
-        context "with backend model #{backend_model}" do
-          let(:response) do
-            AgentHarness::Response.new(
-              output: "Updated the implementation",
-              exit_code: 0,
-              duration: 12.4,
-              provider: :aider,
-              model: backend_model,
-              tokens: { input: 1_000_000, output: 500_000, total: 1_500_000 }
-            )
-          end
-
-          it "persists billable token usage with the backend model name" do
-            described_class.call(agent_run: agent_run, prompt: prompt)
-
-            usages = agent_run.token_usages.order(:request_type)
-
-            expect(usages.pluck(:request_type, :input_tokens, :output_tokens, :llm_model)).to eq([
-              [ "run_delta", 1_000_000, 500_000, backend_model ],
-              [ "run_summary", 1_000_000, 500_000, backend_model ]
-            ])
-
-            aggregate = TokenUsages::Aggregate.new(scope: agent_run.token_usages.billable).call
-
-            expect(aggregate[:total_input_tokens]).to eq(1_000_000)
-            expect(aggregate[:total_output_tokens]).to eq(500_000)
-            expect(aggregate[:cost_by_model].keys).to contain_exactly(backend_model)
-            expect(aggregate[:cost_by_request_type]).to eq("run_delta" => usages.billable.sum(:cost_cents))
-          end
-        end
-      end
-    end
-
     context "when agent times out" do
       before do
         allow(AgentHarness).to receive(:send_message)
@@ -612,7 +571,6 @@ RSpec.describe AgentRuns::Execute do
       "cursor" => :cursor,
       "codex" => :codex,
       "copilot" => :github_copilot,
-      "aider" => :aider,
       "gemini" => :gemini,
       "opencode" => :opencode,
       "kilocode" => :kilocode

--- a/spec/services/agent_runs/issue_runner_failure_history_spec.rb
+++ b/spec/services/agent_runs/issue_runner_failure_history_spec.rb
@@ -191,12 +191,12 @@ RSpec.describe AgentRuns::IssueRunnerFailureHistory do
           { "runner" => "claude_code", "success" => false, "error_type" => "error" },
           { "runner" => "codex", "success" => false, "error_type" => "timeout" },
           { "runner" => "cursor", "success" => false, "error_type" => "infinite_loop" },
-          { "runner" => "aider", "success" => false, "error_type" => "preflight_timeout" }
+          { "runner" => "gemini", "success" => false, "error_type" => "preflight_timeout" }
         ])
     end
 
     it "counts all execution failure types" do
-      expect(call).to eq("claude" => 1, "codex" => 1, "cursor" => 1, "aider" => 1)
+      expect(call).to eq("claude" => 1, "codex" => 1, "cursor" => 1, "gemini" => 1)
     end
   end
 end

--- a/spec/services/agent_runs/runner_resolver_spec.rb
+++ b/spec/services/agent_runs/runner_resolver_spec.rb
@@ -159,29 +159,6 @@ RSpec.describe AgentRuns::RunnerResolver do
       expect(agent_type).to eq("claude_code")
     end
 
-    it "uses the runner's required API service type for dynamic aider tenant API-key selection" do
-      project = create(:project)
-      owner = project.created_by
-      aider_runner = create(:runner, user: owner, runner_key: "aider", auth_type: "subscription",
-        config: { "aider" => { "api_provider" => "zai", "model" => "glm-5.1" } })
-      owner.settings.update!(default_agent_runner: aider_runner.routing_key)
-
-      api_key = create(:provider_api_key, user: owner, api_service_type: "zai")
-      create(:tenant_setting, account: project.account,
-        runner_preferences: { "api_key_ids" => { "zai" => api_key.id } })
-
-      runner_id, agent_type = described_class.call(project: project, goal: "create_pr")
-      runner = Runner.find(runner_id)
-
-      expect(agent_type).to eq("aider")
-      expect(runner).to have_attributes(
-        user: owner,
-        runner_key: "aider",
-        auth_type: "api_key",
-        provider_api_key: api_key
-      )
-    end
-
     it "falls back to an account integration credential when no tenant API key is selected" do
       account = create(:account)
       owner = create(:user, :owner, account: account)

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -459,7 +459,7 @@ RSpec.describe Containers::Provision do
         expect(agent_run).to receive(:log!).with("system", "container.network.ready",
           metadata: hash_including(network: NetworkPolicy::NETWORK_NAME)).ordered
         expect(agent_run).to receive(:log!).with("system", "container.ownership_batch_fixed",
-          metadata: hash_including(dirs_count: 12)).ordered
+          metadata: hash_including(dirs_count: 11)).ordered
         expect(agent_run).to receive(:log!).with("system", "container.codex_config_seeded",
           metadata: hash_including(auth_source: "api_key_proxy")).ordered
         expect(agent_run).to receive(:log!).with("system", "container.firewall.applied",
@@ -488,7 +488,6 @@ RSpec.describe Containers::Provision do
               script.include?("/home/agent/.cache") &&
               script.include?("/home/agent/.gemini") &&
               script.include?("/home/agent/.cursor-agent") &&
-              script.include?("/home/agent/.aider") &&
               script.include?("chown agent:agent /home/agent/.codex")
           } ],
           user: "root"
@@ -724,18 +723,6 @@ RSpec.describe Containers::Provision do
           expect(tmpfs).to have_key("/home/agent/.copilot")
           expect(tmpfs["/home/agent/.copilot"]).to include("mode=0700")
           expect(tmpfs["/home/agent/.copilot"]).to include("size=#{64 * 1024 * 1024}")
-          mock_container
-        end
-
-        service.provision
-      end
-
-      it "configures a writable tmpfs for Aider CLI config" do
-        expect(Docker::Container).to receive(:create) do |config|
-          tmpfs = config["HostConfig"]["Tmpfs"]
-          expect(tmpfs).to have_key("/home/agent/.aider")
-          expect(tmpfs["/home/agent/.aider"]).to include("mode=0700")
-          expect(tmpfs["/home/agent/.aider"]).to include("size=#{64 * 1024 * 1024}")
           mock_container
         end
 

--- a/spec/services/containers/token_optimization_spec.rb
+++ b/spec/services/containers/token_optimization_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Containers::TokenOptimization do
     end
 
     context "with unsupported runners" do
-      %w[kilocode pi aider unknown_runner].each do |runner|
+      %w[kilocode pi unknown_runner].each do |runner|
         it "does not call execute for #{runner}" do
           expect(container_service).not_to receive(:execute)
 

--- a/spec/services/knowledge/analysis_runner_spec.rb
+++ b/spec/services/knowledge/analysis_runner_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe Knowledge::AnalysisRunner, :no_db do
     it "returns true for anthropic-backed providers" do
       expect(described_class.supported_provider?("claude")).to be true
       expect(described_class.supported_provider?("cursor")).to be true
-      expect(described_class.supported_provider?("aider")).to be true
     end
 
     it "returns true for openai-backed providers" do

--- a/spec/support/provider_smoke_helpers.rb
+++ b/spec/support/provider_smoke_helpers.rb
@@ -78,12 +78,6 @@ module ProviderSmokeHelpers
       auth_type: "subscription",
       label: "Gemini subscription"
     ),
-    "aider-subscription" => Scenario.new(
-      name: "aider-subscription",
-      provider_key: "aider",
-      auth_type: "subscription",
-      label: "Aider subscription"
-    ),
     "opencode-openrouter" => Scenario.new(
       name: "opencode-openrouter",
       provider_key: "opencode",

--- a/spec/support/runner_smoke_helpers.rb
+++ b/spec/support/runner_smoke_helpers.rb
@@ -78,12 +78,6 @@ module RunnerSmokeHelpers
       auth_type: "subscription",
       label: "Gemini subscription"
     ),
-    "aider-subscription" => Scenario.new(
-      name: "aider-subscription",
-      runner_key: "aider",
-      auth_type: "subscription",
-      label: "Aider subscription"
-    ),
     "opencode-openrouter" => Scenario.new(
       name: "opencode-openrouter",
       runner_key: "opencode",

--- a/spec/temporal/activities/create_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/create_agent_run_activity_spec.rb
@@ -100,10 +100,10 @@ RSpec.describe Activities::CreateAgentRunActivity do
     end
 
     it "accepts a custom agent_type" do
-      result = activity.execute(project_id: project.id, issue_id: issue.id, agent_type: "aider")
+      result = activity.execute(project_id: project.id, issue_id: issue.id, agent_type: "gemini")
 
       agent_run = AgentRun.find(result[:agent_run_id])
-      expect(agent_run.agent_type).to eq("aider")
+      expect(agent_run.agent_type).to eq("gemini")
       expect(result[:runner_attempt_count]).to eq(1)
     end
 
@@ -476,10 +476,10 @@ RSpec.describe Activities::CreateAgentRunActivity do
     end
 
     it "returns deduplicated runner_attempt_count when fallback is enabled" do
-      allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor aider])
+      allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor codex])
       project.created_by.runners.find_or_create_by!(runner_key: "cursor")
-      project.created_by.runners.find_or_create_by!(runner_key: "aider")
-      project.created_by.settings.update!(fallback_enabled: true, fallback_runners: %w[claude cursor aider])
+      project.created_by.runners.find_or_create_by!(runner_key: "codex")
+      project.created_by.settings.update!(fallback_enabled: true, fallback_runners: %w[claude cursor codex])
 
       result = activity.execute(project_id: project.id, issue_id: issue.id, agent_type: "claude_code")
 
@@ -487,7 +487,7 @@ RSpec.describe Activities::CreateAgentRunActivity do
     end
 
     it "counts configured fallback-only providers even when not explicitly ordered yet" do
-      allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor aider])
+      allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor codex])
       project.created_by.runners.find_or_create_by!(
         runner_key: "cursor",
         enabled_for_agent_runs: false,
@@ -511,7 +511,7 @@ RSpec.describe Activities::CreateAgentRunActivity do
 
     it "counts fallbacks for an explicitly selected runner only when fallback is enabled" do
       primary_provider = create(:runner, user: project.created_by, runner_key: "cursor")
-      fallback_provider = create(:runner, user: project.created_by, runner_key: "aider")
+      fallback_provider = create(:runner, user: project.created_by, runner_key: "codex")
       project.created_by.runners.find_by!(runner_key: "claude").update!(enabled_for_fallback: false)
       project.created_by.settings.update!(fallback_enabled: true, fallback_runners: [ fallback_provider.routing_key ])
 

--- a/spec/temporal/activities/queue_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/queue_agent_run_activity_spec.rb
@@ -39,10 +39,10 @@ RSpec.describe Activities::QueueAgentRunActivity do
     end
 
     it "accepts a custom agent_type" do
-      result = activity.execute(project_id: project.id, issue_id: issue.id, agent_type: "aider")
+      result = activity.execute(project_id: project.id, issue_id: issue.id, agent_type: "gemini")
 
       agent_run = AgentRun.find(result[:agent_run_id])
-      expect(agent_run.agent_type).to eq("aider")
+      expect(agent_run.agent_type).to eq("gemini")
       expect(agent_run.runner_id).to be_nil
     end
 

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -445,7 +445,7 @@ RSpec.describe Activities::RunAgentActivity do
       result = described_class.runner_order(
         agent_type: "claude_code",
         fallback_enabled: false,
-        fallback_runners: %w[cursor aider]
+        fallback_runners: %w[cursor gemini]
       )
 
       expect(result).to eq([ "claude_code" ])
@@ -455,10 +455,10 @@ RSpec.describe Activities::RunAgentActivity do
       result = described_class.runner_order(
         agent_type: "claude_code",
         fallback_enabled: true,
-        fallback_runners: %w[claude cursor aider]
+        fallback_runners: %w[claude cursor gemini]
       )
 
-      expect(result).to eq(%w[claude_code cursor aider])
+      expect(result).to eq(%w[claude_code cursor gemini])
     end
 
     it "includes codex in fallback order when listed" do
@@ -517,7 +517,7 @@ RSpec.describe Activities::RunAgentActivity do
       count = described_class.runner_attempt_count(
         agent_type: "claude_code",
         fallback_enabled: true,
-        fallback_runners: %w[claude cursor aider]
+        fallback_runners: %w[claude cursor gemini]
       )
 
       expect(count).to eq(3)
@@ -1370,15 +1370,15 @@ RSpec.describe Activities::RunAgentActivity do
     it "wraps saved fallback order after the active primary runner entry" do
       claude = user.runners.find_by!(runner_key: "claude")
       cursor = create(:runner, user: user, runner_key: "cursor")
-      aider = create(:runner, user: user, runner_key: "aider")
+      gemini = create(:runner, user: user, runner_key: "gemini")
       provider_run = create(:agent_run, :with_git_context, project: project,
         issue: create(:issue, project: project), runner: cursor, agent_type: "cursor", container_id: "abc123")
       user.settings.update!(fallback_enabled: true,
-        fallback_runners: [ claude.routing_key, cursor.routing_key, aider.routing_key ])
+        fallback_runners: [ claude.routing_key, cursor.routing_key, gemini.routing_key ])
 
       runners = activity.send(:build_runner_order, provider_run, user.settings)
 
-      expect(runners).to eq([ cursor.routing_key, aider.routing_key, claude.routing_key ])
+      expect(runners).to eq([ cursor.routing_key, gemini.routing_key, claude.routing_key ])
     end
 
     it "filters an explicitly selected runner that is no longer container executable" do
@@ -1566,13 +1566,13 @@ RSpec.describe Activities::RunAgentActivity do
 
       it "uses stable sort: runners with equal failure counts keep original order" do
         codex_runner = create(:runner, user: user, runner_key: "codex")
-        aider_runner = create(:runner, user: user, runner_key: "aider")
+        gemini_runner = create(:runner, user: user, runner_key: "gemini")
         user.settings.update!(
           fallback_enabled: true,
-          fallback_runners: [ codex_runner.routing_key, aider_runner.routing_key ]
+          fallback_runners: [ codex_runner.routing_key, gemini_runner.routing_key ]
         )
 
-        # Both claude_code and codex have failed once; aider is untried
+        # Both claude_code and codex have failed once; gemini is untried
         create(:agent_run, :failed, project: project, issue: issue, goal: "create_pr",
           runners_attempted: [
             { "runner" => "claude_code", "success" => false, "error_type" => "error" },
@@ -1581,8 +1581,8 @@ RSpec.describe Activities::RunAgentActivity do
 
         runners = activity.send(:build_runner_order, agent_run, user.settings)
 
-        # aider (0 failures) should come first
-        expect(runners.first).to eq(aider_runner.routing_key)
+        # gemini (0 failures) should come first
+        expect(runners.first).to eq(gemini_runner.routing_key)
         # claude_code and codex (1 failure each) follow in their original order
         expect(runners[1]).to eq("claude_code")
         expect(runners[2]).to eq(codex_runner.routing_key)
@@ -4048,10 +4048,10 @@ expect(container_service).to receive(:execute).with(
       end
 
       before do
-        allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor aider])
+        allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor copilot])
         user.runners.find_or_create_by!(runner_key: "cursor")
-        user.runners.find_or_create_by!(runner_key: "aider")
-        user.settings.update!(fallback_enabled: true, fallback_runners: %w[claude cursor aider])
+        user.runners.find_or_create_by!(runner_key: "copilot")
+        user.settings.update!(fallback_enabled: true, fallback_runners: %w[claude cursor copilot])
         allow(git_ops).to receive_messages(head_sha: "sha123", commit_uncommitted_changes: false, has_changes_since?: false)
       end
 
@@ -4200,7 +4200,7 @@ expect(container_service).to receive(:execute).with(
         result = activity.execute(agent_run_id: agent_run.id)
 
         expect(result[:success]).to be true
-        expect(result[:final_runner]).to eq("aider")
+        expect(result[:final_runner]).to eq("copilot")
       end
 
       it "records runner switch when falling back" do
@@ -4281,7 +4281,7 @@ expect(container_service).to receive(:execute).with(
         expect(agent_run.status).to eq("timeout")
         expect(agent_run.error_message).to include("wall_clock_timeout")
         expect(agent_run.runners_attempted.map { |attempt| attempt["runner"] }).to eq(
-          %w[claude_code cursor aider]
+          %w[claude_code cursor copilot]
         )
         expect(agent_run.final_runner).to be_nil
       end
@@ -4742,7 +4742,7 @@ expect(container_service).to receive(:execute).with(
       end
 
       it "executes routing-key fallbacks with the runner entry config intact" do
-        allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor aider opencode])
+        allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor copilot opencode])
         api_key = create(:runner_api_key, user: user, api_service_type: "openrouter", api_key: "sk-openrouter-secret")
         opencode_runner = create_opencode_runner_entry(
           user: user,
@@ -4759,7 +4759,7 @@ expect(container_service).to receive(:execute).with(
         reset_time = 2.hours.from_now
 
         # Pre-set all runner states as rate limited so runner_unavailable? skips them
-        %w[claude cursor aider].each do |provider_name|
+        %w[claude cursor copilot].each do |provider_name|
           user.runner_states.find_or_create_by!(runner_name: provider_name).tap do |state|
             state.update!(rate_limited_until: reset_time)
           end


### PR DESCRIPTION
## Summary
- Removes Aider as a supported CLI runner across the devcontainer, the `paid-agents` Docker image build/CI, the runner-creation UI/API (model, controller, view, Stimulus JS), supporting services (tier-model defaults, runner resolver, container provisioning/tmpfs, artifact-exclude lists), and all RSpec coverage.
- Historical/point-in-time docs (numbered RDRs, an old implementation-prompt doc, `CHANGELOG.md`) and already-applied migration files are intentionally left untouched — rewriting them would misrepresent history.
- Two specs where Aider was structurally load-bearing (not just filler) were reworked rather than trivially edited: `spec/models/user_setting_spec.rb`'s alphabetical round-robin/random-mode tests (re-anchored on `codex`, which occupies the same relative alphabetical slot between `claude` and `cursor`) and `spec/temporal/activities/run_agent_activity_spec.rb`'s 3-hop fallback-chain `before` hook (re-anchored on `copilot` for the same reason, chosen to avoid a `runner_key` collision with an unrelated helper elsewhere in the file).

## Test plan
- [x] `bin/rubocop` clean on all changed Ruby files
- [x] `bin/lint` (RuboCop, ESLint, Herb) clean
- [x] Full `bin/rspec` suite: 17,297 examples, 25 failures — all 25 confirmed pre-existing via `git stash` isolation against the original `provision.rb` (same failures reproduce identically without this change) and are unrelated to Aider
- [x] Repo-wide grep confirms zero remaining `aider` references outside intentionally-preserved historical docs/migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)