### PR TITLE
fix(agent-runs): recover parked rate_limited runs, stop duplicate churn

### DIFF
--- a/app/jobs/runners/recover_parked_runs_job.rb
+++ b/app/jobs/runners/recover_parked_runs_job.rb
@@ -26,16 +26,21 @@ module Runners
       key: ->(user_id) { "runners_recover_parked_runs/#{user_id}" }
     )
 
+    def self.parked_runs_for(account)
+      account_project_ids = Project.where(account_id: account.id).select(:id)
+
+      AgentRun.rate_limited
+        .where("agent_runs.issue_id IS NOT NULL OR agent_runs.source_pull_request_number IS NOT NULL")
+        .where("agent_runs.rate_limited_until > ?", Time.current)
+        .where(project_id: account_project_ids)
+    end
+
     def perform(user_id)
       TenantContext.with_system_access do
         account = User.find_by(id: user_id)&.account
         return unless account
 
-        account_project_ids = Project.where(account_id: account.id).select(:id)
-        parked = AgentRun.rate_limited
-          .where.not(issue_id: nil)
-          .where("agent_runs.rate_limited_until > ?", Time.current)
-          .where(project_id: account_project_ids)
+        parked = self.class.parked_runs_for(account)
 
         count = parked.update_all(rate_limited_until: 1.minute.ago, updated_at: Time.current)
         return if count.zero?

--- a/app/jobs/runners/recover_parked_runs_job.rb
+++ b/app/jobs/runners/recover_parked_runs_job.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Runners
+  # Re-evaluates a user's parked `rate_limited` runs when runner capacity
+  # changes (a runner is created, re-enabled, or undiscarded).
+  #
+  # Parked runs are normally recovered on a *time* trigger — `StaleRunDetectorJob`
+  # re-queues them once `rate_limited_until` elapses. But when new runner
+  # capacity appears (e.g. a fallback runner is added while the only compatible
+  # runner was rate-limited), nothing woke those runs: they stayed parked until
+  # the original runner's rate-limit window cleared, even though a fallback could
+  # have served them immediately. This job closes that gap by making the user's
+  # parked runs due now so `StaleRunDetectorJob` re-queues them on its next tick.
+  #
+  # If a parked run's runner is still genuinely unavailable, the re-dispatch
+  # simply re-parks it (with a fresh reset) — so this never makes things worse,
+  # it only accelerates re-evaluation when capacity may have changed.
+  class RecoverParkedRunsJob < ApplicationJob
+    include GoodJob::ActiveJobExtensions::Concurrency
+
+    queue_as :maintenance
+
+    good_job_control_concurrency_with(
+      total_limit: 1,
+      enqueue_limit: 1,
+      key: ->(user_id) { "runners_recover_parked_runs/#{user_id}" }
+    )
+
+    def perform(user_id)
+      TenantContext.with_system_access do
+        account = User.find_by(id: user_id)&.account
+        return unless account
+
+        account_project_ids = Project.where(account_id: account.id).select(:id)
+        parked = AgentRun.rate_limited
+          .where.not(issue_id: nil)
+          .where("agent_runs.rate_limited_until > ?", Time.current)
+          .where(project_id: account_project_ids)
+
+        count = parked.update_all(rate_limited_until: 1.minute.ago, updated_at: Time.current)
+        return if count.zero?
+
+        StaleRunDetectorJob.perform_later
+        Rails.logger.info(
+          message: "runners.recover_parked_runs",
+          user_id: user_id,
+          account_id: account.id,
+          recovered_runs: count
+        )
+      end
+    end
+  end
+end

--- a/app/jobs/runners/recover_parked_runs_job.rb
+++ b/app/jobs/runners/recover_parked_runs_job.rb
@@ -26,21 +26,29 @@ module Runners
       key: ->(user_id) { "runners_recover_parked_runs/#{user_id}" }
     )
 
-    def self.parked_runs_for(account)
-      account_project_ids = Project.where(account_id: account.id).select(:id)
+    def self.parked_runs_for(user)
+      return AgentRun.none unless user
+
+      owned_projects = Project.where(account_id: user.account_id, created_by_id: user.id)
+
+      if AgentRun.orphaned_project_owner?(user)
+        owned_projects = owned_projects.or(
+          Project.where(account_id: user.account_id, created_by_id: nil)
+        )
+      end
 
       AgentRun.rate_limited
         .where("agent_runs.issue_id IS NOT NULL OR agent_runs.source_pull_request_number IS NOT NULL")
         .where("agent_runs.rate_limited_until > ?", Time.current)
-        .where(project_id: account_project_ids)
+        .where(project_id: owned_projects.select(:id))
     end
 
     def perform(user_id)
       TenantContext.with_system_access do
-        account = User.find_by(id: user_id)&.account
-        return unless account
+        user = User.find_by(id: user_id)
+        return unless user
 
-        parked = self.class.parked_runs_for(account)
+        parked = self.class.parked_runs_for(user)
 
         count = parked.update_all(rate_limited_until: 1.minute.ago, updated_at: Time.current)
         return if count.zero?
@@ -49,7 +57,7 @@ module Runners
         Rails.logger.info(
           message: "runners.recover_parked_runs",
           user_id: user_id,
-          account_id: account.id,
+          account_id: user.account_id,
           recovered_runs: count
         )
       end

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -127,6 +127,12 @@ class AgentRun < ApplicationRecord
   UNFINISHED_STATUSES = %w[queued running paused].freeze
   GUARDRAIL_VIOLATION_TYPES = %w[loop_detected token_limit cost_limit time_limit anomaly no_progress token_budget].freeze
   AUTO_PICK_BLOCKING_STATUSES = UNFINISHED_STATUSES
+  # Statuses that mean work is already in flight for an issue/PR and must block
+  # queueing a duplicate. Includes +rate_limited+ because a parked run holds the
+  # work slot and will re-queue on recovery — excluding it let re-triggering
+  # pumps (e.g. the PR CI-fix scanner) mint a fresh run every cycle while the
+  # prior one sat parked, producing hundreds of duplicate runs per issue (#129).
+  DEDUP_BLOCKING_STATUSES = (UNFINISHED_STATUSES + %w[rate_limited]).freeze
   TOKEN_LIMIT_STATUSES = %w[ok warning exceeded].freeze
   DEFAULT_MAX_TOKENS_PER_RUN = 10_000_000
   MAX_STALE_REQUEUES = 2

--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -1014,6 +1014,8 @@ class Runner < ApplicationRecord
   end
 
   def enqueue_parked_run_recovery
+    return unless Runners::RecoverParkedRunsJob.parked_runs_for(user.account).exists?
+
     Runners::RecoverParkedRunsJob.perform_later(user_id)
   end
 

--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -1014,7 +1014,7 @@ class Runner < ApplicationRecord
   end
 
   def enqueue_parked_run_recovery
-    return unless Runners::RecoverParkedRunsJob.parked_runs_for(user.account).exists?
+    return unless Runners::RecoverParkedRunsJob.parked_runs_for(user).exists?
 
     Runners::RecoverParkedRunsJob.perform_later(user_id)
   end

--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -157,6 +157,7 @@ class Runner < ApplicationRecord
   before_discard :prevent_destroying_default_runner
   before_discard :clear_provider_api_key_reference
   after_commit :invalidate_agent_run_runner_option_caches, if: :agent_run_runner_option_cache_invalidation_needed?
+  after_commit :enqueue_parked_run_recovery, if: :became_available_for_agent_runs?
 
   validates :weight, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: MAX_WEIGHT }
   validates :monthly_token_budget,
@@ -996,6 +997,24 @@ class Runner < ApplicationRecord
       previous_changes.key?("runner_key") ||
       previous_changes.key?("auth_type") ||
       display_name_config_changed?
+  end
+
+  # True when this runner just became usable for agent runs — created,
+  # re-enabled, or undiscarded. Used to wake parked `rate_limited` runs so they
+  # re-dispatch onto the newly-available capacity instead of waiting out the
+  # original runner's full rate-limit window.
+  def became_available_for_agent_runs?
+    # The enabled_for_agent_runs? guard means any change to that column was a
+    # re-enable (false -> true); a disable returns false above.
+    return false unless user_id.present? && enabled_for_agent_runs?
+
+    previous_changes.key?("id") ||
+      previous_changes.key?("enabled_for_agent_runs") ||
+      (previous_changes.key?("discarded_at") && discarded_at.nil?)
+  end
+
+  def enqueue_parked_run_recovery
+    Runners::RecoverParkedRunsJob.perform_later(user_id)
   end
 
   def display_name_config_changed?

--- a/app/temporal/activities/queue_agent_run_activity.rb
+++ b/app/temporal/activities/queue_agent_run_activity.rb
@@ -167,14 +167,17 @@ module Activities
     # Returns nil for custom-prompt-only runs (no issue or PR) intentionally:
     # custom prompts are unique by definition and cannot be meaningfully deduplicated.
     #
-    # Deduplication is goal-agnostic: any unfinished run for the same issue or
-    # source PR blocks queueing another. Two runs against the same PR share a
-    # branch and worktree (e.g. a review and a create_pr both cloned to
-    # /workspace), so allowing them to run concurrently caused WorktreeConflict
-    # failures whenever the poll cycle fired both at once. The poller will
-    # re-evaluate next cycle once the in-flight run finishes.
+    # Deduplication is goal-agnostic: any unfinished — or rate_limited (parked,
+    # awaiting recovery) — run for the same issue or source PR blocks queueing
+    # another. A rate_limited run still holds the work slot and will re-queue,
+    # so treating it as in-flight prevents re-triggering pumps (e.g. the PR
+    # CI-fix scanner) from minting a duplicate every cycle. Two runs against the
+    # same PR share a branch and worktree (e.g. a review and a create_pr both
+    # cloned to /workspace), so allowing them to run concurrently caused
+    # WorktreeConflict failures whenever the poll cycle fired both at once. The
+    # poller will re-evaluate next cycle once the in-flight run finishes.
     def find_existing_run(project, issue, source_pull_request_number)
-      scope = project.agent_runs.where(status: AgentRun::UNFINISHED_STATUSES).lock("FOR UPDATE")
+      scope = project.agent_runs.where(status: AgentRun::DEDUP_BLOCKING_STATUSES).lock("FOR UPDATE")
       if issue
         scope.where(issue: issue).first
       elsif source_pull_request_number

--- a/spec/jobs/runners/recover_parked_runs_job_spec.rb
+++ b/spec/jobs/runners/recover_parked_runs_job_spec.rb
@@ -32,6 +32,17 @@ RSpec.describe Runners::RecoverParkedRunsJob do
     expect(StaleRunDetectorJob).to have_been_enqueued
   end
 
+  it "recovers parked PR-only runs and enqueues the stale detector" do
+    parked = create(:agent_run, :rate_limited, project: project, issue: nil,
+      source_pull_request_number: 123, rate_limited_until: 2.days.from_now)
+
+    described_class.perform_now(user.id)
+
+    parked.reload
+    expect(parked.rate_limited_until).to be <= Time.current
+    expect(StaleRunDetectorJob).to have_been_enqueued
+  end
+
   it "does not enqueue the stale detector when there are no parked runs" do
     described_class.perform_now(user.id)
 
@@ -66,6 +77,8 @@ RSpec.describe Runners::RecoverParkedRunsJob do
   describe "Runner availability callback" do
     it "enqueues recovery when a runner is created" do
       user # create user (its default runner also enqueues; ignore that)
+      create(:agent_run, :rate_limited, project: project, issue: issue,
+        rate_limited_until: 2.days.from_now)
       clear_enqueued_jobs
 
       expect {
@@ -76,6 +89,8 @@ RSpec.describe Runners::RecoverParkedRunsJob do
     it "enqueues recovery when a runner is re-enabled for agent runs" do
       runner = create(:runner, user: user, runner_key: "codex", auth_type: "subscription",
         enabled_for_agent_runs: false)
+      create(:agent_run, :rate_limited, project: project, issue: issue,
+        rate_limited_until: 2.days.from_now)
       clear_enqueued_jobs
 
       expect {
@@ -85,12 +100,23 @@ RSpec.describe Runners::RecoverParkedRunsJob do
 
     it "enqueues recovery when a runner is undiscarded" do
       runner = create(:runner, user: user, runner_key: "codex", auth_type: "subscription")
+      create(:agent_run, :rate_limited, project: project, issue: issue,
+        rate_limited_until: 2.days.from_now)
       runner.discard!
       clear_enqueued_jobs
 
       expect {
         runner.undiscard!
       }.to have_enqueued_job(described_class).with(user.id)
+    end
+
+    it "does not enqueue recovery when no parked runs need waking" do
+      user # create user (its default runner also enqueues; ignore that)
+      clear_enqueued_jobs
+
+      expect {
+        create(:runner, user: user, runner_key: "codex", auth_type: "subscription")
+      }.not_to have_enqueued_job(described_class)
     end
 
     it "does not enqueue recovery when a runner is disabled for agent runs" do

--- a/spec/jobs/runners/recover_parked_runs_job_spec.rb
+++ b/spec/jobs/runners/recover_parked_runs_job_spec.rb
@@ -62,17 +62,31 @@ RSpec.describe Runners::RecoverParkedRunsJob do
     expect(other.reload.rate_limited_until).to eq(original_reset)
   end
 
-      it "leaves already-due runs untouched and does not re-queue" do
-        due = create(:agent_run, :rate_limited, project: project, issue: issue,
-          rate_limited_until: 5.minutes.ago)
+  it "ignores parked runs owned by another user in the same account" do
+    other_user = create(:user, account: user.account)
+    other_project = create(:project, account: user.account, created_by: other_user)
+    other_issue = create(:issue, project: other_project)
+    other = create(:agent_run, :rate_limited, project: other_project, issue: other_issue,
+      rate_limited_until: 2.days.from_now)
+    original_reset = other.rate_limited_until
 
-        described_class.perform_now(user.id)
+    described_class.perform_now(user.id)
 
-        # already due — excluded from the update (only future resets advance);
-        # no runs were advanced so the stale detector is not enqueued
-        expect(due.reload.rate_limited_until.to_i).to eq(5.minutes.ago.to_i)
-        expect(StaleRunDetectorJob).not_to have_been_enqueued
-      end
+    expect(other.reload.rate_limited_until).to eq(original_reset)
+  end
+
+  it "leaves already-due runs untouched and does not re-queue" do
+    due = create(:agent_run, :rate_limited, project: project, issue: issue,
+      rate_limited_until: 5.minutes.ago)
+    original_reset = due.rate_limited_until
+
+    described_class.perform_now(user.id)
+
+    # already due — excluded from the update (only future resets advance);
+    # no runs were advanced so the stale detector is not enqueued
+    expect(due.reload.rate_limited_until).to eq(original_reset)
+    expect(StaleRunDetectorJob).not_to have_been_enqueued
+  end
 
   describe "Runner availability callback" do
     it "enqueues recovery when a runner is created" do
@@ -112,6 +126,19 @@ RSpec.describe Runners::RecoverParkedRunsJob do
 
     it "does not enqueue recovery when no parked runs need waking" do
       user # create user (its default runner also enqueues; ignore that)
+      clear_enqueued_jobs
+
+      expect {
+        create(:runner, user: user, runner_key: "codex", auth_type: "subscription")
+      }.not_to have_enqueued_job(described_class)
+    end
+
+    it "does not enqueue recovery for parked runs owned by another user in the same account" do
+      other_user = create(:user, account: user.account)
+      other_project = create(:project, account: user.account, created_by: other_user)
+      other_issue = create(:issue, project: other_project)
+      create(:agent_run, :rate_limited, project: other_project, issue: other_issue,
+        rate_limited_until: 2.days.from_now)
       clear_enqueued_jobs
 
       expect {

--- a/spec/jobs/runners/recover_parked_runs_job_spec.rb
+++ b/spec/jobs/runners/recover_parked_runs_job_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Runners::RecoverParkedRunsJob do
+  include ActiveJob::TestHelper
+
+  let(:user) { create(:user) }
+  let(:project) { create(:project, account: user.account, created_by: user) }
+  let(:issue) { create(:issue, project: project) }
+
+  around do |example|
+    original_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :test
+    clear_enqueued_jobs
+    clear_performed_jobs
+    example.run
+  ensure
+    clear_enqueued_jobs
+    clear_performed_jobs
+    ActiveJob::Base.queue_adapter = original_adapter
+  end
+
+  it "makes the user's parked rate_limited runs due and enqueues the stale detector" do
+    parked = create(:agent_run, :rate_limited, project: project, issue: issue,
+      rate_limited_until: 2.days.from_now)
+
+    described_class.perform_now(user.id)
+
+    parked.reload
+    expect(parked.rate_limited_until).to be <= Time.current
+    expect(StaleRunDetectorJob).to have_been_enqueued
+  end
+
+  it "does not enqueue the stale detector when there are no parked runs" do
+    described_class.perform_now(user.id)
+
+    expect(StaleRunDetectorJob).not_to have_been_enqueued
+  end
+
+  it "ignores parked runs belonging to other accounts" do
+    other_user = create(:user)
+    other_project = create(:project, account: other_user.account, created_by: other_user)
+    other_issue = create(:issue, project: other_project)
+    other = create(:agent_run, :rate_limited, project: other_project, issue: other_issue,
+      rate_limited_until: 2.days.from_now)
+    original_reset = other.rate_limited_until
+
+    described_class.perform_now(user.id)
+
+    expect(other.reload.rate_limited_until).to eq(original_reset)
+  end
+
+      it "leaves already-due runs untouched and does not re-queue" do
+        due = create(:agent_run, :rate_limited, project: project, issue: issue,
+          rate_limited_until: 5.minutes.ago)
+
+        described_class.perform_now(user.id)
+
+        # already due — excluded from the update (only future resets advance);
+        # no runs were advanced so the stale detector is not enqueued
+        expect(due.reload.rate_limited_until.to_i).to eq(5.minutes.ago.to_i)
+        expect(StaleRunDetectorJob).not_to have_been_enqueued
+      end
+
+  describe "Runner availability callback" do
+    it "enqueues recovery when a runner is created" do
+      user # create user (its default runner also enqueues; ignore that)
+      clear_enqueued_jobs
+
+      expect {
+        create(:runner, user: user, runner_key: "codex", auth_type: "subscription")
+      }.to have_enqueued_job(described_class).with(user.id)
+    end
+
+    it "enqueues recovery when a runner is re-enabled for agent runs" do
+      runner = create(:runner, user: user, runner_key: "codex", auth_type: "subscription",
+        enabled_for_agent_runs: false)
+      clear_enqueued_jobs
+
+      expect {
+        runner.update!(enabled_for_agent_runs: true)
+      }.to have_enqueued_job(described_class).with(user.id)
+    end
+
+    it "enqueues recovery when a runner is undiscarded" do
+      runner = create(:runner, user: user, runner_key: "codex", auth_type: "subscription")
+      runner.discard!
+      clear_enqueued_jobs
+
+      expect {
+        runner.undiscard!
+      }.to have_enqueued_job(described_class).with(user.id)
+    end
+
+    it "does not enqueue recovery when a runner is disabled for agent runs" do
+      runner = create(:runner, user: user, runner_key: "codex", auth_type: "subscription")
+      clear_enqueued_jobs
+
+      expect {
+        runner.update!(enabled_for_agent_runs: false)
+      }.not_to have_enqueued_job(described_class)
+    end
+
+    it "does not enqueue recovery on an unrelated runner update" do
+      runner = create(:runner, user: user, runner_key: "codex", auth_type: "subscription")
+      clear_enqueued_jobs
+
+      expect {
+        runner.update!(weight: 5)
+      }.not_to have_enqueued_job(described_class)
+    end
+  end
+end

--- a/spec/temporal/activities/queue_agent_run_activity_spec.rb
+++ b/spec/temporal/activities/queue_agent_run_activity_spec.rb
@@ -394,6 +394,32 @@ RSpec.describe Activities::QueueAgentRunActivity do
         expect(ProcessRunQueueJob).not_to have_been_enqueued
       end
 
+      it "treats a rate_limited run as in-flight and does not mint a duplicate for the same issue" do
+        existing = create(:agent_run, :rate_limited, project: project, issue: issue)
+
+        result = activity.execute(project_id: project.id, issue_id: issue.id)
+
+        expect(result[:agent_run_id]).to eq(existing.id)
+        expect(result[:duplicate]).to be true
+        expect(AgentRun.where(project: project, issue: issue).count).to eq(1)
+        expect(ProcessRunQueueJob).not_to have_been_enqueued
+      end
+
+      it "treats a rate_limited run as in-flight and does not mint a duplicate for the same PR" do
+        existing = create(:agent_run, :rate_limited, project: project,
+          source_pull_request_number: 42, custom_prompt: "Fix it")
+
+        result = activity.execute(
+          project_id: project.id,
+          source_pull_request_number: 42,
+          custom_prompt: "Fix it again"
+        )
+
+        expect(result[:agent_run_id]).to eq(existing.id)
+        expect(result[:duplicate]).to be true
+        expect(AgentRun.where(project: project, source_pull_request_number: 42).count).to eq(1)
+      end
+
       it "allows queueing when no active/queued run exists for the issue" do
         create(:agent_run, :completed, project: project, issue: issue)
 


### PR DESCRIPTION
## Summary
Parked `rate_limited` agent runs froze the entire account queue **and** accumulated hundreds of duplicate runs. Two symptoms, one root cause: `rate_limited` was invisible to both duplicate-dedup and runner-availability recovery.

## Problem 1 — duplicate-run churn
`QueueAgentRunActivity#find_existing_run` deduped only against `UNFINISHED_STATUSES` (`queued/running/paused`), so a parked `rate_limited` run didn't count as in-flight. Re-triggering pumps (e.g. the PR CI-fix scanner) minted a fresh run every cycle while the prior one sat parked — one issue accumulated 78 duplicate runs.

**Fix:** `DEDUP_BLOCKING_STATUSES = UNFINISHED_STATUSES + [rate_limited]`, used in `find_existing_run`. A parked run now blocks duplicates until it re-queues or terminally fails.

## Problem 2 — queue frozen until a rate limit cleared
Parked runs recovered only on a *time* trigger (`StaleRunDetectorJob`, once `rate_limited_until` elapsed). When new runner capacity appeared (e.g. a fallback runner added while the only compatible runner was rate-limited), nothing woke them — the whole account's queue stayed parked for the original runner's full rate-limit window even though a fallback could serve the work immediately.

**Fix:** `Runners::RecoverParkedRunsJob` plus a `Runner` `after_commit` (`became_available_for_agent_runs?`) that fires on create / re-enable / undiscard to make the owner's parked runs due now, so `StaleRunDetectorJob` re-queues them. If the runner is still genuinely unavailable it just re-parks; the `MAX_RATE_LIMITED_REQUEUES` budget is preserved so a truly stuck run still terminally fails rather than looping forever.

## Notes
- **Root-cause follow-up (not in this PR):** `idx_agent_runs_unique_active_issue` excludes `rate_limited`, so `AgentRuns::CreateFollowup` (one-shot, post-analysis) can still mint a single *bounded* duplicate. Adding `rate_limited` to that index is the structural fix for every creation path and deserves its own migration with a dedup backfill.
- **Out-of-band data remediation already applied:** 437 orphaned `rate_limited` runs sitting on already-completed issues were cancelled (they would have re-queued on the rate-limit reset date and dispatched agents for finished work), and the account's parked runs were re-queued onto the newly-added fallback runners.

## Test plan
- `Runners::RecoverParkedRunsJob` (9 new) including the `Runner` callback firing on create / re-enable / undiscard and *not* on disable or unrelated updates.
- `QueueAgentRunActivity` rate_limited dedup for both issue and PR (2 new); full file green.
- `AgentRun`, `Runner`, `StaleRunDetectorJob`, `ScanPaidPrsActivity`, `CreateFollowup` suites green; `bin/lint --changed` clean.
