### PR TITLE
fix(runners): inject ZHIPU_API_KEY for z.ai coding plan runners

### DIFF
--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -71,8 +71,11 @@ class Runner < ApplicationRecord
                opencode_model_provider: "xai" },
     "zai" => { label: "z.ai", base_url: "https://api.z.ai/api/paas/v4", service_type: "zai",
                opencode_model_provider: "zai" },
+    # Both KiloCode and OpenCode ship a built-in "zai-coding-plan" provider
+    # whose availability probe checks ZHIPU_API_KEY (not ZAI_CODING_API_KEY).
+    # Override the auto-derived name so the key lands where the CLIs look.
     "zai_coding" => { label: "z.ai (Coding Plan)", base_url: "https://api.z.ai/api/coding/paas/v4", service_type: "zai_coding",
-                      kilocode_provider_id: "zai-coding-plan", opencode_model_provider: "zai_coding" }
+                      env_var: "ZHIPU_API_KEY", kilocode_provider_id: "zai-coding-plan", opencode_model_provider: "zai_coding" }
   }.freeze
 
   DIRECT_OUTBOUND_SERVICE_TYPES = DIRECT_OUTBOUND_API_PROVIDERS.values.map { |c| c[:service_type] }.to_set.freeze

--- a/bin/chat-smoke
+++ b/bin/chat-smoke
@@ -20,7 +20,7 @@ SERVICE_TYPE_ENV_VARS = {
   "mistral" => "MISTRAL_API_KEY",
   "xai" => "XAI_API_KEY",
   "zai" => "ZAI_API_KEY",
-  "zai_coding" => "ZAI_CODING_API_KEY"
+  "zai_coding" => "ZHIPU_API_KEY"
 }.freeze
 MODEL_ENV = "PAID_CHAT_SMOKE_MODEL"
 

--- a/spec/models/runner_spec.rb
+++ b/spec/models/runner_spec.rb
@@ -1105,7 +1105,7 @@ RSpec.describe Runner do
         expect(config["provider"]).to eq({
           "zai-coding-plan" => {
             "options" => {
-              "apiKey" => "{env:ZAI_CODING_API_KEY}",
+              "apiKey" => "{env:ZHIPU_API_KEY}",
               "baseURL" => "https://api.z.ai/api/coding/paas/v4"
             },
             "models" => {
@@ -1388,7 +1388,7 @@ RSpec.describe Runner do
 
       expect(runtime.model).to eq("zai_coding/glm-5.1")
       expect(runtime.env).to include(
-        "ZAI_CODING_API_KEY" => "sk-zai-secret",
+        "ZHIPU_API_KEY" => "sk-zai-secret",
         "OPENAI_BASE_URL" => "https://api.z.ai/api/coding/paas/v4"
       )
       expect(runtime.metadata[:config]).not_to have_key("provider")

--- a/spec/support/provider_smoke_helpers.rb
+++ b/spec/support/provider_smoke_helpers.rb
@@ -43,7 +43,7 @@ module ProviderSmokeHelpers
     "minimax" => "ANTHROPIC_API_KEY",
     "xai" => "XAI_API_KEY",
     "zai" => "ZAI_API_KEY",
-    "zai_coding" => "ZAI_CODING_API_KEY"
+    "zai_coding" => "ZHIPU_API_KEY"
   }.freeze
   DEFAULT_SCENARIO_NAMES = %w[
     claude-subscription

--- a/spec/support/runner_smoke_helpers.rb
+++ b/spec/support/runner_smoke_helpers.rb
@@ -43,7 +43,7 @@ module RunnerSmokeHelpers
     "minimax" => "ANTHROPIC_API_KEY",
     "xai" => "XAI_API_KEY",
     "zai" => "ZAI_API_KEY",
-    "zai_coding" => "ZAI_CODING_API_KEY"
+    "zai_coding" => "ZHIPU_API_KEY"
   }.freeze
   DEFAULT_SCENARIO_NAMES = %w[
     claude-subscription


### PR DESCRIPTION
## Problem

Kilocode GLM runner (agent run [#34860](https://github.com/viamin/paid/issues/0)) failed with:

```
ProviderAuthError: providerID "google", message "Google Generative AI API key is missing"
```

The KiloCode CLI ships a built-in `zai-coding-plan` provider whose availability probe checks `ZHIPU_API_KEY`. Paid was injecting `ZAI_CODING_API_KEY` (auto-derived from `service_type`), which KiloCode never recognized — so it silently skipped the provider and fell back to Google/Gemini.

The exit code 137 (SIGKILL) in the error was a red herring: the preflight killed the process after capturing the auth error, not an OOM.

## Root cause (two issues)

### Fix A — env var mismatch (this PR)

`DIRECT_OUTBOUND_API_PROVIDERS["zai_coding"]` had no `env_var` override, so `kilocode_api_key_env_var` auto-derived `ZAI_CODING_API_KEY` from the service type. Both KiloCode and OpenCode CLIs check `ZHIPU_API_KEY` for provider availability — confirmed via `kilo auth list`:

- `ZAI_CODING_API_KEY` set → **zero z.ai providers detected**
- `ZHIPU_API_KEY` set → all four z.ai/zhipu providers show as configured

The fix adds `env_var: "ZHIPU_API_KEY"` to the `zai_coding` entry, matching the pattern `minimax` already uses for its `ANTHROPIC_API_KEY` override.

### Fix B — CLI version (companion issue)

KiloCode 7.1.3 (current agent-harness `DEFAULT_VERSION`) only has `glm-5` in its model catalog — no `glm-5.2`. Even with the correct env var, the model can't resolve. Version 7.4.16 adds `glm-5.2` and 16 other GLM-5.x variants.

Filed viamin/agent-harness#315 to bump `DEFAULT_VERSION` from `7.1.3` to `7.4.16`.

**Both fixes are required** — the env var fix alone won't work (7.1.3 can't resolve `glm-5.2`), and the CLI bump alone won't work (`ZHIPU_API_KEY` must be set for provider detection).

## Verification

- `kilo auth list` empirically confirms `ZHIPU_API_KEY` is the correct env var
- All providers with `kilocode_provider_id` cross-checked against KiloCode binary's built-in `env` lists — every one now matches
- 163 runner specs pass, lint clean
- No stale `ZAI_CODING_API_KEY` references remain in the codebase

## Companion

- viamin/agent-harness#315 — bump KiloCode CLI version