### PR TITLE
fix: Resource profiler ignores docker-exec OOMs (exit 137), trapping auto-tuned runners in a low-memory doom loop

### DIFF
--- a/app/models/agent_run_resource_profile.rb
+++ b/app/models/agent_run_resource_profile.rb
@@ -7,7 +7,10 @@ class AgentRunResourceProfile < ApplicationRecord
   MIN_RECOMMENDED_MEMORY_LIMIT_BYTES = 512 * 1024 * 1024
   SAFETY_MULTIPLIER = 1.2
   OOM_BUMP_MULTIPLIER = 1.25
-  OOM_MESSAGE_PATTERN = /container OOM-killed/i
+  OOM_MESSAGE_PATTERN = /
+    container\ OOM-killed |
+    container\ OOM\ not\ reported;\ configured\ memory\ limit
+  /ix
 
   # Downward-tuning safety: a recommended limit that has grown because of
   # OOMs is never dropped on a single refresh. Several consecutive

--- a/app/models/agent_run_resource_profile.rb
+++ b/app/models/agent_run_resource_profile.rb
@@ -9,7 +9,7 @@ class AgentRunResourceProfile < ApplicationRecord
   OOM_BUMP_MULTIPLIER = 1.25
   OOM_MESSAGE_PATTERN = /
     container\ OOM-killed |
-    container\ OOM\ not\ reported;\ configured\ memory\ limit
+    container\ OOM\ not\ reported;\ configured\ memory\ limit .* container_running=false
   /ix
 
   # Downward-tuning safety: a recommended limit that has grown because of

--- a/spec/models/agent_run_resource_profile_integration_spec.rb
+++ b/spec/models/agent_run_resource_profile_integration_spec.rb
@@ -29,5 +29,13 @@ RSpec.describe AgentRun, type: :model do
 
       expect(agent_run.resource_profile_oom?).to be(true)
     end
+
+    it "detects docker exec SIGKILL OOM evidence from the run error" do
+      agent_run = create(:agent_run,
+        :failed,
+        error_message: "Agent exited with code 137 (process killed by SIGKILL; container OOM not reported; configured memory limit 0.6 GB, container_running=false)")
+
+      expect(agent_run.resource_profile_oom?).to be(true)
+    end
   end
 end

--- a/spec/models/agent_run_resource_profile_integration_spec.rb
+++ b/spec/models/agent_run_resource_profile_integration_spec.rb
@@ -37,5 +37,19 @@ RSpec.describe AgentRun, type: :model do
 
       expect(agent_run.resource_profile_oom?).to be(true)
     end
+
+    it "ignores docker exec SIGKILL attempts when the container is still running" do
+      agent_run = create(:agent_run,
+        :failed,
+        error_message: "plain failure",
+        runners_attempted: [
+          {
+            "runner" => "claude",
+            "error_message" => "Preflight check failed: Agent exited with code 137 (process killed by SIGKILL; container OOM not reported; configured memory limit 0.6 GB, container_running=true)"
+          }
+        ])
+
+      expect(agent_run.resource_profile_oom?).to be(false)
+    end
   end
 end

--- a/spec/services/agent_run_resource_profiles/refresh_for_run_spec.rb
+++ b/spec/services/agent_run_resource_profiles/refresh_for_run_spec.rb
@@ -131,6 +131,32 @@ RSpec.describe AgentRunResourceProfiles::RefreshForRun do
       expect(specific_profile.recommended_memory_limit_bytes).to be >= (2.gigabytes * 1.25).ceil
     end
 
+    it "treats docker exec SIGKILL OOM messages as OOM samples for limit bumps" do
+      run = create(:agent_run,
+        :failed,
+        project: project,
+        goal: "create_pr",
+        agent_type: "claude_code",
+        final_runner: "claude",
+        completed_at: completed_at,
+        peak_memory_bytes: 1.gigabyte,
+        error_message: "Agent exited with code 137 (process killed by SIGKILL; container OOM not reported; configured memory limit 2.0 GB, container_running=false)")
+      create(:container_metric,
+        agent_run: run,
+        memory_bytes: 1.gigabyte,
+        memory_limit_bytes: 2.gigabytes)
+
+      2.times do |index|
+        create_sample_run(memory_bytes: (index + 2).gigabytes, completed_at: completed_at - (index + 1).days)
+      end
+
+      described_class.call(agent_run: run)
+
+      expect(specific_profile.oom_count).to eq(1)
+      expect(specific_profile.p50_memory_bytes).to eq(2.gigabytes)
+      expect(specific_profile.recommended_memory_limit_bytes).to be >= (2.gigabytes * 1.25).ceil
+    end
+
     it "bumps the recommended limit for an OOM run without a container memory limit" do
       # OOM-killed run whose peak we observed but which has no ContainerMetric
       # row, so memory_limit_bytes defaults to 0. The bump must still fire,


### PR DESCRIPTION
## Summary

Resource profiler ignores docker-exec OOMs (exit 137), trapping auto-tuned runners in a low-memory doom loop

See #3047 for context.

## Quality Warnings

- bundler: failed to load command: mutant (/tmp/bundle/ruby/3.4.0/bin/mutant)
/workspace/app/services/database/runtime_role_guard.rb:29:in 'Database::RuntimeRoleGuard.verify!': Unsafe PostgreSQL runtime role "agent": SUPERUSER and BYPASSRLS. Tenant row-level security is bypassed by superusers and roles with BYPASSRLS. Configure DATABASE_URL to use a dedicated application role without SUPERUSER or BYPASSRLS. (RuntimeError)
	from /workspace/config/initializers/database_runtime_role_guard.rb:7:in ...

---

Closes #3047