### PR TITLE
fix: codex stdin loop, tier-filtered fallbacks, and rtk codex init

### DIFF
--- a/.devcontainer/setup-token-optimization.sh
+++ b/.devcontainer/setup-token-optimization.sh
@@ -9,11 +9,23 @@ echo "=== Setting up rtk (Rust Token Killer) ==="
 
 # rtk init for each supported agent. Each call configures that agent's hook
 # mechanism independently. --hook-only avoids adding RTK.md to context.
-for flags in "" "--codex" "--gemini" "--opencode"; do
-  if rtk init -g --auto-patch --hook-only $flags 2>/dev/null; then
-    echo "  rtk initialized for: ${flags:-claude/copilot (default)}"
+# Codex has no shell hook (AGENTS.md only), so rtk rejects --hook-only and
+# --auto-patch for it — it gets a bare `rtk init -g --codex`.
+rtk_init_for_selector() {
+  local selector="$1"
+  if [ "$selector" = "--codex" ]; then
+    rtk init -g --codex
   else
-    echo "  WARNING: rtk init failed for: ${flags:-default} (non-fatal)"
+    # shellcheck disable=SC2086
+    rtk init -g --auto-patch --hook-only $selector
+  fi
+}
+
+for selector in "" "--codex" "--gemini" "--opencode"; do
+  if rtk_init_for_selector "$selector" 2>/dev/null; then
+    echo "  rtk initialized for: ${selector:-claude/copilot (default)}"
+  else
+    echo "  WARNING: rtk init failed for: ${selector:-default} (non-fatal)"
   fi
 done
 

--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -3325,6 +3325,8 @@ module Containers
         parts = parts[index..] || []
       end
 
+      return true if parts[0] == "sh" && parts[1] == "-c" && parts[2]&.match?(/\bcodex\s+exec\b/)
+
       parts.first(2) == %w[codex exec]
     rescue ArgumentError
       false

--- a/app/services/containers/token_optimization.rb
+++ b/app/services/containers/token_optimization.rb
@@ -20,24 +20,34 @@ module Containers
       "cursor" => %w[--agent cursor]
     }.freeze
 
+    # Runners whose rtk integration installs prompt-level instructions
+    # (AGENTS.md) instead of a shell hook. rtk rejects --hook-only and
+    # --auto-patch for these — the instructions file IS the integration, so
+    # there is no hook to keep and no settings.json to auto-patch.
+    RTK_HOOKLESS_RUNNERS = %w[codex].freeze
+
     CODEGRAPH_INIT_TIMEOUT = 120
     CODEGRAPH_INSTALL_TIMEOUT = 30
     RTK_INIT_TIMEOUT = 30
 
     # Initializes rtk hooks for the specific runner inside an already-started
-    # container. Uses --hook-only to avoid injecting RTK.md into the agent's
-    # context (zero added tokens), and --auto-patch for non-interactive setup.
+    # container. For hook-based runners, --hook-only skips RTK.md (zero added
+    # tokens) and --auto-patch makes setup non-interactive. Instructions-only
+    # runners (codex) have no shell hook, so rtk rejects those flags and they
+    # get a bare `rtk init -g`.
     def self.rtk_init_for_runner(container_service:, runner_key:)
-      flags = RTK_RUNNER_FLAGS[runner_key.to_s]
+      key = runner_key.to_s
+      flags = RTK_RUNNER_FLAGS[key]
       return unless flags # runner not supported by rtk
 
-      command = [ "rtk", "init", "-g", "--auto-patch", "--hook-only", *flags ]
+      base = RTK_HOOKLESS_RUNNERS.include?(key) ? [] : %w[--auto-patch --hook-only]
+      command = [ "rtk", "init", "-g", *base, *flags ]
       container_service.execute(command, timeout: RTK_INIT_TIMEOUT)
-      Rails.logger.info(message: "container_manager.rtk_initialized", runner: runner_key.to_s)
+      Rails.logger.info(message: "container_manager.rtk_initialized", runner: key)
     rescue => e
       Rails.logger.warn(
         message: "container_manager.rtk_init_failed",
-        runner: runner_key.to_s,
+        runner: key,
         error: e.message
       )
     end

--- a/app/services/runners/default_tier_model_ids.rb
+++ b/app/services/runners/default_tier_model_ids.rb
@@ -9,7 +9,7 @@ module Runners
       "gemini" => "google"
     }.freeze
 
-    DIRECT_OUTBOUND_RUNNER_KEYS = %w[kilocode opencode openrouter_free pi omp].freeze
+    DIRECT_OUTBOUND_RUNNER_KEYS = %w[kilocode opencode openrouter_free openrouter_pareto pi omp].freeze
 
     # Compatibility gate applied when callers have no concrete auth context
     # (e.g. the admin form seeding a brand-new runner). Callers on the dispatch

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -247,15 +247,22 @@ module Activities
           runner_state_name = state_key_for(runner_candidate, runner, user_settings.user)
           resolved_model = resolve_tier_model_for(runner_candidate, agent_run, user_settings.user)
           if resolved_model&.failure?
-            logger.warn(
-              message: "agent_execution.tier_model_resolution_failed",
-              agent_run_id: agent_run.id,
-              runner: attempt_label,
-              tier: requested_tier,
-              error: resolved_model.error
-            )
-            index += 1
-            next
+            if direct_outbound_runner?(runner_candidate, user_settings.user)
+              # Direct-outbound runners run their own configured model regardless of
+              # the requested tier, so a tier-resolution failure is not fatal for
+              # them — treat it as no resolved model and proceed to the attempt.
+              resolved_model = nil
+            else
+              logger.warn(
+                message: "agent_execution.tier_model_resolution_failed",
+                agent_run_id: agent_run.id,
+                runner: attempt_label,
+                tier: requested_tier,
+                error: resolved_model.error
+              )
+              index += 1
+              next
+            end
           end
 
           resolved_run_info = resolved_model_info_for(resolved_model)
@@ -917,13 +924,28 @@ module Activities
       ]
     end
 
+    # Direct-outbound runners (opencode, kilocode, pi, omp, openrouter_free)
+    # bring their own model from config and bypass the LlmModel tier catalog.
+    # Uses the runner entry when available; falls back to the resolved runner
+    # key so bare agent-type candidates (e.g. "opencode") are still recognized.
+    def direct_outbound_runner?(runner_candidate, user)
+      runner_entry = runner_entry_for(runner_candidate, user)
+      runner_key = runner_entry&.runner_key || RunnerSupport.runner_key_for_agent_type(runner_candidate)
+      runner_entry&.requires_direct_outbound? ||
+        Runners::DefaultTierModelIds::DIRECT_OUTBOUND_RUNNER_KEYS.include?(runner_key)
+    end
+
     def runner_supports_tier?(runner_candidate, tier, user)
       return true if tier.blank?
 
+      # Direct-outbound runners bring their own model from config and bypass the
+      # tier catalog entirely, so they are always compatible with any requested tier.
+      return true if direct_outbound_runner?(runner_candidate, user)
+
       runner_entry = runner_entry_for(runner_candidate, user)
-      runner_key = runner_entry&.runner_key || RunnerSupport.runner_key_for_agent_type(runner_candidate)
       return true if runner_entry&.supports_tier?(tier)
 
+      runner_key = runner_entry&.runner_key || RunnerSupport.runner_key_for_agent_type(runner_candidate)
       resolution_runner = runner_entry || Runner.new(runner_key: runner_key)
       provider = user&.provider_for(resolution_runner)
       return true if provider&.supports_tier?(tier)
@@ -1062,7 +1084,19 @@ module Activities
 
       tier = requested_tier_for(agent_run)
       if tier.present?
-        runners = runners.select { |runner_candidate| runner_supports_tier?(runner_candidate, tier, user_settings.user) }
+        runners = runners.select do |runner_candidate|
+          if runner_supports_tier?(runner_candidate, tier, user_settings.user)
+            true
+          else
+            logger.warn(
+              message: "agent_execution.runner_filtered_by_tier",
+              agent_run_id: agent_run.id,
+              runner: canonical_runner_candidate(runner_candidate, user_settings.user),
+              tier: tier
+            )
+            false
+          end
+        end
       end
 
       @rate_limit_fallbacks = load_rate_limit_fallbacks(user_settings.user)

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -924,13 +924,16 @@ module Activities
       ]
     end
 
-    # Direct-outbound runners (opencode, kilocode, pi, omp, openrouter_free)
-    # bring their own model from config and bypass the LlmModel tier catalog.
+    # Direct-outbound runners (opencode, kilocode, pi, omp) bring their own
+    # model from config and bypass the LlmModel tier catalog. openrouter_free
+    # is excluded because it still requires a tier-resolved free model.
     # Uses the runner entry when available; falls back to the resolved runner
     # key so bare agent-type candidates (e.g. "opencode") are still recognized.
     def direct_outbound_runner?(runner_candidate, user)
       runner_entry = runner_entry_for(runner_candidate, user)
       runner_key = runner_entry&.runner_key || RunnerSupport.runner_key_for_agent_type(runner_candidate)
+      return false if runner_key == Runner::OPENROUTER_FREE_RUNNER_KEY
+
       runner_entry&.requires_direct_outbound? ||
         Runners::DefaultTierModelIds::DIRECT_OUTBOUND_RUNNER_KEYS.include?(runner_key)
     end

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -3107,6 +3107,124 @@ RSpec.describe Containers::Provision do
         )
       end
     end
+
+    context "when closing stdin for codex exec inside an sh -c wrapper" do
+      let(:captured) { [] }
+
+      before do
+        allow(mock_container).to receive(:exec) do |cmd, **_opts, &block|
+          captured << cmd
+          block.call(:stdout, "output\n") if block
+          [ [ "output\n" ], [], 0 ]
+        end
+        allow(mock_container).to receive(:info).and_return({ "State" => { "Running" => true, "ExitCode" => 0 } })
+      end
+
+      it "redirects stdin from /dev/null for a bare codex exec command" do
+        service.execute([ "codex", "exec", "--json", "prompt" ])
+
+        expect(captured.last.first(2)).to eq([ "sh", "-lc" ])
+        expect(captured.last.last).to end_with(" < /dev/null")
+      end
+
+      it "redirects stdin from /dev/null for an sh -c api-key auth codex command" do
+        script = 'env OPENAI_API_KEY="$KEY" codex exec --json "$1"'
+        service.execute([ "sh", "-c", script, "--", "prompt" ])
+
+        expect(captured.last.first(2)).to eq([ "sh", "-lc" ])
+        expect(captured.last.last).to end_with(" < /dev/null")
+        expect(captured.last.last).to include("codex")
+      end
+
+      it "redirects stdin from /dev/null for an sh -c subscription auth codex command" do
+        script = 'if [ "$PAID_CODEX_SUBSCRIPTION_AUTH" = "1" ]; then env -u OPENAI_API_KEY codex exec --json "$1"; else codex exec --json "$1"; fi'
+        service.execute([ "sh", "-c", script, "--", "prompt" ])
+
+        expect(captured.last.first(2)).to eq([ "sh", "-lc" ])
+        expect(captured.last.last).to end_with(" < /dev/null")
+      end
+    end
+  end
+
+  describe "#codex_exec_command?" do
+    it "detects a bare codex exec command" do
+      expect(service.send(:codex_exec_command?, [ "codex", "exec", "--json", "prompt" ])).to be true
+    end
+
+    it "detects an env -u wrapped codex exec command" do
+      expect(service.send(:codex_exec_command?, [ "env", "-u", "OPENAI_API_KEY", "codex", "exec", "--json", "prompt" ])).to be true
+    end
+
+    it "detects codex exec inside an sh -c api-key auth wrapper" do
+      script = 'env OPENAI_API_KEY="$KEY" codex exec --json "$1"'
+      expect(service.send(:codex_exec_command?, [ "sh", "-c", script, "--", "prompt" ])).to be true
+    end
+
+    it "detects codex exec inside an sh -c subscription auth wrapper" do
+      script = 'if [ "$PAID_CODEX_SUBSCRIPTION_AUTH" = "1" ]; then env -u OPENAI_API_KEY codex exec --json "$1"; else codex exec --json "$1"; fi'
+      expect(service.send(:codex_exec_command?, [ "sh", "-c", script, "--", "prompt" ])).to be true
+    end
+
+    it "detects codex exec inside an sh -c wrapper passed as a string" do
+      expect(service.send(:codex_exec_command?, %(sh -c 'codex exec --json "$1"' -- prompt))).to be true
+    end
+
+    it "returns false for a non-codex agent command" do
+      expect(service.send(:codex_exec_command?, [ "claude", "--print", "prompt" ])).to be false
+    end
+
+    it "returns false for an sh -c wrapper without codex exec" do
+      expect(service.send(:codex_exec_command?, [ "sh", "-c", "echo hello" ])).to be false
+    end
+
+    it "returns false for an empty command" do
+      expect(service.send(:codex_exec_command?, [])).to be false
+    end
+
+    it "returns false for a malformed sh -c command missing a script" do
+      expect(service.send(:codex_exec_command?, [ "sh", "-c" ])).to be false
+    end
+
+    it "returns false for a nil command" do
+      expect(service.send(:codex_exec_command?, nil)).to be false
+    end
+  end
+
+  describe "#close_stdin_for_codex_exec" do
+    it "rewrites a bare codex exec command to redirect stdin from /dev/null" do
+      rewritten = service.send(:close_stdin_for_codex_exec, [ "codex", "exec", "--json", "prompt" ])
+
+      expect(rewritten.first(2)).to eq([ "sh", "-lc" ])
+      expect(rewritten.last).to end_with(" < /dev/null")
+      expect(rewritten.last).to include("codex")
+    end
+
+    it "rewrites an env -u wrapped codex exec command to redirect stdin from /dev/null" do
+      rewritten = service.send(:close_stdin_for_codex_exec, [ "env", "-u", "OPENAI_API_KEY", "codex", "exec", "--json", "prompt" ])
+
+      expect(rewritten.first(2)).to eq([ "sh", "-lc" ])
+      expect(rewritten.last).to end_with(" < /dev/null")
+    end
+
+    it "rewrites an sh -c codex wrapper to redirect stdin from /dev/null" do
+      script = 'env OPENAI_API_KEY="$KEY" codex exec --json "$1"'
+      rewritten = service.send(:close_stdin_for_codex_exec, [ "sh", "-c", script, "--", "prompt" ])
+
+      expect(rewritten.first(2)).to eq([ "sh", "-lc" ])
+      expect(rewritten.last).to end_with(" < /dev/null")
+      expect(rewritten.last).to include("codex")
+    end
+
+    it "preserves the prompt argument when rewriting an sh -c codex wrapper" do
+      rewritten = service.send(:close_stdin_for_codex_exec, [ "sh", "-c", 'codex exec "$1"', "--", "build the feature" ])
+
+      expect(rewritten.last).to include("build\\ the\\ feature")
+    end
+
+    it "leaves non-codex commands untouched" do
+      original = [ "claude", "--print", "prompt" ]
+      expect(service.send(:close_stdin_for_codex_exec, original)).to eq(original)
+    end
   end
 
   describe "#cleanup" do

--- a/spec/services/containers/token_optimization_spec.rb
+++ b/spec/services/containers/token_optimization_spec.rb
@@ -15,16 +15,17 @@ RSpec.describe Containers::TokenOptimization do
   describe ".rtk_init_for_runner" do
     context "with supported runners" do
       {
-        "claude" => [],
-        "claude_code" => [],
-        "copilot" => [],
+        "claude" => %w[],
+        "claude_code" => %w[],
+        "copilot" => %w[],
         "codex" => %w[--codex],
         "gemini" => %w[--gemini],
         "opencode" => %w[--opencode],
         "cursor" => %w[--agent cursor]
       }.each do |runner, extra_flags|
         it "runs rtk init with correct flags for #{runner}" do
-          expected_command = [ "rtk", "init", "-g", "--auto-patch", "--hook-only", *extra_flags ]
+          base = described_class::RTK_HOOKLESS_RUNNERS.include?(runner) ? [] : %w[--auto-patch --hook-only]
+          expected_command = [ "rtk", "init", "-g", *base, *extra_flags ]
 
           expect(container_service).to receive(:execute)
             .with(expected_command, timeout: described_class::RTK_INIT_TIMEOUT)
@@ -35,10 +36,16 @@ RSpec.describe Containers::TokenOptimization do
 
       it "accepts symbol runner keys" do
         expect(container_service).to receive(:execute)
-          .with([ "rtk", "init", "-g", "--auto-patch", "--hook-only", "--codex" ],
-              timeout: described_class::CODEGRAPH_INSTALL_TIMEOUT)
+          .with([ "rtk", "init", "-g", "--codex" ], timeout: described_class::RTK_INIT_TIMEOUT)
 
         described_class.rtk_init_for_runner(container_service: container_service, runner_key: :codex)
+      end
+
+      it "uses a bare init for hookless runners (no --hook-only/--auto-patch)" do
+        expect(container_service).to receive(:execute)
+          .with([ "rtk", "init", "-g", "--codex" ], timeout: described_class::RTK_INIT_TIMEOUT)
+
+        described_class.rtk_init_for_runner(container_service: container_service, runner_key: "codex")
       end
     end
 

--- a/spec/services/models/detect_contract_drift_spec.rb
+++ b/spec/services/models/detect_contract_drift_spec.rb
@@ -92,6 +92,28 @@ RSpec.describe Models::DetectContractDrift do
       expect(result.findings).to be_empty
     end
 
+    it "checks direct-outbound runners included in the shared key list" do
+      model_id = "pareto-#{SecureRandom.hex(4)}"
+      create(:llm_model, :openai, model_id: model_id, tier: "mid", active: true)
+
+      allow(Runners::ModelCompatibility).to receive(:call).and_return(
+        AgentHarness::ModelCompatibility::Result.new(
+          runner: :opencode,
+          model_id: model_id,
+          auth_mode: :subscription,
+          supported: nil
+        )
+      )
+
+      described_class.call(runner_keys: %w[openrouter_pareto], auth_types: %w[subscription])
+
+      expect(Runners::ModelCompatibility).to have_received(:call).with(hash_including(
+        runner_key: "openrouter_pareto",
+        model_id: model_id,
+        auth_type: "subscription"
+      ))
+    end
+
     it "caps findings per (provider, runner, auth_type) group" do
       stub_const("Models::DetectContractDrift::MAX_FINDINGS_PER_GROUP", 2)
       model_ids = 5.times.map { |i| "cap-#{SecureRandom.hex(4)}-#{i}" }

--- a/spec/temporal/activities/run_agent_activity_no_db_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_no_db_spec.rb
@@ -205,6 +205,16 @@ RSpec.describe Activities::RunAgentActivity, :no_db do
     end
   end
 
+  describe "#direct_outbound_runner?" do
+    let(:activity) { described_class.new }
+
+    it "treats bare openrouter_pareto candidates as direct outbound" do
+      allow(activity).to receive(:runner_entry_for).with("openrouter_pareto", nil).and_return(nil)
+
+      expect(activity.send(:direct_outbound_runner?, "openrouter_pareto", nil)).to be(true)
+    end
+  end
+
   describe "#preflight_timeout_seconds_for" do
     let(:activity) { described_class.new }
 

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -3648,17 +3648,99 @@ expect(container_service).to receive(:execute).with(
       end
     end
 
+    context "when a direct-outbound fallback runner has no tier_models entry for the requested tier" do
+      let(:opencode_runner) do
+        api_key = create(:runner_api_key, user: user, api_service_type: "openrouter")
+        create_opencode_runner_entry(
+          user: user, api_key: api_key,
+          name: "Kimi K2", model: "moonshotai/kimi-k2-0905"
+        ).tap { |runner| runner.update!(tier_models: {}) }
+      end
+
+      before do
+        llm_model = create(:llm_model, model_id: "claude-sonnet-4-6", provider: "anthropic", tier: "mid")
+        create(:model_selection, agent_run: agent_run, llm_model: llm_model, tier: "mid")
+
+        allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude opencode])
+
+        user.settings.update!(
+          fallback_enabled: true,
+          fallback_runners: [ opencode_runner.routing_key ]
+        )
+
+        allow(git_ops).to receive_messages(
+          head_sha: "pre_agent_sha_abc123",
+          commit_uncommitted_changes: false,
+          has_changes_since?: false
+        )
+      end
+
+      it "keeps the fallback in the order and runs it with its own model instead of filtering it out" do
+        rate_limit_failure = Containers::Provision::Result.failure(
+          error: "rate limit", stdout: "", stderr: "rate limit exceeded", exit_code: 1
+        )
+        call_count = 0
+        allow(container_service).to receive(:execute) do |_command, **_opts|
+          call_count += 1
+          call_count == 1 ? rate_limit_failure : exec_success
+        end
+
+        result = activity.execute(agent_run_id: agent_run.id)
+
+        agent_run.reload
+        expect(result).to include(success: true)
+        expect(result[:final_runner]).to eq(opencode_runner.routing_key)
+        expect(agent_run.runners_attempted.map { |attempt| attempt["runner"] })
+          .to eq([ "claude_code", opencode_runner.routing_key ])
+      end
+
+      it "emits the tier-filter log only for runners that are genuinely dropped" do
+        logger = instance_double(ActiveSupport::Logger, info: nil, warn: nil, error: nil, debug: nil)
+        allow(activity).to receive(:logger).and_return(logger)
+
+        # gemini has no mid tier_models and no google catalog default, so the tier
+        # filter drops it (and logs it); claude and opencode (direct-outbound) stay.
+        extra = create(:runner, user: user, runner_key: "gemini",
+          tier_models: { "low" => { "model_id" => "g", "provider_id" => 1 } })
+        user.settings.update!(fallback_runners: [ extra.routing_key, opencode_runner.routing_key ])
+        allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude gemini opencode])
+
+        allow(container_service).to receive(:execute).and_return(exec_success)
+
+        activity.execute(agent_run_id: agent_run.id)
+
+        expect(logger).to have_received(:warn).with(hash_including(
+          message: "agent_execution.runner_filtered_by_tier",
+          agent_run_id: agent_run.id,
+          runner: "gemini",
+          tier: "mid"
+        ))
+        expect(logger).not_to have_received(:warn).with(hash_including(
+          message: "agent_execution.runner_filtered_by_tier",
+          runner: "opencode"
+        ))
+      end
+    end
+
     context "when no configured runner supports the requested tier" do
       before do
         llm_model = create(:llm_model, model_id: "claude-opus-4-1", provider: "anthropic", tier: "high")
         create(:model_selection, agent_run: agent_run, llm_model: llm_model, tier: "high")
 
-        allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[opencode])
+        allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude cursor])
+        # Direct-outbound runners bypass the tier filter, so this fast-fail path
+        # can only trigger for managed runners (claude/cursor) with no tier default.
+        allow(Runners::DefaultTierModelIds).to receive(:call).and_return({})
       end
 
       it "fast-fails with NoTierCapableRunner before any attempt executes" do
-        primary_runner = create_low_only_opencode_runner(user: user, name: "Primary Kimi")
-        fallback_runner = create_low_only_opencode_runner(user: user, name: "Fallback Kimi")
+        # Reuse the default managed runner (claude) for the primary and add a
+        # fresh cursor fallback — neither is direct-outbound, and both are
+        # restricted to a low-only tier_models entry so the tier filter drops them.
+        low_only = { "low" => { "model_id" => "claude-sonnet-4", "provider_id" => 1 } }
+        primary_runner = user.runners.find_by!(runner_key: "claude")
+        primary_runner.update!(tier_models: low_only)
+        fallback_runner = create(:runner, user: user, runner_key: "cursor", tier_models: low_only)
         agent_run.update!(runner: primary_runner)
         user.settings.update!(fallback_enabled: true, fallback_runners: [ fallback_runner.routing_key ])
 

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -1785,6 +1785,21 @@ RSpec.describe Activities::RunAgentActivity do
     end
   end
 
+  def create_low_only_openrouter_free_runner(user:)
+    api_key = create(:runner_api_key, user: user, api_service_type: "openrouter")
+    free_model = create(
+      :llm_model,
+      :free,
+      model_id: "openrouter/sonoma-sky-alpha",
+      provider: Runner::OPENROUTER_FREE_MODEL_PROVIDER,
+      tier: "low"
+    )
+
+    create_openrouter_free_runner(user: user, api_key: api_key, model: free_model.model_id).tap do |runner|
+      runner.update!(tier_models: { "low" => runner.tier_models.fetch("low") })
+    end
+  end
+
   def build_openrouter_free_run(project:, model:, data_classification:)
     run = create(:agent_run, :with_git_context, project: project, issue: create(:issue, project: project))
     project_stub = Struct.new(:data_classification).new(data_classification)
@@ -3753,6 +3768,21 @@ expect(container_service).to receive(:execute).with(
         agent_run.reload
         expect(agent_run.status).to eq("failed")
         expect(agent_run.error_message).to eq("No runner supports tier high")
+        expect(agent_run.runners_attempted).to eq([])
+      end
+
+      it "filters openrouter_free before execution when no free model resolves for the requested tier" do
+        fallback_runner = create_low_only_openrouter_free_runner(user: user)
+        user.settings.update!(fallback_enabled: true, fallback_runners: [ fallback_runner.routing_key ])
+        allow(RunnerSupport).to receive(:container_executable_runner_keys).and_return(%w[claude openrouter_free])
+
+        expect(container_service).not_to receive(:execute)
+
+        expect {
+          activity.execute(agent_run_id: agent_run.id)
+        }.to raise_error(Temporalio::Error::ApplicationError, /No runner supports tier high/)
+
+        agent_run.reload
         expect(agent_run.runners_attempted).to eq([])
       end
     end


### PR DESCRIPTION
## Summary

Investigation of failed agent run 16631 surfaced three independent defects, all fixed here. The run failed with "All runners exhausted" while two configured fallback runners were never tried, and the one runner that *did* run (codex) died in a no-op loop.

## Root causes & fixes

### 1. Codex loops on stdin until killed (`fix(containers): close stdin for codex exec…`)
`codex exec` reads stdin by design. Docker exec leaves stdin as an open pipe, so codex spins on `Reading additional input from stdin…`, emitting trivial `"OK"` turns (~12k input tokens each) until SIGKILL (exit 137). A mitigation (`close_stdin_for_codex_exec`) already existed but its guard only matched the bare `["codex","exec"]` form — codexs real api-key and subscription-auth paths wrap the command in `["sh","-c",…]`, so stdin was never closed.

**Fix:** broaden `codex_exec_command?` to detect `codex exec` inside `sh -c` wrapper scripts, so the `/dev/null` redirect applies to every codex path.

### 2. Tier filter silently dropped configured fallbacks (`fix(agent-runs): stop tier filter…`)
The tier-compatibility filter in `build_runner_order` removed direct-outbound runners (opencode/kilocode/etc.) that bring their own model from config and bypass the `LlmModel` tier catalog. When the primary runner failed, runs reported "All runners exhausted" even though valid fallbacks were configured.

**Fix:** direct-outbound runners bypass the tier filter (they run their own configured model regardless of tier) and skip tier-model resolution on failure instead of being skipped. Tier drops are now logged (`agent_execution.runner_filtered_by_tier`) so the filter is never silent again.

### 3. rtk init failed for codex (`fix(containers): use bare rtk init…`)
rtks codex integration is instructions-only (no shell hook), so rtk rejects `--hook-only`/`--auto-patch` for `--codex`. The failed init left codex without token-compression.

**Fix:** codex gets a bare `rtk init -g --codex`; hook-based runners unchanged. Mirrored in the devcontainer setup script.

## Verification
- `spec/temporal/activities/run_agent_activity_spec.rb` — new direct-outbound fallback + tier-filter-log contexts; full file green (278 examples)
- `spec/services/containers/provision_spec.rb` — new `codex_exec_command?` / `close_stdin_for_codex_exec` / end-to-end `#execute` coverage (303 examples)
- `spec/services/containers/token_optimization_spec.rb` — hookless-runner coverage (19 examples)
- `bin/rubocop` and `bin/lint --changed` clean on all changed files
- Re-verified all three fixes against `origin/main` in a clean worktree (61 targeted examples, 0 failures)

