### PR TITLE
fix(dashboard): interleave upcoming queue by scheduler dispatch order

### DIFF
--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -935,6 +935,7 @@ class AgentRun < ApplicationRecord
     auto_pick: { label: "Auto-pick", indicator: 9 }
   }.freeze
   UNKNOWN_PRIORITY = { label: "Unknown", indicator: nil }.freeze
+  QUEUE_GOAL_PRIORITY_GOALS = %w[create_issue enhance_issue analyze_issue].freeze
 
   def queue_priority_tier
     return :manual if manual?
@@ -1163,7 +1164,7 @@ class AgentRun < ApplicationRecord
   IN_PROGRESS_SQL = Arel.sql("#{IN_PROGRESS_CASE_SQL} ASC").freeze
   GOAL_PRIORITY_CASE_SQL = <<~SQL.squish.freeze
     CASE
-      WHEN goal IN ('create_issue', 'enhance_issue', 'analyze_issue') THEN 0
+      WHEN goal IN ('#{QUEUE_GOAL_PRIORITY_GOALS.join("', '")}') THEN 0
       ELSE 1
     END
   SQL
@@ -1430,6 +1431,16 @@ class AgentRun < ApplicationRecord
     source_pull_request_number.present?
   end
 
+  def queue_order_rank
+    [
+      queue_priority_rank,
+      existing_pr? ? 0 : 1,
+      queue_goal_priority_rank,
+      created_at,
+      id
+    ]
+  end
+
   def create_issue_goal?
     goal == "create_issue"
   end
@@ -1470,6 +1481,16 @@ class AgentRun < ApplicationRecord
   def automatic?
     trigger_type == "automatic"
   end
+
+  def queue_priority_rank
+    self[:queue_priority] || QUEUE_PRIORITIES.dig(queue_priority_tier, :indicator)&.-(1) || Float::INFINITY
+  end
+
+  def queue_goal_priority_rank
+    self[:goal_priority] || (QUEUE_GOAL_PRIORITY_GOALS.include?(goal) ? 0 : 1)
+  end
+
+  private :queue_priority_rank, :queue_goal_priority_rank
 
   def queued?
     status == "queued"

--- a/app/services/dashboard/queue_preview.rb
+++ b/app/services/dashboard/queue_preview.rb
@@ -31,9 +31,61 @@ module Dashboard
       visible_runs = snapshot.select { |run| visible_project_ids.include?(run.project_id) }
       preload_associations(visible_runs)
 
-      visible_runs.first(limit).each_with_index.map do |run, index|
+      interleave_by_dispatch_order(visible_runs).each_with_index.map do |run, index|
         Entry.new(position: index + 1, run:)
       end
+    end
+
+    # Renders the queue in the round-robin dispatch order the scheduler aims
+    # for, instead of the static project_active_count snapshot. QUEUE_ORDER
+    # clusters every run from an idle project at the top (they share the same
+    # current active-count tier), so a backlog-heavy project looks like it
+    # will monopolize every agent slot. In reality the scheduler claims one
+    # run, increments that project's active count, then moves to whichever
+    # project now has the fewest in-flight runs. Replaying that here
+    # interleaves projects so a single project's backlog can't visually
+    # starve the rest.
+    #
+    # This is an approximation of dispatch order, not an exact prediction:
+    # in-flight counts only increase as runs are "dispatched" (run completion
+    # would decrement them), so the result reflects steady-state fair-share
+    # ordering rather than wall-clock timing. Per-project run order (priority,
+    # then FIFO) is preserved because the snapshot is already sorted by
+    # QUEUE_ORDER, so grouping by project keeps each project's runs in their
+    # correct sequence. The user_active_count tier is constant across a
+    # user's visible projects (orphaned projects resolve to the same fallback
+    # owner), so it is intentionally omitted from the tiebreak.
+    def interleave_by_dispatch_order(visible_runs)
+      active_counts = AgentRun
+        .capacity_inflight
+        .where(project_id: visible_project_ids)
+        .group(:project_id)
+        .count
+
+      queues = visible_runs.group_by(&:project_id).transform_values { |runs| runs.dup }
+      active = active_counts.transform_values(&:to_i)
+
+      interleaved = []
+      while interleaved.size < limit
+        candidates = queues.reject { |_, queued| queued.empty? }
+        break if candidates.empty?
+
+        project_id = candidates.min_by { |pid, queued| [ active[pid].to_i, dispatch_rank(queued.first) ] }.first
+        run = queues[project_id].shift
+        active[project_id] = active[project_id].to_i + 1
+        interleaved << run
+      end
+      interleaved
+    end
+
+    # Tie-break key matching QUEUE_ORDER below the project_active_count /
+    # user_active_count tiers: queue priority, PR-continuation ahead within
+    # the manual tier, create_issue-family goals first, then FIFO.
+    def dispatch_rank(run)
+      indicator = AgentRun::QUEUE_PRIORITIES.dig(run.queue_priority_tier, :indicator) || Float::INFINITY
+      in_progress = run.existing_pr? ? 0 : 1
+      goal_rank = %w[create_issue enhance_issue analyze_issue].include?(run.goal) ? 0 : 1
+      [ indicator, in_progress, goal_rank, run.created_at, run.id ]
     end
 
     def visible_project_ids

--- a/app/services/dashboard/queue_preview.rb
+++ b/app/services/dashboard/queue_preview.rb
@@ -5,7 +5,9 @@ module Dashboard
     Entry = Struct.new(:position, :run, keyword_init: true)
     CACHE_TTL = 10.seconds
 
-    MAX_SCAN = 200
+    # Sample more queued rows than we display so the fair-share replay can see
+    # additional projects before the preview limit truncates the result.
+    MAX_SCAN = 500
 
     def self.call(...)
       new(...).call
@@ -70,22 +72,12 @@ module Dashboard
         candidates = queues.reject { |_, queued| queued.empty? }
         break if candidates.empty?
 
-        project_id = candidates.min_by { |pid, queued| [ active[pid].to_i, dispatch_rank(queued.first) ] }.first
+        project_id = candidates.min_by { |pid, queued| [ active[pid].to_i, queued.first.queue_order_rank ] }.first
         run = queues[project_id].shift
         active[project_id] = active[project_id].to_i + 1
         interleaved << run
       end
       interleaved
-    end
-
-    # Tie-break key matching QUEUE_ORDER below the project_active_count /
-    # user_active_count tiers: queue priority, PR-continuation ahead within
-    # the manual tier, create_issue-family goals first, then FIFO.
-    def dispatch_rank(run)
-      indicator = AgentRun::QUEUE_PRIORITIES.dig(run.queue_priority_tier, :indicator) || Float::INFINITY
-      in_progress = run.existing_pr? ? 0 : 1
-      goal_rank = %w[create_issue enhance_issue analyze_issue].include?(run.goal) ? 0 : 1
-      [ indicator, in_progress, goal_rank, run.created_at, run.id ]
     end
 
     def visible_project_ids

--- a/app/services/dashboard/queue_preview.rb
+++ b/app/services/dashboard/queue_preview.rb
@@ -65,7 +65,7 @@ module Dashboard
         .group(:project_id)
         .count
 
-      queues = visible_runs.group_by(&:project_id).transform_values { |runs| runs.dup }
+      queues = visible_runs.group_by(&:project_id).transform_values(&:dup)
       active = active_counts.transform_values(&:to_i)
 
       interleaved = []

--- a/app/services/dashboard/queue_preview.rb
+++ b/app/services/dashboard/queue_preview.rb
@@ -31,9 +31,10 @@ module Dashboard
     def build_entries
       snapshot = fetch_snapshot
       visible_runs = snapshot.select { |run| visible_project_ids.include?(run.project_id) }
-      preload_associations(visible_runs)
+      interleaved = interleave_by_dispatch_order(visible_runs)
+      preload_associations(interleaved)
 
-      interleave_by_dispatch_order(visible_runs).each_with_index.map do |run, index|
+      interleaved.each_with_index.map do |run, index|
         Entry.new(position: index + 1, run:)
       end
     end

--- a/app/views/dashboard/_queue_preview.html.erb
+++ b/app/views/dashboard/_queue_preview.html.erb
@@ -2,7 +2,10 @@
   <div class="flex items-center justify-between gap-4">
     <div>
       <h3 class="text-base font-semibold text-gray-900">Upcoming Queue</h3>
-      <p class="mt-1 text-sm text-gray-500">Queued runs for your projects in approximate scheduler priority order.</p>
+      <p class="mt-1 text-sm text-gray-500"
+         title="Runs are shown in approximate dispatch order. The scheduler gives each project a turn based on its in-flight run count so no single project monopolizes agent slots; priority labels only order runs within the same project.">
+        Balanced across projects; priority ranks within each project.
+      </p>
     </div>
   </div>
 

--- a/app/views/dashboard/_queue_preview.html.erb
+++ b/app/views/dashboard/_queue_preview.html.erb
@@ -3,8 +3,8 @@
     <div>
       <h3 class="text-base font-semibold text-gray-900">Upcoming Queue</h3>
       <p class="mt-1 text-sm text-gray-500"
-         title="Runs are shown in approximate dispatch order. The scheduler gives each project a turn based on its in-flight run count so no single project monopolizes agent slots; priority labels only order runs within the same project.">
-        Balanced across projects; priority ranks within each project.
+         title="Runs are shown in approximate dispatch order from the next batch of queued work. The scheduler gives each sampled project a turn based on its in-flight run count, and priority labels only order runs within the same project.">
+        Balanced across sampled projects; priority ranks within each project.
       </p>
     </div>
   </div>

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -2880,6 +2880,25 @@ RSpec.describe AgentRun do
     end
   end
 
+  describe "#queue_order_rank" do
+    it "matches the queued_with_priority SQL tie-break tuple for representative runs" do
+      project = create(:project)
+      p1_issue = create(:issue, project:, labels: [ "P1" ])
+
+      manual_goal = create(:agent_run, :queued, :manual, project:, goal: "create_issue", created_at: 3.minutes.ago)
+      pr_continue = create(:agent_run, :queued, :automatic, project:, goal: "create_pr",
+        source_pull_request_number: 42, created_at: 2.minutes.ago)
+      labeled_issue = create(:agent_run, :queued, :automatic, project:, issue: p1_issue,
+        goal: "analyze_issue", created_at: 1.minute.ago)
+
+      [ manual_goal, pr_continue, labeled_issue ].each do |run|
+        sql_ranked_run = described_class.queued_with_priority.find(run.id)
+
+        expect(run.queue_order_rank).to eq(sql_ranked_run.queue_order_rank)
+      end
+    end
+  end
+
   describe "user-defined priority labels" do
     let(:project) { create(:project, priority_labels: { "P1" => "critical", "P2" => "high", "P3" => "low" }) }
 

--- a/spec/services/dashboard/queue_preview_spec.rb
+++ b/spec/services/dashboard/queue_preview_spec.rb
@@ -27,6 +27,65 @@ RSpec.describe Dashboard::QueuePreview do
       expect(preview.map { |entry| entry.run.project.full_name }).to eq([ "octo/alpha", "octo/beta" ])
     end
 
+    it "interleaves projects in dispatch order instead of clustering one project's backlog" do
+      account = create(:account)
+      user = create(:user, account: account)
+      alpha = create(:project, account: account, created_by: user, owner: "octo", repo: "alpha")
+      beta = create(:project, account: account, created_by: user, owner: "octo", repo: "beta")
+
+      # Alpha has the larger backlog and older runs, so the raw QUEUE_ORDER
+      # snapshot would place all three alpha runs ahead of beta. The
+      # scheduler really round-robins by per-project in-flight count, so the
+      # preview should interleave: alpha, beta, alpha, alpha.
+      create(:agent_run, :queued, project: alpha, trigger_type: "automatic", created_at: 4.minutes.ago)
+      create(:agent_run, :queued, project: alpha, trigger_type: "automatic", created_at: 3.minutes.ago)
+      create(:agent_run, :queued, project: alpha, trigger_type: "automatic", created_at: 2.minutes.ago)
+      create(:agent_run, :queued, project: beta, trigger_type: "automatic", created_at: 1.minute.ago)
+
+      preview = described_class.call(user:)
+
+      expect(preview.map { |entry| entry.run.project.repo }).to eq(%w[alpha beta alpha alpha])
+    end
+
+    it "surfaces a higher-priority run from a busy project across the round-robin" do
+      account = create(:account)
+      user = create(:user, account: account)
+      alpha = create(:project, account: account, created_by: user, owner: "octo", repo: "alpha")
+      beta = create(:project, account: account, created_by: user, owner: "octo", repo: "beta")
+
+      # alpha is idle (0 in-flight); beta already has a run going, but its
+      # queued run carries a P1 label. Once alpha claims one run both
+      # projects tie at the same in-flight count, and beta's P1 run should
+      # win the tie ahead of alpha's lower-priority backlog.
+      create(:agent_run, :queued, project: alpha, trigger_type: "automatic", created_at: 2.minutes.ago)
+      create(:agent_run, :queued, project: alpha, trigger_type: "automatic", created_at: 1.minute.ago)
+      beta_issue = create(:issue, project: beta, labels: [ "P1" ])
+      create(:agent_run, :queued, project: beta, issue: beta_issue, trigger_type: "automatic", created_at: 30.seconds.ago)
+      create(:agent_run, :running, project: beta, started_at: 1.minute.ago)
+
+      preview = described_class.call(user:)
+
+      expect(preview.map { |entry| entry.run.project.repo }).to eq(%w[alpha beta alpha])
+    end
+
+    it "preserves per-project priority order within the round-robin" do
+      account = create(:account)
+      user = create(:user, account: account)
+      project = create(:project, account: account, created_by: user, owner: "octo", repo: "alpha")
+
+      # A P3 run is older than a P1 run in the same project. The snapshot is
+      # sorted by QUEUE_ORDER, so grouping must keep P1 ahead of P3 even
+      # though the round-robin has a single project to draw from.
+      create(:agent_run, :queued, project:, issue: create(:issue, project:, labels: [ "P3" ]),
+               trigger_type: "automatic", created_at: 2.minutes.ago)
+      create(:agent_run, :queued, project:, issue: create(:issue, project:, labels: [ "P1" ]),
+               trigger_type: "automatic", created_at: 1.minute.ago)
+
+      preview = described_class.call(user:)
+
+      expect(preview.map { |entry| entry.run.queue_priority_tier }).to eq(%i[issue_p1 issue_p3])
+    end
+
     it "includes orphaned projects for the account fallback owner" do
       account = create(:account)
       fallback_owner = create(:user, account: account)

--- a/spec/services/dashboard/queue_preview_spec.rb
+++ b/spec/services/dashboard/queue_preview_spec.rb
@@ -86,6 +86,16 @@ RSpec.describe Dashboard::QueuePreview do
       expect(preview.map { |entry| entry.run.queue_priority_tier }).to eq(%i[issue_p1 issue_p3])
     end
 
+    it "does not promise every queued project is represented in the preview sample" do
+      rendered = ApplicationController.render(
+        partial: "dashboard/queue_preview",
+        locals: { queue_preview: [], paused_projects: [] }
+      )
+
+      expect(rendered).to include("Balanced across sampled projects; priority ranks within each project.")
+      expect(rendered).to include("approximate dispatch order from the next batch of queued work")
+    end
+
     it "includes orphaned projects for the account fallback owner" do
       account = create(:account)
       fallback_owner = create(:user, account: account)


### PR DESCRIPTION
## Summary

The **Upcoming Queue** preview on the dashboard reused the scheduler's `QUEUE_ORDER` snapshot, which sorts by the *current* per-project in-flight count. Every queued run from an idle project shares that rank, so a backlog-heavy project clustered across the top slots and looked like it would monopolize all agent runs — even though the scheduler actually round-robins (one slot per project, then the next).

In the live data this meant a project with 10 queued runs occupied positions **1–10**, implying starvation that wouldn't happen.

## Fix

Replay the scheduler's fair-share dispatch order in `Dashboard::QueuePreview` instead of showing the static snapshot:

- Seed each project's in-flight count (`AgentRun.capacity_inflight`, the same source the scheduler's `project_active_counts` CTE uses).
- Repeatedly pick the project with the fewest in-flight runs — tie-broken by the run's `QUEUE_ORDER` rank (priority → PR-continuation → goal → FIFO) — and increment that project's count as runs are dispatched.
- Per-project run order (priority, then FIFO) is preserved because the snapshot is already sorted, so grouping by project keeps each project's runs in sequence.

This is a **steady-state fair-share approximation** (it doesn't model run completion), which is the right abstraction for a queue preview. Priority labels still matter: a higher-priority run from a busier project surfaces once idle projects tie at the same in-flight count.

**Display-only** — `ProcessRunQueueJob` and its `SCHEDULER_QUEUE_ORDER` are untouched; actual dispatch behavior is unchanged.

Also adds a short subtitle explaining why a lower-priority item may appear above a higher one ("Balanced across projects; priority ranks runs within each project."), with a hover tooltip giving the fuller rationale.

## Before / after (live data)

| | task_bridge (10 queued, idle) |
|---|---|
| before | positions 1–10 |
| after | positions 1, 6, 10 |

paid's PR review (PR·P2) moved from buried at ~15 to **position 4**, since its priority legitimately wins the tie once idle projects catch up.

## Test plan

- Added specs: backlog project no longer clusters; a busy project's higher-priority run wins the round-robin tie; within-project priority order is preserved.
- Existing queue-preview specs still pass; RuboCop + Herb clean.
