### PR TITLE
fix(containers): redirect yarn cache to workspace volume to prevent ENOSPC

### DIFF
--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -2627,7 +2627,8 @@ module Containers
         "PROJECT_ID=#{project.id}",
         "HOME=/home/agent",
         "BUNDLE_PATH=/tmp/bundle",
-        "BUNDLE_APP_CONFIG=/tmp/bundle-config"
+        "BUNDLE_APP_CONFIG=/tmp/bundle-config",
+        "YARN_CACHE_FOLDER=/workspace/.yarn-cache"
       ]
 
       env.concat(run_scoped_environment(proxy_base)) if agent_run.present?

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -780,11 +780,12 @@ RSpec.describe Containers::Provision do
         service.provision
       end
 
-      it "sets writable Bundler paths for all agent containers" do
+      it "sets writable Bundler and Yarn cache paths for all agent containers" do
         expect(Docker::Container).to receive(:create) do |config|
           env = config["Env"]
           expect(env).to include("BUNDLE_PATH=/tmp/bundle")
           expect(env).to include("BUNDLE_APP_CONFIG=/tmp/bundle-config")
+          expect(env).to include("YARN_CACHE_FOLDER=/workspace/.yarn-cache")
           mock_container
         end
 


### PR DESCRIPTION
## Problem

Agent containers mount `/home/agent/.cache` as a **512MB tmpfs**. Yarn defaults to caching at `~/.cache/yarn`, which fills the tmpfs on large dependency trees — Paid's own `yarn install` produces ~500MB of cache, leaving only ~14MB of headroom. This caused `ENOSPC: no space left on device` during `yarn install`, cascading into corrupted gems, bundler lock contention, and eventual runner failure (exit 143/SIGTERM).

Observed in agent run 20105: the codex runner exhausted the 512MB tmpfs mid-`yarn install`, corrupted the bundler gem cache, and was killed with SIGTERM. The misleading error message `"Agent exited with code 143: Reading additional input from stdin..."` was stale stderr from startup — the real cause was disk exhaustion on the tmpfs.

## Fix

Set `YARN_CACHE_FOLDER=/workspace/.yarn-cache` in the container environment, redirecting the yarn cache to the workspace volume (backed by host disk with ample space). This mirrors the existing `BUNDLE_PATH=/tmp/bundle` pattern for Bundler.

## Why not increase the tmpfs?

The tmpfs uses RAM (backed by the host's 20GB). Increasing it to 2GB would steal from the container's memory budget. The workspace volume is disk-backed with far more headroom and no memory tradeoff.

## Safety

- `.yarn-cache/` is already in `.gitignore` (line 117) and `CONTAINER_ARTIFACT_EXCLUDES` (line 64) — no risk of cache being committed
- No cache-reuse regression — the old tmpfs cache was also per-run (ephemeral); each run gets its own workspace volume regardless
- Workspace volume is owned by `agent:agent` after `fix_all_ownership!`

## Test plan

- [x] Updated `provision_spec.rb` to assert `YARN_CACHE_FOLDER` is set
- [x] All existing env-var provision tests pass
- [ ] Verify a `yarn install` inside an agent container completes without ENOSPC on a large project