### PR TITLE
fix(chat): restore ActionCable auth and recover stuck streaming state

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -4,6 +4,15 @@ module ApplicationCable
   class Connection < ActionCable::Connection::Base
     identified_by :current_user
 
+    # Cookie read by the connection to authorize the websocket. ActionCable
+    # serves connections from Rails.application.env_config, which carries the
+    # cookie-jar configuration but NOT the Warden/session middleware (env_config
+    # has neither "warden" nor "rack.session"). So request.env["warden"] is
+    # always nil here and request.session is empty — the connection cannot use
+    # Devise's warden proxy to identify the subscriber. ApplicationController
+    # stamps this encrypted cookie on every authenticated request instead.
+    CABLE_USER_COOKIE = :cable_user_id
+
     def connect
       self.current_user = find_verified_user
     end
@@ -11,12 +20,19 @@ module ApplicationCable
     private
 
     def find_verified_user
-      user_id = request.env["warden"]&.user&.id
-      if user_id && (user = User.find_by(id: user_id))
-        user
-      else
-        reject_unauthorized_connection
-      end
+      user = request.env["warden"]&.user || user_from_cable_cookie
+      user || reject_unauthorized_connection
+    end
+
+    def user_from_cable_cookie
+      user_id = cookies.encrypted[CABLE_USER_COOKIE]
+      return unless user_id
+
+      # The connection runs outside ApplicationController, so no tenant context
+      # is set and the RLS-scoped users table hides every row. Bypass RLS to
+      # resolve the user the encrypted cookie identifies; channel actions
+      # establish their own tenant context for the actual work.
+      TenantContext.with_system_access { User.find_by(id: user_id) }
     end
   end
 end

--- a/app/channels/chat_channel.rb
+++ b/app/channels/chat_channel.rb
@@ -18,7 +18,11 @@ class ChatChannel < ApplicationCable::Channel
   def send_message(data)
     return unless @chat_session
 
-    TenantContext.with(current_user.account) do
+    # ActionCable channels run outside ApplicationController; TenantContext.with
+    # does not propagate the RLS session variable to the query connection here,
+    # so role/rate-limit lookups silently come back empty. Bypass RLS and rely
+    # on the explicit checks below (Pundit policy + account-scoped session).
+    TenantContext.with_system_access do
       content = data["content"].to_s
       return if content.blank?
       return transmit_event("error", { message: "You are not authorized to send messages" }) unless authorized_to_send_messages?
@@ -44,7 +48,7 @@ class ChatChannel < ApplicationCable::Channel
   def resolve_tool_call(data)
     return unless @chat_session
 
-    TenantContext.with(current_user.account) do
+    TenantContext.with_system_access do
       decision = data["decision"].to_s
       message = @chat_session.messages.find_by(id: data["message_id"])
       return transmit_event("error", { message: "Pending tool call not found" }) unless message
@@ -70,8 +74,8 @@ class ChatChannel < ApplicationCable::Channel
   private
 
   def find_session
-    TenantContext.with(current_user.account) do
-      ChatSession.where(account: current_user.account)
+    TenantContext.with_system_access do
+      ChatSession.where(account_id: current_user.account_id)
         .find_by(id: params[:session_id])
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,7 @@ class ApplicationController < ActionController::Base
 
   around_action :with_current_attributes, prepend: true
   before_action :authenticate_user!
+  before_action :stamp_cable_auth_cookie, if: :user_signed_in?
   after_action :verify_authorized, unless: :skip_pundit?
   after_action :verify_policy_scoped, if: :verify_policy_scoped?
 
@@ -42,6 +43,20 @@ class ApplicationController < ActionController::Base
     Current.account
   end
   helper_method :current_account
+
+  # ActionCable websocket requests bypass the Warden/session middleware, so the
+  # connection can't read request.env["warden"]. Stamp an encrypted user-id
+  # cookie on every authenticated request so ApplicationCable::Connection can
+  # authorize the subscriber (see app/channels/application_cable/connection.rb).
+  # httponly denies JS access (defense vs. XSS exfiltration); secure scopes it
+  # to HTTPS where the app enforces SSL.
+  def stamp_cable_auth_cookie
+    cookies.encrypted[ApplicationCable::Connection::CABLE_USER_COOKIE] = {
+      value: current_user.id,
+      httponly: true,
+      secure: Rails.application.config.force_ssl
+    }
+  end
 
   def feature_enabled?(flag_name, project: nil)
     FeatureFlags.enabled?(flag_name, project:)

--- a/app/javascript/controllers/chat_controller.js
+++ b/app/javascript/controllers/chat_controller.js
@@ -14,9 +14,9 @@ export default class extends Controller {
     this.subscription = consumer.subscriptions.create(
       { channel: "ChatChannel", session_id: this.sessionIdValue },
       {
-        connected: () => this.setStatus("Connected"),
-        disconnected: () => this.setStatus("Disconnected"),
-        rejected: () => this.setStatus("Subscription rejected"),
+        connected: () => this.handleConnected(),
+        disconnected: () => this.handleDisconnected(),
+        rejected: () => this.handleRejected(),
         received: (data) => this.handleEvent(data)
       }
     )
@@ -24,6 +24,40 @@ export default class extends Controller {
 
   disconnect() {
     this.subscription?.unsubscribe()
+  }
+
+  // A dropped/rejected connection mid-turn strands the streaming lock: the
+  // terminators that normally release it (message_complete / error /
+  // message_tool_confirmation) travel over the socket we just lost, so any
+  // emitted during the gap are gone. Without recovery, `sendMessage` no-ops
+  // forever (it guards on `streaming`) and the only escape is a page reload.
+  // Reset on disconnect/reconnect/reject so the input recovers. No-op when no
+  // turn is in flight, so stable connections and the initial connect — where
+  // dispatching chat:idle would also auto-focus the textarea — are unaffected.
+  handleConnected() {
+    this.resetStreamingState()
+    this.setStatus("Connected")
+  }
+
+  handleDisconnected() {
+    this.resetStreamingState()
+    this.setStatus("Disconnected")
+  }
+
+  handleRejected() {
+    this.resetStreamingState()
+    this.setStatus("Subscription rejected")
+  }
+
+  resetStreamingState() {
+    if (!this.streaming) return
+
+    this.removePendingAssistantMessage()
+    this.streaming = false
+    this.currentStreamId = null
+    this.currentAttemptToolCards = []
+    this.toggleTyping(false)
+    this.dispatchChatState("chat:idle")
   }
 
   sendMessage(event) {

--- a/spec/channels/application_cable/connection_spec.rb
+++ b/spec/channels/application_cable/connection_spec.rb
@@ -2,19 +2,33 @@
 
 require "rails_helper"
 
-RSpec.describe ApplicationCable::Connection do
-  let(:account) { create(:account) }
-  let(:user) { create(:user, account: account) }
+# Exercises the REAL ApplicationCable::Connection authorization (no stubbing of
+# current_user). This is the coverage that was missing: spec/channels/chat_channel_spec
+# uses `stub_connection current_user: ...`, so a regression in connection auth
+# (e.g. relying on request.env["warden"], which ActionCable websocket requests
+# do not carry) would not surface there.
+RSpec.describe ApplicationCable::Connection, type: :channel do
+  let(:user) { create(:user) }
 
-  it "connects with the current user from warden" do
-    connect "/cable", env: { "warden" => instance_double(Warden::Proxy, user: user) }
+  it "authorizes the connection when the cable auth cookie is present and valid" do
+    cookies.encrypted[described_class::CABLE_USER_COOKIE] = user.id
+
+    connect
 
     expect(connection.current_user).to eq(user)
   end
 
-  it "rejects connections without a signed-in user" do
+  it "rejects the connection when the cookie is absent" do
     expect {
-      connect "/cable", env: { "warden" => instance_double(Warden::Proxy, user: nil) }
-    }.to have_rejected_connection
+      connect
+    }.to raise_error(ActionCable::Connection::Authorization::UnauthorizedError)
+  end
+
+  it "rejects the connection when the cookie references a nonexistent user" do
+    cookies.encrypted[described_class::CABLE_USER_COOKIE] = User.maximum(:id).to_i + 1
+
+    expect {
+      connect
+    }.to raise_error(ActionCable::Connection::Authorization::UnauthorizedError)
   end
 end

--- a/spec/jobs/chat_sessions/process_message_job_spec.rb
+++ b/spec/jobs/chat_sessions/process_message_job_spec.rb
@@ -258,6 +258,34 @@ RSpec.describe ChatSessions::ProcessMessageJob, type: :job do
       .with(hash_including(type: "error", message: "An unexpected error occurred"))
   end
 
+  # Exercises the REAL SendMessage service (not mocked) through the job with a
+  # streaming LLM client, asserting the complete broadcast contract a
+  # ChatChannel subscriber depends on to render a reply. This is the path the
+  # chat UI uses; the per-example mocks above stub SendMessage entirely and so
+  # cannot detect a regression in the streaming/broadcast wiring.
+  it "broadcasts the full streaming sequence with chunk content and rendered html" do
+    allow(ChatSessions::BuildLlmClient).to receive(:call).and_return(streaming_llm_client)
+
+    expect {
+      described_class.perform_now(
+        chat_session_id: chat_session.id,
+        content: "hi",
+        stream_message_id: stream_message_id
+      )
+    }.to have_broadcasted_to(stream_name)
+      .with(hash_including(type: "message_start", message_id: stream_message_id))
+      .and have_broadcasted_to(stream_name)
+      .with(hash_including(type: "message_chunk", message_id: stream_message_id, content: "Hello "))
+      .and have_broadcasted_to(stream_name)
+      .with(hash_including(type: "message_chunk", message_id: stream_message_id, content: "there!"))
+      .and have_broadcasted_to(stream_name)
+      .with(hash_including(type: "message_created", role: "assistant",
+        stream_message_id: stream_message_id, html: include("Hello there!")))
+      .and have_broadcasted_to(stream_name)
+      .with(hash_including(type: "message_complete", message_id: stream_message_id,
+        tokens: { input: 10, output: 5 }))
+  end
+
   it "broadcasts error and discards on missing session" do
     expect {
       described_class.perform_now(
@@ -272,6 +300,18 @@ RSpec.describe ChatSessions::ProcessMessageJob, type: :job do
     Class.new do
       def call(*)
         raise AgentHarness::RateLimitError, "API rate limit exceeded"
+      end
+    end.new
+  end
+
+  # A streaming client that emits two chunks then returns a final assistant
+  # response, exercising the real AgentLoop chunk path through the job.
+  def streaming_llm_client
+    Class.new do
+      def call(_conversation, on_chunk: nil)
+        on_chunk&.call("Hello ")
+        on_chunk&.call("there!")
+        { content: "Hello there!", tool_calls: [], tokens_input: 10, tokens_output: 5, model: "gpt-4o" }
       end
     end.new
   end


### PR DESCRIPTION
## Summary

Chat was completely unusable: sending a message left the UI stuck on "Waiting for assistant…", the sender's own message never rendered, and empty sessions got reaped by the idle cleaner. This restores end-to-end chat over ActionCable.

## Root cause (three layers, all in the cable path)

1. **Connection auth** — ActionCable serves websocket connections from `Rails.application.env_config`, which carries the cookie-jar config but **not** the Warden/session middleware. `find_verified_user` read `request.env["warden"]`, which is always nil on the socket, so **every** connection was rejected as `{"type":"disconnect","reason":"unauthorized","reconnect":false}`.
2. **Connection user lookup** — even with the cookie fix, `User.find_by` returned nil because the cable connection runs outside `ApplicationController` (no tenant context → RLS hides the row).
3. **Channel subscription + send auth** — `TenantContext.with(account)` does **not** propagate the RLS session variable in the ActionCable worker thread, so `find_session` and the Pundit role lookup came back empty → `reject_subscription`, then "You are not authorized to send messages".

Layers 2–3 only surface against the live server — the existing specs stub the connection (`stub_connection current_user:`) and don't replicate the cable thread's RLS behavior, so the regression had no automated guard.

## Fix

- `application_cable/connection.rb` — authorize via an encrypted `cable_user_id` cookie stamped on every signed-in request (`httponly: true`, `secure` under `force_ssl`); resolve the user under `TenantContext.with_system_access`.
- `application_controller.rb` — `before_action` stamps the cookie when signed in.
- `chat_channel.rb` — `find_session` / `send_message` / `resolve_tool_call` use `with_system_access`; `find_session` explicitly scopes by `current_user.account_id`. Isolation is preserved (explicit scope + Pundit), and the actual LLM work still runs in `ProcessMessageJob` under its own tenant context.
- `chat_controller.js` — release the latched "streaming" lock when the cable connection drops/reconnects/is rejected mid-turn, so a turn that never reaches a terminator no longer permanently disables the input.

## Tests

- `spec/channels/application_cable/connection_spec.rb` — real (non-stubbed) connection auth: authorizes with a valid cookie, rejects when absent / user missing. Fails against the prior warden-only code.
- `spec/jobs/chat_sessions/process_message_job_spec.rb` — streaming-broadcast contract (real `SendMessage` → job → asserts chunk contents + rendered html + token totals).

## Verification

Driven a real browser (Playwright) against the restarted dev server: `ChatChannel` `confirm_subscription` (was `reject_subscription`), `send_message` accepted, `message_start model: glm-5.1` streamed back, user message + assistant response both rendered.

## Known limitation (follow-up)

The `cable_user_id` cookie is session-scoped (clears on browser close) but is **not** explicitly invalidated on sign-out — `CookieJar#delete` no-ops when the cookie isn't in the incoming request jar, and a `Users::SessionsController` override surfaced a Devise error. Both attempts were reverted to avoid shipping unverified auth code. Channel actions remain Pundit-gated, so the residual exposure is a stale subscription for a logged-out user on an un-closed browser. Proper sign-out invalidation (e.g., a session-bound token validated on connect) is left as a follow-up.

Draft while review/verification continues.
