### PR TITLE
feat(lid): adopt Linked-Intent Development across the toolchain

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -84,19 +84,19 @@
     "setup-signing-key": "bash .devcontainer/setup-signing-key.sh",
     // This single sequential chain is the ordering backbone of devcontainer setup:
     //   bin/setup -> install Claude CLI -> install Compound Engineering plugin
-    //   -> configure auto-approve mode.
+    //   -> install LID (Linked-Intent Development) plugin -> configure auto-approve mode.
     // It is chained (not split into parallel entries) for several reasons:
     //  - the Claude CLI install uses `bundle exec`, which needs gems from bin/setup;
-    //  - the plugin install must run after the `claude` binary exists and BEFORE
-    //    configure-llm-tools.sh wraps `claude`/`codex` with approval-bypass flags
-    //    that are invalid alongside the `plugin` subcommand;
+    //  - the plugin installs (Compound Engineering, LID) must run after the `claude`
+    //    binary exists and BEFORE configure-llm-tools.sh wraps `claude`/`codex` with
+    //    approval-bypass flags that are invalid alongside the `plugin` subcommand;
     //  - configure-llm-tools.sh writes the canonical ~/.config/opencode/opencode.json
     //    last, re-asserting auto-approve after the plugin installer rewrites it.
     // Running it last also guarantees the parallel binary-install entries below
     // (codex, gemini, opencode, ...) have finished, so their wrappers/config apply.
     // Each added step is `|| echo`-guarded so a plugin failure stays non-fatal;
     // a bin/setup or Claude-install failure still propagates and fails creation.
-    "setup": "corepack enable && corepack prepare yarn@1.22.22 --activate && bin/setup --skip-server && (eval \"$(bundle exec ruby scripts/extract-provider-install-contract.rb claude | sed -n 's/^INSTALL_COMMAND=//p')\" || echo 'WARNING: Claude CLI installation failed (non-fatal)') && (bash .devcontainer/install-compound-engineering.sh || echo 'WARNING: Compound Engineering plugin install incomplete (non-fatal)') && bash .devcontainer/configure-llm-tools.sh",
+    "setup": "corepack enable && corepack prepare yarn@1.22.22 --activate && bin/setup --skip-server && (eval \"$(bundle exec ruby scripts/extract-provider-install-contract.rb claude | sed -n 's/^INSTALL_COMMAND=//p')\" || echo 'WARNING: Claude CLI installation failed (non-fatal)') && (bash .devcontainer/install-compound-engineering.sh || echo 'WARNING: Compound Engineering plugin install incomplete (non-fatal)') && (bash .devcontainer/install-lid.sh || echo 'WARNING: LID plugin install incomplete (non-fatal)') && bash .devcontainer/configure-llm-tools.sh",
     // LLM CLI Tools - Installation via agent-harness contracts
     // Each tool is installed via scripts/install-from-contract.sh which delegates
     // to scripts/extract-provider-install-contract.rb. This means versions and

--- a/.devcontainer/install-lid.sh
+++ b/.devcontainer/install-lid.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Install the Linked-Intent Development (LID) Claude Code plugins
+# (jszmajda/lid) inside the devcontainer.
+#
+# LID is a methodology, not a tool. The workflow lives in CLAUDE.md
+# (canonical; AGENTS.md is a symlink), which Codex, OpenCode, and Oh My Pi read
+# natively — so for those tools no plugin install is needed. Claude Code is the
+# richest integration and gets the auto-invoking skills via its plugin system.
+#
+# Ordering: this runs in postCreate BEFORE configure-llm-tools.sh, while the
+# `claude` binary is still unwrapped. configure-llm-tools.sh later replaces it
+# with a wrapper that injects --dangerously-skip-permissions, which is not
+# valid alongside the `plugin` subcommand, so plugin management must happen
+# first.
+#
+# Every step is idempotent and non-fatal: a failure logs a warning and
+# continues so plugin setup never blocks the rest of devcontainer creation.
+
+set -uo pipefail
+set -x
+echo "[DEBUG] Starting install-lid.sh"
+
+MARKETPLACE_SOURCE="jszmajda/lid"
+MARKETPLACE_NAME="jszmajda-lid"
+CORE_PLUGINS=("linked-intent-dev" "arrow-maintenance")
+# lid-experimental is opt-in; set INSTALL_LID_EXPERIMENTAL=1 to enable.
+EXPERIMENTAL_PLUGIN="lid-experimental"
+BIN_WAIT_SECONDS="${LID_BIN_WAIT_SECONDS:-180}"
+STEP_TIMEOUT="${LID_STEP_TIMEOUT:-180}"
+
+# Run a network/plugin step under a hard timeout, with stdin closed. This keeps
+# container creation from hanging if a tool hits a first-run prompt on a fresh
+# (empty) config volume or a network call stalls: </dev/null turns any prompt
+# into immediate EOF, and `timeout` is the backstop. Always returns 0 (non-fatal)
+# — on failure or timeout it logs a warning and the build continues.
+run_step() {
+  local desc="$1"
+  shift
+  if ! timeout -k 10 "$STEP_TIMEOUT" "$@" </dev/null; then
+    echo "WARNING: ${desc} failed or timed out (${STEP_TIMEOUT}s); skipping." >&2
+  fi
+}
+
+# Wait up to BIN_WAIT_SECONDS for the Claude CLI binary that the "setup" chain
+# installs immediately before this script. Returns non-zero if it never appears.
+wait_for_bin() {
+  local bin="$1" waited=0
+  while ! command -v "$bin" >/dev/null 2>&1; do
+    if [ "$waited" -ge "$BIN_WAIT_SECONDS" ]; then
+      return 1
+    fi
+    sleep 2
+    waited=$((waited + 2))
+  done
+  return 0
+}
+
+# ============================================================================
+# Claude Code
+# ============================================================================
+# Non-interactive equivalents of /plugin marketplace add + /plugin install.
+# State is written to the container-local ~/.claude named volume (persisted
+# across rebuilds, not shared with the host).
+if wait_for_bin claude; then
+  echo "[DEBUG] Registering LID marketplace for Claude Code..."
+  run_step "Claude LID marketplace add" claude plugin marketplace add "$MARKETPLACE_SOURCE"
+  for plugin in "${CORE_PLUGINS[@]}"; do
+    echo "[DEBUG] Installing ${plugin} for Claude Code..."
+    run_step "Claude plugin install ${plugin}" claude plugin install "${plugin}@${MARKETPLACE_NAME}"
+  done
+  if [ "${INSTALL_LID_EXPERIMENTAL:-0}" = "1" ]; then
+    echo "[DEBUG] Installing ${EXPERIMENTAL_PLUGIN} (opt-in) for Claude Code..."
+    run_step "Claude plugin install ${EXPERIMENTAL_PLUGIN}" claude plugin install "${EXPERIMENTAL_PLUGIN}@${MARKETPLACE_NAME}"
+  fi
+else
+  echo "WARNING: 'claude' binary not found after ${BIN_WAIT_SECONDS}s; skipping LID plugin install." >&2
+fi
+
+echo ""
+echo "[DEBUG] LID plugin installation complete."
+echo "Installed for: Claude Code (Codex, OpenCode, Oh My Pi read CLAUDE.md/AGENTS.md natively)"

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,1 +1,10 @@
 CHANGELOG.md
+
+# Vendored LID reference docs — byte-identical to upstream (jszmajda/lid),
+# so excluded from host style checks. Authored files in docs/lid/ (README.md,
+# workflow.md) stay linted. See docs/lid/README.md. Do not edit these here.
+docs/lid/ears-syntax.md
+docs/lid/hld-template.md
+docs/lid/lld-templates.md
+docs/lid/decision-doc-template.md
+docs/lid/audit-checklist.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,47 @@ Paid (Platform for AI Development) is a Rails 8 application that orchestrates AI
 
 **Status**: Phase 6 (Enterprise Trust & Governance) complete as of 2026-05-27. Phase 7 (Proof, Adoption & Interoperability) complete as of 2026-05-29. Phase 8 (Managed Platform & Ecosystem) complete as of 2026-05-30. The system now offers managed cloud and private deployment models, enterprise operations with documented SLO/SLA expectations, and stable ecosystem extension points, on top of the completed proof, adoption, and interoperability work.
 
+## Linked-Intent Development (LID)
+
+Paid uses [Linked-Intent Development (LID)](https://linked-intent.dev) to keep intent and code coherent. Intent flows one direction:
+
+```
+HLD → LLDs → EARS → Tests → Code
+```
+
+The high-level design and low-level designs are the source of truth; code is compiled output that may be regenerated from specs.
+
+- **New features / substantive changes**: walk the full arrow — confirm the HLD/LLD, write or update the EARS spec, write the failing-first test, then the code.
+- **Bug fixes**: walk the arrow to find where intent diverged, then cascade from there. No short-circuit straight to code.
+- **Trivial changes** (typos, formatting, broken links, stale references): no arrow walk needed.
+
+| What you need | Where to look |
+|---|---|
+| High-level design (the why) | `docs/high-level-design.md` |
+| Design tree (LLDs + their specs) | `docs/intent/` — one folder per segment |
+| EARS specs (testable claims) | `docs/intent/<segment>/<segment>-specs.md` |
+| Arrow overlay (large projects) | `docs/arrows/index.yaml` |
+| LID workflow + templates (non-Claude tools) | `docs/lid/` — vendored procedure for tools without the plugin |
+
+**Conventions**:
+
+- EARS specs carry path-concatenated IDs (e.g. `AGENT-RUN-001`) and status markers: `[x]` implemented, `[ ]` gap, `[D]` deferred.
+- Code and tests carry `@spec SPEC-ID` annotations linking to the EARS claims they implement. A spec ID is a grep target: `grep -r AGENT-RUN-001` returns the spec text, the tests, and the code.
+- Docs carry *current* intent, written to be read cold — mutation, not accumulation. Delete obsolete specs rather than annotating history.
+- **Tests before code.** Write the failing-first test that asserts the EARS claim before the implementation.
+- **Memory vs. intent.** Before saving durable project knowledge to agent or tool memory, test whether it is project *intent* — would a fresh agent, in any tool, next session, need it to build this system correctly? If yes, record it in the arrow (HLD / LLD / EARS / decision doc), which travels and cascades — not in private, per-tool memory, where intent escapes the arrow. Knowledge about the user or how they like to work stays in memory. (This complements `WORKLOG.md` as session working memory and `docs/solutions/` as cross-session learnings; neither is a substitute for intent that belongs in the design.)
+
+**Going-forward policy**: brownfield, Full-mode adoption. The HLD is the floor; LLDs and EARS are added as new features are built and as subsystems are mapped over time. Not all existing code is traced yet — that is expected. When you build or change a component, add or update its segment under `docs/intent/`.
+
+## LID
+
+- Mode: Full
+- Version: 1.3.0
+
+## LID Tooling
+
+- **Coherence check**: `bin/coherence-check.mjs` — deterministic LID coherence report (`@spec` integrity, arrow references, staleness, coverage). Run it for the structural checks in `docs/lid/workflow.md` § Coherence verification. Non-Claude tools use `docs/lid/` for the full workflow procedure that Claude Code gets via the plugin.
+
 ## Git Workflow
 
 - **The `main` branch is protected** - Never commit directly to `main`. Always create a feature branch and open a pull request.

--- a/bin/coherence-check.mjs
+++ b/bin/coherence-check.mjs
@@ -1,0 +1,366 @@
+#!/usr/bin/env node
+
+/**
+ * LID Coherence Check — optional reference implementation.
+ *
+ * This script is one way to perform the deterministic checks the arrow-maintenance
+ * skill specifies. It is language-neutral in concept: equivalent implementations
+ * in Python, bash, Ruby, Go, or any other language are fully acceptable. The
+ * arrow-maintenance skill invokes whatever `bin/coherence-check.*` is present and
+ * treats its output as authoritative; if nothing is present, the skill performs
+ * the checks in-prompt (slower, more expensive).
+ *
+ * Install: copy this file to your project as `bin/coherence-check.mjs`, mark it
+ * executable, and run `./bin/coherence-check.mjs` (or `node bin/coherence-check.mjs`).
+ * Adjust the file globs and spec-ID regex to match your project's conventions.
+ *
+ * Paid adaptations (vs. the upstream reference impl): the grep include list adds
+ * `*.rb` (this is a Rails app) and the exclude list adds `vendor`, `tmp`,
+ * `.bundle`, `storage` (gem sources / transient Rails dirs that would yield
+ * false-positive @spec matches); `--color=never` guards the line parser against
+ * a `GREP_OPTIONS=--color=always` env silently injecting ANSI escapes. Re-apply
+ * these after re-syncing from upstream.
+ *
+ * Checks performed (aligned with audit-checklist.md):
+ *   1. @spec annotation integrity (orphaned refs, reverse orphans)
+ *   2. Arrow reference integrity (broken file references in arrow detail docs)
+ *   3. Arrow staleness (audited >30 days ago; UNMAPPED/MAPPED status)
+ *   4. Coverage summary (per-arrow and repo-wide)
+ *
+ * Not a blocker. Not a CI gate. Just a fast report. Exit code is always 0.
+ */
+
+import { readFileSync, readdirSync, existsSync } from 'fs';
+import { join, resolve } from 'path';
+import { execSync } from 'child_process';
+
+const ROOT = resolve(process.cwd());
+const INTENT_DIR = join(ROOT, 'docs', 'intent');
+const ARROWS_DIR = join(ROOT, 'docs', 'arrows');
+const ARROWS_INDEX = join(ARROWS_DIR, 'index.yaml');
+
+// ───────── Helpers ─────────
+
+function fileExists(relPath) {
+  return existsSync(join(ROOT, relPath));
+}
+
+function readFile(absPath) {
+  try {
+    return readFileSync(absPath, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+function daysSince(dateStr) {
+  if (!dateStr) return Infinity;
+  const d = new Date(dateStr);
+  if (isNaN(d.getTime())) return Infinity;
+  return Math.floor((Date.now() - d.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+// ───────── 1. @spec annotation integrity ─────────
+
+function collectSpecIdsFromCode() {
+  let output;
+  try {
+    output = execSync(
+      `grep -rn --color=never "@spec" --include="*.rb" --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" --include="*.py" --include="*.go" --include="*.rs" --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=dist --exclude-dir=build --exclude-dir=target --exclude-dir=cdk.out --exclude-dir=coverage --exclude-dir=.next --exclude-dir=__pycache__ --exclude-dir=vendor --exclude-dir=tmp --exclude-dir=.bundle --exclude-dir=storage .`,
+      { cwd: ROOT, encoding: 'utf-8', maxBuffer: 50 * 1024 * 1024 }
+    );
+  } catch (e) {
+    output = e.stdout || '';
+  }
+
+  const codeRefs = new Map(); // specId -> [{file, line}]
+  // Negative lookahead (?![a-z]) prevents mid-CamelCase matches like "GSI-B" from "GSI-ByReminderDue"
+  // Post-filter (below): require at least one digit — excludes "A-Z" and "YYYYMMDD-HHMM" false positives
+  const idPattern = /[A-Z][A-Z0-9]*(?:-[A-Z0-9]+)+(?![a-z])/g;
+
+  for (const line of output.split('\n').filter(Boolean)) {
+    const match = line.match(/^\.\/(.+?):(\d+):(.*)/);
+    if (!match) continue;
+    const [, file, lineNum, rest] = match;
+
+    if (!/\bspec\b/i.test(rest)) continue; // filter to @spec context
+
+    let m;
+    while ((m = idPattern.exec(rest)) !== null) {
+      const id = m[0];
+      if (!/\d/.test(id)) continue; // skip ID-shaped tokens with no digits
+      if (!codeRefs.has(id)) codeRefs.set(id, []);
+      codeRefs.get(id).push({ file, line: parseInt(lineNum) });
+    }
+  }
+
+  return codeRefs;
+}
+
+// Node-as-folder: spec files live beside their design doc as `*-specs.md`
+// anywhere in the docs/intent/ tree. Walk it recursively.
+function walkSpecFiles(dir) {
+  const out = [];
+  for (const ent of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, ent.name);
+    if (ent.isDirectory()) out.push(...walkSpecFiles(p));
+    else if (ent.name.endsWith('-specs.md')) out.push(p);
+  }
+  return out;
+}
+
+function collectSpecIdsFromSpecs() {
+  const specDefs = new Map();
+
+  if (!existsSync(INTENT_DIR)) return specDefs;
+
+  const files = walkSpecFiles(INTENT_DIR);
+
+  for (const file of files) {
+    const content = readFile(file);
+    if (!content) continue;
+
+    for (const line of content.split('\n')) {
+      // Checklist style: - [x] **SPEC-ID**: description
+      const checklist = line.match(/^-\s+\[([ xD])\]\s+\*\*([A-Z][\w-]+)\*\*/);
+      if (checklist) {
+        const [, marker, id] = checklist;
+        const status = marker === 'x' ? 'implemented' : marker === 'D' ? 'deferred' : 'gap';
+        specDefs.set(id, { file, status });
+        continue;
+      }
+      // Heading style: ### SPEC-ID
+      const heading = line.match(/^###\s+([A-Z][\w-]+)\b/);
+      if (heading) {
+        specDefs.set(heading[1], { file, status: 'defined' });
+        continue;
+      }
+      // Bold style: **SPEC-ID**: description, with optional leading "- " dash-bullet (no checkbox)
+      const bold = line.match(/^(?:-\s+)?\*\*([A-Z][\w-]+)\*\*:/);
+      if (bold) {
+        specDefs.set(bold[1], { file, status: 'defined' });
+        continue;
+      }
+      // Table-cell style: | **SPEC-ID** | description | ... | (markdown table row)
+      const tableCell = line.match(/^\|\s*\*\*([A-Z][\w-]+)\*\*\s*\|/);
+      if (tableCell) {
+        specDefs.set(tableCell[1], { file, status: 'defined' });
+      }
+    }
+  }
+
+  return specDefs;
+}
+
+function checkSpecIntegrity() {
+  const codeRefs = collectSpecIdsFromCode();
+  const specDefs = collectSpecIdsFromSpecs();
+
+  const reverseOrphans = [];
+  const uncovered = [];
+
+  for (const [id, locations] of codeRefs) {
+    if (!specDefs.has(id)) reverseOrphans.push({ id, locations });
+  }
+
+  for (const [id, info] of specDefs) {
+    if (info.status === 'gap' && !codeRefs.has(id)) {
+      uncovered.push({ id, file: info.file });
+    }
+  }
+
+  return { codeRefs, specDefs, reverseOrphans, uncovered };
+}
+
+// ───────── 2. Arrow reference integrity ─────────
+
+function parseArrowsIndex() {
+  const content = readFile(ARROWS_INDEX);
+  if (!content) return { arrows: {} };
+
+  const arrows = {};
+  let currentArrow = null;
+  let inArrowsSection = false;
+
+  for (const line of content.split('\n')) {
+    if (/^arrows:\s*$/.test(line)) { inArrowsSection = true; continue; }
+    if (/^[a-z][\w-]*:/.test(line) && !line.startsWith('  ')) {
+      inArrowsSection = false;
+      currentArrow = null;
+      continue;
+    }
+    if (/^#/.test(line)) continue;
+    if (!inArrowsSection) continue;
+
+    const arrowMatch = line.match(/^  ([a-z][\w-]+):\s*$/);
+    if (arrowMatch) {
+      currentArrow = arrowMatch[1];
+      arrows[currentArrow] = {};
+      continue;
+    }
+    if (!currentArrow) continue;
+
+    const kv = line.match(/^\s{4}(\w+):\s*(.+)/);
+    if (kv) {
+      let [, key, value] = kv;
+      value = value.replace(/^["']|["']$/g, '').trim();
+      if (value === 'null') value = null;
+      if (value === '[]') value = [];
+      arrows[currentArrow][key] = value;
+    }
+  }
+
+  return { arrows };
+}
+
+function checkArrowReferences() {
+  const { arrows } = parseArrowsIndex();
+  const issues = [];
+
+  for (const [name, meta] of Object.entries(arrows)) {
+    if (!meta.detail) continue;
+    const detailPath = join(ARROWS_DIR, meta.detail);
+    if (!existsSync(detailPath)) {
+      issues.push({ arrow: name, type: 'missing_detail', path: meta.detail });
+      continue;
+    }
+
+    const content = readFile(detailPath);
+    if (!content) continue;
+
+    const refPattern = /(?:^[-*]\s+|→\s+|:\s+)`?([a-zA-Z][\w./~-]+\.[a-zA-Z]+)`?/gm;
+    let m;
+    while ((m = refPattern.exec(content)) !== null) {
+      const ref = m[1];
+      if (ref.includes('://') || ref.includes('*') || ref.includes('...')) continue;
+      if (ref.match(/^\d+\.\d+/) || ref.match(/^[a-z]+\.[a-z]+$/)) continue;
+      if (ref.includes('/') && !fileExists(ref)) {
+        issues.push({ arrow: name, type: 'broken_ref', path: ref, detail: meta.detail });
+      }
+    }
+  }
+
+  return { arrows, issues };
+}
+
+// ───────── 3. Staleness ─────────
+
+function checkStaleness() {
+  const { arrows } = parseArrowsIndex();
+  const stale = [];
+  const needsWork = [];
+
+  for (const [name, meta] of Object.entries(arrows)) {
+    const status = meta.status;
+    if (status === 'UNMAPPED' || status === 'MAPPED') {
+      needsWork.push({ arrow: name, status, reason: `status is ${status}` });
+      continue;
+    }
+    if (status === 'OBSOLETE' || status === 'OK') continue;
+
+    const last = meta.audited || meta.sampled;
+    const days = daysSince(last);
+    if (days > 30) {
+      stale.push({ arrow: name, status, lastAudited: last || 'never', daysSince: days === Infinity ? 'never' : days });
+    }
+  }
+
+  return { stale, needsWork };
+}
+
+// ───────── 4. Coverage summary ─────────
+
+function coverageSummary(specDefs, codeRefs) {
+  let total = 0, implemented = 0, deferred = 0, gaps = 0;
+  for (const [, info] of specDefs) {
+    total++;
+    if (info.status === 'implemented') implemented++;
+    else if (info.status === 'deferred') deferred++;
+    else if (info.status === 'gap') gaps++;
+  }
+  const defined = [...specDefs.values()].filter(v => v.status === 'defined').length;
+  return { total, implemented, deferred, gaps, defined, codeRefsTotal: codeRefs.size };
+}
+
+// ───────── Report ─────────
+
+function section(title) {
+  console.log('');
+  console.log('═'.repeat(60));
+  console.log(`  ${title}`);
+  console.log('═'.repeat(60));
+}
+
+function run() {
+  console.log('LID Coherence Report');
+  console.log(`Generated: ${new Date().toISOString().slice(0, 10)}`);
+  console.log(`Root: ${ROOT}`);
+
+  section('@spec Integrity');
+  const { codeRefs, specDefs, reverseOrphans, uncovered } = checkSpecIntegrity();
+  console.log(`  @spec annotations in code: ${codeRefs.size} unique IDs`);
+  console.log(`  Spec definitions: ${specDefs.size} across docs/intent/`);
+
+  if (reverseOrphans.length) {
+    console.log(`\n  Reverse orphans (${reverseOrphans.length}) — @spec cites a spec that doesn't exist:`);
+    for (const { id, locations } of reverseOrphans.slice(0, 25)) {
+      const loc = locations[0];
+      console.log(`    ${id}  (${loc.file}:${loc.line}${locations.length > 1 ? ` +${locations.length - 1}` : ''})`);
+    }
+    if (reverseOrphans.length > 25) console.log(`    ... and ${reverseOrphans.length - 25} more`);
+  } else {
+    console.log('  No reverse orphans.');
+  }
+
+  if (uncovered.length) {
+    console.log(`\n  Uncovered [ ] specs (${uncovered.length}) — gap markers with no @spec ref:`);
+    for (const { id, file } of uncovered.slice(0, 25)) console.log(`    ${id}  (${file})`);
+    if (uncovered.length > 25) console.log(`    ... and ${uncovered.length - 25} more`);
+  }
+
+  section('Arrow Reference Integrity');
+  const { arrows, issues } = checkArrowReferences();
+  console.log(`  Arrows in index: ${Object.keys(arrows).length}`);
+  if (issues.length) {
+    for (const issue of issues) {
+      if (issue.type === 'missing_detail') console.log(`    [MISSING] ${issue.arrow}: ${issue.path}`);
+      else console.log(`    [BROKEN]  ${issue.arrow}: ${issue.path} (in ${issue.detail})`);
+    }
+  } else {
+    console.log('  All arrow references valid.');
+  }
+
+  section('Staleness');
+  const { stale, needsWork } = checkStaleness();
+  if (needsWork.length) {
+    console.log('  Needs work:');
+    for (const w of needsWork) console.log(`    ${w.arrow}: ${w.reason}`);
+  }
+  if (stale.length) {
+    console.log('  Stale (>30 days since audit):');
+    for (const s of stale) console.log(`    ${s.arrow}: ${s.status}, ${s.lastAudited} (${s.daysSince} days)`);
+  }
+  if (!needsWork.length && !stale.length) console.log('  All arrows current.');
+
+  const statusCounts = {};
+  for (const [, meta] of Object.entries(arrows)) {
+    const s = meta.status || 'UNKNOWN';
+    statusCounts[s] = (statusCounts[s] || 0) + 1;
+  }
+  if (Object.keys(statusCounts).length) {
+    console.log('\n  Status summary:');
+    for (const [s, c] of Object.entries(statusCounts).sort()) console.log(`    ${s}: ${c}`);
+  }
+
+  section('Coverage');
+  const cov = coverageSummary(specDefs, codeRefs);
+  console.log(`  Total specs: ${cov.total + cov.defined}`);
+  console.log(`    [x] implemented: ${cov.implemented}`);
+  console.log(`    [ ] active gap:  ${cov.gaps}`);
+  console.log(`    [D] deferred:    ${cov.deferred}`);
+  console.log(`    (defined, no marker): ${cov.defined}`);
+  console.log(`  Unique @spec IDs in code: ${cov.codeRefsTotal}`);
+  console.log('');
+}
+
+run();

--- a/bin/update
+++ b/bin/update
@@ -14,6 +14,7 @@ INSTALL_AST_GREP_PATH = APP_ROOT.join("bin/install-ast-grep")
 PACKAGE_JSON_PATH = APP_ROOT.join("package.json")
 GEMFILE_LOCK_PATH = APP_ROOT.join("Gemfile.lock")
 YARN_LOCK_PATH = APP_ROOT.join("yarn.lock")
+CLAUDE_MD_PATH = APP_ROOT.join("CLAUDE.md")
 
 YARN_PATTERNS = {
   AGENT_DOCKERFILE_PATH => /^(\s*&& corepack prepare yarn@)([^\s]+)( --activate\s*)$/,
@@ -31,6 +32,15 @@ BINARY_RELEASES = {
   }
 }.freeze
 
+# Vendored LID reference (docs/lid/ + bin/coherence-check.mjs). bin/update
+# reports drift against upstream but does NOT auto-apply — re-syncing requires
+# re-applying local adaptations (Rails globs in coherence-check.mjs; the
+# tool-agnostic edits in workflow.md). See docs/lid/README.md § Sync policy.
+LID_SOURCE = "jszmajda/lid"
+LID_PLUGIN_VERSION_URL =
+  "https://raw.githubusercontent.com/#{LID_SOURCE}/main/" \
+  "plugins/linked-intent-dev/.claude-plugin/plugin.json"
+
 # Minimum age (in hours) a package version must have been published before
 # bin/update will adopt it. This quarantine period reduces exposure to supply
 # chain attacks that are typically detected and yanked within hours.
@@ -46,7 +56,7 @@ def fetch_json(uri_string, headers: {})
   request = Net::HTTP::Get.new(uri)
   headers.each { |key, value| request[key] = value }
 
-  response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+  response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true, open_timeout: 10, read_timeout: 15) do |http|
     http.request(request)
   end
   raise "Failed to fetch #{uri}: #{response.code}" unless response.is_a?(Net::HTTPSuccess)
@@ -109,6 +119,25 @@ def fetch_npm_publish_time(package_name, version)
   time_str ? Time.parse(time_str) : nil
 rescue StandardError
   nil
+end
+
+def fetch_lid_latest_version
+  fetch_json(LID_PLUGIN_VERSION_URL).fetch("version")
+end
+
+def pinned_lid_version
+  # Read only the `## LID` block so a stray `- Version:` elsewhere in CLAUDE.md
+  # (e.g., a Bundler/tool-config section) can't be mistaken for the LID pin.
+  block = +""
+  in_block = false
+  CLAUDE_MD_PATH.each_line do |line|
+    if line.start_with?("## ")
+      in_block = line.strip == "## LID"
+      next
+    end
+    block << line if in_block
+  end
+  block[/^- Version:\s*(\S+)\s*$/, 1]
 end
 
 def age_hours(published_at)
@@ -530,6 +559,29 @@ Dir.chdir(APP_ROOT) do
     else
       puts "  All updated packages are older than #{MIN_PACKAGE_AGE_HOURS}h ✓"
     end
+  end
+
+  puts "\n== Checking vendored LID reference =="
+  begin
+    pinned = pinned_lid_version
+    if pinned.nil?
+      warn "  ⚠ Could not read - Version: from CLAUDE.md (## LID block); skipping LID check."
+    else
+      latest = fetch_lid_latest_version
+      if latest == pinned
+        puts "  LID v#{pinned} — vendored reference is up to date ✓"
+      else
+        warn "  ⚠ LID is out of date: CLAUDE.md pins v#{pinned}, upstream is v#{latest}."
+        warn "    Three surfaces to reconcile:"
+        warn "      1. Vendored docs/lid/ + bin/coherence-check.mjs — re-sync per docs/lid/README.md § Sync policy."
+        warn "      2. CLAUDE.md (## LID - Version:) — bump to v#{latest}."
+        warn "      3. Installed Claude plugin in devcontainers — rebuild containers; install-lid.sh currently"
+        warn "         pulls latest, so verify the installed version matches the pin."
+        warn "    (bin/update reports only; it does not auto-apply any of these.)"
+      end
+    end
+  rescue StandardError => error
+    warn "  ⚠ Could not check LID for updates: #{error.message}"
   end
 
   puts "\n== Skipped pinned binary installs =="

--- a/docs/arrows/README.md
+++ b/docs/arrows/README.md
@@ -1,0 +1,24 @@
+# `docs/arrows/` — Arrow of Intent Tracking
+
+This directory tracks the arrow of intent across the project — the chain from
+high-level design through to realized code:
+
+```
+HLD → LLDs → EARS → Tests → Code
+```
+
+## Files
+
+- **`index.yaml`** — the dependency graph. Load it first to understand what's
+  available, what's blocked, and what needs work. The status enum and field
+  reference live in the
+  [upstream schema](https://github.com/jszmajda/lid/blob/main/plugins/arrow-maintenance/skills/arrow-maintenance/references/index-schema.md).
+- **`{segment-name}.md`** — one orientation page per arrow segment
+  (References, Spec Coverage, Key Findings), created as segments are mapped.
+
+## Status
+
+Empty — nothing mapped yet. Paid adopts LID going-forward (Full mode,
+brownfield), so this overlay grows as arrow segments are created under
+`docs/intent/`. See `docs/intent/README.md` for when to add a segment and the
+root `AGENTS.md` for the full workflow.

--- a/docs/arrows/index.yaml
+++ b/docs/arrows/index.yaml
@@ -1,0 +1,28 @@
+# Arrow overlay for Paid.
+#
+# This is the dependency graph of arrow segments — the chain from high-level
+# design through to realized code: HLD → LLDs → EARS → Tests → Code. Agents
+# load this file first to orient before touching any per-segment arrow doc.
+#
+# Schema: https://github.com/jszmajda/lid/blob/main/plugins/arrow-maintenance/skills/arrow-maintenance/references/index-schema.md
+#
+# Paid adopts LID going-forward (Full mode, brownfield). No segments are
+# mapped yet — the tree is intentionally empty. Add nodes here as arrow
+# segments are created under docs/intent/. See docs/intent/README.md.
+
+schema_version: 2
+last_updated: 2026-07-30
+
+# Taxonomy groups segments by domain cluster. Purely organizational.
+# Empty until segments exist to cluster.
+taxonomy: {}
+
+# The design tree of nodes. Leaf nodes are arrow segments (own EARS + an arrow
+# doc); intermediate nodes (sub-HLDs) group children. Empty = nothing mapped.
+arrows: {}
+
+# Items found during mapping that don't yet belong to a segment.
+# arrow-maintenance cleans this up on each audit.
+unmapped:
+  docs:
+    intent: []

--- a/docs/high-level-design.md
+++ b/docs/high-level-design.md
@@ -1,0 +1,198 @@
+---
+parent: root
+prefix: PAID
+---
+
+# High-Level Design: Paid (Platform for AI Development)
+
+> This is the LID high-level design — the top of the arrow of intent. It states
+> the *why* and the *how* at the project level. Per-component detail lives in
+> `docs/intent/` as low-level designs (LLDs) and EARS specs, added as the
+> project grows. For deeper narrative on any topic below, see the linked
+> long-form docs under `docs/`.
+
+## Problem
+
+Shipping software with AI coding agents is no longer bottlenecked by code
+generation. Frontier models write plausible code on demand. The hard problems
+have moved elsewhere:
+
+- **Trust.** An agent that writes code is also an agent that can exfiltrate
+  secrets, mutate state, and merge its own work. Running it safely means
+  isolating it, scoping its credentials, and keeping a human at the merge gate.
+- **Repeatability.** Each agent session starts with no memory of the last one.
+  Prompt, model, and workflow choices made in one session do not carry forward
+  unless they are captured as data.
+- **Observability.** You cannot improve what you cannot measure. Token cost,
+  iteration counts, success rates, and prompt effectiveness are invisible in an
+  ad-hoc agent run.
+- **Orchestration.** Turning a labeled issue into a merged PR is a multi-step
+  workflow — plan, execute in an isolated container, open a PR, respond to
+  review — that must be durable, resumable, and parallelizable.
+
+Paid exists to make AI agents useful and safe for real software work by solving
+these four problems together, as one system.
+
+## Approach: Data Over Configuration
+
+Paid's load-bearing bet is that **configuration is ephemeral, but data
+endures**. Every decision point that could be hardcoded as configuration is
+instead stored as data — prompts, model preferences, workflow patterns, quality
+thresholds. Prompts are versioned entities with lineage and metrics, not
+hardcoded strings; model choice is logged, not pinned; quality thresholds are
+queried records, not constants. Over time the system learns what actually works
+rather than what was assumed to work. See `docs/VISION.md` for the full thesis.
+
+This is the through-line for every component: when a behavior could be a rule or
+a record, Paid stores the record.
+
+## Approach: Isolation by Default
+
+Agents run in Docker containers built from a dedicated agent image
+(`docker/agent/Dockerfile`). They receive scoped, short-lived credentials via a
+secrets proxy rather than long-lived tokens; they operate on git worktrees, not
+the working repo; and they cannot interfere with each other or reach the host.
+Isolation is the precondition for running multiple agents in parallel and for
+giving an agent broad permissions inside its container without broad
+permissions on the system.
+
+## Approach: Human Final Say
+
+Every code change goes through a pull request. By default a human merges each
+one — human review is where quality is enforced, trust is built, and the system
+learns from feedback. A project owner may opt a project into auto-merge
+(`auto_merge_mode`: `off` by default, `dependabot_only`, or `all`), in which
+case qualifying PRs merge without a per-PR owner click; that delegation is
+explicit, scoped, and revocable. The Paid Review Bot (`paid-code-reviewer[bot]`)
+adds an automated review pass, but the authority over whether a change lands
+always rests with a human — exercised per-PR by default, or through the
+auto-merge configuration when the owner has enabled it.
+
+## Approach: All LLM Calls Through One Interface
+
+Every LLM interaction in the application goes through the `agent_harness` gem —
+never via raw HTTP to a provider API. This keeps provider-specific behavior
+(error classification, rate-limit parsing, execution flags) in one place and
+lets the control plane swap models and providers without scattered call sites.
+The secrets proxy forwards authenticated requests from containers; it is
+infrastructure, not an application-level LLM interface.
+
+## Tenets
+
+The operating principles that tie the approaches above to day-to-day work:
+
+- **Data over configuration.** When a behavior could be a rule or a record,
+  store the record.
+- **Human final say.** The authority over whether a change lands rests with a
+  human — exercised per-PR by default, or through explicit, revocable
+  auto-merge configuration that delegates the per-merge decision under rules
+  the owner defined.
+- **Isolation by default.** Agents run in containers with scoped credentials,
+  on worktrees, unable to reach one another or the host.
+- **Observable everything.** Token cost, iteration counts, success rates, and
+  prompt effectiveness are tracked as data so the system can learn.
+- **One LLM interface.** All application-level LLM calls flow through
+  `agent_harness`; fail loudly rather than papering over provider differences
+  in the control plane.
+- **Models are commodities.** No bet on a single provider; today's best model
+  is tomorrow's baseline.
+- **Fix forward.** Never skip hooks, disable linters, or ignore failing tests.
+  Fix the underlying issue.
+
+## Goals
+
+1. **Turn labeled issues into merged PRs, end to end.** Watch, plan, execute in
+   an isolated container, open a PR, and respond to review — as a durable,
+   resumable workflow.
+2. **Keep agents safe and isolated.** Scoped credentials, worktree-based
+   execution, and no path from an agent to a secret or to another agent's run.
+3. **Make agent work observable and improvable.** Capture the data — tokens,
+   cost, iterations, prompt lineage, quality — that turns guesswork into
+   measurement.
+4. **Stay portable across models and providers.** Swap the model or provider
+   behind a component without rewriting call sites.
+5. **Run in multiple deployment models.** Managed cloud and private deployment,
+   with enterprise operations (SLO/SLA) and stable ecosystem extension points.
+
+## Non-Goals
+
+- **Not a replacement for developers.** Humans are the authority over changes;
+  agents merge only on owner-configured auto-merge, which is off by default.
+- **Not a prompt playground.** Paid manages production workflows, not
+  experiments.
+- **Not adversarial security review of downstream projects.** Paid runs agents
+  the project's owner has authorized; securing the target codebase is that
+  owner's responsibility.
+
+## Target Users
+
+Development teams who want to put AI coding agents to work on their GitHub
+repositories with the safety, observability, and repeatability that ad-hoc
+agent usage lacks — across managed-cloud and private-deployment models.
+
+## Architecture
+
+The system has four main layers. Full detail lives in `docs/ARCHITECTURE.md`
+and `docs/AGENT_SYSTEM.md`; this section names the layers and how intent flows
+between them.
+
+1. **Rails control plane** — Hotwire UI, PostgreSQL, GoodJob background jobs,
+   and the tenant/account model with row-level security. Thin controllers
+   delegate to service objects (Servo, verb-noun naming). `db/schema.rb` is the
+   canonical, self-documenting schema.
+2. **Temporal orchestration** — durable workflows for agent execution.
+3. **Container management** — Docker containers built from the agent image,
+   using git worktrees for isolated agent execution; a secrets proxy supplies
+   scoped credentials.
+4. **Agent layer** — the `agent_harness` gem: a unified interface to CLI agents
+   (Claude Code, Codex, Cursor, Gemini CLI, OpenCode, and others) and the
+   single interface for all application-level LLM calls.
+
+Intent flows from the control plane (an issue is picked, a prompt is built, a
+strategy is chosen) into orchestration (a durable workflow), into container
+management (an isolated environment is provisioned), into the agent layer (the
+agent executes against a worktree and opens a PR), and back to the control plane
+(metrics, review, the human merge decision).
+
+### Directory layout
+
+```
+app/
+├── controllers/      # Thin controllers delegating to services
+├── models/           # ActiveRecord: associations, validations, scopes
+├── services/         # Business logic via Servo (organized by capability)
+├── jobs/             # GoodJob jobs
+└── views/            # ERB templates
+docker/agent/         # The agent container image
+docs/                 # Long-form docs; docs/intent/ holds the LID arrow
+```
+
+## Key Design Decisions
+
+| Decision | Chosen | Rationale |
+|---|---|---|
+| Schema format | `schema.rb` + the `fx` gem | Self-documenting canonical schema; functions/triggers versioned in `db/functions/` and `db/triggers/`. |
+| Tenant isolation | PostgreSQL row-level security on core tables | Enforced tenant scoping at the database, not just the application. |
+| Change tracking | Logidze on configuration/access/financial tables | "Who changed what and when" where it matters; not on high-volume operational tables. |
+| LLM interface | `agent_harness` for all calls | One place for provider behavior; swap models without scattered call sites. |
+| Agent execution | Docker + git worktrees + secrets proxy | Isolation and scoped credentials by default. |
+| Agent image tooling | Versions pinned from `agent_harness` contracts | Control plane and agent image stay in lockstep without separate pins. |
+| Release management | release-please + Conventional Commits | Semantic releases from conventional commit headers. |
+
+## LID adoption posture
+
+This repository adopts LID in **Full** mode on a **going-forward** basis. The
+HLD is the universal floor. LLDs and EARS specs are added as new features are
+built and as existing subsystems are mapped over time; not all existing code is
+traced yet, which is expected for brownfield adoption. When you build or change
+a component, add (or update) its segment under `docs/intent/`.
+
+## References
+
+- `docs/ARCHITECTURE.md` — system design and technology stack
+- `docs/AGENT_SYSTEM.md` — Temporal workflows and container management
+- `docs/VISION.md` — the "data over configuration" thesis and guiding principles
+- `docs/GLOSSARY.md` — domain terms
+- `db/schema.rb` — canonical database schema with table and column comments
+- `docs/rdrs/` — architectural decision records
+- `CLAUDE.md` (canonical; `AGENTS.md` is a symlink) — operating workflow for agents

--- a/docs/intent/README.md
+++ b/docs/intent/README.md
@@ -1,0 +1,54 @@
+# Intent tree
+
+This directory holds the LID arrow below the high-level design: one folder per
+design node, each containing a low-level design (`*-design.md`) and its EARS
+specs (`*-specs.md`).
+
+```
+docs/
+├── high-level-design.md          # HLD — the why (root of the tree)
+└── intent/
+    └── <segment>/                # one folder per design node
+        ├── <segment>-design.md   # LLD — the how
+        └── <segment>-specs.md    # EARS — testable claims
+```
+
+## Conventions
+
+- **IDs are path-concatenated.** A spec ID is the root-to-leaf path plus a
+  number, e.g. `AGENT-RUN-001`. Deeper nesting extends the path one segment at
+  a time (`AGENT-RUN-COST-003`). A prefix-grep gathers an entire subtree:
+  `grep -r AGENT-RUN` returns every spec, test, and code anchor beneath that
+  node.
+- **LLD frontmatter** declares `parent:` (the node above) and `prefix:` (the
+  EARS ID prefix for the node's specs).
+- **EARS specs** state one testable claim per line. Status markers:
+  `[x]` implemented · `[ ]` active gap · `[D]` deferred.
+- **`@spec` annotations** in code and tests link back to the EARS IDs they
+  implement. A spec ID is a grep target — `grep -r AGENT-RUN-001` returns the
+  requirement, the tests asserting it, and the code implementing it.
+- **Tests before code.** Write the failing-first test that asserts the EARS
+  claim before the implementation.
+- **Mutation, not accumulation.** Docs carry *current* intent, written to be
+  read cold. Delete obsolete specs rather than annotating history.
+
+## Going-forward policy
+
+This is a brownfield, Full-mode adoption. The HLD is the floor; segments are
+added as new features are built and as existing subsystems are mapped over
+time. It is expected that much of the existing codebase is not yet traced. When
+you build or change a component, add or update its segment here so the arrow
+stays walkable from that point forward.
+
+## When to add a segment
+
+- **New feature or component** → add `<segment>/<segment>-design.md` +
+  `<segment>-specs.md` before (or alongside) the code.
+- **Substantive change to an existing component** → update its LLD and specs,
+  then cascade to tests and code.
+- **Bug fix** → find where intent diverged (which spec/LLD it traces to), fix
+  the intent there, and cascade. No short-circuit straight to code.
+- **Trivial change** (typo, formatting, broken link) → no segment work needed.
+
+For the full workflow and the `## LID` mode declaration, see `CLAUDE.md`
+(canonical; `AGENTS.md` is a symlink).

--- a/docs/lid/README.md
+++ b/docs/lid/README.md
@@ -1,0 +1,89 @@
+# `docs/lid/` — LID Method Reference
+
+This directory is a **vendored reference library** for the Linked-Intent
+Development (LID) *method*. It is distinct from `docs/intent/`, which holds
+**Paid's own** design tree (its HLD, LLDs, and EARS specs). Nothing here is a
+Paid EARS claim or design doc — these files describe *how to do LID*, not what
+Paid is.
+
+## Why this exists
+
+LID is enforced richly in **Claude Code** (and Cursor) via the `jszmajda/lid`
+plugin, whose `SKILL.md` skills auto-invoke the six-phase workflow on any code
+change. Tools that are **not** plugin hosts — Codex, Gemini CLI, OpenCode, and
+others used in this repo — read only `CLAUDE.md`/`AGENTS.md`. That instruction
+file carries the LID *policy* (the arrow, the conventions), but not the
+*procedure* (the six phases with their mandatory stops, the intent-narrowing
+edge audit, the templates, the coherence checks).
+
+`docs/lid/` vendors the procedure so every tool working on Paid gets the same
+workflow Claude Code gets automatically. It also matters beyond Paid's own
+development: Paid orchestrates agents that work *on* downstream projects, some
+of which are themselves LID projects, so the canonical procedure belongs
+in-repo as a reference.
+
+## Contents
+
+| File | What it is | Source |
+|---|---|---|
+| `workflow.md` | The six-phase LID workflow + cascade/coherence rules | adapted from `linked-intent-dev/SKILL.md` |
+| `hld-template.md` | HLD standard sections | vendored verbatim |
+| `lld-templates.md` | LLD structure template | vendored verbatim |
+| `ears-syntax.md` | EARS syntax, spec-ID format, scope disambiguation | vendored verbatim |
+| `decision-doc-template.md` | Decision-doc structure + earns-its-place heuristic | vendored verbatim |
+| `audit-checklist.md` | The five coherence/audit checks | vendored verbatim |
+
+The runnable coherence check is `bin/coherence-check.mjs` (a vendored +
+Rails-adapted reference implementation — adds `*.rb` to the scan and `vendor`,
+`tmp`, `.bundle`, `storage` to the excludes, plus `--color=never` to keep ANSI
+escapes out of the line parser), declared in `CLAUDE.md` under `## LID Tooling`.
+
+## How to use it (non-Claude tools)
+
+1. Read `workflow.md` start-to-finish once — it is the procedure Claude Code
+   runs automatically.
+2. On any code change, walk the arrow: HLD check → LLD → EARS → intent-narrowing
+   edge audit → tests-first → code, stopping for review at each phase boundary.
+3. Use the templates (`hld-template.md`, `lld-templates.md`, `ears-syntax.md`,
+   `decision-doc-template.md`) when authoring or revising the design tree under
+   `docs/intent/`.
+4. Run `bin/coherence-check.mjs` for the structural checks in
+   `workflow.md` § Coherence verification.
+
+For the project-level *policy* (mode, conventions, navigation), see the
+`## Linked-Intent Development (LID)` section of `CLAUDE.md` (canonical;
+`AGENTS.md` is a symlink).
+
+## Provenance & license
+
+All files here originate from [`jszmajda/lid`](https://github.com/jszmajda/lid)
+(MIT, © 2026 Jess Szmajda), pinned to plugin `linked-intent-dev` **v1.3.0** —
+the version recorded in `CLAUDE.md` under `## LID`. The four `*-template.md` /
+`*-syntax.md` / `audit-checklist.md` files are **byte-identical** to upstream
+so a future sync is a plain `diff`. `workflow.md` is **adapted** (the
+Claude-only frontmatter, auto-trigger framing, LID-on-LID section, and
+plugin-internal path references were removed or rewritten for tool-agnostic
+use); re-apply those adaptations after re-syncing.
+
+## Sync policy
+
+When bumping `- Version:` in the `## LID` block of `CLAUDE.md`:
+
+1. `git clone https://github.com/jszmajda/lid` (or `git pull` an existing clone).
+2. Re-copy the verbatim files from
+   `plugins/linked-intent-dev/skills/linked-intent-dev/references/` and
+   `plugins/arrow-maintenance/skills/arrow-maintenance/references/` over the
+   matching files here — verify with `diff` that only intended upstream changes
+   landed.
+3. Re-derive `workflow.md` from
+   `plugins/linked-intent-dev/skills/linked-intent-dev/SKILL.md`, re-applying
+   the adaptations documented above.
+4. Re-sync `bin/coherence-check.mjs` from
+   `plugins/arrow-maintenance/skills/arrow-maintenance/references/coherence-check.mjs`
+   and re-apply the Rails globs (`*.rb`; exclude `vendor`, `tmp`, `.bundle`,
+   `storage`) and `--color=never`.
+5. Update the version number in this README's "Provenance & license" section.
+
+Do **not** edit the verbatim files locally — changes belong upstream. Local
+adaptation is confined to `workflow.md`, `bin/coherence-check.mjs`, and this
+README.

--- a/docs/lid/audit-checklist.md
+++ b/docs/lid/audit-checklist.md
@@ -1,0 +1,66 @@
+# Audit Checklist
+
+Run these five checks every time you audit — whether as part of a `/arrow-maintenance` command run or when the ambient skill notices something worth surfacing. When a project-local coherence script is declared under `## LID Tooling` in `CLAUDE.md`, invoke it for the deterministic checks and treat its output as authoritative; otherwise perform in-prompt.
+
+**Incremental mode.** When `audited_sha` is populated for a segment and git history is available, the discovery step (which segments need re-auditing this run) is *project-wide*: `git diff --name-only {min(audited_sha across segments)} HEAD` → map each changed file to its segment via arrow docs' References — only audit those segments. The per-check scoping below applies *within* each segment selected for audit; it does not replace the top-level incremental discovery.
+
+## 1. Reference coherence
+
+For each per-segment arrow doc, verify:
+
+- Every file path in `## References` (HLD section, LLD, EARS spec file, tests, code) resolves to an existing file.
+- Every EARS spec ID cited in the arrow doc exists in the referenced spec file.
+- Every LLD section heading referenced in the arrow doc appears in the LLD.
+
+**Finding format**: `{segment}: reference rot — {path} (cited in {arrow-doc-line}) no longer exists`.
+
+## 2. Coverage
+
+For each behavioral EARS spec in the project, verify at least one eval assertion cites the spec ID (via `spec_ids` in the eval's assertions array).
+
+**Finding format**: `{segment}: spec {ID} has no eval assertion citing it`.
+
+Scope: only behavioral-skill specs. Pure-prose skills have no eval coverage by design.
+
+## 3. Staleness
+
+For each segment with `status` in `{MAPPED, PARTIAL, BROKEN}`:
+
+- Compare `audited` date against today.
+- When `audited_sha` is populated and git history is available, list files modified since `audited_sha` in the segment's territory.
+
+**Finding format**: `{segment}: last audited {date} ({N} days ago), {M} files modified since audit`.
+
+Scope: not a failure — a signal. `OK` and `OBSOLETE` segments are not flagged for staleness.
+
+## 4. Drift signals
+
+Scan across the project:
+
+- Code files modified since `audited_sha` in segments not marked `OK` and not currently in active work (no pending PR / uncommitted changes).
+- EARS specs whose text was revised but whose cited tests have not been touched in the same commit range.
+- Tests that pass but have no `@spec` annotation, suggesting the behavior is tested but unlinked to intent.
+- **Reverse orphans** — `@spec` annotations in code or tests that reference spec IDs not present in any spec file. These are *asks*, not fixes: surface for user decision (create the spec, delete the annotation, or treat as alias of an existing spec). Do not auto-resolve.
+
+**Finding format**: `{segment}: drift signal — {description} ({location})`.
+
+## 5. Orphan artifacts
+
+Enumerate:
+
+- LLD files in `docs/intent/` not listed as `detail` or referenced from any arrow doc's `## References`.
+- `*-specs.md` files in the `docs/intent/` tree not referenced from any arrow doc.
+- Code files containing `@spec` annotations but not in any arrow doc's `## References`.
+- Entries in `index.yaml`'s `unmapped.docs` list — these are the trackable orphans; bulk-assign where clear, flag where ambiguous.
+
+**Finding format**: `orphan: {path} — not referenced from any arrow segment`.
+
+## After the checks
+
+In command mode (`/arrow-maintenance`):
+
+- Apply unambiguous fixes in place (regenerate coverage tables, refresh `audited`/`audited_sha`, clean assignable `unmapped.docs` entries, update status transitions where clear).
+- Produce a structured report: findings resolved, findings requiring user decision.
+- The report distinguishes the two categories and lists each finding with its location.
+
+In ambient mode: surface findings as a report, do not modify files (except opportunistically in changes the surrounding conversation is already performing).

--- a/docs/lid/decision-doc-template.md
+++ b/docs/lid/decision-doc-template.md
@@ -1,0 +1,125 @@
+# Decision Doc Template Reference
+
+A **decision doc** records a single design decision at high enough resolution that a future reader can *re-run the judgment* if circumstances change — not just learn what was chosen. It is the expanded form of a Decisions & Alternatives table row, reserved for the few decisions that earn it. Decision docs are **rare**.
+
+## When to write one (the earns-its-place heuristic)
+
+> **Apply the test from the landed state, looking forward — not from the deliberation, looking back.** The question is *not* "was this hard to decide?" Plenty of decisions are contested while the work is in flight and then read as **obvious, even native, once they land** — the structure ends up self-evidently the way it had to be. The question is: **once this lands, would a cold reader of the result find the choice non-obvious — would they question it, or be tempted to reverse it, not knowing why it went this way?**
+
+That yields three outcomes, not two:
+
+- **Record nothing.** The choice is obvious or native once it lands; the structure documents itself. Writing down a settled-and-obvious decision is the same residue the *docs carry current intent* tenet strips — a fresh author of the landed system would not explain why the natural shape is natural.
+- **A Decisions & Alternatives row.** A cold reader would plausibly wonder "why this?", and one line of rationale settles it (one option clearly dominates, or an inherited constraint eliminated the rest).
+- **A full decision doc.** The choice stays genuinely *live*: a cold reader would re-litigate it without the full tradeoffs laid out — competing options weighed against criteria.
+
+Competitive options scored against weighted criteria are a *symptom* that a doc may be warranted, not the test itself — the test is the reader's forward-looking need. A directory full of decision docs is a smell.
+
+## Where it lives
+
+A decision doc lives in the `decisions/` directory of the node that owns it:
+
+- **Segment-level decision** → `docs/intent/<segment>/decisions/<name>.md`.
+- **Project-level (HLD) decision** → `docs/decisions/<name>.md`, parallel to `docs/intent/`.
+
+Name it for the decision (`namespace-structure.md`, not `001.md`). The decision doc is **owned by the design node whose decision it is** — it shares that node's position in the tree, owns no EARS specs, and carries no spec IDs. The owning design doc links to it from its Decisions & Alternatives table.
+
+A decision belongs where its **substance** lives, even when implementing it cascades an obligation into a sibling segment — record it there and note the sibling obligation as a cascade, not co-ownership. Only a decision whose substance genuinely spans siblings rises to their shared parent (`docs/decisions/`).
+
+## Lifecycle
+
+While the decision is open it is a **plan-space working artifact** — options live, discussion present. When the decision is made, its durable reasoning lands here and the transient deliberation is shed. Like every LID doc, it is **written to be read cold**: present tense, no narration of how the discussion unfolded, no "we decided X after Y raised Z." "Options in the domain" means *the options that exist in this problem space*, not a chronology of what was proposed when.
+
+## Frontmatter
+
+```yaml
+---
+node: {owning-segment}        # the node whose decision this is — a segment, or high-level-design for a project-level decision
+---
+```
+
+A decision doc carries no `status` field. Its presence in `docs/` *is* its acceptance — deliberation happens in plan-space, so a doc only lands here once the decision is made. A superseded decision is deleted and replaced, not flagged (mutation, not accumulation; git preserves the history).
+
+When a decision builds on or relates to another — when it would be unintelligible without that premise — say so in **Context**: open with a one-line pointer to the decision it depends on. Keep this as freeform prose, not a fixed field; what a decision relates to varies too much to bind to a schema.
+
+## Structure
+
+```markdown
+# Decision: {title}
+
+## Context
+
+Why the decision is needed, the background, and what's at stake if it's wrong.
+A cold reader should understand why this decision exists from the domain itself —
+not from when or by whom it was raised. No temporal framing ("forced now").
+
+## Decision Elements
+
+The machinery a future reader needs to re-run the judgment if circumstances change. Every
+element must be able to **drive selection** — an element that all options pass, or score
+equally on, is noise; cut it. A foundational invariant every option respects is background,
+not a decision element.
+
+Elements come in two forms:
+
+- **Gates** — *binary* criteria (pass/fail). An option that fails a gate is eliminated, not
+  merely scored down. A gate may be **doc-local** (a boundary this decision sets) or
+  **inherited** (a standing constraint that applies at this node). Include a gate only if it
+  eliminates an option actually in contention.
+- **Weighted criteria** — graded considerations. Mark each with its importance:
+  **major / moderate / minor** (a project may substitute its own ordered vocabulary as long
+  as the ordering is unambiguous). Where a criterion's importance derives from a **tenet**,
+  name the tenet — this is how decisions are made to *turn on* tenets. Tenets are engaged
+  through the criteria (and named again in Selection); they get no section of their own. A
+  decision that cites no tenet anywhere is a signal: either it is purely local, or the
+  project is missing a tenet.
+
+  Before finalizing the criteria, **probe for latent criteria the discussion has not
+  surfaced** — the same latent-intent discovery the core LID workflow applies to
+  specs. Ask what a thoughtful critic would weigh that no one has named yet,
+  especially criteria that cut *against* the emerging recommendation. Criteria you
+  surface and then eliminate need not be written down; criteria that survive and
+  could move the decision must be.
+
+## Options in the Domain
+
+One `###` subhead per option — not a comparison table. Tables read cleanly with two
+or three shallow criteria and collapse as criteria deepen; per-option prose keeps each
+option's context attached to it. Each option carries:
+
+- **Description** — what the option *is*, in enough detail that a reader with no access
+  to the originating discussion can reconstruct it. Give each option its **strongest
+  honest representation** — describe it as its advocate would. An option a future
+  maintainer cannot understand from the text alone is under-described; this is the
+  most common failure of this section.
+- **Demonstration** *(optional)* — a concrete example (an ID, a snippet, a path)
+  showing the option in action.
+- **Analysis** — a bullet per element. Lead each bullet with a **verdict**, then the
+  factual basis:
+  - Constraints (gates): **passes** or **eliminated**.
+  - Criteria: **strong / partial / weak** fit against the criterion.
+
+  The verdict classifies the option's fit to *that element* — it is not a judgment of
+  the option overall (every option is strong on some elements and weak on others).
+  Keep the basis clause clinical: state what is true, don't editorialize ("fails the
+  intent," "exactly what we want"). The three things stay separate — **importance**
+  (major/moderate/minor) lives on the criterion, **fit** (strong/partial/weak) lives on
+  the option↔criterion pair, and the **weighing** of fit against importance happens
+  only in Selection.
+- **Summary** *(optional)* — one neutral line naming the option's essential trade.
+
+Hold a **high bar for "obvious."** Omit only what a cold reader would independently
+know — not what the authoring conversation happened to surface.
+
+## Selection
+
+The option chosen, why it wins against the elements (especially the high-importance
+criteria and any gate that shaped the option set), and the implications of committing: what
+it forecloses, and what it obligates downstream. Name the tenet(s) the decision turns on —
+or the tenet it is taken *against*, when a capability need overrides one — closing the
+tenet-coverage loop opened in Decision Elements.
+
+Judgment lives **here and only here**. It may be capricious if it must, but it is
+strongly preferred to arise from the analysis above rather than override it. If the
+recommendation contradicts the criteria, say so plainly — don't quietly reshape the
+analysis to fit.
+```

--- a/docs/lid/ears-syntax.md
+++ b/docs/lid/ears-syntax.md
@@ -1,0 +1,173 @@
+# EARS Syntax Reference
+
+EARS (Easy Approach to Requirements Syntax) provides structured patterns for writing unambiguous, testable requirements.
+
+**Source**: https://alistairmavin.com/ears/
+
+---
+
+## Spec File Format
+
+Specs live beside their design doc as `{node}-specs.md` within the node's folder under `docs/intent/`, with status markers. Each requirement is one line:
+
+```markdown
+- [x] **{ID}**: {Requirement statement}
+- [ ] **{ID}**: {Requirement statement}
+- [D] **{ID}**: {Requirement statement}
+```
+
+### Status Markers
+
+- `[x]` — **Implemented**: Code and tests exist that realize this spec
+- `[ ]` — **Active gap**: Should be implemented, work to do
+- `[D]` — **Deferred**: Correct intent, not needed yet (e.g., scaling optimization not needed at current user count)
+
+### Removing Specs
+
+**Delete specs that are no longer wanted.** Do not mark them — just remove the line. Git preserves history if the rationale needs to be recovered later. A spec's presence means the intent is current; absence means the intent was withdrawn.
+
+### Example
+
+```markdown
+## User Authentication
+
+- [x] **AUTH-UI-001**: The system shall display a login button on the home screen.
+- [x] **AUTH-UI-002**: When the user taps the login button, the system shall navigate to the authentication flow.
+- [ ] **AUTH-API-001**: The system shall validate JWT tokens on every authenticated API request.
+- [D] **AUTH-API-002**: Where multi-factor authentication is enabled, the system shall require a second factor.
+```
+
+---
+
+## Semantic ID Format
+
+**An ID is the root-to-leaf path, an optional within-leaf type/area segment, and a zero-padded number.** The path segments are tree positions; the prefix *is* the position up to the leaf that owns the spec. At depth-2 — one HLD over a flat set of LLDs, the default — the path is a single segment, so an ID is `{LEAF}-{NNN}` (`AUTH-001`, `CART-003`) or, with a within-leaf facet, `{LEAF}-{TYPE}-{NNN}` (`AUTH-UI-001`, `CART-API-012`). As the tree deepens, the path extends one segment at a time: `PEVAL-RUN-014` for the runner under prompt-eval, `PEVAL-PERF-LOAD-003` for load-testing under performance under prompt-eval.
+
+- **The path encodes ancestry up to the leaf.** Read left to right, the path names the owning leaf and every ancestor up to the root. The cascade boundary is the *leaf's* path: two specs whose leaf paths differ belong to different segments.
+- **A leaf may append one within-leaf type/area segment.** After the leaf path, a project MAY add a single facet segment that groups specs *inside* that leaf — `AUTH-UI-001` (leaf `AUTH`, UI facet), `ENGINE-LEDGER-001` (leaf `ENGINE`, ledger area). The facet is not a tree node and not a cascade boundary; it is an in-leaf grouping convention. This is the long-standing `{FEATURE}-{TYPE}-{NNN}` shape.
+- **A subtree greps by construction.** Because the path *is* the position, `grep PEVAL-PERF` gathers the whole performance subtree and `grep PEVAL-RUN` gathers the runner leaf, facet and all. Prefix-grep gathers specs and code regardless of where the path/facet split falls.
+- **The leaf's `prefix:` frontmatter is authoritative for where the path ends.** The path/facet boundary is not always parseable from the ID string alone (`AUTH-UI-001` could be leaf `AUTH` + facet `UI`, or a leaf at path `AUTH-UI`). The owning leaf declares its EARS prefix in `prefix:` frontmatter; that frontmatter, with `index.yaml` when the overlay is present, is the bridge from an ID to its design doc. Prefix-grep still gathers specs and code without it.
+
+Constraints:
+
+- **Global uniqueness across the project.** Two specs cannot share an ID. Path concatenation enforces this by construction — two leaves in different parts of the tree have different paths.
+- **Grep-friendliness.** IDs use uppercase letters, digits, and hyphens only. No other characters. `grep "PEVAL-RUN-014"` should find every annotation, test, and spec-file citation of a given ID, and a prefix grep should gather a subtree or a leaf.
+- **ID stability.** Ordinary growth — adding or refining specs within a segment — never renames an ID. IDs are stable **except under a deliberate, tooled re-parent or rename**, which rewrites the affected paths across spec files, docs, and `@spec` annotations together as one atomic operation (owned by the arrow-maintenance plugin). Revisions mutate text, not IDs. Deletion is permanent; the number is not recycled.
+- **Numbering on conflict.** When drafting a new spec whose path already exists, surface the collision rather than silently picking — most often the new spec belongs at a deeper segment, which extends the path and resolves the conflict.
+
+Keep IDs stable — don't renumber when inserting requirements.
+
+---
+
+## EARS Requirement Patterns
+
+### 1. Ubiquitous (always true)
+
+**Pattern**: "The system shall..."
+
+```
+- **CART-UI-001**: The system shall display the item count in the cart icon.
+```
+
+### 2. Event-Driven (triggered by action)
+
+**Pattern**: "When [trigger], the system shall..."
+
+```
+- **CART-UI-002**: When the user taps "Add to Cart", the system shall add the item and show a confirmation.
+```
+
+### 3. State-Driven (while condition is true)
+
+**Pattern**: "While [state], the system shall..."
+
+```
+- **CART-UI-003**: While the cart is empty, the system shall display an empty state message.
+```
+
+### 4. Optional (feature-dependent)
+
+**Pattern**: "Where [feature enabled], the system shall..."
+
+```
+- **AUTH-OPT-001**: Where biometric auth is enabled, the system shall prompt for Face ID before checkout.
+```
+
+### 5. Unwanted (error handling)
+
+**Pattern**: "If [unwanted condition], then the system shall..."
+
+```
+- **CART-UI-004**: If the network request fails, then the system shall display cached data with an error banner.
+```
+
+---
+
+## Scope Disambiguation
+
+A spec should be interpretable correctly even if found via grep without its surrounding section or file context. The dangerous anti-pattern is a spec that **reads as a universal rule but is actually scoped to a specific mode, variant, or context** — it becomes an implementation trap when a second variant is added.
+
+### Checklist
+
+1. **Name the scope in the WHEN clause.** If a spec applies to a specific mode, pass, or context, state it explicitly — don't rely on the section header.
+2. **Litmus test:** "If a second variant of this behavior existed, would this spec still be unambiguous?" If no, the scope is implicit and needs to be stated.
+3. **Cross-file domain concepts:** When a spec references a concept defined in another spec file, include a brief parenthetical — not a full definition, but enough to prevent a plausible-but-wrong implementation.
+
+### Watch ubiquitous specs
+
+Ubiquitous specs ("The system shall...") are most vulnerable — they have no WHEN clause to carry scope. Ask: is this truly ubiquitous, or does it just feel that way because there's currently only one context?
+
+### Examples
+
+**Bad** — sounds universal, actually scoped to one notification channel:
+```
+- **NOTIF-BE-003**: Notifications shall use a 30-second delivery timeout.
+```
+
+**Good** — scope is explicit:
+```
+- **NOTIF-BE-003**: Both email and push notifications shall use a 30-second delivery timeout.
+```
+
+**Bad** — cross-file concept with no inline context:
+```
+- **CART-API-012**: When processing retry queue items, the system shall implement a 500ms delay between requests.
+```
+
+**Good** — parenthetical prevents wrong interpretation:
+```
+- **CART-API-012**: When processing retry queue items (failed payment attempts re-queued after gateway timeout), the system shall implement a 500ms delay between payment gateway requests.
+```
+
+---
+
+## Code Annotations
+
+Reference specs in implementation:
+
+```typescript
+// @spec CART-UI-001, CART-UI-002
+export function CartIcon({ ... }) {
+  // Implementation
+}
+```
+
+In tests:
+
+```typescript
+// @spec CART-UI-002
+it('adds item to cart on tap', () => {
+  // Test implementation
+});
+```
+
+---
+
+## Traceability
+
+In implementation plans, map specs to phases:
+
+```markdown
+## Phase 1: Core Cart UI
+Specs: CART-UI-001 through CART-UI-010
+```

--- a/docs/lid/hld-template.md
+++ b/docs/lid/hld-template.md
@@ -1,0 +1,98 @@
+# HLD Template Reference
+
+A project's High-Level Design (HLD) is the **root of the design tree** — the single top-level document that answers *what* and *why* for the whole project. One HLD per project. File location: `docs/high-level-design.md`.
+
+The same shape also appears *below* the root. When a subsystem grows too deep for one LLD, it promotes into a **sub-HLD**: an HLD-shaped document that is the root of its own subtree, holding that subtree's problem, approach, and key decisions while parenting its children. "HLD" and "LLD" are roles by position in the tree, not fixed types — this template is a starting point for any node acting as a tree root or grouping node, which carries the sections it needs. A sub-HLD **owns no EARS**; it delegates specs to its child LLDs (see the LLD template reference). Depth-2 — one HLD over a flat set of LLDs — is the default; sub-HLDs are a triggered exception, not a requirement. A *merely categorical* grouping — a label with no shared parent intent a parent doc should hold — is **not** a sub-HLD: its members stay flat leaves (it may still group them for navigation, as `index.yaml`'s `taxonomy` field does). The test is whether a parent design doc *should* exist, not whether one already does — write a parent where shared intent warrants it; keep things flat where it does not.
+
+**Non-root pointers.** A sub-HLD carries a `parent:` pointer naming its parent node (so the tree is walkable upward) and a `prefix:` carrying the EARS namespace it roots. The directory and file names are human-readable and need not equal that prefix; `prefix:` is the authoritative bridge from the human name to the namespace. Its child LLDs extend the prefix and own the actual specs — the sub-HLD owns none directly — but `prefix:` lets a reader grep the whole subtree (`grep EXP`). The root HLD has neither pointer.
+
+**File placement — node-as-folder.** Every node is a directory. A sub-HLD `foo` is `docs/intent/…/foo/` holding `foo-design.md` plus a child directory per child — e.g. the `arrow-maintenance` sub-HLD is `docs/intent/arrow-maintenance/arrow-maintenance-design.md` with child directories `maintenance/` and `map-codebase/`. (A leaf is the same shape, additionally holding `foo-specs.md`.) Promoting a leaf to a sub-HLD adds child directories beside its `-design.md` and moves its EARS down into the new leaf children. (See the LLD template reference for the matching detail.)
+
+```markdown
+---
+parent: high-level-design
+prefix: EXP
+---
+```
+
+## Standard sections
+
+The HLD uses these sections. In **Full LID**, every section is filled. In **Scoped LID**, sections may be explicitly marked `*(not yet specified)*` rather than filled with placeholder prose — gaps are visible rather than hidden.
+
+```markdown
+# High-Level Design: {Project Name}
+
+## Problem
+
+The problem this project exists to solve. What is broken, who suffers, why now.
+
+## Approach
+
+How the project solves the problem in general terms. If there are multiple load-bearing approaches (a core mechanism plus secondary disciplines), name each as its own sub-section.
+
+## Target Users
+
+Who the project serves. Concrete postures or roles, not demographics. What they need and at what cost.
+
+## Goals
+
+What success looks like — specific, falsifiable when possible. Prefer outcomes over outputs.
+
+## Non-Goals
+
+What this project explicitly is not. Useful boundary — makes it easier to say "no" to surface growth.
+
+## Tenets
+
+One-line tie-breakers: which way the project leans when a decision has two defensible answers and no spec covers it. A tenet is forward-looking — it governs choices the arrow has not reached yet — which makes it distinct from Key Design Decisions, which record choices already made, and from specs, which fix a definite action at a known trigger. A tenet leans a class of unforeseen choices; a candidate phrased as *when X, do Y* is a spec — route it to EARS, not the tenet list, even when its opposite is a defensible choice. The discriminating test is the **defensible opposite**: a real tenet's reverse is a choice a different project could reasonably make. "We prefer X over Y" where Y is absurd is a platitude, not a tenet, and resolves nothing. State each as a single line and order them so that when two conflict, the higher one wins. A short HLD has two or three load-bearing tenets, not a manifesto.
+
+```markdown
+- **Boring over clever.** When a problem has a well-worn solution and a novel one, prefer the well-worn one unless the novel one is decisively better — a future maintainer should not have to reverse-engineer ingenuity.
+- **Fail loud, not silent.** When an operation cannot complete correctly, surface the failure rather than degrading quietly.
+```
+
+## System Design
+
+High-level architecture: major components, how they fit, what boundaries separate them. Mermaid diagrams preferred for structural views; ASCII for UI mockups when needed.
+
+## Key Design Decisions
+
+Load-bearing choices and the reasoning behind them. Each decision names the alternatives considered and why this direction was chosen. Prefer a few deep decisions with clear rationale over many shallow ones.
+
+## Success Metrics
+
+How you know the project is working. Where possible, describe falsification signals — conditions under which the project would be judged broken.
+
+## FAQ (optional)
+
+Questions the team has answered often enough that the answer belongs in the HLD.
+
+## References
+
+Prior art, linked specs, related projects, external docs.
+```
+
+## Notes
+
+- **Keep it short enough to re-read.** An HLD that sprawls beyond ~2000 lines stops being an orientation doc. Push detail down into child LLDs; when a single subsystem's detail outgrows one LLD, promote it into a sub-HLD with its own child LLDs.
+- **Docs carry current intent, written to be read cold.** When the HLD changes, update in place and delete what's wrong. Write it as if authored fresh today from current intent alone — no narration of how it changed, no meaning that needs the conversation that produced it, no rebuttals to questions only a past discussion raised. Rationale and considered alternatives that a fresh author would independently write stay; they are present intent, not history.
+- **Diagrams.** Mermaid is the default for structural, flow, state, and ERD diagrams — renders natively on GitHub and is token-efficient for agent consumption. ASCII is the convention for UI mockups. Detect existing project conventions first; ask once if unclear.
+- **Trade-off sketches.** When drafting a new HLD or making a consequential architectural change, first sketch 2–3 competing options (~200 words each with downstream consequences) and present them for user selection before committing to a full draft. See the `linked-intent-dev` skill's Phase 1 guidance.
+- **Non-Goals earn their place.** An explicit non-goal that constrains future surface growth is worth more than a vague goal.
+- **Tenets are elicited, not assumed.** When drafting or revising the HLD, surface the few decisions that could reasonably go more than one acceptable way and ask the user to state a preference. See the `linked-intent-dev` skill's Phase 1 guidance.
+
+## Scoped-LID variant
+
+For Scoped LID projects, mark unspecified sections explicitly:
+
+```markdown
+## System Design
+
+*(not yet specified)*
+
+## Success Metrics
+
+*(not yet specified — scope is too narrow for project-level metrics; see LLD for scope-specific success criteria)*
+```
+
+Leaving a section unfilled is better than filling it with placeholder prose — agents can tell which parts of the intent are authored and which are still gaps.

--- a/docs/lid/lld-templates.md
+++ b/docs/lid/lld-templates.md
@@ -1,0 +1,201 @@
+# LLD Templates Reference
+
+Low-Level Designs (LLDs) document component-specific technical decisions. LLDs are **pure design documents** — they describe *how* things work, the constraints, trade-offs, and decisions. They do not track implementation status.
+
+An LLD is a **leaf of the design tree**: it owns its segment's EARS specs and sits under an HLD (the root) or a sub-HLD. "LLD" is a role by position, not a fixed type — the template below is a **starting point**, not a rigid shape. A node carries the sections it needs; flat depth-2 (one HLD over a flat set of LLDs) is the default. When a leaf LLD outgrows itself — its intent differentiating into sub-parts that each warrant their own design — it **promotes into a sub-HLD** with child LLDs beneath it (see the HLD template reference); the promoted node sheds its EARS to those children, since only leaves own specs.
+
+**Frontmatter.** Every LLD carries two pointers: `parent:` names the node above it (the root HLD at depth-2, or a sub-HLD when nested), so the tree is walkable upward; `prefix:` carries the EARS namespace the leaf owns — its full root-to-leaf path — so a reader knows its spec namespace (`AUTH-*`, or `EXP-BIDIFF-*` when nested) without grepping. The directory and file names are human-readable and need not equal this prefix (`arrow-maintenance/maintenance.md` may own prefix `SCALE-MAINT`); `prefix:` is the authoritative bridge from the human name to the namespace, and it marks where the leaf path ends — a spec ID may append an optional within-leaf type/area segment and a number after the leaf prefix (`AUTH-UI-001`). A pure-prose leaf that owns no EARS omits `prefix:`. (Grouping sub-HLDs also carry `prefix:` — the namespace they root — per the HLD template reference.)
+
+```markdown
+---
+parent: high-level-design
+prefix: AUTH
+---
+```
+
+Implementation status is tracked in:
+- **Spec files** (`{node}-specs.md`, beside each design doc under `docs/intent/`) via `[x]`/`[ ]`/`[D]` markers on EARS specs
+- **Arrow docs** (`docs/arrows/`) via coverage tables (if using arrow-maintenance plugin)
+
+## Greenfield vs. Brownfield
+
+The template below is used for both greenfield LLDs (authored before implementation) and brownfield LLDs (reverse-engineered from existing code). There is no separate brownfield template. What varies is the *content's starting state*:
+
+- **Brownfield Decisions & Alternatives** rows carry `[inferred]` in the Rationale column when the decision was observed in code rather than authored by the user. As the user confirms or refutes the inference in subsequent sessions, the `[inferred]` marker is removed and the rationale is written out.
+- **Brownfield Open Questions & Future Decisions** holds observed-but-unexplained behaviors and technical debt discovered during reconnaissance. These migrate into Decisions, into specs, or into a planned remediation as the user engages with the code.
+- **Brownfield Major sections** may describe current state alongside intended behavior when the two differ — flag divergence explicitly rather than pretending the code matches intent.
+
+As a brownfield LLD matures through normal LID cascades, inferred content becomes authored content. No migration or "graduation" step is needed — the LLD evolves in place.
+
+## File Location
+
+Every node is a **directory** under `/docs/intent/`, named for the node. A leaf LLD `foo` is `docs/intent/foo/foo-design.md`, with its EARS beside it as `foo-specs.md` and a `decisions/` dir if it has decision docs. At the default depth-2, each LLD is one such folder directly under `docs/intent/`:
+- `docs/intent/user-authentication-flow/user-authentication-flow-design.md` (+ `user-authentication-flow-specs.md`)
+- `docs/intent/payment-processing-pipeline/payment-processing-pipeline-design.md`
+- `docs/intent/offline-sync-strategy/offline-sync-strategy-design.md`
+
+**The directory layout mirrors the design tree's structure (node-as-folder).** A sub-HLD `foo` is the directory `docs/intent/…/foo/` holding `foo-design.md` plus a child directory per child — e.g. the `arrow-maintenance` sub-HLD is `docs/intent/arrow-maintenance/arrow-maintenance-design.md` with child directories `maintenance/` (holding `maintenance-design.md` + `maintenance-specs.md`) and `map-codebase/`. A leaf and a sub-HLD have the same shape, distinguished only by whether the folder holds a `-specs.md` (leaf) or child directories (sub-HLD). When a leaf promotes into a sub-HLD, its `-specs.md` goes away — the EARS move down into the new leaf children — and child directories appear beside its `-design.md`. Directory and file names are human-readable and need not equal the EARS prefix; each node's `prefix:` frontmatter carries it (see the EARS syntax reference). Decision docs follow `references/decision-doc-template.md`.
+
+## Standard Structure
+
+```markdown
+# [Component Name]
+
+## Context and Design Philosophy
+
+Why this component exists and guiding principles.
+
+## [Major Section 1]
+
+Technical details...
+
+## [Major Section 2]
+
+Technical details...
+
+## Decisions & Alternatives
+
+For each significant design choice, record what was chosen, what was considered, and why. This section preserves context for future sessions — if requirements change, the team can revisit a specific decision rather than re-exploring the entire design space.
+
+This table is the sanctioned home for rejected alternatives and why they were trimmed. A "we considered X and rejected it because Y" note belongs here, where a fresh author choosing the current design would independently record it. The same note as a defensive aside in body prose ("there is no separate X…") is residue under *docs carry current intent* — the rationale is legitimate; only its placement makes it keep-worthy here and a fossil elsewhere.
+
+| Decision | Chosen | Alternatives Considered | Rationale |
+|----------|--------|------------------------|-----------|
+| (decision point) | (selected approach) | (brief list) | (why this direction) |
+
+## Open Questions & Future Decisions
+
+### Resolved
+1. ✅ Decision made with rationale
+
+### Deferred
+1. Decision to make during implementation
+
+## References
+
+- Related docs, external resources
+```
+
+## When to Use Narrative vs Structured Format
+
+### Use Narrative Format For:
+
+**Complex constraint interactions** - When multiple requirements interact:
+
+```markdown
+## Offline Buffering Strategy
+
+The offline buffer must balance three competing constraints: reliable
+persistence across app crashes, efficient upload resumption, and minimal
+battery impact during background sync. IndexedDB provides the persistence
+foundation, storing metadata including uploadId and progress markers. When
+network drops mid-upload, the multipart session preserves server-side state
+while the client maintains enough context to resume without re-uploading
+completed parts. The 5MB part size represents a deliberate trade-off between
+retry cost (smaller parts mean less re-upload on failure) and request overhead
+(larger parts mean fewer HTTP round-trips).
+```
+
+**Multi-service orchestration** - When showing flow between components:
+
+```markdown
+## Processing Pipeline
+
+Order processing flows through three phases, each with distinct error handling
+requirements. Phase 1 (validation) tolerates retry since it's idempotent - the
+same input always produces the same result. Phase 2 (payment) requires careful
+state tracking because payment gateway calls are expensive and partially-
+completed transactions should be preserved. Phase 3 (fulfillment) uses database
+transactions to ensure atomic updates across Orders, Inventory, and Shipping.
+```
+
+### Use Structured Format For:
+
+**API contracts and interfaces**:
+
+```markdown
+## API Endpoints
+
+| Endpoint              | Method | Request          | Response        |
+| --------------------- | ------ | ---------------- | --------------- |
+| `/orders`             | POST   | OrderCreateReq   | OrderConfirm    |
+| `/orders/{id}`        | GET    | -                | Order           |
+| `/orders/{id}/status` | GET    | -                | OrderStatus     |
+```
+
+**Configuration and thresholds**:
+
+```markdown
+## Rate Limiting Thresholds
+
+**Per-user limits**:
+- Standard tier: 100 requests/minute
+- Premium tier: 1000 requests/minute
+- Enterprise tier: Custom
+
+**Global limits**:
+- Burst: 10,000 requests/second
+- Sustained: 5,000 requests/second
+```
+
+**State enumerations**:
+
+```markdown
+## Order States
+
+- `pending` - Created, awaiting payment
+- `paid` - Payment confirmed
+- `processing` - Being prepared
+- `shipped` - In transit
+- `delivered` - Complete
+- `cancelled` - Order cancelled
+```
+
+## Visual Diagrams
+
+Include ASCII diagrams for UI layouts:
+
+```markdown
+## Visual Hierarchy
+
+┌─────────────────────────────────────┐
+│ My Orders                     [⚙]   │ ← Top nav
+├─────────────────────────────────────┤
+│ Active│History│ Returns             │ ← Tab bar
+│ ██████│       │                     │
+├─────────────────────────────────────┤
+│ Order #12345              In Transit│ ← Order card
+│ ┌─────────────────────────────────┐ │
+│ │ 2 items · $47.99                │ │
+│ │ Arrives: Jan 22                 │ │
+│ └─────────────────────────────────┘ │
+│              [Track Order]          │ ← CTA button
+└─────────────────────────────────────┘
+```
+
+## Design Decision Documentation
+
+Capture the "why" alongside the "what":
+
+```markdown
+## Decision: Payment Provider
+
+**Chosen**: Stripe
+
+**Rationale**: Stripe provides comprehensive fraud detection, handles
+PCI compliance, and offers a well-documented API. The 2.9% + $0.30 fee
+is competitive and predictable. Their webhook system enables reliable
+async processing.
+
+**Alternatives considered**:
+- PayPal: Higher fees for our volume, more complex integration
+- Square: Better for in-person, weaker for online-only
+- Adyen: Enterprise pricing not cost-effective at our scale
+```
+
+## Section Depth Guidelines
+
+- Keep sections focused on single concerns
+- Use H2 for major sections, H3 for subsections
+- If a section exceeds ~100 lines, consider splitting
+- Link to separate reference docs for detailed specs

--- a/docs/lid/workflow.md
+++ b/docs/lid/workflow.md
@@ -1,0 +1,217 @@
+<!--
+  Vendored + adapted from jszmajda/lid — plugin `linked-intent-dev`, skill
+  `linked-intent-dev/SKILL.md` @ v1.3.0 (MIT, © 2026 Jess Szmajda).
+  Tool-agnostic LID procedure. Claude Code and Cursor get this auto-invoked via
+  the plugin; other tools (Codex, Gemini CLI, OpenCode, …) read it from here.
+  Do not edit locally — re-sync from upstream when bumping `- Version:` in the
+  `## LID` block of CLAUDE.md. Provenance + sync policy: docs/lid/README.md.
+-->
+
+# Linked-Intent Development — Workflow
+
+This is the LID workflow: a structured design-before-code process. LID's goal is to narrow the agent's output distribution to the user's latent intent — specs, tests, and linkage together make the arrow of intent walkable, and the workflow's stops are where the agent's interpretation meets the user's intent for reconciliation.
+
+## Three rules govern every phase
+
+**Stop and iterate at every phase boundary.** After completing each phase below, present the output to the user, incorporate numbered feedback, and proceed only on explicit approval. Each stop is mandatory. Skipping stops is the single most common way this workflow degrades into a rush — the discipline is non-optional. (Carveout: a single directed audit pass — like an arrow-maintenance audit (Claude Code's `/arrow-maintenance`, or `bin/coherence-check.mjs` in this project) — is not phase-structured and does not pause mid-pass. This workflow is generative; phases here produce intent, so every boundary gets a stop.)
+
+**Run a coherence pre-flight before starting or resuming implementation.** When picking up work — new session, returning to a change, cascading from an upstream change — verify that the HLD, LLDs, EARS specs, and tests are mutually coherent for the segment about to be touched:
+
+- Do the EARS specs trace to the current LLD?
+- Do the tests trace to the current EARS specs?
+- Does the LLD still reflect the HLD's architecture?
+
+If drift is detected, fix the docs first, then implement. A resumption check prevents one session's drift from being compounded into the next session's change.
+
+**Write docs as their fresh author.** Every HLD, LLD, and EARS spec produced by these phases must read as if authored fresh today, by someone who knew only the current intent and nothing of this conversation. As you draft or revise a doc, run the test on each line — would that fresh author put it on the page? Three residues fail it: narration of how the intent changed; meaning that only resolves for someone who was in this conversation; and answers or rebuttals that exist only because we discussed the question here. The keep-side is load-bearing too — rationale, considered alternatives, and constraints a fresh author would independently write stay; they are present intent, not residue. Record rejected alternatives and why in the LLD's Decisions & Alternatives table, not as asides in body prose. This is the *docs carry current intent* tenet. Write in the project's own domain language — name components, segments, and specs with the words the user and the codebase already use, not generic or LID-imposed labels. This is the *Speak the project's language* tenet.
+
+## Mode-aware triggering
+
+Every LID project declares its mode in its instruction file (the project's `AGENTS.md`, or `CLAUDE.md` under Claude Code) under the `## LID` block's `- Mode:` bullet. Defaults to Full if the block or bullet is missing or malformed (surface a one-line warning).
+
+- **Full LID**: the workflow applies broadly — any prompt that could result in a code change is in scope.
+- **Scoped LID**: additionally checks whether the files or subsystems the prompt touches fall within the declared scope. Scope is declared in the instruction file under a `## LID Scope` section with include/exclude glob patterns. If every file the prompt touches is outside scope (in the exclude list, or not in the include list), the workflow does not apply. If any touched path is in scope, the workflow applies. For prompts that reference no specific paths, default to applying the workflow and ask the user to confirm when ambiguous. When the `## LID Scope` section is missing or empty in a Scoped-mode project (misconfiguration), fall back to treating all prompts as in-scope and surface a warning suggesting scope be declared.
+
+## The six phases
+
+### Phase 1 — HLD check (with bootstrap when needed)
+
+**First, check whether the project is LID-configured.** If the instruction file (`CLAUDE.md`, with `AGENTS.md` as a symlink to it) has no LID directives AND no LID-shaped artifacts exist (no `docs/intent/` content, no `docs/high-level-design.md`, no `docs/arrows/index.yaml`), this is a fresh project and the user is starting LID adoption. Bootstrap it: create `docs/intent/`, add the LID directives and a `## LID` block to the instruction file (`- Mode:` default Full unless the user indicates Scoped, `- Version:` set to the LID version recorded in the project), and seed `docs/high-level-design.md` from the user's description. Under Claude Code this is automated by the `linked-intent-dev` / `update-lid` skills; in other tools, do it by hand using the templates in `hld-template.md` and `lld-templates.md`.
+
+Once configured, proceed with the HLD check: does a top-level HLD exist at `docs/high-level-design.md`? Does it cover the domain of the change? If the change alters the project's architecture, update the HLD first. If no HLD exists (fresh project), draft one from the user's description.
+
+For consequential architectural changes (a new approach, a significant trade-off, a new mode) — and on a fresh-project HLD draft — before committing to a full HLD **sketch 2–3 competing options** (~200 words each, naming downstream consequences) and present them for user selection. Surfacing decisions as *choices among alternatives* — rather than as the agent's best guess — is the primary edge-detection mechanism at the HLD level.
+
+When drafting or revising the HLD, **elicit tenets**: surface the few decisions that could reasonably go more than one acceptable way, ask the user which way to lean, and record each as a one-line tie-breaker under `## Tenets`. Apply the defensible-opposite test before proposing one — if the reverse of the tenet is absurd rather than a choice a different project could reasonably make, it is a platitude and resolves nothing; drop it. Apply a second test too: a tenet leans a class of decisions no spec anticipates — if the candidate reads as a triggered action (*when X, do Y* with a definite outcome), it is a spec, not a tenet; route it to EARS rather than the tenet list, even when its opposite is defensible. A tenet is edge detection for choices no spec will anticipate. Surface the load-bearing ones you can see and invite more; do not interrogate the user for an exhaustive set.
+
+Whatever you draft, verify the HLD reads **context-free**: rationale present, alternatives named, no reliance on conversation context that won't travel to the next session.
+
+See `hld-template.md` for standard HLD sections.
+
+**STOP for user review.**
+
+### Phase 2 — LLD check or draft
+
+Does a leaf LLD exist for the intent component being changed?
+
+If not, draft one using the template at `lld-templates.md`.
+
+The design layer is a recursive tree, and "HLD" and "LLD" are **roles by position**: the root is the HLD, the leaves are the LLDs that own EARS, and a component with enough internal depth to outgrow one doc is promoted to a **sub-HLD** — HLD-shaped for its subtree, owning no EARS of its own — with child components beneath it. Depth-2 (one HLD over a flat set of leaf LLDs) is the default; nesting is a triggered exception. So a single large LLD is a candidate for promotion to a sub-HLD, not automatically a smell — weigh promotion when a leaf outgrows itself rather than splitting reflexively.
+
+When a node looks like it holds more than one thing, three shapes are possible, and which fits turns on the intent, not the size of the doc: if the parts share parent intent a parent doc should hold, **promote** to a sub-HLD over child leaves; if they are distinct intents with no shared parent, they are **sibling leaves**, each owning its own prefix; if they are merely categories of one intent — cross-cutting concerns (errors, security, performance, monitoring) or requirement *types* — keep one leaf and fold them into within-leaf `<LEAF>-<TYPE>` facets. The deciding test for promotion is whether the parent doc would carry real intent or just a table of contents: a categorical grouping is a taxonomy label, not a sub-HLD.
+
+In complex projects multiple LLDs may look semantically relevant. Do not silently pick — surface the candidate leaf LLDs with their scopes and ask the user which applies.
+
+If a leaf LLD exists, confirm coherence with the change and update as needed.
+
+After drafting or substantially revising an LLD, run an **LLD-level edge-case probe**: a list of "what happens when..." questions pointed at *this LLD's own gaps* — missing state transitions, unstated invariants, unspecified API error shapes, ordering assumptions inside the component. (Cross-component and cross-spec interactions come later in Phase 4, not here.) When a subagent is available, delegate the probe to the subagent for cleaner, less-biased coverage. Present the gap list; the user triages which gaps to fix in the LLD vs. defer as open questions.
+
+Verify the LLD reads **context-free**: the Decisions & Alternatives table has filled-out Rationale columns, alternatives considered are named, and the prose doesn't rely on assumptions only present in the conversation. A reader without your chat history should be able to follow the design.
+
+**STOP for user review.**
+
+### Phase 3 — EARS spec draft or update
+
+Every LLD change produces a corresponding EARS update. See `ears-syntax.md` for format.
+
+- Spec IDs are stable. Revisions mutate text, not IDs, unless scope genuinely changes.
+- Deleted IDs are not reused — git preserves the history.
+- Delete specs that are no longer wanted rather than marking them obsolete.
+
+After drafting or revising specs, run **post-draft consistency verification**:
+
+- **Coverage** — are there behaviors described in the LLD that have no corresponding EARS spec?
+- **Contradiction** — do any specs say different things about the same behavior?
+- **Implicit scoping** — are any specs phrased as universal when they actually apply only to one context? When the current change adds a new mode or variant, audit sibling specs for scope that was implicit when only one variant existed. See `ears-syntax.md § Scope Disambiguation` for the litmus.
+- **Context-free reading** — read each spec as if you have no conversation context. Are scopes explicit (no reliance on the surrounding section name to disambiguate)? Are conditions concrete (no "as we discussed" assumptions)? Specs travel by `grep`, so each line has to stand alone.
+
+Present a brief consistency report alongside the specs.
+
+**STOP for user review.**
+
+### Phase 4 — Intent-narrowing edge audit
+
+Distinct from the Phase 2 LLD-level probe in what it targets. Phase 2 asked "what's under-specified in *this LLD*?" — structural gaps inside one component. Phase 4 asks "given the LLD + specs *together*, where could the agent's interpretation diverge from what the user meant?" The targets here are **cross-spec and cross-segment**:
+
+- Interactions between this LLD's specs and a sibling segment's specs (who owns what state?).
+- Specs that read cleanly in isolation but admit two different behaviors when composed with another spec in the same segment.
+- Namespace or feature-prefix ambiguity (does spec X apply to mode A, mode B, or both?).
+- Sequencing ambiguity across specs (if A and B are both required, does order matter?).
+- Places where the user's latent intent is probably narrower than what the specs literally allow.
+
+Ask the user to resolve these *before* tests are written. LID's fundamental purpose — narrowing the agent's output distribution to the user's latent intent — is carried by this step more than any other.
+
+**STOP for user review.**
+
+### Phase 5 — Tests first
+
+Write tests **before** the code that satisfies them, per the HLD's intent-preloading rationale.
+
+- Tests carry `@spec` annotations citing the EARS IDs they verify.
+- Place the `@spec` annotation on the test that directly exercises the spec's behavior, not on every inner assertion.
+- Do not proceed to code until tests exist and fail in the expected way.
+
+**STOP for user review.**
+
+### Phase 6 — Code
+
+Implement. Code carries `@spec` annotations placed at the **entry point of the behavior's implementation graph** — the topmost function or module that owns the specified behavior, not every helper in its subtree. When a behavior spans multiple subsystems (e.g., UI + API + database), annotate at the entry point in each subsystem.
+
+On completion, run **coherence verification** (below).
+
+## Coherence verification
+
+Two layers at the end of Phase 6.
+
+**Structural checks (deterministic; soft-block completion):**
+
+1. All tests pass.
+2. Every `@spec` annotation in the changed files points to a spec ID that exists in a spec file.
+3. Every behavioral EARS spec cited by the LLD has at least one test citing it.
+4. No spec file references a deleted spec ID.
+
+*Soft-block* means the skill will not consider the change complete until these pass, and surfaces failures clearly. The user can override per the user-is-always-right tenet — LID is not a linter or CI gate. The skill makes the cost visible; the user decides.
+
+When the project declares a coherence-check script under `## LID Tooling` in the instruction file, structural checks may be delegated to that script. Without a declaration, perform checks in-prompt. In this project the script is `bin/coherence-check.mjs` (declared in `CLAUDE.md` under `## LID Tooling`).
+
+**Semantic checks (agent judgment; surfaced, do not block):**
+
+1. Do the updated specs describe behavior consistent with the LLD?
+2. Does the updated LLD match the HLD's architecture?
+
+Re-read each adjacent level of the arrow for the changed segment and produce a short report: for each spec/LLD/HLD pair, either "consistent" with a one-line justification or "needs review" with a specific point of tension. Semantic findings are surfaced for user review but do not block — "match" at the prose level is judgment, not a theorem.
+
+## Decision docs
+
+Most design decisions are recorded as a row in the relevant LLD's Decisions & Alternatives table. A few earn a full **decision doc** — a standalone artifact laying out a decision's context, criteria, options, and selection at enough resolution that a future cold reader can re-run the judgment.
+
+Apply the test from the **landed** state, not the deliberation: *would a cold reader of the result find the choice non-obvious — question it, or be tempted to reverse it?* — not *was it hard to decide?* A decision that was contested while you worked but reads as obvious or native once it lands needs **neither a doc nor a row**; the structure documents itself, and recording a settled-obvious choice is the residue the *docs carry current intent* tenet strips. Add a **table row** when a cold reader would wonder "why this?" and a line settles it. Write a **full decision doc** only when the choice stays genuinely live — a reader would re-litigate it without the competing options and criteria. Decision docs are rare; a directory full of them is a smell.
+
+A decision doc lives in the owning node's `decisions/` directory (`docs/intent/<segment>/decisions/` for a segment-level decision, `docs/decisions/` for a project-level one), is owned by that node, and carries no EARS IDs. See `decision-doc-template.md` for structure, the earns-its-place heuristic, and the fit-verdict format.
+
+## Cascade discipline
+
+**Cascade** means: when a change is made at one level of the arrow, the levels *downstream* are reviewed and updated in the same session so adjacent levels stay coherent. An LLD change implies potential spec/test/code changes; an HLD change implies potential LLD/spec/test/code changes.
+
+**Within one arrow segment — one LLD and the specs, tests, and code that cite its EARS IDs — cascade is free.** Update downstream levels in the same session without further confirmation.
+
+**Across segment boundaries, pause.** A change whose effect crosses into another LLD's territory is flagged; ask before propagating into the adjacent segment. Real LLDs are uneven; aggressive cross-boundary cascade propagates incoherence from under-specified regions into well-specified ones.
+
+**A decision belongs where its substance lives.** When a decision's substance sits in one segment but implementing it cascades an obligation into a sibling segment, record the decision in the segment that owns its substance and note the sibling obligation as a cascade — not co-ownership. Only a decision whose *substance* genuinely spans siblings rises to their shared parent. (Example: a component's internal subprocess-split decision lives in that component's LLD even though it creates a contract a sibling component consumes — the sibling gets a cascade note, not co-ownership. Contrast: a decision that rewrites the EARS ID format the HLD itself defines has HLD-spanning substance and belongs at the root.)
+
+An arrow segment is the territory owned by one **leaf** LLD, and its boundary is the **leaf prefix** — the full root-to-leaf path that identifies the segment. Because EARS IDs are path-concatenated, the boundary check is a prefix comparison: specs sharing the leaf prefix are in the same segment; specs whose path diverges at any earlier point belong to a different segment. When two unrelated leaves would collide on a path prefix, ask the user to disambiguate the position rather than silently coalescing them.
+
+**HLD-originating cascade** fans out across every segment. Walk the affected LLDs in turn, pausing at each segment to confirm the change lands cleanly before cascading to that segment's specs, tests, and code.
+
+**Cascade and uncommitted work.** When cascade would touch files the user has uncommitted changes in, warn with a description and proceed only after confirmation.
+
+**Cascade and inconsistent arrows.** Arrows are often inconsistent — mid-transition aborts, overlapping scoped arrows, partial cascades from prior sessions. When you notice, surface it; do not auto-repair.
+
+**Lifecycle events.** When cascade implies a split, merge, or rename of a segment, update `docs/arrows/index.yaml` (status, parent/children, `merged_into`) and walk every cross-reference — `blocks`, `blockedBy`, taxonomy, other arrow docs' References — in the same session. Because EARS IDs are path-concatenated, re-parenting or renaming a leaf rewrites its IDs and every `@spec` annotation citing them; do it as one atomic pass.
+
+## Bug fixes
+
+Bug fixes are not a special case. They walk the arrow like any other change: find where behavior diverged from intent, determine whether intent needs to change / is already expressed but wrong / was never expressed at all, and cascade from there.
+
+Fixing code without walking the arrow is a bypass — warn but do not block, per the user-is-always-right tenet.
+
+## User overrides
+
+If the user says "skip EARS here," "skip tests for this change," or otherwise overrides a phase requirement, warn about the drift risk and honor the override. The user is always right; make the cost visible.
+
+## Brownfield LLD content
+
+LLDs for reverse-engineered components use the **same template and section structure** as greenfield LLDs. What varies is the content's starting state:
+
+- **Decisions & Alternatives** table entries carry `[inferred]` in the Rationale column when the decision was observed in code rather than authored. As the user confirms or refutes the inference, the `[inferred]` marker is removed and the rationale is written out.
+- **Open Questions & Future Decisions** holds observed-but-unexplained behaviors and technical debt found during reconnaissance.
+- **Major sections** may describe current state alongside intended behavior when they differ; flag divergence explicitly.
+
+The LLD matures in place under the standard cascade discipline — no migration command or graduation step.
+
+## `@spec` annotation pattern
+
+```typescript
+// @spec AUTH-UI-001, AUTH-UI-002
+export function LoginForm({ ... }) { ... }
+```
+
+Place at the entry point of the behavior's implementation graph, not on every helper. Test files:
+
+```typescript
+// @spec AUTH-UI-010
+it('validates email format before submission', () => { ... });
+```
+
+## Reference docs
+
+These sit beside this file under `docs/lid/`:
+
+- `hld-template.md` — HLD standard sections template.
+- `lld-templates.md` — LLD structure template.
+- `ears-syntax.md` — EARS syntax, spec ID format, scope disambiguation.
+- `decision-doc-template.md` — decision-doc structure, the earns-its-place heuristic, and the fit-verdict format.
+- `audit-checklist.md` — the five coherence/audit checks behind Coherence verification.
+- `README.md` — provenance, sync policy, and how non-plugin tools use this directory.
+
+The deterministic checks in Coherence verification are runnable via `bin/coherence-check.mjs` (declared in `CLAUDE.md` under `## LID Tooling`). The arrow overlay schema lives at `docs/arrows/index.yaml` with `docs/arrows/README.md`.


### PR DESCRIPTION
## What

Adopts [Linked-Intent Development (LID)](https://linked-intent.dev) in Paid so design intent and code stay coherent across **every** coding tool — not just Claude Code.

## Why

Claude Code gets LID's six-phase workflow for free via the `jszmajda/lid` plugin. The other tools used here (Codex, Gemini CLI, OpenCode) read only `AGENTS.md` and get the *policy*, not the *procedure* — a materially lighter experience. This change vendors the procedure into the repo so all tools run the same workflow, and seeds the design tree + arrow overlay so LID is walkable from day one.

## Changes

- **Devcontainer** — `.devcontainer/install-lid.sh` installs the `linked-intent-dev` + `arrow-maintenance` Claude plugins, wired into the setup chain before the approval-bypass wrapper.
- **Instruction file** (`CLAUDE.md`, which `AGENTS.md` / `.github/copilot-instructions.md` symlink) — LID policy section, `## LID` mode declaration (Full, v1.3.0), a Memory-vs-intent directive, and a `## LID Tooling` pointer.
- **Design tree** — `docs/high-level-design.md`, `docs/intent/README.md`, and a stubbed `docs/arrows/` overlay (`index.yaml` + README).
- **`docs/lid/`** — vendored method reference (workflow, EARS syntax, HLD/LLD/decision-doc templates, audit checklist). Verbatim files are byte-identical to upstream for trivial sync; `workflow.md` and `bin/coherence-check.mjs` are adapted.
- **`bin/coherence-check.mjs`** — vendored + Rails-adapted deterministic coherence checker (`.rb` scanning, `--color=never`).
- **`bin/update`** — report-only LID drift check (CLAUDE.md pin vs upstream) plus bounded network timeouts on all fetches.

## Status

Draft. Reviewed: rubocop / markdownlint / `ruby -c` green; `bin/coherence-check.mjs` verified against the existing `issue-analysis` segment (5 specs, all coherent); `bin/update` LID check verified live (pinned 1.3.0 == upstream 1.3.0).

## Open item

`install-lid.sh` installs `latest` while `CLAUDE.md` pins 1.3.0 — three surfaces (installed plugin, vendored docs, pin) can drift across container vintages. `bin/update` now warns on drift, but per-version pinning of a Claude marketplace plugin needs verifying the mechanism. Tracking as a follow-up.
