### PR TITLE
fix(auto-pick): cancel queued runs when disabled

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -322,6 +322,7 @@ class Project < ApplicationRecord
   after_update_commit :clear_scheduler_pause_on_token_change, if: :saved_change_to_github_token_id?
   after_update_commit :clear_scheduler_pause_on_installation_change, if: :saved_change_to_github_installation_id?
   after_update_commit :seed_eligible_issues, if: :auto_pick_just_enabled?
+  after_update_commit :cancel_queued_auto_pick_runs, if: :auto_pick_just_disabled?
   after_update_commit :ensure_playwright_mcp_definition!, if: :verification_just_enabled?
   after_destroy_commit :stop_github_polling
   after_destroy_commit :cleanup_qdrant_collection
@@ -1426,6 +1427,10 @@ class Project < ApplicationRecord
     saved_change_to_auto_pick_enabled? && auto_pick_enabled?
   end
 
+  def auto_pick_just_disabled?
+    saved_change_to_auto_pick_enabled? && !auto_pick_enabled?
+  end
+
   def verification_just_enabled?
     return false unless saved_change_to_screenshot_settings?
 
@@ -1475,6 +1480,36 @@ class Project < ApplicationRecord
     Issues::BulkEnqueueEligible.call(project: self, skip_project_gate: true)
   rescue => e
     Rails.logger.error(message: "auto_pick.bulk_seed_failed", project_id: id, error: e.message)
+  end
+
+  # @spec AUTO-PICK-QUEUE-001
+  def cancel_queued_auto_pick_runs
+    now = Time.current
+    queued_auto_pick_runs = agent_runs
+      .where(status: "queued")
+      .where("agent_runs.auto_pick = TRUE OR (agent_runs.trigger_type = 'automatic' AND agent_runs.goal = 'enhance_issue')")
+    queued_auto_pick_run_ids = queued_auto_pick_runs.ids
+    return if queued_auto_pick_run_ids.empty?
+
+    cancelled_count = queued_auto_pick_runs
+      .where(id: queued_auto_pick_run_ids)
+      .update_all(
+        status: "cancelled",
+        completed_at: now,
+        error_message: "Auto-Pick disabled for project",
+        updated_at: now
+      )
+    return if cancelled_count.zero?
+
+    Dashboard::CacheVersion.bump(account, scope: Dashboard::CacheVersion::LISTS_SCOPE)
+    LiveDashboardBroadcastJob.perform_later(account_id, queued_auto_pick_run_ids.first, refresh_queue_preview: true)
+    Rails.logger.info(
+      message: "auto_pick.queued_runs_cancelled",
+      project_id: id,
+      cancelled_count: cancelled_count
+    )
+  rescue => e
+    Rails.logger.error(message: "auto_pick.queued_runs_cancel_failed", project_id: id, error: e.message)
   end
 
   def enqueue_knowledge_collection

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1484,32 +1484,41 @@ class Project < ApplicationRecord
 
   # @spec AUTO-PICK-QUEUE-001
   def cancel_queued_auto_pick_runs
-    now = Time.current
     queued_auto_pick_runs = agent_runs
       .where(status: "queued")
       .where("agent_runs.auto_pick = TRUE OR (agent_runs.trigger_type = 'automatic' AND agent_runs.goal = 'enhance_issue')")
-    queued_auto_pick_run_ids = queued_auto_pick_runs.ids
-    return if queued_auto_pick_run_ids.empty?
+      .to_a
+    return if queued_auto_pick_runs.empty?
 
-    cancelled_count = queued_auto_pick_runs
-      .where(id: queued_auto_pick_run_ids)
-      .update_all(
-        status: "cancelled",
-        completed_at: now,
-        error_message: "Auto-Pick disabled for project",
-        updated_at: now
-      )
-    return if cancelled_count.zero?
+    cancelled_run_ids = queued_auto_pick_runs.filter_map { |run| run.id if cancel_auto_pick_run(run) }
+    return if cancelled_run_ids.empty?
 
-    Dashboard::CacheVersion.bump(account, scope: Dashboard::CacheVersion::LISTS_SCOPE)
-    LiveDashboardBroadcastJob.perform_later(account_id, queued_auto_pick_run_ids.first, refresh_queue_preview: true)
+    # No manual LiveDashboardBroadcastJob/CacheVersion bump here: cancel_auto_pick_run
+    # cancels each run through AgentRun#cancel!, whose after_commit broadcast_project_updates
+    # callback already enqueues LiveDashboardBroadcastJob(refresh_queue_preview: true) per run.
     Rails.logger.info(
       message: "auto_pick.queued_runs_cancelled",
       project_id: id,
-      cancelled_count: cancelled_count
+      cancelled_count: cancelled_run_ids.size
     )
   rescue => e
     Rails.logger.error(message: "auto_pick.queued_runs_cancel_failed", project_id: id, error: e.message)
+  end
+
+  # Cancels via AgentRuns::Cancel (not update_all) so that a queued run already
+  # claimed by a Temporal workflow (AgentRun.claimed) actually has that
+  # workflow and any container torn down, and so the normal AgentRun
+  # after_commit broadcasts fire for each run.
+  def cancel_auto_pick_run(run)
+    AgentRuns::Cancel.call(agent_run: run, error: "Auto-Pick disabled for project")
+  rescue => e
+    Rails.logger.error(
+      message: "auto_pick.queued_run_cancel_failed",
+      project_id: id,
+      agent_run_id: run.id,
+      error: e.message
+    )
+    false
   end
 
   def enqueue_knowledge_collection

--- a/app/services/agent_runs/cancel.rb
+++ b/app/services/agent_runs/cancel.rb
@@ -6,20 +6,21 @@ module AgentRuns
       new(...).call
     end
 
-    def initialize(agent_run:, skip_status_update: false)
+    def initialize(agent_run:, skip_status_update: false, error: nil)
       @agent_run = agent_run
       @skip_status_update = skip_status_update
+      @error = error
     end
 
     def call
       cancel_temporal_workflow
       cleanup_container
-      agent_run.cancel! unless skip_status_update
+      agent_run.cancel!(error: error) unless skip_status_update
     end
 
     private
 
-    attr_reader :agent_run, :skip_status_update
+    attr_reader :agent_run, :skip_status_update, :error
 
     def cancel_temporal_workflow
       return if agent_run.temporal_workflow_id.blank?

--- a/app/services/issues/enqueue_eligible.rb
+++ b/app/services/issues/enqueue_eligible.rb
@@ -14,6 +14,12 @@ module Issues
     end
 
     def call
+      # @spec AUTO-PICK-QUEUE-001
+      unless project.auto_pick_enabled?
+        log_project_deferred
+        return nil
+      end
+
       unless skip_project_gate || Issues::AutoPickProjectGate.call(project)
         log_project_deferred
         return nil

--- a/docs/arrows/index.yaml
+++ b/docs/arrows/index.yaml
@@ -11,15 +11,26 @@
 # segments are created under docs/intent/. See docs/intent/README.md.
 
 schema_version: 2
-last_updated: 2026-07-30
+last_updated: 2026-08-01
 
 # Taxonomy groups segments by domain cluster. Purely organizational.
 # Empty until segments exist to cluster.
-taxonomy: {}
+taxonomy:
+  automation:
+    label: Automation
+    description: Automated work selection and queueing behavior.
 
 # The design tree of nodes. Leaf nodes are arrow segments (own EARS + an arrow
-# doc); intermediate nodes (sub-HLDs) group children. Empty = nothing mapped.
-arrows: {}
+# doc); intermediate nodes (sub-HLDs) group children.
+arrows:
+  auto-pick-queue:
+    title: Auto-Pick Queue
+    path: docs/intent/auto-pick-queue/auto-pick-queue-design.md
+    specs: docs/intent/auto-pick-queue/auto-pick-queue-specs.md
+    parent: PAID
+    taxonomy: automation
+    status: OK
+    audited: 2026-08-01
 
 # Items found during mapping that don't yet belong to a segment.
 # arrow-maintenance cleans this up on each audit.

--- a/docs/intent/auto-pick-queue/auto-pick-queue-design.md
+++ b/docs/intent/auto-pick-queue/auto-pick-queue-design.md
@@ -1,0 +1,35 @@
+---
+parent: PAID
+prefix: AUTO-PICK-QUEUE
+---
+
+# Low-Level Design: Auto-Pick Queue
+
+> Companion to the high-level design (`docs/high-level-design.md`). This
+> segment covers the queue-seeding lifecycle for project Auto-Pick.
+
+## Purpose
+
+Auto-Pick turns eligible project issues into queued automatic agent runs. The
+project toggle is the operator control for that lifecycle: enabling it seeds
+eligible work, and disabling it stops future automatic picks and drains queued
+automatic picks.
+
+## Disable Semantics
+
+Queued Auto-Pick runs are cancelled, not deleted, when Auto-Pick is disabled.
+That preserves run history while removing the work from scheduler and dashboard
+queue views. The drain applies to queued runs only (`status = "queued"`) so a
+run that has already started executing is left to the normal cancellation and
+execution controls.
+
+Some Auto-Pick-adjacent enhancement rechecks are queued as automatic
+`enhance_issue` runs by the GitHub sync path without the `auto_pick` flag set.
+Those runs still belong to the Auto-Pick lifecycle for queue-drain purposes and
+are cancelled when Auto-Pick is disabled. Manual `enhance_issue` runs remain
+queued.
+
+Enqueue paths may bypass broader project gates after a caller has already
+established eligibility, but they must still respect the canonical
+`auto_pick_enabled` switch at call time so stale sync or retry work cannot
+recreate queued Auto-Pick runs after the operator turns the feature off.

--- a/docs/intent/auto-pick-queue/auto-pick-queue-specs.md
+++ b/docs/intent/auto-pick-queue/auto-pick-queue-specs.md
@@ -1,0 +1,15 @@
+# EARS Specs: Auto-Pick Queue
+
+> Testable claims for Auto-Pick queue seeding and draining. Status markers:
+> `[x]` implemented · `[ ]` active gap · `[D]` deferred.
+> Each ID is a grep target across specs, tests, and code (`grep -r AUTO-PICK-QUEUE-001`).
+
+## Toggle Lifecycle
+
+- [x] **AUTO-PICK-QUEUE-001** — When a project has Auto-Pick disabled, the
+  system SHALL cancel that project's queued Auto-Pick agent runs, including
+  automatic `enhance_issue` recheck runs, so they are removed from scheduler
+  and dashboard upcoming-queue views, while leaving manual and non-queued runs
+  unchanged.
+  *Tests:* `spec/models/project_spec.rb`, `spec/services/issues/enqueue_eligible_spec.rb`.
+  *Code:* `Project#cancel_queued_auto_pick_runs`, `Issues::EnqueueEligible#call`.

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -778,11 +778,37 @@ RSpec.describe Project do
     end
 
     it "does not bulk seed when auto_pick is disabled" do
+      # @spec AUTO-PICK-QUEUE-001
       project = create(:project, auto_pick_enabled: true)
 
       project.update!(auto_pick_enabled: false)
 
       expect(Issues::BulkEnqueueEligible).not_to have_received(:call)
+    end
+
+    it "cancels queued auto-pick runs when auto_pick is disabled" do
+      # @spec AUTO-PICK-QUEUE-001
+      project = create(:project, auto_pick_enabled: true)
+      queued_auto_pick = create(:agent_run, :queued, project: project, auto_pick: true, trigger_type: "automatic")
+      claimed_auto_pick = create(:agent_run, :queued, project: project, auto_pick: true, trigger_type: "automatic", temporal_workflow_id: "claimed")
+      automatic_enhance_issue = create(:agent_run, :queued, :enhance_issue_goal, project: project, auto_pick: false, trigger_type: "automatic")
+      manual_enhance_issue = create(:agent_run, :queued, :enhance_issue_goal, :manual, project: project, auto_pick: false)
+      running_auto_pick = create(:agent_run, :running, project: project, auto_pick: true, trigger_type: "automatic")
+      manual_run = create(:agent_run, :queued, :manual, project: project, auto_pick: false)
+      other_project_run = create(:agent_run, :queued, auto_pick: true, trigger_type: "automatic")
+
+      expect {
+        project.update!(auto_pick_enabled: false)
+      }.to have_enqueued_job(LiveDashboardBroadcastJob)
+        .with(project.account_id, queued_auto_pick.id, refresh_queue_preview: true)
+
+      expect(queued_auto_pick.reload).to have_attributes(status: "cancelled", error_message: "Auto-Pick disabled for project")
+      expect(claimed_auto_pick.reload.status).to eq("cancelled")
+      expect(automatic_enhance_issue.reload.status).to eq("cancelled")
+      expect(manual_enhance_issue.reload.status).to eq("queued")
+      expect(running_auto_pick.reload.status).to eq("running")
+      expect(manual_run.reload.status).to eq("queued")
+      expect(other_project_run.reload.status).to eq("queued")
     end
 
     it "does not bulk seed when other attributes change" do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -748,10 +748,12 @@ RSpec.describe Project do
 
   describe "after_update_commit on auto_pick_enabled change" do
     let(:temporal_client) { instance_double(Temporalio::Client) }
+    let(:workflow_handle) { double("workflow_handle", cancel: true) } # rubocop:disable RSpec/VerifiedDoubles
 
     before do
       allow(Paid).to receive_messages(temporal_client: temporal_client, poll_task_queue: "paid-poll-tasks")
       allow(temporal_client).to receive(:start_workflow)
+      allow(temporal_client).to receive(:workflow_handle).and_return(workflow_handle)
       allow(Issues::BulkEnqueueEligible).to receive(:call)
     end
 
@@ -797,18 +799,40 @@ RSpec.describe Project do
       manual_run = create(:agent_run, :queued, :manual, project: project, auto_pick: false)
       other_project_run = create(:agent_run, :queued, auto_pick: true, trigger_type: "automatic")
 
-      expect {
-        project.update!(auto_pick_enabled: false)
-      }.to have_enqueued_job(LiveDashboardBroadcastJob)
-        .with(project.account_id, queued_auto_pick.id, refresh_queue_preview: true)
+      project.update!(auto_pick_enabled: false)
 
       expect(queued_auto_pick.reload).to have_attributes(status: "cancelled", error_message: "Auto-Pick disabled for project")
-      expect(claimed_auto_pick.reload.status).to eq("cancelled")
+      expect(claimed_auto_pick.reload).to have_attributes(status: "cancelled", error_message: "Auto-Pick disabled for project")
       expect(automatic_enhance_issue.reload.status).to eq("cancelled")
       expect(manual_enhance_issue.reload.status).to eq("queued")
       expect(running_auto_pick.reload.status).to eq("running")
       expect(manual_run.reload.status).to eq("queued")
       expect(other_project_run.reload.status).to eq("queued")
+    end
+
+    it "cancels the Temporal workflow of a claimed queued auto-pick run when auto_pick is disabled" do
+      # @spec AUTO-PICK-QUEUE-001
+      project = create(:project, auto_pick_enabled: true)
+      create(:agent_run, :queued, project: project, auto_pick: true, trigger_type: "automatic", temporal_workflow_id: "claimed")
+
+      project.update!(auto_pick_enabled: false)
+
+      expect(temporal_client).to have_received(:workflow_handle).with("claimed")
+      expect(workflow_handle).to have_received(:cancel)
+    end
+
+    it "enqueues a live dashboard broadcast for each cancelled queued auto-pick run when auto_pick is disabled" do
+      # @spec AUTO-PICK-QUEUE-001
+      project = create(:project, auto_pick_enabled: true)
+      queued_auto_pick = create(:agent_run, :queued, project: project, auto_pick: true, trigger_type: "automatic")
+      claimed_auto_pick = create(:agent_run, :queued, project: project, auto_pick: true, trigger_type: "automatic", temporal_workflow_id: "claimed")
+
+      expect {
+        project.update!(auto_pick_enabled: false)
+      }.to have_enqueued_job(LiveDashboardBroadcastJob)
+        .with(project.account_id, queued_auto_pick.id, refresh_queue_preview: true)
+        .and have_enqueued_job(LiveDashboardBroadcastJob)
+        .with(project.account_id, claimed_auto_pick.id, refresh_queue_preview: true)
     end
 
     it "does not bulk seed when other attributes change" do

--- a/spec/services/issues/enqueue_eligible_spec.rb
+++ b/spec/services/issues/enqueue_eligible_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
   end
 
   def project_class
-    @project_class ||= Struct.new(:id) do
+    @project_class ||= Struct.new(:id, :auto_pick_enabled?) do
       def auto_enhance_enabled? = false
       def model_preferences
         @model_preferences ||= {}
@@ -45,6 +45,7 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
   let(:service) { described_class.new(issue, project: project) }
 
   before do
+    allow(project).to receive_messages(auto_pick_enabled?: true, model_preferences: {})
     allow(Issues::AutoPickProjectGate).to receive(:call).with(project).and_return(true)
     allow(Automation::Strategies::AutoPick::DefaultCandidateSource).to receive(:eligible_scope)
       .with(project)
@@ -52,7 +53,6 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
     allow(eligible_scope).to receive(:where).with(id: issue.id).and_return(issue_scope)
     allow(service).to receive(:blocking_runs).with("create_pr").and_return(create_pr_blocking_runs)
     allow(service).to receive(:blocking_runs).with("analyze_issue").and_return(analyze_issue_blocking_runs)
-    allow(project).to receive(:model_preferences).and_return({})
   end
 
   def build_run(id:, previously_new_record:)
@@ -198,6 +198,21 @@ RSpec.describe Issues::EnqueueEligible, :no_db do
     allow(Rails.logger).to receive(:info)
 
     result = service.call
+
+    expect(result).to be_nil
+    expect(Rails.logger).to have_received(:info).with(
+      hash_including(message: "enqueue_eligible.project_deferred", issue_id: issue.id, project_id: project.id)
+    )
+    expect(eligible_scope).not_to have_received(:where)
+  end
+
+  it "returns nil when auto-pick is disabled even if the caller skips the project gate" do
+    # @spec AUTO-PICK-QUEUE-001
+    allow(project).to receive(:auto_pick_enabled?).and_return(false)
+    skipped_service = described_class.new(issue, project: project, skip_project_gate: true)
+    allow(Rails.logger).to receive(:info)
+
+    result = skipped_service.call
 
     expect(result).to be_nil
     expect(Rails.logger).to have_received(:info).with(


### PR DESCRIPTION
## Summary

- Cancel queued Auto-Pick agent runs when a project has Auto-Pick disabled so they leave scheduler and dashboard queue views.
- Prevent stale Auto-Pick enqueue paths from creating new queued runs after the project toggle is off.
- Add the Auto-Pick queue LID segment and specs tying the behavior to `AUTO-PICK-QUEUE-001`.

## Root Cause

Disabling Auto-Pick stopped future project-gated picks, but existing queued Auto-Pick runs remained queued and visible in the Upcoming Queue. Some enqueue paths could also bypass the broader project gate after earlier eligibility checks, so stale work could recreate queued Auto-Pick runs after the operator disabled the feature.

## Validation

- `bin/rspec spec/models/project_spec.rb spec/services/issues/enqueue_eligible_spec.rb spec/services/issues/bulk_enqueue_eligible_spec.rb`
- `bin/rubocop app/models/project.rb app/services/issues/enqueue_eligible.rb spec/models/project_spec.rb spec/services/issues/enqueue_eligible_spec.rb`
- `bin/coherence-check.mjs`
- `git diff --check`

Note: `bin/coherence-check.mjs` still reports two pre-existing reverse-orphan `@spec` warnings (`A-Z0-9`, `LID-RUN-001`) unrelated to this change.