### PR TITLE
fix(rls): make projects visible without a GitHub token

### DIFF
--- a/db/migrate/20260730190357_make_projects_github_token_optional_in_rls.rb
+++ b/db/migrate/20260730190357_make_projects_github_token_optional_in_rls.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# A project may use a GitHub App installation instead of a PAT, leaving
+# github_token_id NULL (the chk_projects_exactly_one_github_credential check
+# enforces exactly one credential). The original tenant policy required every
+# visible project to reference a github_token owned by the current account, which
+# hid installation-backed projects from their own account. Treat github_token_id
+# as optional, mirroring how created_by_id already works; ownership is still
+# gated by the account_id check.
+class MakeProjectsGithubTokenOptionalInRls < ActiveRecord::Migration[8.1]
+  # Ownership is still gated by the account_id check. The only change is that a
+  # missing github_token no longer hides a project from its own account.
+  RELAXED_CONDITION = <<~SQL.squish
+    projects.account_id = paid_current_account_id()
+    AND (
+      projects.github_token_id IS NULL
+      OR EXISTS (
+        SELECT 1 FROM github_tokens
+        WHERE github_tokens.id = projects.github_token_id
+          AND github_tokens.account_id = paid_current_account_id()
+      )
+    )
+    AND (
+      projects.created_by_id IS NULL
+      OR EXISTS (
+        SELECT 1 FROM users
+        WHERE users.id = projects.created_by_id
+          AND users.account_id = paid_current_account_id()
+      )
+    )
+  SQL
+
+  # Restores the original behaviour: a github_token owned by the current account
+  # is required for a project to be visible.
+  STRICT_CONDITION = <<~SQL.squish
+    projects.account_id = paid_current_account_id()
+    AND EXISTS (
+      SELECT 1 FROM github_tokens
+      WHERE github_tokens.id = projects.github_token_id
+        AND github_tokens.account_id = paid_current_account_id()
+    )
+    AND (
+      projects.created_by_id IS NULL
+      OR EXISTS (
+        SELECT 1 FROM users
+        WHERE users.id = projects.created_by_id
+          AND users.account_id = paid_current_account_id()
+      )
+    )
+  SQL
+
+  def up
+    safety_assured { recreate_projects_policy(RELAXED_CONDITION) }
+  end
+
+  def down
+    safety_assured { recreate_projects_policy(STRICT_CONDITION) }
+  end
+
+  private
+
+  def recreate_projects_policy(condition)
+    execute "DROP POLICY IF EXISTS tenant_isolation ON projects"
+    execute <<~SQL
+      CREATE POLICY tenant_isolation ON projects
+        AS PERMISSIVE
+        FOR ALL
+        USING (paid_tenant_bypass() OR (#{condition}))
+        WITH CHECK (paid_tenant_bypass() OR (#{condition}))
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_29_183603) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_30_190357) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"

--- a/spec/migrations/make_projects_github_token_optional_in_rls_dbless_spec.rb
+++ b/spec/migrations/make_projects_github_token_optional_in_rls_dbless_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require Rails.root.join("db/migrate/20260730190357_make_projects_github_token_optional_in_rls")
+
+RSpec.describe MakeProjectsGithubTokenOptionalInRls, :no_db do
+  let(:migration) { described_class.new }
+
+  let(:recorded_sql) do
+    recorded = []
+    allow(migration).to receive(:execute) { |sql| recorded << sql }
+    migration.up
+    recorded
+  end
+
+  it "drops the existing projects tenant_isolation policy before recreating it" do
+    expect(recorded_sql.join("\n")).to include("DROP POLICY IF EXISTS tenant_isolation ON projects")
+  end
+
+  it "recreates the projects policy treating github_token_id as optional" do
+    sql = recorded_sql.join("\n")
+
+    expect(sql).to include("CREATE POLICY tenant_isolation ON projects")
+    expect(sql).to include("projects.github_token_id IS NULL")
+    # Both the read (USING) and write (WITH CHECK) clauses must tolerate a missing token.
+    expect(sql.scan("projects.github_token_id IS NULL").length).to be >= 2
+  end
+
+  it "preserves account and creator ownership checks in the new policy" do
+    sql = recorded_sql.join("\n")
+
+    expect(sql).to include("projects.account_id = paid_current_account_id()")
+    expect(sql).to include("projects.created_by_id IS NULL")
+    expect(sql).to include("github_tokens.account_id = paid_current_account_id()")
+  end
+end

--- a/spec/security/tenant_context_spec.rb
+++ b/spec/security/tenant_context_spec.rb
@@ -19,6 +19,7 @@ require Rails.root.join("db/migrate/20260507224416_enable_rls_on_strategy_experi
 require Rails.root.join("db/migrate/20260508064240_tighten_orchestration_decisions_strategy_version_tenant_check")
 require Rails.root.join("db/migrate/20260509083302_ensure_strategy_version_id_on_orchestration_decisions")
 require Rails.root.join("db/migrate/20260511040425_fix_strategies_rls_infinite_recursion")
+require Rails.root.join("db/migrate/20260730190357_make_projects_github_token_optional_in_rls")
 
 RSpec.describe TenantContext, :tenant_isolation do
   around do |example|
@@ -44,6 +45,16 @@ RSpec.describe TenantContext, :tenant_isolation do
       described_class.with(account_a) do
         expect(Project.all).to contain_exactly(project_a)
       end
+    end
+  end
+
+  it "exposes projects without a github token to their own account only" do
+    tokenless_a = described_class.with_system_access { create(:project, :with_github_installation, account: account_a) }
+    described_class.with_system_access { create(:project, :with_github_installation, account: account_b) }
+
+    as_restricted_role do
+      described_class.with(account_a) { expect(Project.all).to contain_exactly(tokenless_a) }
+      described_class.with(account_b) { expect(Project.all).not_to include(tokenless_a) }
     end
   end
 
@@ -260,6 +271,7 @@ RSpec.describe TenantContext, :tenant_isolation do
       EnableRlsOnStrategyExperimentTables.new.up unless strategy_experiment_tables_have_rls?
       EnableRlsOnStrategiesAndStrategyVersions.new.up unless strategies_have_rls?
       FixStrategiesRlsInfiniteRecursion.new.up
+      MakeProjectsGithubTokenOptionalInRls.new.up
     end
     OrchestrationDecision.reset_column_information
     ActiveRecord::Base.connection.execute("RESET ROLE")
@@ -308,6 +320,7 @@ RSpec.describe TenantContext, :tenant_isolation do
       EnableRlsOnStrategyExperimentTables.new.up unless strategy_experiment_tables_have_rls?
       EnableRlsOnStrategiesAndStrategyVersions.new.up unless strategies_have_rls?
       FixStrategiesRlsInfiniteRecursion.new.up
+      MakeProjectsGithubTokenOptionalInRls.new.up
     end
     OrchestrationDecision.reset_column_information
   end


### PR DESCRIPTION
## Problem

`test@example.com` could only see 5 of 16 projects. All 16 belong to the same account, so this wasn't account scoping or data loss — it was the `projects` tenant-isolation RLS policy.

The `projects` policy (`db/migrate/20260421162139_enable_tenant_row_level_security.rb`) required, for a project to be visible: `account_id = current` **AND** `EXISTS (github_tokens ... github_tokens.account_id = current)` **AND** `created_by` optional.

The second clause is a **hard** `EXISTS` — it does not allow a NULL `github_token_id`. The 11 hidden projects (including `paid` and all 10 added on Jul 28) have `github_token_id IS NULL`, so the `EXISTS` is false and RLS filters them out.

This is a real, supported state: the `chk_projects_exactly_one_github_credential` check constraint explicitly allows `github_token_id IS NULL` (GitHub App **installation**-backed projects). The policy was incorrectly hiding every installation-backed project from its own account.

Verified under real RLS (no bypass):
- before fix: account 3 → **5** projects (the token-backed ones)
- after fix: account 3 → **16** projects; other accounts still → **0** (no cross-account leak)

## Fix

Treat `github_token_id` as **optional** in the projects policy (`projects.github_token_id IS NULL OR EXISTS (...)`), mirroring how `created_by_id` is already handled. Ownership is still enforced by the `account_id` check; cross-account isolation is unchanged.

- New migration drops & recreates the `tenant_isolation` policy on `projects` (relaxed read **and** write).
- `down` restores the original strict policy.

## Tests

- `spec/security/tenant_context_spec.rb`: behavior spec under real RLS — an installation-backed (token-less) project is visible to its own account and hidden from every other account. All 13 isolation examples pass.
- `spec/migrations/make_projects_github_token_optional_in_rls_dbless_spec.rb`: asserts the generated policy SQL drops the old policy and treats `github_token_id` as optional in both `USING` and `WITH CHECK`, while preserving the `account_id` and `created_by` ownership checks.

## Notes

- Applied the same relaxed policy to the dev database directly so all 16 projects are visible now; this PR makes it durable for every environment.
- `created_by_id` was already optional in this policy; this brings `github_token_id` to parity.