### PR TITLE
fix(analyze-issue): widen to available chat runner when default is unavailable

### DIFF
--- a/app/services/knowledge/runner_selector.rb
+++ b/app/services/knowledge/runner_selector.rb
@@ -10,6 +10,15 @@ module Knowledge
       new(user_setting:).runners_for(:chat)
     end
 
+    # Broadens chat selection beyond the kb_chat settings to every
+    # chat-enabled Runner the user owns, applying the same circuit-breaker /
+    # rate-limit availability filter as #runners_for. Used when the
+    # settings-based selection yields no candidates because the configured
+    # runner is currently unavailable (rate-limited / circuit-open).
+    def self.available_chat_runner_keys(user_setting:)
+      new(user_setting:).available_chat_runner_keys
+    end
+
     def initialize(user_setting:)
       @user_setting = user_setting
     end
@@ -23,6 +32,21 @@ module Knowledge
       candidates.select do |runner|
         runner_available?(runner, runner_states)
       end
+    end
+
+    # Chat runner keys derived from the user's actual Runner records (not just
+    # the kb_chat settings), filtered to supported chat runners and to those
+    # that are currently available. Returns keys in runner priority order.
+    #
+    # @spec ISSUE-ANALYSIS-002
+    def available_chat_runner_keys
+      # .uniq matches configured_runners_for: an owner can hold several
+      # api_key Runner rows for the same key (e.g. two opencode accounts),
+      # and each provider should only be attempted once.
+      candidate_keys = user_setting.user.runners.kept_only.for_chat.ordered.pluck(:runner_key).uniq
+      filtered = filter_supported_runners(candidate_keys, operation: :chat)
+      runner_states = user_setting.user.runner_states.where(runner_name: filtered).index_by(&:runner_name)
+      filtered.select { |runner| runner_available?(runner, runner_states) }
     end
 
     private

--- a/app/temporal/activities/analyze_issue_activity.rb
+++ b/app/temporal/activities/analyze_issue_activity.rb
@@ -132,6 +132,7 @@ module Activities
       { content: "", sections: [], total_tokens: 0 }
     end
 
+    # @spec ISSUE-ANALYSIS-003
     def call_llm(agent_run, prompt)
       chat_providers(agent_run.project).each do |provider|
         response = AgentHarness.send_message(prompt, **llm_options(provider))
@@ -162,10 +163,28 @@ module Activities
       true
     end
 
+    # @spec ISSUE-ANALYSIS-001 ISSUE-ANALYSIS-002
     def chat_providers(project)
       setting = project.effective_owner&.settings
       providers = setting ? Knowledge::ProviderSelector.for_chat(user_setting: setting) : []
-      providers.presence || [ DEFAULT_PROVIDER ]
+      return providers if providers.any?
+
+      broadened = setting ? Knowledge::ProviderSelector.available_chat_runner_keys(user_setting: setting) : []
+      return broadened if broadened.any?
+
+      # Last resort: the platform default. Only used when it is not currently
+      # known-unavailable for this owner, so we never silently target a
+      # rate-limited / circuit-open runner. An empty list makes call_llm fail
+      # loudly rather than masking the outage by forcing a known-bad provider.
+      default_provider_available?(project) ? [ DEFAULT_PROVIDER ] : []
+    end
+
+    # @spec ISSUE-ANALYSIS-002
+    def default_provider_available?(project)
+      owner = project.effective_owner or return true
+
+      state = owner.runner_states.find_by(runner_name: DEFAULT_PROVIDER)
+      state.nil? || !state.unavailable?
     end
 
     def llm_options(provider)
@@ -233,10 +252,12 @@ module Activities
       end.join("\n\n")
     end
 
+    # @spec ISSUE-ANALYSIS-004
     def trusted_comments(project, comments)
       comments.select { |comment| project.trusted_github_user?(comment.user&.login) }
     end
 
+    # @spec ISSUE-ANALYSIS-004
     def ensure_trusted_issue!(issue)
       return if issue.trusted?
 
@@ -263,6 +284,7 @@ module Activities
       end.join("\n\n")
     end
 
+    # @spec ISSUE-ANALYSIS-005
     def parse_response!(agent_run, response)
       output = response.respond_to?(:output) ? response.output.to_s : response.to_s
       parsed = extract_analysis_json(output)

--- a/docs/intent/issue-analysis/issue-analysis-design.md
+++ b/docs/intent/issue-analysis/issue-analysis-design.md
@@ -1,0 +1,62 @@
+---
+parent: PAID
+prefix: ISSUE-ANALYSIS
+---
+
+# Low-Level Design: Issue Analysis
+
+> Companion to the high-level design (`docs/high-level-design.md`). This is the
+> LLD for the `analyze_issue` goal — the lightweight, container-free LLM
+> readiness assessment Paid runs when auto-pick selects an issue on a project
+> with auto-enhance enabled.
+
+## Purpose
+
+Before committing to a full `create_pr` agent run (clone, container, agent),
+Paid asks an LLM whether the issue plus the knowledge base give an autonomous
+agent enough to start. This is a single direct LLM call — no Docker, no repo
+clone — implemented by `Activities::AnalyzeIssueActivity`.
+
+## Provider selection
+
+The analysis call does **not** use the agent run's assigned runner. Runner
+assignment (including dispatch reroute / fallback) governs *which runner
+executes the agent container*; the analysis activity resolves its own LLM
+provider independently, through the knowledge/chat provider layer:
+
+1. **Configured preference.** `Knowledge::ProviderSelector.for_chat` reads the
+   owner's `kb_chat_runner` + `kb_chat_fallback_runners`, filtered by circuit
+   breaker / rate-limit availability (`RunnerState#unavailable?`).
+2. **Broadening.** When the preference yields no candidates (the configured
+   runner is unavailable), `Knowledge::ProviderSelector.available_chat_runner_keys`
+   widens to every chat-enabled `Runner` the owner actually has, applying the
+   same availability filter. This is what lets an analysis succeed on `codex`
+   when `claude` is rate-limited.
+3. **Platform default, availability-gated.** Only when nothing above produces a
+   candidate does the activity fall back to `DEFAULT_PROVIDER` ("claude") — and
+   only if that default is not itself currently unavailable for the owner.
+
+The previous design forced `[DEFAULT_PROVIDER]` whenever the preference list was
+empty, which re-selected the exact provider the availability filter had just
+excluded and guaranteed the call targeted a known-unhealthy runner. That is the
+run-17220 failure mode this segment now guards against (see
+`ISSUE-ANALYSIS-002`).
+
+If no provider is available at all, `call_llm` raises a non-retryable
+`AnalyzeIssueLlmFailed` ("No LLM provider produced an issue analysis") rather
+than silently masking the outage.
+
+## Inputs and trust
+
+- The issue must be trusted (`issue.trusted?`); untrusted issues are rejected
+  before the LLM is called.
+- Issue comments are filtered through the project's trusted-user allowlist.
+- Knowledge search and context-bundle failures degrade gracefully (empty
+  context) rather than aborting the assessment.
+
+## Response contract
+
+The LLM returns JSON: `sufficient_context` (bool), `reasoning` (string),
+`missing_context_areas` (array). Malformed or incomplete JSON is a non-retryable
+`AnalyzeIssueInvalidJson` error; the harness is trusted to deliver clean
+`response.output`, not Paid.

--- a/docs/intent/issue-analysis/issue-analysis-specs.md
+++ b/docs/intent/issue-analysis/issue-analysis-specs.md
@@ -1,0 +1,42 @@
+# EARS Specs: Issue Analysis
+
+> Testable claims for the `analyze_issue` goal. Status markers:
+> `[x]` implemented · `[ ]` active gap · `[D]` deferred.
+> Each ID is a grep target across specs, tests, and code (`grep -r ISSUE-ANALYSIS-002`).
+
+## Provider selection and fallback
+
+- [x] **ISSUE-ANALYSIS-001** — When auto-pick selects an issue on a project
+  with auto-enhance enabled, the system SHALL perform an LLM readiness
+  assessment using the owner's configured chat runner(s), filtered by
+  circuit-breaker / rate-limit availability.
+  *Tests:* `spec/temporal/activities/analyze_issue_activity_spec.rb`.
+  *Code:* `app/temporal/activities/analyze_issue_activity.rb#chat_providers`.
+
+- [x] **ISSUE-ANALYSIS-002** — When the configured chat runner is unavailable
+  (rate-limited or circuit-open), the analysis SHALL widen to an available
+  chat-enabled runner the owner has, rather than forcing the unavailable
+  runner (including the platform default) back into the candidate list.
+  *Tests:* `spec/temporal/activities/analyze_issue_activity_spec.rb` ("provider fallback"),
+  `spec/services/knowledge/provider_selector_spec.rb` (".available_chat_runner_keys").
+  *Code:* `app/services/knowledge/runner_selector.rb#available_chat_runner_keys`,
+  `app/temporal/activities/analyze_issue_activity.rb#default_provider_available?`.
+
+- [x] **ISSUE-ANALYSIS-003** — When no chat runner is available at all, the
+  system SHALL fail the run loudly with a non-retryable `AnalyzeIssueLlmFailed`
+  error instead of masking the outage by targeting a known-unhealthy provider.
+  *Tests:* `spec/temporal/activities/analyze_issue_activity_spec.rb` ("raises when no chat runner is available").
+  *Code:* `app/temporal/activities/analyze_issue_activity.rb#call_llm`.
+
+## Trust and response contract
+
+- [x] **ISSUE-ANALYSIS-004** — The system SHALL reject untrusted issues and
+  filter issue comments through the trusted-user allowlist before any LLM call.
+  *Tests:* `spec/temporal/activities/analyze_issue_activity_spec.rb` ("rejects untrusted issues", "filters untrusted issue comments").
+  *Code:* `app/temporal/activities/analyze_issue_activity.rb#ensure_trusted_issue!`, `#trusted_comments`.
+
+- [x] **ISSUE-ANALYSIS-005** — The system SHALL surface malformed or
+  incomplete analysis JSON as a non-retryable `AnalyzeIssueInvalidJson` error,
+  trusting agent-harness to deliver clean `response.output`.
+  *Tests:* `spec/temporal/activities/analyze_issue_activity_spec.rb` ("malformed JSON", "missing required keys").
+  *Code:* `app/temporal/activities/analyze_issue_activity.rb#parse_response!`.

--- a/spec/services/knowledge/provider_selector_spec.rb
+++ b/spec/services/knowledge/provider_selector_spec.rb
@@ -81,4 +81,43 @@ RSpec.describe Knowledge::ProviderSelector do
       expect(state.reload.circuit_state).to eq("half_open")
     end
   end
+
+  # @spec ISSUE-ANALYSIS-002
+  describe ".available_chat_runner_keys" do
+    before { user.runners.delete_all }
+
+    it "returns the owner's available chat runners, excluding unavailable ones" do
+      create(:runner, user: user, runner_key: "claude", enabled_for_chat: true)
+      create(:runner, user: user, runner_key: "codex", enabled_for_chat: true)
+      create(:runner_state, :rate_limited, user: user, runner_name: "claude")
+
+      expect(described_class.available_chat_runner_keys(user_setting: setting)).to eq([ "codex" ])
+    end
+
+    it "returns an empty array when every chat runner is unavailable" do
+      create(:runner, user: user, runner_key: "claude", enabled_for_chat: true)
+      create(:runner_state, :rate_limited, user: user, runner_name: "claude")
+
+      expect(described_class.available_chat_runner_keys(user_setting: setting)).to eq([])
+    end
+
+    it "ignores runners that are not enabled for chat" do
+      create(:runner, user: user, runner_key: "claude", enabled_for_chat: true)
+      create(:runner, user: user, runner_key: "codex", enabled_for_chat: false)
+
+      expect(described_class.available_chat_runner_keys(user_setting: setting)).to eq([ "claude" ])
+    end
+
+    it "dedupes runners that share a key so each provider is tried once" do
+      # An owner can legitimately hold several api_key Runner rows for the
+      # same direct-outbound key (e.g. two kilocode accounts).
+      key_a = create(:provider_api_key, user: user, api_service_type: "zai_coding")
+      key_b = create(:provider_api_key, user: user, api_service_type: "zai_coding")
+      config = { "kilocode" => { "api_provider" => "zai_coding", "model" => "glm-5.1" } }
+      create(:runner, :api_key, user: user, runner_key: "kilocode", provider_api_key: key_a, name: "A", config: config)
+      create(:runner, :api_key, user: user, runner_key: "kilocode", provider_api_key: key_b, name: "B", config: config)
+
+      expect(described_class.available_chat_runner_keys(user_setting: setting)).to eq([ "kilocode" ])
+    end
+  end
 end

--- a/spec/temporal/activities/analyze_issue_activity_spec.rb
+++ b/spec/temporal/activities/analyze_issue_activity_spec.rb
@@ -238,6 +238,49 @@ RSpec.describe Activities::AnalyzeIssueActivity do
     end
   end
 
+  describe "provider fallback" do
+    # Reproduces the run-17220 failure: the configured kb_chat_runner
+    # (claude) is rate-limited, yet analyze_issue must not force the
+    # known-unavailable DEFAULT_PROVIDER back into the candidate list. It
+    # should widen to an available chat-enabled runner the owner has.
+    let(:account) { create(:account) }
+    let(:owner) { create(:user, account: account) }
+    let(:project) { create(:project, account: account, created_by: owner) }
+
+    before do
+      create(:user_setting, user: owner, kb_chat_runner: "claude", kb_chat_fallback_runners: [])
+      # Claude is rate-limited -> Knowledge::ProviderSelector.for_chat returns []
+      create(:runner_state, :rate_limited, user: owner, runner_name: "claude")
+      # An available alternative the owner actually has configured
+      create(:runner, user: owner, runner_key: "codex", enabled_for_chat: true)
+    end
+
+    # @spec ISSUE-ANALYSIS-002
+    it "selects an available chat runner instead of forcing the rate-limited default" do
+      selected_provider = nil
+      allow(AgentHarness).to receive(:send_message) do |_, **opts|
+        selected_provider = opts[:provider]
+        llm_response
+      end
+
+      activity.execute(agent_run_id: agent_run.id)
+
+      expect(selected_provider).to eq(:codex)
+      expect(selected_provider).not_to eq(:claude)
+    end
+
+    # @spec ISSUE-ANALYSIS-003
+    it "raises when no chat runner is available at all" do
+      # Remove the available codex runner so nothing remains; claude is still
+      # rate-limited, so the DEFAULT_PROVIDER must not be forced back in.
+      owner.runners.where(runner_key: "codex").destroy_all
+
+      expect {
+        activity.execute(agent_run_id: agent_run.id)
+      }.to raise_error(Temporalio::Error::ApplicationError, "No LLM provider produced an issue analysis")
+    end
+  end
+
   describe "knowledge usage attribution" do
     include_context "without qdrant vector search"
 


### PR DESCRIPTION
## Problem

Agent run [#17220](http://localhost:3000/projects/29/agent_runs/17220) (`goal: analyze_issue`) failed in ~10 s with `No LLM provider produced an issue analysis`, even though the account had a healthy `codex` runner available. The dispatcher had already rerouted the run `claude -> codex`, but the analysis LLM call ignored that and forced rate-limited `claude` anyway.

## Root cause

`AnalyzeIssueActivity#chat_providers` did:

```ruby
providers.presence || [ DEFAULT_PROVIDER ]   # DEFAULT_PROVIDER = "claude"
```

`Knowledge::ProviderSelector.for_chat` correctly returned `[]` because claude's `RunnerState` was rate-limited (`rate_limited_until` in the future). The fallback then **re-selected the exact provider the availability filter had just excluded** — guaranteeing the call targeted a known-unhealthy runner, with no alternative tried despite `codex`/`opencode` being available.

The analyze path uses the knowledge/chat provider layer (`kb_chat_runner`), which is decoupled from agent-run runner fallback (`fallback_runners`) — and `kb_chat_fallback_runners` was empty, so there was nothing to fall back to.

## Fix

`chat_providers` now resolves candidates progressively:

1. Configured `kb_chat` runner(s), availability-filtered (unchanged)
2. **NEW** — widen to any available chat-enabled `Runner` the owner has (`Knowledge::ProviderSelector.available_chat_runner_keys`)
3. Platform default, **availability-gated** (`default_provider_available?`) — a rate-limited default is no longer forced back in

If nothing is available, it fails loudly with `AnalyzeIssueLlmFailed` rather than masking the outage. For run 17220 this would have tried `codex` instead of forcing rate-limited claude.

The `|| [DEFAULT_PROVIDER]` anti-pattern was confirmed isolated to this one call site.

## Changes

- `app/services/knowledge/runner_selector.rb` — `available_chat_runner_keys` (class + instance): broadens to the owner's chat-enabled Runner records, **deduped** to mirror `configured_runners_for` (run 17220's owner had two `opencode` runners — without dedup, `opencode` would be attempted twice).
- `app/temporal/activities/analyze_issue_activity.rb` — rewritten `chat_providers` + `default_provider_available?`.
- `docs/intent/issue-analysis/` — new LID segment (LLD + EARS) with `@spec ISSUE-ANALYSIS-001..005` anchors.

## Testing

- Failing-first: `spec/temporal/activities/analyze_issue_activity_spec.rb` ("provider fallback") + `spec/services/knowledge/provider_selector_spec.rb` (`.available_chat_runner_keys`, incl. a dedup regression test that fails without `.uniq`).
- 84 specs green across analyze activity + knowledge selector/executor + chat-session creation.
- `bin/rubocop` clean, LID `bin/coherence-check.mjs` clean (5 specs, no orphans), markdownlint clean.

Draft while review settles on the runtime-fallback scope (see review notes).