### PR TITLE
chore(deps): bump ast-grep from 0.42.1 to 0.45.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -47,12 +47,12 @@ RUN corepack enable && corepack prepare yarn@1.22.22 --activate
 # Keep this inline instead of COPYing a repo script: the devcontainer image is
 # often rebuilt from a minimal or noisy workspace context, and BuildKit has
 # intermittently failed to resolve bin/install-ast-grep from that context.
-ARG AST_GREP_VERSION=0.42.1
+ARG AST_GREP_VERSION=0.45.0
 RUN set -eu; \
   arch="$(dpkg --print-architecture)"; \
   case "$arch" in \
-    amd64) rust_triple="x86_64-unknown-linux-gnu"; checksum="5de8b87cba67fc8dc3e239d54b6484802ad745a7ae3de76be4fe89661dc52657" ;; \
-    arm64) rust_triple="aarch64-unknown-linux-gnu"; checksum="3ba383839044cf9817929435f5ce0027f91d06931e8efb32d942e58d73d92be5" ;; \
+    amd64) rust_triple="x86_64-unknown-linux-gnu"; checksum="78931ae35ebac33d9a72b3aecea3e3d62d6e5b0b718ac8bbedfbe69d68421e41" ;; \
+    arm64) rust_triple="aarch64-unknown-linux-gnu"; checksum="62b60892dafacfa76d6de87157659f880bbf85ff38bdab52db12f1f14ec60f94" ;; \
     *) echo "Unsupported architecture: $arch" >&2; exit 1 ;; \
   esac; \
   zipfile="app-${rust_triple}.zip"; \

--- a/bin/install-ast-grep
+++ b/bin/install-ast-grep
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-AST_GREP_VERSION="${AST_GREP_VERSION:-0.42.1}"
+AST_GREP_VERSION="${AST_GREP_VERSION:-0.45.0}"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 
 case "$(uname -s)" in
@@ -16,7 +16,7 @@ case "$(dpkg --print-architecture)" in
   amd64)
     RUST_TRIPLE="x86_64-unknown-linux-gnu"
     case "${AST_GREP_VERSION}" in
-      0.42.1) EXPECTED_CHECKSUM="5de8b87cba67fc8dc3e239d54b6484802ad745a7ae3de76be4fe89661dc52657" ;;
+      0.45.0) EXPECTED_CHECKSUM="78931ae35ebac33d9a72b3aecea3e3d62d6e5b0b718ac8bbedfbe69d68421e41" ;;
       0.41.0) EXPECTED_CHECKSUM="e71afdcbb2e79f7710a56d2f89662bdd0a6e9d639c4abecd5d5f129d80a38bac" ;;
       *) echo "No checksum configured for ast-grep ${AST_GREP_VERSION} on amd64" >&2; exit 1 ;;
     esac
@@ -24,7 +24,7 @@ case "$(dpkg --print-architecture)" in
   arm64)
     RUST_TRIPLE="aarch64-unknown-linux-gnu"
     case "${AST_GREP_VERSION}" in
-      0.42.1) EXPECTED_CHECKSUM="3ba383839044cf9817929435f5ce0027f91d06931e8efb32d942e58d73d92be5" ;;
+      0.45.0) EXPECTED_CHECKSUM="62b60892dafacfa76d6de87157659f880bbf85ff38bdab52db12f1f14ec60f94" ;;
       0.41.0) EXPECTED_CHECKSUM="6f089d014d5fda8fed2e63e5095acf8ebec4c4cd2e721bd663f2284ace42b623" ;;
       *) echo "No checksum configured for ast-grep ${AST_GREP_VERSION} on arm64" >&2; exit 1 ;;
     esac

--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -172,11 +172,11 @@ RUN mkdir -p "$COREPACK_HOME" \
 
 # Install ast-grep (AST-based code search/lint)
 # https://github.com/ast-grep/ast-grep/releases
-RUN AST_GREP_VERSION=0.42.1 \
+RUN AST_GREP_VERSION=0.45.0 \
     && DEB_ARCH="$(dpkg --print-architecture)" \
     && case "$DEB_ARCH" in \
-        amd64) RUST_TRIPLE="x86_64-unknown-linux-gnu"; EXPECTED_CHECKSUM="5de8b87cba67fc8dc3e239d54b6484802ad745a7ae3de76be4fe89661dc52657" ;; \
-        arm64) RUST_TRIPLE="aarch64-unknown-linux-gnu"; EXPECTED_CHECKSUM="3ba383839044cf9817929435f5ce0027f91d06931e8efb32d942e58d73d92be5" ;; \
+        amd64) RUST_TRIPLE="x86_64-unknown-linux-gnu"; EXPECTED_CHECKSUM="78931ae35ebac33d9a72b3aecea3e3d62d6e5b0b718ac8bbedfbe69d68421e41" ;; \
+        arm64) RUST_TRIPLE="aarch64-unknown-linux-gnu"; EXPECTED_CHECKSUM="62b60892dafacfa76d6de87157659f880bbf85ff38bdab52db12f1f14ec60f94" ;; \
         *) echo "Unsupported architecture: $DEB_ARCH" >&2; exit 1 ;; \
     esac \
     && ZIPFILE="app-${RUST_TRIPLE}.zip" \


### PR DESCRIPTION
## Summary

Bumps ast-grep from 0.42.1 to 0.45.0, updating the sha256 checksums for amd64 and arm64 in all three install locations: the devcontainer Dockerfile, the agent Dockerfile, and `bin/install-ast-grep`.

The 0.42.1 checksum entries are kept in `bin/install-ast-grep` alongside 0.45.0 so pinned installs of the older release continue to resolve.
