### PR TITLE
fix(pr-review): block auto-merge when paid_agent review fails unposted (#3086)

### DIFF
--- a/app/temporal/activities/scan_paid_prs_activity.rb
+++ b/app/temporal/activities/scan_paid_prs_activity.rb
@@ -2547,15 +2547,26 @@ module Activities
     # Returns true when every enabled blocking review method has a
     # completion signal. Review methods and their completion criteria:
     #
-    #   copilot / codex / paid_agent — checked by no_outstanding_review_feedback?
+    #   paid_agent (sole bot method, non-escalated PRs only) — the most
+    #     recent finished review-goal run must not be a failure that posted
+    #     no review. A failed, unposted run means the required review never
+    #     landed, so the gate holds until a run succeeds (or the retry-limit
+    #     escalation path releases it by escalating). Outstanding feedback
+    #     from a review that *was* posted is still checked by
+    #     no_outstanding_review_feedback?.
+    #   copilot / codex — checked by no_outstanding_review_feedback?
     #     (review bot status + thread resolution). Not re-checked here.
     #   ci_action — the check run named by action_name must be present
     #     and have a successful conclusion.
     #   manual — at least one trusted non-bot user must have submitted
     #     an APPROVED review (distinct from owner approval, which gates
     #     the merge trigger itself).
-    def all_blocking_review_methods_complete?(project, reviews, checks, pr_data: nil)
+    def all_blocking_review_methods_complete?(project, reviews, checks, pr_data: nil, issue: nil)
       return true unless project.review_enabled? && project.wait_for_reviews?
+
+      if issue && paid_agent_review_unposted_failure?(project, issue, reviews)
+        return false
+      end
 
       if project.review_method_enabled?("ci_action")
         return false unless ci_action_review_complete?(project, checks, pr_data)
@@ -2566,6 +2577,47 @@ module Activities
       end
 
       true
+    end
+
+    # Returns true when paid_agent is enabled as the SOLE bot review method,
+    # the PR is still in a review-gated phase (not escalated), no paid_agent
+    # review has been posted, and the most recent finished review-goal run in
+    # the current cycle ended in a retryable failure status without posting a
+    # review. The PR then never received the required review, so auto-merge
+    # must hold until a run succeeds, or until exhausting retries drives the
+    # escalation path (which moves the PR to the escalated phase, exempt
+    # below). A posted review — clean or not — is left to the existing
+    # no_outstanding_review_feedback? path, so this only closes the "review
+    # never landed" hole (#3086).
+    #
+    # Scope is deliberately narrow:
+    # - Sole-method only: mixed-bot projects (e.g. copilot + paid_agent) do
+    #   NOT escalate on paid_agent exhaustion — the other bot is meant to keep
+    #   gating (see review_goal_retry_limit_requires_escalation?). Blocking
+    #   here for a mixed project would deadlock with no recovery.
+    # - Escalated PRs are exempt: owner approval intentionally unblocks
+    #   auto-merge for an escalated PR (see scan_escalated_pr), and the race
+    #   this guard prevents (merge firing before escalation confirms) is
+    #   already resolved once the PR has escalated.
+    def paid_agent_review_unposted_failure?(project, issue, reviews)
+      return false if issue.escalated_phase?
+      return false unless paid_agent_sole_review_method?(project)
+      return false if paid_agent_review_present?(reviews)
+
+      latest_run = latest_finished_automatic_review_run(
+        project, issue, progress_state: pr_progress_state(project, issue)
+      )
+      return false unless latest_run&.status&.in?(REVIEW_GOAL_RETRYABLE_FAILURE_STATUSES)
+      return false if latest_run.review_posted_at.present?
+
+      true
+    end
+
+    # Returns true when any posted review came from the paid_agent review bot.
+    def paid_agent_review_present?(reviews)
+      return false if reviews.blank?
+
+      reviews.any? { |review| RunnerSupport.runner_bot_username_for?("paid_agent", review[:user_login]) }
     end
 
     # ci_action is complete when the configured action_name appears in
@@ -2993,7 +3045,7 @@ module Activities
         unresolved_threads: unresolved_threads
       )
       blocking_reviews_complete = all_blocking_review_methods_complete?(
-        project, reviews, checks, pr_data: pr_data
+        project, reviews, checks, pr_data: pr_data, issue: issue
       )
       reviews_fresh = !review_stale_for_head?(client, project, issue, pr_data, reviews)
       dependencies_resolved = if human_dependency_check_required?(

--- a/spec/temporal/activities/scan_paid_prs_activity_spec.rb
+++ b/spec/temporal/activities/scan_paid_prs_activity_spec.rb
@@ -4701,6 +4701,166 @@ RSpec.describe Activities::ScanPaidPrsActivity do
       end
     end
 
+    context "when paid_agent review-goal retries are exhausted without posting a review (#3086)" do
+      let(:pr_issue) do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          pr_followup_count: 0)
+      end
+
+      before do
+        project.update!(
+          owner_reviewer_login: "viamin",
+          auto_merge_mode: "all",
+          review_settings: {
+            "enabled" => true,
+            "methods" => {
+              "paid_agent" => { "enabled" => true, "termination" => { "max_review_rounds" => 3 } }
+            }
+          }
+        )
+        pr_issue
+        # Three failed automatic review-goal runs exhaust the retry budget
+        # (MAX_REVIEW_GOAL_RETRIES = 3). At that point check_paid_agent_review_status
+        # stops emitting paid_agent_review_pending, so without the merge gate the PR
+        # would auto-merge before the escalation path confirms — the #3086 regression.
+        3.times do
+          create(:agent_run, :automatic, :failed, :review_goal,
+            project: project, issue: pr_issue,
+            source_pull_request_number: 42)
+        end
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success" } ],
+          reviews: [
+            { id: 1, user_login: "viamin", state: "APPROVED", body: "Approved",
+              submitted_at: 1.hour.ago }
+          ],
+          review_threads: []
+        )
+      end
+
+      it "does not auto-merge until escalation releases the gate" do
+        result = activity.execute(project_id: project.id)
+
+        types = automation_scan_results(result).flat_map { |r| r[:triggers].map { |t| t[:type] } }
+        expect(types).not_to include("owner_approved")
+      end
+
+      it "auto-merges once a paid_agent review is posted" do
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success" } ],
+          reviews: [
+            { id: 1, user_login: "paid-code-reviewer[bot]", state: "COMMENTED",
+              body: "Review complete.\n<!-- paid-review-clean -->", submitted_at: 1.hour.ago },
+            { id: 2, user_login: "viamin", state: "APPROVED", body: "", submitted_at: Time.current }
+          ],
+          review_threads: []
+        )
+
+        result = activity.execute(project_id: project.id)
+
+        types = automation_scan_results(result).flat_map { |r| r[:triggers].map { |t| t[:type] } }
+        expect(types).to include("owner_approved")
+      end
+    end
+
+    context "when a mixed copilot+paid_agent project has failed paid_agent runs but a clean copilot review" do
+      let(:pr_issue) do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation" ],
+          pr_review_phase: "ready",
+          pr_followup_count: 0)
+      end
+
+      before do
+        # Mixed-bot projects do NOT escalate on paid_agent exhaustion — the other
+        # bot is meant to keep gating. The merge gate must not block here, or the
+        # PR deadlocks with no recovery (#3086 review).
+        project.update!(
+          owner_reviewer_login: "viamin",
+          auto_merge_mode: "all",
+          review_settings: {
+            "enabled" => true,
+            "methods" => {
+              "copilot" => { "enabled" => true },
+              "paid_agent" => { "enabled" => true, "termination" => { "max_review_rounds" => 3 } }
+            }
+          }
+        )
+        pr_issue
+        3.times do
+          create(:agent_run, :automatic, :failed, :review_goal,
+            project: project, issue: pr_issue,
+            source_pull_request_number: 42)
+        end
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success" } ],
+          reviews: default_clean_copilot_review + [
+            { id: 2, user_login: "viamin", state: "APPROVED", body: "", submitted_at: Time.current }
+          ],
+          review_threads: []
+        )
+      end
+
+      it "lets copilot's clean review satisfy the gate and auto-merge (no deadlock)" do
+        result = activity.execute(project_id: project.id)
+
+        types = automation_scan_results(result).flat_map { |r| r[:triggers].map { |t| t[:type] } }
+        expect(types).to include("owner_approved")
+      end
+    end
+
+    context "when an escalated sole-method PR has a failed paid_agent run and owner approval" do
+      let(:pr_issue) do
+        create(:issue, :pull_request,
+          project: project, github_number: 42,
+          labels: [ "paid-generated", "paid-automation", "paid-escalated" ],
+          pr_review_phase: "escalated",
+          pr_followup_count: 0)
+      end
+
+      before do
+        project.update!(
+          owner_reviewer_login: "viamin",
+          auto_merge_mode: "all",
+          review_settings: {
+            "enabled" => true,
+            "methods" => {
+              "paid_agent" => { "enabled" => true, "termination" => { "max_review_rounds" => 3 } }
+            }
+          }
+        )
+        pr_issue
+        # The PR escalated BECAUSE paid_agent exhausted its retry budget, so the
+        # sibling review-feedback gate has already cleared (returns [] at the
+        # limit). This isolates whether the new gate still blocks an escalated
+        # PR that the owner has approved.
+        3.times do
+          create(:agent_run, :automatic, :failed, :review_goal,
+            project: project, issue: pr_issue,
+            source_pull_request_number: 42)
+        end
+        stub_github_for_pr(
+          checks: [ { name: "ci", conclusion: "success" } ],
+          reviews: [
+            { id: 1, user_login: "viamin", state: "APPROVED", body: "Approved",
+              submitted_at: Time.current }
+          ],
+          review_threads: []
+        )
+      end
+
+      it "auto-merges because escalation puts the owner in control" do
+        result = activity.execute(project_id: project.id)
+
+        types = automation_scan_results(result).flat_map { |r| r[:triggers].map { |t| t[:type] } }
+        expect(types).to include("owner_approved")
+      end
+    end
+
     context "when ready PR is fork-backed and Claude ci_action review is enabled" do
       before do
         project.update!(


### PR DESCRIPTION
## Problem

PR #3086 was auto-merged with **zero reviews** despite `paid_agent` being a configured blocking review method. Four review-goal runs had all failed (`All runners exhausted: … Opencode GLM`), none posted a review, yet the PR merged ~8 min after the last failure — beating the escalation path.

## Root cause

When paid_agent review-goal runs keep failing without posting a review and the **retry budget is exhausted** (default 3), `check_paid_agent_review_status` returns `[]` (early return at the retry-limit check). It stops emitting `paid_agent_review_pending`, so the review no longer gates the merge. `all_blocking_review_methods_complete?` never checked `paid_agent` at all → it returned `true` → auto-merge fired, winning the race over the 2-cycle escalation confirmation.

## Fix

Add a paid_agent completeness check to `all_blocking_review_methods_complete?` (`app/temporal/activities/scan_paid_prs_activity.rb`). It holds the merge when:
- paid_agent is enabled as the **sole bot review method**,
- the PR is **not escalated**,
- **no paid_agent review has been posted**, and
- the latest finished review-goal run ended in a retryable failure without posting.

Release valve is unchanged: exhausting retries still drives escalation → `pr_review_phase = "escalated"` → escalated PRs route through `scan_escalated_pr` (the documented owner-approval-unblocks path).

### Why the narrow scope
- **Sole-method only** — mixed-bot projects (e.g. copilot + paid_agent) never escalate on paid_agent exhaustion by design (the other bot keeps gating). Blocking there would **deadlock with no recovery**.
- **Escalated exempt** — owner approval intentionally unblocks auto-merge for an escalated PR (see `scan_escalated_pr`); the race this prevents is already resolved once escalated.
- **Reset boundary** aligned with the retry path via the memoized `progress_state`, so the gate and retry engine agree on whether a failure "counts."
- A posted review (clean or not) is left to the existing `no_outstanding_review_feedback?` path — this only closes the "review never landed" hole.

## Verification

- New failing-first test reproduces #3086 (3 exhausted failed runs, no review → merge blocked); confirmed it failed before the fix.
- Boundary test: once a `paid-code-reviewer[bot]` review posts → merge proceeds.
- Mixed-project test: copilot clean review + failed paid_agent runs → merges (no deadlock).
- Escalated test: escalated sole-method PR + exhausted runs + owner approval → merges.
- `scan_paid_prs_activity_spec.rb` + `scan_paid_prs_activity_retry_limit_spec.rb`: **434 examples, 0 failures**.
- RuboCop clean.

## Out of scope (deliberately)
- DB-error blast-radius isolation belongs at the per-PR scan loop (the whole path shares this characteristic); not patched one-off here.
- `paid-code-reviewer` bare-login bot matching is systemic to `RunnerSupport`; left consistent with existing usage.

Refs #3086