### PR TITLE
fix(pr-review): gate PR escalation on scan cycles, not wall clock

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -255,8 +255,8 @@ class Issue < ApplicationRecord
     pr_progress_state(**kwargs).retryable?(limit:)
   end
 
-  def pr_stuck?(limit:, stale_after:, **kwargs)
-    pr_progress_state(**kwargs).stuck?(limit:, stale_after:)
+  def pr_stuck?(limit:, confirmations:, required_confirmations:, **kwargs)
+    pr_progress_state(**kwargs).stuck?(limit:, confirmations:, required_confirmations:)
   end
 
   def associated_pull_request

--- a/app/services/notifications/rules/pr_followup_limit_reached.rb
+++ b/app/services/notifications/rules/pr_followup_limit_reached.rb
@@ -4,7 +4,7 @@ module Notifications
   module Rules
     class PrFollowupLimitReached < Rule
       SOURCE = "pr_followup_limit_reached"
-      NO_PROGRESS_ESCALATION_WINDOW = Activities::ScanPaidPrsActivity::NO_PROGRESS_ESCALATION_WINDOW
+      REQUIRED_STUCK_CONFIRMATIONS = Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS
 
       def initialize(progress_states: nil)
         @progress_states = index_progress_states(progress_states)
@@ -23,7 +23,9 @@ module Notifications
             issue.pr_review_phase.in?(%w[ready escalated]) &&
             synced_with_latest_pr_state?(issue) &&
             !progress_state_for(issue).latest_unsuccessful_review? &&
-            progress_state_for(issue).stuck?(limit: issue.project.max_pr_followup_runs, stale_after: NO_PROGRESS_ESCALATION_WINDOW)
+            progress_state_for(issue).stuck?(limit: issue.project.max_pr_followup_runs,
+              confirmations: issue.stuck_confirmation_count.to_i,
+              required_confirmations: REQUIRED_STUCK_CONFIRMATIONS)
         end
       end
 

--- a/app/services/notifications/rules/stalled_draft_pr.rb
+++ b/app/services/notifications/rules/stalled_draft_pr.rb
@@ -4,7 +4,7 @@ module Notifications
   module Rules
     class StalledDraftPr < Rule
       SOURCE = "stalled_draft_pr"
-      NO_PROGRESS_ESCALATION_WINDOW = Activities::ScanPaidPrsActivity::NO_PROGRESS_ESCALATION_WINDOW
+      REQUIRED_STUCK_CONFIRMATIONS = Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS
       ERROR_THRESHOLD = 10
 
       private
@@ -23,7 +23,8 @@ module Notifications
         return false unless synced_with_latest_pr_state?(issue)
 
         progress_state_for(issue).stuck?(limit: issue.project.max_draft_review_rounds,
-          stale_after: NO_PROGRESS_ESCALATION_WINDOW)
+          confirmations: issue.stuck_confirmation_count.to_i,
+          required_confirmations: REQUIRED_STUCK_CONFIRMATIONS)
       end
 
       def build(issue)

--- a/app/services/pull_requests/progress_state.rb
+++ b/app/services/pull_requests/progress_state.rb
@@ -44,15 +44,18 @@ module PullRequests
         latest_unsuccessful_run_at.present? && !escalation_worthy?(limit:)
       end
 
-      def stuck?(limit:, stale_after:)
+      # A PR is "stuck" when its unified automatic-run failure streak has reached
+      # the phase-appropriate limit AND that stuck state has been confirmed across
+      # the required number of scan cycles. Confirmation is downtime-immune by
+      # construction: scans only run while Paid is active, so wall-clock downtime
+      # never advances the confirmation count. `confirmations` is the persisted
+      # per-issue scan count (see ScanPaidPrsActivity#update_stuck_confirmation!).
+      def stuck?(limit:, confirmations:, required_confirmations:)
         return false unless escalation_worthy?(limit:)
         return false if latest_unsuccessful_run_at.blank?
-        return false if stale_after.to_i <= 0
+        return false if required_confirmations.to_i <= 0
 
-        progress_at = last_meaningful_progress_at || latest_unsuccessful_run_at
-        return false if progress_at.blank?
-
-        progress_at <= stale_after.to_i.seconds.ago
+        confirmations.to_i >= required_confirmations.to_i
       end
 
       def latest_unsuccessful_review?

--- a/app/temporal/activities/mark_escalated_activity.rb
+++ b/app/temporal/activities/mark_escalated_activity.rb
@@ -67,20 +67,21 @@ module Activities
       return true unless resolve_escalation_reason(input) == Issue::PR_ESCALATION_REASON_OPERATIONAL_FAILURES
 
       progress_state = PullRequests::ProgressState.call(project:, issue:)
-      operational_failure_breaker_holds?(progress_state)
+      operational_failure_breaker_holds?(issue, progress_state)
     end
 
-    def operational_failure_breaker_holds?(progress_state)
+    def operational_failure_breaker_holds?(issue, progress_state)
       progress_state.consecutive_operational_failures >= Activities::ScanPaidPrsActivity::MAX_CONSECUTIVE_OPERATIONAL_FAILURES &&
         !progress_state.all_provider_transient_outages? &&
-        no_meaningful_progress_window_elapsed?(progress_state)
+        escalation_confirmed?(issue)
     end
 
-    def no_meaningful_progress_window_elapsed?(progress_state)
-      progress_at = progress_state.last_meaningful_progress_at || progress_state.latest_unsuccessful_run_at
-      return false if progress_at.blank?
-
-      progress_at <= Activities::ScanPaidPrsActivity::NO_PROGRESS_ESCALATION_WINDOW.ago
+    # Re-validates the scan-confirmation gate at escalation time. The count is
+    # advanced once per scan by ScanPaidPrsActivity#update_stuck_confirmation!,
+    # so it reflects how many active scans confirmed the stuck state — never
+    # inflated by Paid downtime.
+    def escalation_confirmed?(issue)
+      issue.stuck_confirmation_count.to_i >= Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS
     end
 
     def record_noop_decision(project, issue, reason:, phase_before:)

--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -23,9 +23,13 @@ module Activities
     MIN_COMMENT_LENGTH = 20
     CI_ACTION_DISPATCH_GRACE_PERIOD = 2.minutes
     DEFAULT_CONSECUTIVE_UNSUCCESSFUL_PR_RUNS = 3
-    # Give the system multiple poll cycles and follow-up runs to recover
-    # before escalating a PR solely for lack of progress.
-    NO_PROGRESS_ESCALATION_WINDOW = 3.hours
+    # Escalation requires the stuck state to persist across this many scan
+    # cycles, not a wall-clock duration. Scans only run while Paid is active,
+    # so an outage (which produces no scans) can never advance the count and
+    # drive a false escalation. The first eligible scan records the observation;
+    # each subsequent confirming scan that still finds the PR stuck increments
+    # the count until it reaches this threshold.
+    REQUIRED_STUCK_CONFIRMATIONS = 2
     # Floor for re-scanning a PR even when GitHub's `updated_at` has not
     # advanced. `updated_at` does not bump for check-run state changes,
     # unanswered bot review requests, or review-goal retry timers — without
@@ -250,6 +254,15 @@ module Activities
     end
 
     def build_lifecycle_signals(project, issue)
+      # Advance the scan-confirmation counter before evaluating the breakers so
+      # the gates below reflect this scan's observation. Mutated exactly here,
+      # once per PR per scan attempt. ScanPaidPrsActivity re-runs wholesale on a
+      # Temporal retry (max_attempts: 3); that can advance the count one extra
+      # time for PRs already processed before the failure — an accepted, rare
+      # edge case consistent with the scanner's other per-scan writes (e.g.
+      # last_pr_scan_at), which at worst escalates a stuck PR one cycle early.
+      update_stuck_confirmation!(project, issue)
+
       progress_state = pr_progress_state(project, issue)
       op_breaker = operational_failure_breaker?(project, issue, progress_state)
       no_progress_stuck = no_progress_stuck?(project, issue, progress_state)
@@ -1236,38 +1249,22 @@ module Activities
       streak = progress_state.consecutive_unsuccessful_automatic_runs
 
       if progress_state.latest_unsuccessful_review?
-        "No meaningful progress for #{no_progress_escalation_window_label} after " \
-          "#{streak} consecutive unsuccessful automatic runs; latest run was review"
+        "No meaningful progress after #{streak} consecutive unsuccessful automatic runs (latest run was review)"
       elsif issue.draft_phase?
-        "No meaningful progress for #{no_progress_escalation_window_label} after " \
-          "#{streak} consecutive unsuccessful automatic runs in the current PR cycle"
+        "No meaningful progress after #{streak} consecutive unsuccessful automatic runs in the current PR cycle"
       else
-        "No meaningful progress for #{no_progress_escalation_window_label} after " \
-          "#{streak} consecutive unsuccessful automatic runs"
+        "No meaningful progress after #{streak} consecutive unsuccessful automatic runs"
       end
     end
 
     def operational_failure_reason
-      "No meaningful progress for #{no_progress_escalation_window_label} after " \
+      "No meaningful progress after " \
         "#{MAX_CONSECUTIVE_OPERATIONAL_FAILURES} consecutive provider/infrastructure failures"
     end
 
     def review_goal_retry_escalation_reason(project, issue, progress_state: nil)
-      "Review-goal retry budget exhausted with no meaningful progress for " \
-        "#{no_progress_escalation_window_label} " \
+      "Review-goal retry budget exhausted with no meaningful progress " \
         "(#{review_goal_consecutive_failure_count(project, issue, progress_state:)} consecutive failures)"
-    end
-
-    def no_progress_escalation_window_label
-      seconds = NO_PROGRESS_ESCALATION_WINDOW.to_i
-
-      if (seconds % 1.hour).zero?
-        hours = seconds / 1.hour
-        "#{hours} #{'hour'.pluralize(hours)}"
-      else
-        minutes = seconds / 1.minute
-        "#{minutes} #{'minute'.pluralize(minutes)}"
-      end
     end
 
     def followup_limit_reached?(project, issue, progress_state = pr_progress_state(project, issue))
@@ -1324,17 +1321,20 @@ module Activities
     # streak is non-transient (e.g. auth expiry, task-level timeout).
     def operational_failure_breaker?(project, issue, progress_state = pr_progress_state(project, issue))
       return false if issue.escalated_phase?
-      return false unless progress_state.consecutive_operational_failures >= MAX_CONSECUTIVE_OPERATIONAL_FAILURES
-      return false if progress_state.all_provider_transient_outages?
+      return false unless operational_failure_eligible?(progress_state)
 
-      no_meaningful_progress_window_elapsed?(progress_state)
+      escalation_confirmed?(issue)
     end
 
     def no_progress_stuck?(project, issue, progress_state = pr_progress_state(project, issue))
       limit = no_progress_stuck_limit(project, issue, progress_state)
       return false if limit <= 0
 
-      progress_state.stuck?(limit:, stale_after: NO_PROGRESS_ESCALATION_WINDOW)
+      progress_state.stuck?(
+        limit:,
+        confirmations: issue.stuck_confirmation_count.to_i,
+        required_confirmations: REQUIRED_STUCK_CONFIRMATIONS
+      )
     end
 
     def no_progress_stuck_limit(project, issue, progress_state)
@@ -2171,11 +2171,54 @@ module Activities
       end
     end
 
-    def no_meaningful_progress_window_elapsed?(progress_state)
-      progress_at = progress_state.last_meaningful_progress_at || progress_state.latest_unsuccessful_run_at
-      return false if progress_at.blank?
+    # Returns true when the PR's escalation-eligible stuck state has been
+    # confirmed across enough scan cycles. Backed by the persisted
+    # stuck_confirmation_count, which is advanced once per scan by
+    # update_stuck_confirmation!.
+    def escalation_confirmed?(issue)
+      issue.stuck_confirmation_count.to_i >= REQUIRED_STUCK_CONFIRMATIONS
+    end
 
-      progress_at <= NO_PROGRESS_ESCALATION_WINDOW.ago
+    # The escalation-eligible predicate: the PR would be escalated except for
+    # the scan-confirmation gate. Either the operational-failure breaker core or
+    # the unified failure-streak limit has been reached. Once escalated the PR
+    # is no longer eligible (dismissal returns it to a non-escalated phase).
+    def escalation_eligible?(project, issue, progress_state)
+      return false if issue.escalated_phase?
+      # Cheap short-circuit for the common healthy-PR case: with no failures on
+      # the books the PR can't be at either limit, so skip the DB-backed limit
+      # lookups below (no_progress_stuck_limit queries review-run history).
+      return false if progress_state.consecutive_unsuccessful_automatic_runs.zero? &&
+        progress_state.consecutive_operational_failures.zero?
+
+      operational_failure_eligible?(progress_state) ||
+        no_progress_stuck_limit(project, issue, progress_state) > 0
+    end
+
+    def operational_failure_eligible?(progress_state)
+      progress_state.consecutive_operational_failures >= MAX_CONSECUTIVE_OPERATIONAL_FAILURES &&
+        !progress_state.all_provider_transient_outages?
+    end
+
+    # Advances the per-issue scan-confirmation count once per scan. When the PR
+    # is escalation-eligible the count increments (each scan re-confirms the
+    # stuck state); otherwise it resets to zero. Downtime produces no scans, so
+    # the count never advances while Paid is offline.
+    def update_stuck_confirmation!(project, issue)
+      progress_state = pr_progress_state(project, issue)
+      eligible = escalation_eligible?(project, issue, progress_state)
+      current = issue.stuck_confirmation_count.to_i
+      new_count = eligible ? current + 1 : 0
+      return if new_count == current
+
+      issue.update_column(:stuck_confirmation_count, new_count)
+      logger.info(
+        message: "pr_scanner.stuck_confirmation_updated",
+        issue_id: issue.id,
+        pr_number: issue.github_number,
+        stuck_confirmation_count: new_count,
+        escalation_eligible: eligible
+      )
     end
 
     def review_run_cycle_boundary

--- a/db/migrate/20260730203545_add_stuck_confirmation_count_to_issues.rb
+++ b/db/migrate/20260730203545_add_stuck_confirmation_count_to_issues.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddStuckConfirmationCountToIssues < ActiveRecord::Migration[8.1]
+  def change
+    add_column :issues, :stuck_confirmation_count, :integer,
+      null: false,
+      default: 0,
+      comment: "Number of consecutive scans that observed this PR in an escalation-eligible " \
+               "stuck state. Replaces the wall-clock no-progress window so Paid downtime " \
+               "(which produces no scans) cannot drive false escalations."
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_30_190357) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_30_203545) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1313,6 +1313,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_30_190357) do
     t.text "runner_retry_abandon_reason", comment: "Human-readable reason the issue was abandoned due to the retry cap."
     t.datetime "runner_retry_abandoned_at", comment: "When non-null, the issue was abandoned because every available provider reached the per-issue retry cap. Excluded from auto-pick until cleared (e.g. by a successful run)."
     t.string "source", default: "github", null: false
+    t.integer "stuck_confirmation_count", default: 0, null: false, comment: "Number of consecutive scans that observed this PR in an escalation-eligible stuck state. Replaces the wall-clock no-progress window so Paid downtime (which produces no scans) cannot drive false escalations."
     t.string "title", limit: 1000, null: false
     t.datetime "updated_at", null: false
     t.index ["deployed_at"], name: "idx_issues_deployed_at_on_prs", where: "(is_pull_request = true)"

--- a/docs/pr_failure_progress_model.md
+++ b/docs/pr_failure_progress_model.md
@@ -32,11 +32,26 @@ determine whether automation has recovered.
 - Automatic `create_pr` and `review` runs therefore contribute to the same failure accounting model.
 - Existing phase fields still describe workflow state, but they no longer create separate failure-counting regimes.
 
+### Scan-confirmation gate (downtime-immune)
+
+The stuck state must be **confirmed across scan cycles**, not by a wall-clock
+window. Each scan that finds the PR escalation-eligible (failure streak at its
+phase-appropriate limit, or the operational-failure breaker tripped) increments
+`issues.stuck_confirmation_count`; a scan that finds the PR recovered resets it
+to zero. Escalation only fires once the count reaches
+`ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS`.
+
+Because the counter only advances when a scan actually runs, an outage — during
+which Paid is offline and produces no scans — can never push a PR into
+escalation on its own. This replaces the previous 3-hour wall-clock window,
+which ticked during downtime and drove false escalations after Paid came back
+online.
+
 ## Straight Answer
 
 - A PR is stuck when its unified automatic-run failure streak has reached the
-  phase-appropriate limit and there has been no meaningful progress for the
-  no-progress window.
+  phase-appropriate limit and that stuck state has persisted across the required
+  number of **scan cycles** (not wall-clock time).
 - That stuck state clears when the PR makes meaningful progress or hits an
   explicit cycle boundary reset; manual escalation dismissal alone does not
   clear it.

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -702,7 +702,7 @@ RSpec.describe Issue do
         expect(issue.last_pr_meaningful_progress_at).to eq(Time.zone.parse("2026-05-15 12:00:00"))
         expect(issue.pr_escalation_worthy?(limit: 3)).to be(true)
         expect(issue.pr_retryable?(limit: 3)).to be(false)
-        expect(issue.pr_stuck?(limit: 3, stale_after: 3600)).to be(true)
+        expect(issue.pr_stuck?(limit: 3, confirmations: 2, required_confirmations: 2)).to be(true)
         expect(PullRequests::ProgressState).to have_received(:call).exactly(5).times
       end
 

--- a/spec/services/notifications/rules/pr_followup_limit_reached_no_db_spec.rb
+++ b/spec/services/notifications/rules/pr_followup_limit_reached_no_db_spec.rb
@@ -3,10 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Notifications::Rules::PrFollowupLimitReached, :no_db do
-  describe "::NO_PROGRESS_ESCALATION_WINDOW" do
+  describe "::REQUIRED_STUCK_CONFIRMATIONS" do
     it "matches the PR scanner threshold" do
-      expect(described_class::NO_PROGRESS_ESCALATION_WINDOW).to eq(
-        Activities::ScanPaidPrsActivity::NO_PROGRESS_ESCALATION_WINDOW
+      expect(described_class::REQUIRED_STUCK_CONFIRMATIONS).to eq(
+        Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS
       )
     end
   end

--- a/spec/services/notifications/rules/pr_followup_limit_reached_spec.rb
+++ b/spec/services/notifications/rules/pr_followup_limit_reached_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Notifications::Rules::PrFollowupLimitReached do
   let(:issue) do
     create(:issue, :pull_request, project: project, github_number: 42,
       pr_review_phase: "ready", pr_followup_count: 3,
+      stuck_confirmation_count: Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS,
       github_updated_at: 10.minutes.ago, last_pr_scan_at: 5.minutes.ago)
   end
 
@@ -37,12 +38,14 @@ RSpec.describe Notifications::Rules::PrFollowupLimitReached do
         pr_review_phase: "ready",
         last_pr_scan_at: last_pr_scan_at,
         github_updated_at: github_updated_at,
+        stuck_confirmation_count: stuck_confirmation_count,
         project: project
       )
     end
     let(:rule) { described_class.new }
     let(:last_pr_scan_at) { Time.zone.parse("2026-05-15 12:05:00") }
     let(:github_updated_at) { Time.zone.parse("2026-05-15 12:00:00") }
+    let(:stuck_confirmation_count) { Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS }
 
     before do
       allow(issue).to receive(:pr_progress_state).and_return(
@@ -111,9 +114,10 @@ RSpec.describe Notifications::Rules::PrFollowupLimitReached do
       expect(issue).not_to have_received(:pr_progress_state)
     end
 
-    it "does not match when the failure count is met but the staleness window has not elapsed" do
-      allow(issue).to receive(:pr_progress_state).and_return(
-        PullRequests::ProgressState::Result.new(
+    it "does not match when the scan-confirmation count has not been reached" do
+      allow(issue).to receive_messages(
+        stuck_confirmation_count: 0,
+        pr_progress_state: PullRequests::ProgressState::Result.new(
           consecutive_unsuccessful_automatic_runs: 3,
           consecutive_operational_failures: 0,
           consecutive_provider_transient_outages: 0,

--- a/spec/services/notifications/rules/stalled_draft_pr_spec.rb
+++ b/spec/services/notifications/rules/stalled_draft_pr_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Notifications::Rules::StalledDraftPr do
   let(:issue) do
     create(:issue, :pull_request, project: project, github_number: 42,
       pr_review_phase: "draft", auto_continue_paused: false,
+      stuck_confirmation_count: Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS,
       github_updated_at: 10.minutes.ago, last_pr_scan_at: 5.minutes.ago)
   end
 

--- a/spec/services/pull_requests/progress_state_spec.rb
+++ b/spec/services/pull_requests/progress_state_spec.rb
@@ -432,7 +432,7 @@ RSpec.describe PullRequests::ProgressState, :no_db do
     expect(result.all_provider_transient_outages?).to be false
   end
 
-  it "stuck? uses latest_unsuccessful_run_at as fallback instead of epoch when no progress recorded" do
+  it "stuck? is gated on scan confirmations, not wall-clock time" do
     now = Time.zone.parse("2026-05-15 12:00:00")
     runs = [
       build_run(goal: "review", status: "failed", at: now - 10.minutes),
@@ -443,20 +443,20 @@ RSpec.describe PullRequests::ProgressState, :no_db do
     travel_to(now) do
       result = described_class.call(project: project, issue: issue, runs: runs)
 
-      # With 3 failures and no progress, stuck? should NOT be true when stale_after
-      # exceeds the time since the latest failure (the failures are recent).
+      # With 3 failures and no progress, the streak is at the limit. But stuck?
+      # is NOT true until the scan-confirmation count reaches the threshold —
+      # elapsed wall-clock time is irrelevant (downtime must not cause this).
       expect(result.last_meaningful_progress_at).to be_nil
-      expect(result.stuck?(limit: 3, stale_after: 3600)).to be false
-
-      # But stuck? IS true when stale_after is shorter than time since latest failure
-      expect(result.stuck?(limit: 3, stale_after: 300)).to be true
+      expect(result.stuck?(limit: 3, confirmations: 0, required_confirmations: 2)).to be false
+      expect(result.stuck?(limit: 3, confirmations: 1, required_confirmations: 2)).to be false
+      expect(result.stuck?(limit: 3, confirmations: 2, required_confirmations: 2)).to be true
     end
   end
 
   it "stuck? returns false when there are no unsuccessful runs at all" do
     result = described_class.call(project: project, issue: issue, runs: [])
 
-    expect(result.stuck?(limit: 1, stale_after: 1)).to be false
+    expect(result.stuck?(limit: 1, confirmations: 99, required_confirmations: 1)).to be false
   end
 
   it "loads database-backed history in ordered batches and stops after meaningful progress" do

--- a/spec/temporal/activities/mark_escalated_activity_spec.rb
+++ b/spec/temporal/activities/mark_escalated_activity_spec.rb
@@ -5,8 +5,11 @@ require "ostruct"
 
 RSpec.describe Activities::MarkEscalatedActivity do
   def create_operational_failures!(issue, count: 3)
+    # The operational-failure re-validation gate now keys off the persisted
+    # scan-confirmation count (downtime-immune), not a wall-clock window.
+    issue.update!(stuck_confirmation_count: Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS)
     count.times do |i|
-      run_at = (Activities::ScanPaidPrsActivity::NO_PROGRESS_ESCALATION_WINDOW + i.minutes + 1.minute).ago
+      run_at = (4.hours + i.minutes + 1.minute).ago
 
       # Use a non-transient operational failure (Clone failed) so the breaker
       # recognizes these as escalation-worthy. "All providers exhausted" is

--- a/spec/temporal/activities/scan_paid_prs_activity_retry_limit_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_retry_limit_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       stub_const("ProgressStateDouble", Class.new do
         def latest_unsuccessful_review?; end
         def escalation_worthy?(limit:); end
-        def stuck?(limit:, stale_after:); end
+        def stuck?(limit:, confirmations:, required_confirmations:); end
         def latest_unsuccessful_run_at; end
         def consecutive_unsuccessful_automatic_runs; end
         def consecutive_operational_failures; end
@@ -70,6 +70,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       allow(activity).to receive(:fetch_pr_data)
       allow(activity).to receive(:escalation_dismissed?).with(issue).and_return(false)
       allow(activity).to receive(:focus_for).and_return("review_feedback")
+      allow(activity).to receive(:update_stuck_confirmation!)
     end
 
     context "when a restarted PR already has an active create_pr run" do
@@ -417,7 +418,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       stub_const("FailureStreakProgressStateStub", Class.new do
         def escalation_worthy?(limit:); end
         def latest_unsuccessful_review?; end
-        def stuck?(limit:, stale_after:); end
+        def stuck?(limit:, confirmations:, required_confirmations:); end
       end)
     end
 
@@ -710,6 +711,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       stub_const("ExecuteCacheGithubTokenStub", Class.new)
       stub_const("ExecuteCacheGithubClientStub", Class.new)
       stub_const("ExecuteCacheProgressStateStub", Class.new)
+      allow(activity).to receive(:update_stuck_confirmation!)
     end
 
     let(:activity) { described_class.new }
@@ -740,7 +742,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         draft_review_count: 0,
         review_goal_retry_count: 0,
         pr_followup_count: 0,
-        escalated_phase?: false
+        escalated_phase?: false,
+        stuck_confirmation_count: 0
       )
     end
     let(:first_progress_state) do
@@ -883,6 +886,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       stub_const("LifecycleSignalsProjectStub", Class.new)
       stub_const("LifecycleSignalsIssueStub", Class.new)
       stub_const("LifecycleSignalsProgressStateStub", Class.new)
+      allow(activity).to receive(:update_stuck_confirmation!)
     end
 
     let(:activity) { described_class.new }
@@ -957,21 +961,26 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
     let(:activity) { described_class.new }
     let(:project) { instance_double(NoProgressProjectStub) }
-    let(:issue) { instance_double(NoProgressIssueStub) }
+    let(:issue) { instance_double(NoProgressIssueStub, stuck_confirmation_count: 0) }
     let(:progress_state) { instance_double(NoProgressProgressStateStub, latest_unsuccessful_review?: false) }
 
-    it "stays false until the stale no-progress window has elapsed" do
+    it "passes the persisted scan-confirmation count into stuck?" do
+      allow(issue).to receive(:stuck_confirmation_count).and_return(
+        Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS
+      )
       allow(activity).to receive(:failure_streak_limit_reached?).with(project, issue, progress_state).and_return(true)
       allow(activity).to receive(:pr_failure_limit).with(project, issue).and_return(3)
       expect(progress_state).to receive(:stuck?).with(
         limit: 3,
-        stale_after: Activities::ScanPaidPrsActivity::NO_PROGRESS_ESCALATION_WINDOW
+        confirmations: Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS,
+        required_confirmations: Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS
       ).and_return(true)
 
       expect(activity.send(:no_progress_stuck?, project, issue, progress_state)).to be(true)
     end
 
-    it "returns false when the PR still has recent progress despite the streak" do
+    it "returns false when the confirmation count has not reached the threshold" do
+      allow(issue).to receive(:stuck_confirmation_count).and_return(0)
       allow(activity).to receive(:failure_streak_limit_reached?).with(project, issue, progress_state).and_return(true)
       allow(activity).to receive(:pr_failure_limit).with(project, issue).and_return(3)
       allow(progress_state).to receive(:stuck?).and_return(false)
@@ -980,6 +989,9 @@ RSpec.describe Activities::ScanPaidPrsActivity do
     end
 
     it "uses the review-goal retry limit when follow-up streak escalation is disabled" do
+      allow(issue).to receive(:stuck_confirmation_count).and_return(
+        Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS
+      )
       allow(activity).to receive(:review_goal_retry_limit_requires_escalation?)
         .with(project, issue, progress_state:)
         .and_return(true)
@@ -988,7 +1000,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       expect(activity).not_to receive(:failure_streak_limit_reached?)
       expect(progress_state).to receive(:stuck?).with(
         limit: 2,
-        stale_after: Activities::ScanPaidPrsActivity::NO_PROGRESS_ESCALATION_WINDOW
+        confirmations: Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS,
+        required_confirmations: Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS
       ).and_return(true)
 
       expect(activity.send(:no_progress_stuck?, project, issue, progress_state)).to be(true)

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -69,10 +69,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
   def create_stale_review_runs!(issue, statuses:, trigger_type: "automatic")
     Array(statuses).each_with_index do |status, index|
-      timestamp = (
-        Activities::ScanPaidPrsActivity::NO_PROGRESS_ESCALATION_WINDOW +
-        ((Array(statuses).size - index + 1) * 5).minutes
-      ).ago
+      timestamp = (4.hours + ((Array(statuses).size - index + 1) * 5).minutes).ago
       create(:agent_run,
         project: project,
         issue: issue,
@@ -185,6 +182,79 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
       expect(activity.send(:paid_agent_pr_author?, project, "paid-agents[bot]")).to be(false)
       expect(activity.send(:third_party_bot_author?, project, "dependabot[bot]")).to be(true)
+    end
+  end
+
+  describe "scan-confirmation escalation gate (downtime-immune)" do
+    let(:pr_issue) do
+      create(:issue, :pull_request,
+        project: project,
+        github_number: 99,
+        pr_review_phase: "ready")
+    end
+    let(:at_limit_state) do
+      PullRequests::ProgressState::Result.new(
+        consecutive_unsuccessful_automatic_runs: 3,
+        consecutive_operational_failures: 0,
+        consecutive_provider_transient_outages: 0,
+        last_meaningful_progress_at: nil,
+        latest_automatic_run_at: 4.hours.ago,
+        latest_unsuccessful_run_at: 4.hours.ago,
+        latest_unsuccessful_run_goal: "review",
+        latest_unsuccessful_run_status: "failed"
+      )
+    end
+
+    before do
+      allow(activity).to receive(:pr_progress_state).with(project, pr_issue).and_return(at_limit_state)
+      allow(activity).to receive(:failure_streak_limit_reached?).with(project, pr_issue, at_limit_state).and_return(true)
+      allow(activity).to receive(:pr_failure_limit).with(project, pr_issue).and_return(3)
+      allow(activity).to receive_messages(
+        operational_failure_breaker?: false,
+        review_goal_retry_limit_requires_escalation?: false
+      )
+      allow(activity).to receive(:active_run_exists?).with(project, pr_issue).and_return(false)
+    end
+
+    it "does not escalate on the first eligible scan despite a long wall-clock gap (Paid downtime)", :aggregate_failures do
+      # The last failure was 4 hours ago — well beyond the old 3-hour wall-clock
+      # window that previously drove false escalations during Paid outages. With
+      # the scan-confirmation gate, a single scan only records the observation.
+      signals = activity.send(:build_lifecycle_signals, project, pr_issue)
+
+      expect(pr_issue.reload.stuck_confirmation_count).to eq(1)
+      expect(signals[:no_progress_stuck]).to be(false)
+      expect(signals[:escalation_reason]).to be_nil
+    end
+
+    it "escalates once the stuck state persists across the required scan cycles", :aggregate_failures do
+      activity.send(:build_lifecycle_signals, project, pr_issue) # first observation
+      signals = activity.send(:build_lifecycle_signals, project, pr_issue) # confirming scan
+
+      expect(pr_issue.reload.stuck_confirmation_count).to eq(2)
+      expect(signals[:no_progress_stuck]).to be(true)
+      expect(signals[:escalation_reason_key]).to eq(Issue::PR_ESCALATION_REASON_FAILURE_STREAK)
+    end
+
+    it "resets the confirmation count when progress clears the stuck state", :aggregate_failures do
+      2.times { activity.send(:build_lifecycle_signals, project, pr_issue) }
+      expect(pr_issue.reload.stuck_confirmation_count).to eq(2)
+
+      recovered = PullRequests::ProgressState::Result.new(
+        consecutive_unsuccessful_automatic_runs: 0,
+        consecutive_operational_failures: 0,
+        consecutive_provider_transient_outages: 0,
+        last_meaningful_progress_at: 1.minute.ago,
+        latest_automatic_run_at: 1.minute.ago,
+        latest_unsuccessful_run_at: nil,
+        latest_unsuccessful_run_goal: nil,
+        latest_unsuccessful_run_status: nil
+      )
+      allow(activity).to receive(:pr_progress_state).with(project, pr_issue).and_return(recovered)
+      allow(activity).to receive(:failure_streak_limit_reached?).with(project, pr_issue, recovered).and_return(false)
+      activity.send(:build_lifecycle_signals, project, pr_issue)
+
+      expect(pr_issue.reload.stuck_confirmation_count).to eq(0)
     end
   end
 
@@ -1509,7 +1579,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           create(:issue, :pull_request,
             project: project, github_number: 42,
             labels: [ "paid-generated", "paid-automation", "paid-ready" ],
-            pr_review_phase: "ready", paid_state: "completed")
+            pr_review_phase: "ready", paid_state: "completed",
+            stuck_confirmation_count: Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS - 1)
           3.times do
             create(:agent_run, :failed,
               project: project,
@@ -1575,7 +1646,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
             project: project, github_number: 42,
             github_creator_login: "dependabot[bot]",
             labels: [ "paid-generated", "paid-automation", "paid-ready" ],
-            pr_review_phase: "ready", paid_state: "completed")
+            pr_review_phase: "ready", paid_state: "completed",
+            stuck_confirmation_count: Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS - 1)
           stub_automation_label_events!(issue_number: 42)
           3.times do
             create(:agent_run, :failed,
@@ -5225,13 +5297,14 @@ RSpec.describe Activities::ScanPaidPrsActivity do
             created_at: 4.hours.ago - i.minutes
           )
         end
+        pr_issue.update!(stuck_confirmation_count: Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS - 1)
 
         result = activity.execute(project_id: project.id)
 
         expect(automation_scan_results(result).size).to eq(1)
         trigger = automation_scan_results(result).first
         expect(trigger[:triggers].first[:type]).to eq("escalate_to_owner")
-        expect(trigger[:triggers].first[:details]).to include("No meaningful progress for 3 hours after")
+        expect(trigger[:triggers].first[:details]).to include("No meaningful progress after")
       end
 
       it "escalates after 3 consecutive timeout failures" do
@@ -5242,19 +5315,21 @@ RSpec.describe Activities::ScanPaidPrsActivity do
             created_at: 4.hours.ago - i.minutes
           )
         end
+        pr_issue.update!(stuck_confirmation_count: Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS - 1)
 
         result = activity.execute(project_id: project.id)
 
         expect(automation_scan_results(result).size).to eq(1)
         trigger = automation_scan_results(result).first
         expect(trigger[:triggers].first[:type]).to eq("escalate_to_owner")
-        expect(trigger[:triggers].first[:details]).to include("No meaningful progress for 3 hours after")
+        expect(trigger[:triggers].first[:details]).to include("No meaningful progress after")
       end
 
       it "escalates after 3 consecutive mixed operational failures" do
         create_followup_run(status: "timeout", error_message: "wall_clock_timeout", created_at: 4.hours.ago)
         create_followup_run(status: "rate_limited", error_message: "All providers rate limited", created_at: 4.hours.ago - 1.minute)
         create_followup_run(status: "failed", error_message: "All providers exhausted: claude_code", created_at: 4.hours.ago - 2.minutes)
+        pr_issue.update!(stuck_confirmation_count: Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS - 1)
 
         result = activity.execute(project_id: project.id)
 
@@ -5310,7 +5385,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
         triggers = automation_scan_results(result)
         escalation_triggers = triggers.select do |t|
-          t[:triggers].any? { |tr| tr[:details]&.include?("No meaningful progress for 3 hours after") }
+          t[:triggers].any? { |tr| tr[:details]&.include?("No meaningful progress after") }
         end
         expect(escalation_triggers).to be_empty
       end
@@ -5362,6 +5437,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
           error_message: "All providers exhausted: claude_code",
           created_at: 2.hours.ago - 2.minutes
         )
+        pr_issue.update!(stuck_confirmation_count: Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS - 1)
 
         result = activity.execute(project_id: project.id)
 
@@ -7610,7 +7686,8 @@ RSpec.describe Activities::ScanPaidPrsActivity do
 
       it "still skips ready PRs at the follow-up limit when auto-fix is enabled" do
         project.update!(auto_fix_merge_conflicts: true, max_pr_followup_runs: 1)
-        unchanged_pr.update!(pr_review_phase: "ready", pr_followup_count: 1)
+        unchanged_pr.update!(pr_review_phase: "ready", pr_followup_count: 1,
+          stuck_confirmation_count: Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS)
         create(:agent_run, :failed,
           project: project,
           goal: "create_pr",
@@ -7903,6 +7980,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       it "escalates when retry limit is reached" do
         pr_issue.update!(review_goal_retry_count: 3)
         create_stale_review_runs!(pr_issue, statuses: %w[failed failed failed])
+        pr_issue.update!(stuck_confirmation_count: Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS - 1)
 
         result = activity.execute(project_id: project.id)
 
@@ -7958,6 +8036,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         pr_issue.update!(pr_review_phase: "ready", review_goal_retry_count: 3)
         create_stale_review_runs!(pr_issue, statuses: %w[failed failed failed])
         stub_github_for_pr(draft: false, reviews: [], head_committed_at: 5.hours.ago)
+        pr_issue.update!(stuck_confirmation_count: Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS - 1)
 
         result = activity.execute(project_id: project.id)
 
@@ -8221,6 +8300,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         })
         pr_issue
         create_stale_review_runs!(pr_issue, statuses: %w[failed failed failed])
+        pr_issue.update!(stuck_confirmation_count: Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS - 1)
         stub_github_for_pr(reviews: [], checks: [ { name: "rspec", conclusion: "success" } ], head_committed_at: 5.hours.ago)
       end
 
@@ -8253,6 +8333,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         })
         pr_issue
         create_stale_review_runs!(pr_issue, statuses: %w[failed failed failed])
+        pr_issue.update!(stuck_confirmation_count: Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS - 1)
         stub_github_for_pr(reviews: [], checks: [ { name: "rspec", conclusion: "success" } ], head_committed_at: 5.hours.ago)
       end
 
@@ -8723,6 +8804,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
     before do
       enable_paid_agent_review!(project, max_review_rounds: 3)
       create_stale_review_runs!(retry_limit_issue, statuses: %w[failed failed failed])
+      retry_limit_issue.update!(stuck_confirmation_count: Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS - 1)
       stub_github_for_pr(draft: true, reviews: [], head_committed_at: 5.hours.ago)
     end
 
@@ -8842,6 +8924,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
     before do
       enable_paid_agent_review!(project, max_review_rounds: 1)
       create_stale_review_runs!(low_rounds_issue, statuses: [ "failed" ])
+      low_rounds_issue.update!(stuck_confirmation_count: Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS - 1)
       stub_github_for_pr(draft: true, reviews: [], head_committed_at: 5.hours.ago)
     end
 
@@ -8868,6 +8951,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
     before do
       enable_paid_agent_review!(project)
       create_stale_review_runs!(ready_retry_issue, statuses: %w[failed failed failed])
+      ready_retry_issue.update!(stuck_confirmation_count: Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS - 1)
       stub_github_for_pr(reviews: [], head_committed_at: 5.hours.ago)
     end
 
@@ -9186,6 +9270,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         }
       })
       create_stale_review_runs!(custom_retries_issue, statuses: [ "failed" ])
+      custom_retries_issue.update!(stuck_confirmation_count: Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS - 1)
       stub_github_for_pr(draft: true, reviews: [], head_committed_at: 5.hours.ago)
     end
 
@@ -9277,6 +9362,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
     before do
       enable_paid_agent_review!(project, max_review_rounds: 3)
       create_stale_review_runs!(no_output_retry_limit_issue, statuses: %w[no_output no_output no_output])
+      no_output_retry_limit_issue.update!(stuck_confirmation_count: Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS - 1)
       stub_github_for_pr(draft: true, reviews: [], head_committed_at: 5.hours.ago)
     end
 
@@ -9569,6 +9655,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         }
       })
       create_stale_review_runs!(manual_retry_issue, statuses: %w[failed failed failed])
+      manual_retry_issue.update!(stuck_confirmation_count: Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS - 1)
       stub_github_for_pr(draft: true, reviews: [], head_committed_at: 5.hours.ago)
     end
 
@@ -9606,6 +9693,7 @@ RSpec.describe Activities::ScanPaidPrsActivity do
         }
       })
       create_stale_review_runs!(ci_retry_issue, statuses: %w[failed failed failed])
+      ci_retry_issue.update!(stuck_confirmation_count: Activities::ScanPaidPrsActivity::REQUIRED_STUCK_CONFIRMATIONS - 1)
       stub_github_for_pr(draft: true, reviews: [], head_committed_at: 5.hours.ago)
     end
 


### PR DESCRIPTION
## Problem

PRs were being marked `paid-escalated` due to "no progress within 3 hours" even when Paid hadn't actually been working on them. The escalation gate was a **3-hour wall-clock window** (`NO_PROGRESS_ESCALATION_WINDOW`), which keeps ticking while Paid is offline. After an outage, the first post-outage scan escalated PRs purely because the clock advanced — even though Paid made zero attempts during the downtime.

## Solution

Replace the wall-clock window with a **scan-cycle confirmation gate**, backed by a new `issues.stuck_confirmation_count` column.

- Each scan that finds a PR escalation-eligible (failure streak at its phase-appropriate limit, or the operational-failure breaker tripped) **increments** `stuck_confirmation_count`.
- A scan that finds the PR recovered **resets** it to `0`.
- Escalation fires once the count reaches `REQUIRED_STUCK_CONFIRMATIONS` (`2`).

Because the counter only advances when a scan actually runs, an outage produces no scans and can never manufacture an escalation on its own. The failure-streak limit (real failed runs) remains the primary gate; scan confirmation is the "give it cycles to recover" cushion that wall-clock was poorly proxying.

## Changes

- **Migration:** `issues.stuck_confirmation_count` (integer, default 0)
- `PullRequests::ProgressState::Result#stuck?` — takes `confirmations:` / `required_confirmations:` instead of wall-clock `stale_after:`
- `ScanPaidPrsActivity#update_stuck_confirmation!` — advances the count once per scan (in `build_lifecycle_signals`); `operational_failure_breaker?` / `no_progress_stuck?` gate on it
- `MarkEscalatedActivity` re-validation and the `StalledDraftPr` / `PrFollowupLimitReached` notification rules use the new gate
- Escalation reason text is now owner-readable (drops internal "scan cycles" jargon)

## Behavior note

This escalates genuinely-stuck PRs faster than the old 3-hour window (2 scans ≈ minutes, vs. 3 hours). The grace period now comes from real failed-run attempts plus scan confirmation, not elapsed time. `REQUIRED_STUCK_CONFIRMATIONS` is a single tunable constant if more cushion is desired.

## Testing

Added a downtime-immune escalation test proving: no-escalate on the first eligible scan despite a long wall-clock gap, escalate on the second confirming scan, and reset on recovery. Updated all existing escalation/spec callers to the new `stuck?` signature. Full affected suites pass (scan activity, retry-limit, mark/dismiss escalation, progress state, notification rules, auto_continue strategy).

## Review notes

- Activity-retry caveat: `ScanPaidPrsActivity` retries up to `max_attempts: 3`; a retried scan can advance the count one extra time for already-processed PRs — an accepted, rare edge case (at worst a stuck PR escalates one cycle early), consistent with the scanner's existing per-scan writes like `last_pr_scan_at`. Documented inline.
- Perf: `escalation_eligible?` short-circuits on zero failures so healthy PRs (the common case) pay no extra DB queries from the new check.

Draft while review settles on the confirmation threshold and messaging.
EOF 2>&1 | tail -5
