### PR TITLE
fix(projects): avoid NoMethodError on edit re-render with unsaved mutation req

### DIFF
--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -903,7 +903,7 @@
               </div>
             </div>
 
-            <% if @mutation_req %>
+            <% if @mutation_req&.updated_at %>
               <div class="pt-2">
                 <span class="text-xs text-gray-500">Last updated: <%= @mutation_req.updated_at.strftime("%b %-d, %Y") %></span>
               </div>

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -1711,6 +1711,20 @@ RSpec.describe "Projects" do
         expect(response.body).to include("Could not load repository screenshot config: GitHub is down")
       end
 
+      it "re-renders the form without crashing when mutation_test params accompany a validation failure" do
+        project = create(:project, account: account, github_token: github_token)
+
+        expect {
+          patch project_path(project), params: {
+            project: { name: "" },
+            mutation_test: { enabled: "1", command: "bundle exec mutant run", failure_behavior: "warn" }
+          }
+        }.not_to raise_error
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to include("Mutation Testing")
+      end
+
       it "allows updating priority label names" do
         project = create(:project, account: account, github_token: github_token)
         patch project_path(project), params: {


### PR DESCRIPTION
## Problem

Editing project settings crashed with `NoMethodError: undefined method 'strftime' for nil` at `app/views/projects/edit.html.erb:908` whenever a save was re-rendered with mutation-test form params present.

## Root cause

`ProjectsController#update` sets `@mutation_req` to a **new, unsaved** `PreCommitRequirement` (via `mutation_test_requirement_for_form`) when re-rendering after a validation failure. An unsaved record has `updated_at == nil`, but the view guarded on `if @mutation_req` (truthy object), then called `.updated_at.strftime(...)` — raising `NoMethodError`. The resulting 500 **masked the actual validation error** the user needed to see.

## Fix

Guard on `@mutation_req&.updated_at` so the "Last updated" timestamp only renders for persisted records (which always have a timestamp).

## Testing

- Added a failing-first regression test (`spec/requests/projects_spec.rb`) that PATCHes with mutation_test params + an invalid project field (`name: ""`). It reproduced the crash before the fix and passes now.
- Full project/mutation request + system specs green (257 examples, 0 failures).

## Follow-up

This unmasks the underlying validation error that was hidden. Worth confirming the original repro project now surfaces a meaningful error instead of a 500.