### PR TITLE
fix(db): capture schema snapshot and verify completeness on backup/restore

### DIFF
--- a/bin/db-dump
+++ b/bin/db-dump
@@ -23,7 +23,16 @@ usage() {
   echo "Usage: bin/db-dump [BACKUP_FILENAME]"
   echo ""
   echo "Dump database data to a custom-format archive in backups/."
+  echo "Also captures a schema snapshot (*_postdata.sql) and object-count"
+  echo "manifest (*_manifest.txt) for restore verification."
   echo "Automatically disables RLS before dumping so all rows are captured."
+  echo ""
+  echo "Also creates two companion files alongside the data dump:"
+  echo "  *_postdata.sql   Post-data schema snapshot (FKs, triggers, RLS policies)"
+  echo "  *_manifest.txt    Object counts for post-restore verification"
+  echo ""
+  echo "These capture RLS policies and other objects that schema.rb alone"
+  echo "does not include, enabling bin/db-restore to detect drift."
   echo ""
   echo "Defaults are read from the Rails database config."
   echo ""
@@ -64,6 +73,42 @@ pg_dump_args() {
     PG_DUMP_ARGS+=(-U "$user")
   fi
   PG_DUMP_ARGS+=("$DB_NAME")
+}
+
+# Capture a post-data schema snapshot (FKs, triggers, RLS policies — objects that
+# schema.rb alone does not fully capture, especially RLS policies). Also write a
+# manifest with object counts so bin/db-restore can verify completeness.
+# Non-fatal: the data backup is already complete when this runs.
+capture_schema_snapshot() {
+  local postdata_path="${BACKUP_PATH%.dump}_postdata.sql"
+  local manifest_path="${BACKUP_PATH%.dump}_manifest.txt"
+
+  local schema_args=(--schema-only --section=post-data --no-owner --no-privileges)
+
+  if [[ "$BACKEND" == "docker" ]]; then
+    docker exec -e PGPASSWORD="$COMPOSE_DB_PASSWORD" "$COMPOSE_CONTAINER" \
+      pg_dump "${schema_args[@]}" -U "$COMPOSE_DB_USER" "$DB_NAME" > "$postdata_path" || return 1
+  else
+    local host_args=()
+    [[ -n "${DB_HOST:-}" ]] && host_args=(-h "$DB_HOST")
+    PGPASSWORD="$DB_PASSWORD" pg_dump "${host_args[@]}" "${schema_args[@]}" -U "$DB_USER" "$DB_NAME" > "$postdata_path" || return 1
+  fi
+
+  chmod 600 "$postdata_path" 2>/dev/null || true
+
+  local fk_count trigger_count rls_tables rls_policies
+  fk_count=$(run_sql "$DB_NAME" -c "SELECT count(*) FROM pg_constraint WHERE contype = 'f' AND connamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public')") || return 1
+  trigger_count=$(run_sql "$DB_NAME" -c "SELECT count(*) FROM pg_trigger t JOIN pg_class c ON c.oid = t.tgrelid JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND NOT t.tgisinternal") || return 1
+  rls_tables=$(run_sql "$DB_NAME" -c "SELECT count(*) FROM pg_tables WHERE schemaname = 'public' AND rowsecurity = true") || return 1
+  rls_policies=$(run_sql "$DB_NAME" -c "SELECT count(*) FROM pg_policy") || return 1
+
+  cat > "$manifest_path" <<MANIFEST
+foreign_keys=${fk_count}
+triggers=${trigger_count}
+rls_tables=${rls_tables}
+rls_policies=${rls_policies}
+MANIFEST
+  chmod 600 "$manifest_path" 2>/dev/null || true
 }
 
 mkdir -p "$BACKUPS_DIR"
@@ -131,8 +176,14 @@ else
   exit 1
 fi
 
+# Capture post-data schema snapshot and manifest for restore verification.
+# Non-fatal: the data backup is already complete at this point.
+capture_schema_snapshot || echo "Warning: Schema snapshot capture failed (data backup is complete)" >&2
+
 # Lock the dump to the owner -- it contains all tenant data with RLS disabled.
 chmod 600 "$BACKUP_PATH" 2>/dev/null || true
 
 FILESIZE=$(du -h "$BACKUP_PATH" | cut -f1)
 echo "Dumped ${DB_NAME} data to ${BACKUP_PATH} (${FILESIZE})"
+echo "Schema snapshot:  ${BACKUP_PATH%.dump}_postdata.sql"
+echo "Schema manifest:  ${BACKUP_PATH%.dump}_manifest.txt"

--- a/bin/db-restore
+++ b/bin/db-restore
@@ -28,6 +28,12 @@ usage() {
   echo "Truncates all existing data before restoring."
   echo "Requires a freshly migrated database (schema must match the dump)."
   echo "Automatically disables RLS and triggers during restore so all rows are written."
+  echo "Verifies schema completeness after restore (if a *_manifest.txt exists)."
+  echo ""
+  echo "After restore, verifies schema completeness by comparing FK, trigger,"
+  echo "and RLS counts against the *_manifest.txt file created by bin/db-dump."
+  echo "If counts are lower than expected, points to the *_postdata.sql snapshot"
+  echo "for reconciliation."
   echo ""
   echo "Defaults are read from the Rails database config."
   echo ""
@@ -103,6 +109,84 @@ guard_destructive_restore() {
 
   if ! local_db_host; then
     require_restore_confirmation "remote"
+  fi
+}
+
+# Verify schema completeness after restore by comparing FK, trigger, and RLS
+# counts against the manifest captured by bin/db-dump. Warns (does not fail)
+# when counts are lower than expected, pointing to the post-data snapshot for
+# reconciliation.
+verify_schema() {
+  local db="$1"
+  local manifest_path="${BACKUP_PATH%.dump}_manifest.txt"
+  local postdata_path="${BACKUP_PATH%.dump}_postdata.sql"
+
+  local fk_count trigger_count rls_tables rls_policies
+  fk_count=$(run_sql "$db" -c "SELECT count(*) FROM pg_constraint WHERE contype = 'f' AND connamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public')" 2>/dev/null || true)
+  trigger_count=$(run_sql "$db" -c "SELECT count(*) FROM pg_trigger t JOIN pg_class c ON c.oid = t.tgrelid JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = 'public' AND NOT t.tgisinternal" 2>/dev/null || true)
+  rls_tables=$(run_sql "$db" -c "SELECT count(*) FROM pg_tables WHERE schemaname = 'public' AND rowsecurity = true" 2>/dev/null || true)
+  rls_policies=$(run_sql "$db" -c "SELECT count(*) FROM pg_policy" 2>/dev/null || true)
+
+  if [[ ! "$fk_count" =~ ^[0-9]+$ ]] || [[ ! "$trigger_count" =~ ^[0-9]+$ ]]; then
+    echo ""
+    echo "  (Could not query schema — verification skipped)"
+    return 0
+  fi
+
+  echo ""
+  echo "Schema verification:"
+  echo "  Foreign keys:  ${fk_count}"
+  echo "  Triggers:      ${trigger_count}"
+  echo "  RLS tables:    ${rls_tables}"
+  echo "  RLS policies:  ${rls_policies}"
+
+  if [[ ! -f "$manifest_path" ]]; then
+    echo "  (No manifest from backup — counts not verified)"
+    return 0
+  fi
+
+  local exp_fk exp_triggers exp_rls_tables exp_rls_policies
+  exp_fk=$(grep '^foreign_keys=' "$manifest_path" | cut -d= -f2)
+  exp_triggers=$(grep '^triggers=' "$manifest_path" | cut -d= -f2)
+  exp_rls_tables=$(grep '^rls_tables=' "$manifest_path" | cut -d= -f2)
+  exp_rls_policies=$(grep '^rls_policies=' "$manifest_path" | cut -d= -f2)
+
+  if ! [[ "$exp_fk" =~ ^[0-9]+$ && "$exp_triggers" =~ ^[0-9]+$ && "$exp_rls_tables" =~ ^[0-9]+$ && "$exp_rls_policies" =~ ^[0-9]+$ ]]; then
+    echo "  (Manifest is malformed — counts not verified)"
+    return 0
+  fi
+
+  local warnings=0
+  if [[ "$fk_count" -lt "$exp_fk" ]]; then
+    echo "  WARNING: Foreign keys ${fk_count} < backup had ${exp_fk}"
+    warnings=1
+  fi
+  if [[ "$trigger_count" -lt "$exp_triggers" ]]; then
+    echo "  WARNING: Triggers ${trigger_count} < backup had ${exp_triggers}"
+    warnings=1
+  fi
+  if [[ "$rls_tables" =~ ^[0-9]+$ && "$rls_tables" -lt "$exp_rls_tables" ]]; then
+    echo "  WARNING: RLS tables ${rls_tables} < backup had ${exp_rls_tables}"
+    warnings=1
+  fi
+  if [[ "$rls_policies" =~ ^[0-9]+$ && "$rls_policies" -lt "$exp_rls_policies" ]]; then
+    echo "  WARNING: RLS policies ${rls_policies} < backup had ${exp_rls_policies}"
+    warnings=1
+  fi
+
+  if [[ "$warnings" -eq 1 ]]; then
+    echo ""
+    echo "  Schema objects are missing! Restore may be incomplete."
+    if [[ -f "$postdata_path" ]]; then
+      echo "  A post-data snapshot is available at:"
+      echo "    $postdata_path"
+      echo "  Review and apply with: psql -h <host> -U <user> -d <db> < \"$postdata_path\""
+    else
+      echo "  No post-data snapshot found. Run 'bin/db-dump' on a known-good"
+      echo "  database to create one for future restores."
+    fi
+  else
+    echo "  All counts match the backup manifest."
   fi
 }
 
@@ -257,5 +341,7 @@ else
   echo "Error: No running postgres container found and DB_NAME not set. Start services with 'bin/dev' or set DB_NAME." >&2
   exit 1
 fi
+
+verify_schema "$DB_NAME"
 
 echo "Restore complete."


### PR DESCRIPTION
## Summary

Data-only backups silently miss RLS policies, FK constraints, and triggers that `schema.rb` cannot capture — especially RLS policies, which Rails' schema dumper doesn't emit. After restoring from an old backup, these objects were absent with no warning, causing tenant isolation gaps and schema drift that required hours of manual reconciliation.

`bin/db-dump` now creates two companion files alongside every data backup:

| File | Contents |
|---|---|
| `*_postdata.sql` | Post-data schema snapshot: FK constraints, triggers, RLS policies, indexes (~361K) |
| `*_manifest.txt` | Object counts for post-restore verification (FK, trigger, RLS-table, RLS-policy) |

`bin/db-restore` now verifies schema completeness after data load by comparing live counts against the manifest. When counts are lower than expected, it warns (does not fail) and points to the `*_postdata.sql` snapshot for reconciliation.

## Design decisions

- **Non-fatal by design** — snapshot capture failure never blocks a successful data backup; verification failure never blocks a completed restore. Both produce warnings, not errors.
- **Backward compatible** — old backups without companion files restore normally; verification prints counts with "(No manifest from backup — counts not verified)".
- **Robust validation** — manifest values are regex-validated as numeric before comparison; corrupted or hand-edited manifests produce "(Manifest is malformed)" instead of crashing under `set -e`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
