### PR TITLE
fix(llm): normalize markdown code fences before parsing LLM JSON

### DIFF
--- a/app/services/agent_run_patterns/diagnose.rb
+++ b/app/services/agent_run_patterns/diagnose.rb
@@ -4,6 +4,8 @@ require "json"
 
 module AgentRunPatterns
   class Diagnose
+    include Llm::OutputNormalizer
+
     DEFAULT_MODEL = "claude-sonnet-4-6"
     MIN_CONFIDENCE = 0.55
     TIMEOUT = 45
@@ -150,7 +152,7 @@ module AgentRunPatterns
     end
 
     def parse_json(output)
-      cleaned = output.to_s.gsub(/\A```(?:json)?\s*/, "").gsub(/\s*```\z/, "").strip
+      cleaned = strip_markdown_fence(output.to_s.strip)
       return if cleaned.blank?
 
       JSON.parse(cleaned)

--- a/app/services/knowledge/decisions/draft.rb
+++ b/app/services/knowledge/decisions/draft.rb
@@ -23,6 +23,8 @@ module Knowledge
     # @example
     #   Knowledge::Decisions::Draft.call(agent_run: agent_run)
     class Draft
+      include Llm::OutputNormalizer
+
       TIMEOUT = 30
       DEFAULT_MODEL = "claude-sonnet-4-6"
       DEFAULT_PROVIDER = "claude"
@@ -314,7 +316,7 @@ module Knowledge
       def parse_text_output(output)
         return nil if output.blank?
 
-        cleaned = output.gsub(/\A```(?:json)?\s*/, "").gsub(/\s*```\z/, "").strip
+        cleaned = strip_markdown_fence(output.to_s.strip)
         JSON.parse(cleaned, symbolize_names: true)
       rescue JSON::ParserError => e
         Rails.logger.warn(

--- a/app/services/screenshots/derive_hints.rb
+++ b/app/services/screenshots/derive_hints.rb
@@ -16,6 +16,8 @@ module Screenshots
   # Best-effort: returns +{}+ (and leaves the column unchanged) on any failure,
   # so callers fall back to capturing every configured route.
   class DeriveHints
+    include Llm::OutputNormalizer
+
     DEFAULT_MODEL = "claude-sonnet-4-6"
     TIMEOUT = 30
     MAX_FILES = 100
@@ -130,15 +132,10 @@ module Screenshots
     end
 
     def parse_json(text)
-      cleaned = strip_fence(text.to_s.strip)
+      cleaned = strip_markdown_fence(text.to_s.strip)
       JSON.parse(cleaned)
     rescue JSON::ParserError
       {}
-    end
-
-    def strip_fence(text)
-      match = text.match(/\A```(?:json)?\s*\n(.*)\n```\z/m)
-      match ? match[1].strip : text
     end
 
     def prompt

--- a/app/temporal/activities/analyze_issue_activity.rb
+++ b/app/temporal/activities/analyze_issue_activity.rb
@@ -8,6 +8,8 @@ module Activities
   #
   # This is a direct LLM call — no container provisioning or repo cloning.
   class AnalyzeIssueActivity < BaseActivity
+    include Llm::OutputNormalizer
+
     activity_name "AnalyzeIssue"
 
     LLM_TIMEOUT = 90
@@ -306,12 +308,7 @@ module Activities
     end
 
     def extract_analysis_json(output)
-      stripped = strip_json_fence(output)
-      JSON.parse(stripped, symbolize_names: true)
-    end
-
-    def strip_json_fence(output)
-      output.gsub(/\A```(?:json)?\s*/, "").gsub(/\s*```\z/, "").strip
+      JSON.parse(strip_markdown_fence(output.to_s.strip), symbolize_names: true)
     end
 
     def track_tokens(agent_run, response)

--- a/app/temporal/activities/analyze_knowledge_gaps_activity.rb
+++ b/app/temporal/activities/analyze_knowledge_gaps_activity.rb
@@ -6,6 +6,8 @@ module Activities
   #
   # Returns structured recommendations for the RecordKnowledgeRecommendationsActivity.
   class AnalyzeKnowledgeGapsActivity < BaseActivity
+    include Llm::OutputNormalizer
+
     activity_name "AnalyzeKnowledgeGaps"
 
     DEFAULT_MODEL = "claude-sonnet-4-6"
@@ -121,7 +123,7 @@ module Activities
 
     def parse_response(response)
       output = response.respond_to?(:output) ? response.output.to_s : response.to_s
-      parsed = JSON.parse(strip_json_fence(output), symbolize_names: true)
+      parsed = JSON.parse(strip_markdown_fence(output.to_s.strip), symbolize_names: true)
       Array(parsed[:recommendations]).map do |rec|
         rec.slice(:recommendation_type, :collector_type, :priority, :description, :evidence)
       end
@@ -131,10 +133,6 @@ module Activities
         error: e.message
       )
       []
-    end
-
-    def strip_json_fence(output)
-      output.gsub(/\A```(?:json)?\s*/, "").gsub(/\s*```\z/, "").strip
     end
   end
 end

--- a/app/temporal/activities/enhance_issue_activity.rb
+++ b/app/temporal/activities/enhance_issue_activity.rb
@@ -4,6 +4,8 @@ module Activities
   # Enhances a GitHub issue with knowledge-base-backed implementation context,
   # or asks focused clarifying questions when the issue is not actionable yet.
   class EnhanceIssueActivity < BaseActivity
+    include Llm::OutputNormalizer
+
     activity_name "EnhanceIssue"
 
     COMMENT_MARKER = "<!-- paid:enhance-issue -->"
@@ -302,7 +304,7 @@ module Activities
 
     def parse_response!(agent_run, response)
       output = response.respond_to?(:output) ? response.output.to_s : response.to_s
-      parsed = JSON.parse(strip_json_fence(output), symbolize_names: true)
+      parsed = JSON.parse(strip_markdown_fence(output.to_s.strip), symbolize_names: true)
       return parsed if parsed.key?(:sufficient_context) && parsed[:comment_body].present?
 
       raise JSON::ParserError, "missing sufficient_context or comment_body"
@@ -313,10 +315,6 @@ module Activities
         type: "EnhanceIssueInvalidJson",
         non_retryable: true
       )
-    end
-
-    def strip_json_fence(output)
-      output.gsub(/\A```(?:json)?\s*/, "").gsub(/\s*```\z/, "").strip
     end
 
     def comment_body_for(parsed)

--- a/docs/intent/issue-analysis/issue-analysis-specs.md
+++ b/docs/intent/issue-analysis/issue-analysis-specs.md
@@ -36,7 +36,10 @@
   *Code:* `app/temporal/activities/analyze_issue_activity.rb#ensure_trusted_issue!`, `#trusted_comments`.
 
 - [x] **ISSUE-ANALYSIS-005** — The system SHALL surface malformed or
-  incomplete analysis JSON as a non-retryable `AnalyzeIssueInvalidJson` error,
-  trusting agent-harness to deliver clean `response.output`.
-  *Tests:* `spec/temporal/activities/analyze_issue_activity_spec.rb` ("malformed JSON", "missing required keys").
-  *Code:* `app/temporal/activities/analyze_issue_activity.rb#parse_response!`.
+  incomplete analysis JSON as a non-retryable `AnalyzeIssueInvalidJson` error.
+  A markdown code fence around the JSON (```` ```json ... ``` ````, including a
+  trailing newline after the closing fence) SHALL be normalized away before
+  parsing, so a fenced-but-otherwise-valid response is not mistaken for a
+  failure.
+  *Tests:* `spec/temporal/activities/analyze_issue_activity_spec.rb` ("malformed JSON", "missing required keys", "strips a markdown code fence").
+  *Code:* `app/temporal/activities/analyze_issue_activity.rb#parse_response!`, `#extract_analysis_json`.

--- a/spec/temporal/activities/analyze_issue_activity_spec.rb
+++ b/spec/temporal/activities/analyze_issue_activity_spec.rb
@@ -122,6 +122,26 @@ RSpec.describe Activities::AnalyzeIssueActivity do
       }.to raise_error(Temporalio::Error::ApplicationError, "LLM returned invalid analysis JSON")
     end
 
+    it "strips a markdown code fence (even with a trailing newline) from the LLM response" do
+      fenced = <<~JSON
+        ```json
+        {
+          "sufficient_context": false,
+          "reasoning": "Needs more detail.",
+          "missing_context_areas": ["steps to reproduce"]
+        }
+        ```
+      JSON
+
+      allow(llm_response).to receive(:output).and_return(fenced)
+
+      result = activity.execute(agent_run_id: agent_run.id)
+
+      expect(result[:sufficient_context]).to be false
+      expect(result[:missing_context_areas]).to eq([ "steps to reproduce" ])
+      expect(agent_run.reload.status).to eq("completed")
+    end
+
     it "tracks token usage correctly" do
       activity.execute(agent_run_id: agent_run.id)
 

--- a/spec/temporal/activities/enhance_issue_activity_spec.rb
+++ b/spec/temporal/activities/enhance_issue_activity_spec.rb
@@ -396,6 +396,19 @@ RSpec.describe Activities::EnhanceIssueActivity do
       }.to raise_error(Temporalio::Error::ApplicationError, "LLM returned invalid enhancement JSON")
     end
 
+    it "parses a markdown-fenced response with a trailing newline after the closing fence" do
+      body = {
+        sufficient_context: true,
+        comment_body: "## Implementation context\n- `app/models/audit_log.rb`"
+      }.to_json
+      allow(llm_response).to receive(:output).and_return("```json\n#{body}\n```\n")
+
+      result = activity.execute(agent_run_id: agent_run.id)
+
+      expect(result[:sufficient_context]).to be true
+      expect(agent_run.reload.status).to eq("completed")
+    end
+
     it "raises GitHub API failures before calling the LLM" do
       allow(client).to receive(:issue_comments).and_raise(GithubClient::Error.new("GitHub unavailable"))
 


### PR DESCRIPTION
## Summary

Fixes a class of agent-run failures where an LLM wraps its JSON response in a markdown code fence. Run [20172](http://localhost:3000/projects/27/agent_runs/20172) failed non-retryably as `AnalyzeIssueInvalidJson` ("LLM returned invalid analysis JSON") even though the model returned **valid** JSON.

## Root cause

Claude Haiku 4.5 returned:

```
```json
{ ...valid... }
```
```

…with a **trailing newline after the closing fence** (`...}\n```\n`). The local fence-stripper used the regex `\s*```\z`, which only tolerates whitespace *before* the closing fence and requires it at the absolute end-of-string. The trailing newline defeated it, the closing fence survived, and `JSON.parse` rejected `...}` + ` ``` ` → "unexpected token at end of stream '```'".

## What changed

The same buggy, duplicated fence-stripping regex existed in **six** LLM-JSON parsers. All are replaced with the existing shared helper `Llm::OutputNormalizer#strip_markdown_fence` (operates on first/last lines, robust to trailing whitespace), matching the precedent already set by `DecomposeFeatureActivity` / `ParseMultiIssuePlanActivity`:

| Path | Failure mode |
|---|---|
| `analyze_issue_activity` | non-retryable run failure (the reported run) |
| `enhance_issue_activity` | non-retryable; fires on **every** auto-enhance |
| `analyze_knowledge_gaps_activity` | silently returns `[]` |
| `agent_run_patterns/diagnose` | diagnosis falls back |
| `knowledge/decisions/draft` | decision record dropped |
| `screenshots/derive_hints` | degrades gracefully to `{}` |

The four duplicated `strip_json_fence` / `strip_fence` helpers are deleted.

## Verification

- Failing-first regression tests for `analyze_issue` and `enhance_issue` — verified each fails against the original code with the exact production error ("unexpected token at end of stream '```'"), then passes after the fix.
- `100 examples, 0 failures` across all affected specs (re-run on the fresh `origin/main` base).
- `bin/rubocop` clean on all changed files; pre-commit hook passed.
- Updated the `ISSUE-ANALYSIS-005` EARS note (dropped the now-false "trusting agent-harness to deliver clean response.output" clause).
