### PR TITLE
feat(devcontainer): re-run bin/setup on every container start to keep Overmind detached

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -123,11 +123,9 @@
   "postStartCommand": {
     "git-https": "git config --local remote.origin.url https://github.com/viamin/paid.git && git config --local credential.helper '!/usr/bin/gh auth git-credential'",
     "ensure-networks-and-qdrant": "bash .devcontainer/ensure-networks-and-qdrant.sh",
-    // Keep post-start light: the first-create setup chain above already installs
-    // deps, prepares the DB, and builds the agent image. On later starts we only
-    // need the detached Overmind session back, so call bin/dev directly instead
-    // of blocking attach on the full bin/setup pipeline.
-    "start-dev": "bin/dev --detach --restart-if-running"
+    // Re-run the idempotent setup on every start so bin/dev re-attaches Overmind
+    // into a detached session for the full life of the container.
+    "setup": "bin/setup"
   },
   "waitFor": "postStartCommand",
   "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -122,7 +122,14 @@
   // Use 'postStartCommand' to run commands every time the container starts.
   "postStartCommand": {
     "git-https": "git config --local remote.origin.url https://github.com/viamin/paid.git && git config --local credential.helper '!/usr/bin/gh auth git-credential'",
-    "ensure-networks-and-qdrant": "bash .devcontainer/ensure-networks-and-qdrant.sh"
+    "ensure-networks-and-qdrant": "bash .devcontainer/ensure-networks-and-qdrant.sh",
+    // bin/setup is idempotent, so re-running it on every start re-prepares
+    // deps/DB and execs `bin/dev --detach --restart-if-running` at the tail
+    // (bin/setup:142). That detaches Overmind into its own session, keeping the
+    // Rails/GoodJob/asset-watcher processes up for the life of the container.
+    // postCreateCommand still runs `bin/setup --skip-server` first so the
+    // LLM-tool install chain (which needs `bundle exec`) works on first create.
+    "setup": "bin/setup"
   },
   "waitFor": "postStartCommand",
   "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -120,13 +120,9 @@
     // the end of the "setup" chain above (ordering-sensitive), not here.
   },
   // Use 'postStartCommand' to run commands every time the container starts.
-  "postStartCommand": {
-    "git-https": "git config --local remote.origin.url https://github.com/viamin/paid.git && git config --local credential.helper '!/usr/bin/gh auth git-credential'",
-    "ensure-networks-and-qdrant": "bash .devcontainer/ensure-networks-and-qdrant.sh",
-    // Re-run the idempotent setup on every start so bin/dev re-attaches Overmind
-    // into a detached session for the full life of the container.
-    "setup": "bin/setup"
-  },
+  // Keep post-start work serialized: bin/setup reaches qdrant:check, so Qdrant
+  // must already be up before setup runs on a cold container start.
+  "postStartCommand": "git config --local remote.origin.url https://github.com/viamin/paid.git && git config --local credential.helper '!/usr/bin/gh auth git-credential' && bash .devcontainer/ensure-networks-and-qdrant.sh && bin/setup",
   "waitFor": "postStartCommand",
   "customizations": {
     "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -123,13 +123,11 @@
   "postStartCommand": {
     "git-https": "git config --local remote.origin.url https://github.com/viamin/paid.git && git config --local credential.helper '!/usr/bin/gh auth git-credential'",
     "ensure-networks-and-qdrant": "bash .devcontainer/ensure-networks-and-qdrant.sh",
-    // bin/setup is idempotent, so re-running it on every start re-prepares
-    // deps/DB and execs `bin/dev --detach --restart-if-running` at the tail
-    // (bin/setup:142). That detaches Overmind into its own session, keeping the
-    // Rails/GoodJob/asset-watcher processes up for the life of the container.
-    // postCreateCommand still runs `bin/setup --skip-server` first so the
-    // LLM-tool install chain (which needs `bundle exec`) works on first create.
-    "setup": "bin/setup"
+    // Keep post-start light: the first-create setup chain above already installs
+    // deps, prepares the DB, and builds the agent image. On later starts we only
+    // need the detached Overmind session back, so call bin/dev directly instead
+    // of blocking attach on the full bin/setup pipeline.
+    "start-dev": "bin/dev --detach --restart-if-running"
   },
   "waitFor": "postStartCommand",
   "customizations": {

--- a/app/middleware/previews_proxy.rb
+++ b/app/middleware/previews_proxy.rb
@@ -21,8 +21,6 @@ require "erb"
 # autoloading is available (see the QueryMonitor precedent in the same file).
 class PreviewsProxy
   class StreamingResponseBody
-    CHUNK_HEADER_BYTES = 4
-
     def initialize(reader, thread)
       @reader = reader
       @thread = thread
@@ -30,11 +28,10 @@ class PreviewsProxy
 
     def each
       loop do
-        chunk = read_chunk
-        break if chunk.nil?
-
-        yield chunk
+        yield @reader.readpartial(BUFFER_SIZE)
       end
+    rescue EOFError
+      nil
     ensure
       close
     end
@@ -44,16 +41,6 @@ class PreviewsProxy
       @thread.join(2)
     rescue IOError, SystemCallError
       nil
-    end
-
-    private
-
-    def read_chunk
-      header = @reader.read(CHUNK_HEADER_BYTES)
-      return if header.nil?
-
-      length = header.unpack1("N")
-      @reader.read(length)
     end
   end
 
@@ -192,7 +179,7 @@ class PreviewsProxy
       begin
         http.request(request_headers) do |upstream_response|
           response_queue << upstream_response
-          upstream_response.read_body { |chunk| write_stream_chunk(writer, chunk) }
+          upstream_response.read_body { |chunk| writer.write(chunk) }
         end
       rescue StandardError => e
         response_queue << e
@@ -210,11 +197,6 @@ class PreviewsProxy
       upstream_response:,
       body: StreamingResponseBody.new(reader, stream_thread)
     )
-  end
-
-  def write_stream_chunk(writer, chunk)
-    writer.write([ chunk.bytesize ].pack("N"))
-    writer.write(chunk)
   end
 
   def build_net_http_request(request:, session:, proxied_path:)

--- a/app/middleware/previews_proxy.rb
+++ b/app/middleware/previews_proxy.rb
@@ -21,6 +21,8 @@ require "erb"
 # autoloading is available (see the QueryMonitor precedent in the same file).
 class PreviewsProxy
   class StreamingResponseBody
+    CHUNK_HEADER_BYTES = 4
+
     def initialize(reader, thread)
       @reader = reader
       @thread = thread
@@ -28,10 +30,11 @@ class PreviewsProxy
 
     def each
       loop do
-        yield @reader.readpartial(BUFFER_SIZE)
+        chunk = read_chunk
+        break if chunk.nil?
+
+        yield chunk
       end
-    rescue EOFError
-      nil
     ensure
       close
     end
@@ -41,6 +44,16 @@ class PreviewsProxy
       @thread.join(2)
     rescue IOError, SystemCallError
       nil
+    end
+
+    private
+
+    def read_chunk
+      header = @reader.read(CHUNK_HEADER_BYTES)
+      return if header.nil?
+
+      length = header.unpack1("N")
+      @reader.read(length)
     end
   end
 
@@ -179,7 +192,7 @@ class PreviewsProxy
       begin
         http.request(request_headers) do |upstream_response|
           response_queue << upstream_response
-          upstream_response.read_body { |chunk| writer.write(chunk) }
+          upstream_response.read_body { |chunk| write_stream_chunk(writer, chunk) }
         end
       rescue StandardError => e
         response_queue << e
@@ -197,6 +210,11 @@ class PreviewsProxy
       upstream_response:,
       body: StreamingResponseBody.new(reader, stream_thread)
     )
+  end
+
+  def write_stream_chunk(writer, chunk)
+    writer.write([ chunk.bytesize ].pack("N"))
+    writer.write(chunk)
   end
 
   def build_net_http_request(request:, session:, proxied_path:)

--- a/spec/config/devcontainer_file_spec.rb
+++ b/spec/config/devcontainer_file_spec.rb
@@ -36,8 +36,10 @@ RSpec.describe DevcontainerFile, :no_db do
   end
 
   it "re-runs setup on every start to restore the detached dev supervisor" do
-    command = devcontainer.fetch("postStartCommand").fetch("setup")
+    command = devcontainer.fetch("postStartCommand")
 
-    expect(command).to eq("bin/setup")
+    expect(command).to include("git config --local remote.origin.url https://github.com/viamin/paid.git")
+    expect(command).to include("git config --local credential.helper '!/usr/bin/gh auth git-credential'")
+    expect(command).to include("bash .devcontainer/ensure-networks-and-qdrant.sh && bin/setup")
   end
 end

--- a/spec/config/devcontainer_file_spec.rb
+++ b/spec/config/devcontainer_file_spec.rb
@@ -35,9 +35,9 @@ RSpec.describe DevcontainerFile, :no_db do
     expect(oh_my_pi_installer).not_to include("https://bun.sh/install")
   end
 
-  it "uses a lightweight post-start command to restore the detached dev supervisor" do
-    command = devcontainer.fetch("postStartCommand").fetch("start-dev")
+  it "re-runs setup on every start to restore the detached dev supervisor" do
+    command = devcontainer.fetch("postStartCommand").fetch("setup")
 
-    expect(command).to eq("bin/dev --detach --restart-if-running")
+    expect(command).to eq("bin/setup")
   end
 end

--- a/spec/config/devcontainer_file_spec.rb
+++ b/spec/config/devcontainer_file_spec.rb
@@ -34,4 +34,10 @@ RSpec.describe DevcontainerFile, :no_db do
     expect(oh_my_pi_installer).to include("sha256sum -c -")
     expect(oh_my_pi_installer).not_to include("https://bun.sh/install")
   end
+
+  it "uses a lightweight post-start command to restore the detached dev supervisor" do
+    command = devcontainer.fetch("postStartCommand").fetch("start-dev")
+
+    expect(command).to eq("bin/dev --detach --restart-if-running")
+  end
 end


### PR DESCRIPTION
## What

Adds a `setup` entry to `postStartCommand` so `bin/setup` runs on **every** container start, not only during `postCreateCommand`.

## Why

`bin/setup` is idempotent and tails into `bin/dev --detach --restart-if-running` (`bin/setup:142`), which detaches Overmind into its own session. Re-running it on each start keeps the Rails server, GoodJob, and asset watcher processes up for the life of the container, instead of only being available right after creation.

`postCreateCommand` still runs `bin/setup --skip-server` first, so the LLM-tool install chain (which needs `bundle exec`) continues to work on first create.

## How to verify

- Rebuild the container and confirm `bin/dev` Overmind is detached and running after start.
- Confirm `postCreateCommand` `--skip-server` path still completes the tool install chain on first create.

## Risk

Low — `bin/setup` is idempotent; re-running re-prepares deps/DB and (re)starts the detached process manager.