### PR TITLE
fix(chat): require confirmation for issue write tools

### DIFF
--- a/app/mcp/tools/create_issue.rb
+++ b/app/mcp/tools/create_issue.rb
@@ -30,13 +30,20 @@ module Tools
             type: "array",
             items: { type: "string" },
             description: "GitHub usernames to assign"
+          },
+          confirmed: {
+            type: "boolean",
+            description: "Must be true to execute this write operation"
           }
         },
-        required: %w[project_id title]
+        required: %w[project_id title confirmed]
       }
     end
 
-    def perform(project_id:, title:, body: "", labels: [], assignees: [])
+    # @spec CHAT-TOOL-CONFIRMATION-001
+    def perform(project_id:, title:, confirmed: false, body: "", labels: [], assignees: [])
+      raise ArgumentError, "Confirmation required: set confirmed=true to create an issue" unless confirmed
+
       project = project_for(project_id)
       client = require_github_client!(project)
       repo = project.full_name

--- a/app/mcp/tools/edit_issue.rb
+++ b/app/mcp/tools/edit_issue.rb
@@ -34,13 +34,20 @@ module Tools
             type: "array",
             items: { type: "string" },
             description: "New assignees (replaces all existing)"
+          },
+          confirmed: {
+            type: "boolean",
+            description: "Must be true to execute this write operation"
           }
         },
-        required: %w[project_id issue_number]
+        required: %w[project_id issue_number confirmed]
       }
     end
 
-    def perform(project_id:, issue_number:, title: nil, body: nil, state: nil, labels: nil, assignees: nil)
+    # @spec CHAT-TOOL-CONFIRMATION-001
+    def perform(project_id:, issue_number:, confirmed: false, title: nil, body: nil, state: nil, labels: nil, assignees: nil)
+      raise ArgumentError, "Confirmation required: set confirmed=true to edit an issue" unless confirmed
+
       project = project_for(project_id)
       client = require_github_client!(project)
       repo = project.full_name

--- a/app/mcp/tools/set_labels.rb
+++ b/app/mcp/tools/set_labels.rb
@@ -24,13 +24,20 @@ module Tools
             type: "array",
             items: { type: "string" },
             description: "Complete desired label set"
+          },
+          confirmed: {
+            type: "boolean",
+            description: "Must be true to execute this write operation"
           }
         },
-        required: %w[project_id issue_number labels]
+        required: %w[project_id issue_number labels confirmed]
       }
     end
 
-    def perform(project_id:, issue_number:, labels:)
+    # @spec CHAT-TOOL-CONFIRMATION-001
+    def perform(project_id:, issue_number:, labels:, confirmed: false)
+      raise ArgumentError, "Confirmation required: set confirmed=true to set issue labels" unless confirmed
+
       project = project_for(project_id)
       client = require_github_client!(project)
       repo = project.full_name

--- a/app/services/github_client.rb
+++ b/app/services/github_client.rb
@@ -333,7 +333,7 @@ class GithubClient
   # @param repo [String] Repository in "owner/name" format
   # @return [Array<Sawyer::Resource>] List of labels
   def labels(repo)
-    handle_errors { client.labels(repo) }
+    handle_errors { with_auto_paginate { client.labels(repo, per_page: 100) } }
   end
 
   # Creates a label on a repository.

--- a/docs/intent/chat-tool-confirmation/chat-tool-confirmation-design.md
+++ b/docs/intent/chat-tool-confirmation/chat-tool-confirmation-design.md
@@ -1,0 +1,14 @@
+# Chat Tool Confirmation Design
+
+prefix: CHAT-TOOL-CONFIRMATION
+
+Interactive chat can propose write tools, but the model must not be able to
+self-authorize those mutations. Paid advertises write tools without their
+`confirmed` argument, persists the proposed call as a pending chat message, and
+injects `confirmed: true` only after a human approves the tool call.
+
+Each pre-dispatch GitHub issue write tool (`create_issue`, `edit_issue`, and
+`set_labels`) therefore owns a uniform execution guard: unconfirmed calls fail
+before side effects, while approved chat resolutions and explicit MCP clients
+that pass `confirmed: true` can proceed through normal Pundit authorization and
+tool execution.

--- a/docs/intent/chat-tool-confirmation/chat-tool-confirmation-specs.md
+++ b/docs/intent/chat-tool-confirmation/chat-tool-confirmation-specs.md
@@ -1,0 +1,14 @@
+# Chat Tool Confirmation Specs
+
+> Testable claims for interactive chat write-tool confirmation. Status markers:
+> `[x]` implemented, `[ ]` gap, `[D]` deferred.
+
+- [x] **CHAT-TOOL-CONFIRMATION-001** - A pre-dispatch GitHub issue write tool
+  exposed to chat SHALL require `confirmed: true` at execution time before
+  performing side effects, including GitHub issue creation, issue edits, and
+  label replacement.
+
+  *Tests:* `spec/mcp/tools/create_issue_spec.rb`,
+  `spec/mcp/tools/edit_issue_spec.rb`, `spec/mcp/tools/set_labels_spec.rb`.
+  *Code:* `app/mcp/tools/create_issue.rb#perform`,
+  `app/mcp/tools/edit_issue.rb#perform`, `app/mcp/tools/set_labels.rb#perform`.

--- a/spec/mcp/tools/create_issue_spec.rb
+++ b/spec/mcp/tools/create_issue_spec.rb
@@ -53,8 +53,18 @@ RSpec.describe Tools::CreateIssue do
       ])
     end
 
+    # @spec CHAT-TOOL-CONFIRMATION-001
+    it "raises when not confirmed" do
+      expect do
+        tool.call(project_id: project.id, title: "Test issue", confirmed: false)
+      end.to raise_error(ArgumentError, /Confirmation required/)
+
+      expect(github_client).not_to have_received(:create_issue)
+    end
+
+    # @spec CHAT-TOOL-CONFIRMATION-001
     it "creates an issue and returns number and url" do
-      result = tool.call(project_id: project.id, title: "Test issue", body: "Test body")
+      result = tool.call(project_id: project.id, title: "Test issue", body: "Test body", confirmed: true)
 
       expect(github_client).to have_received(:create_issue).with(
         project.full_name, title: "Test issue", body: "Test body", labels: [], assignees: []
@@ -66,7 +76,7 @@ RSpec.describe Tools::CreateIssue do
     end
 
     it "creates an issue with labels" do
-      result = tool.call(project_id: project.id, title: "Test issue", labels: %w[bug enhancement])
+      result = tool.call(project_id: project.id, title: "Test issue", labels: %w[bug enhancement], confirmed: true)
 
       expect(github_client).to have_received(:create_issue).with(
         project.full_name, title: "Test issue", body: "", labels: %w[bug enhancement], assignees: []
@@ -75,7 +85,7 @@ RSpec.describe Tools::CreateIssue do
     end
 
     it "creates an issue with assignees" do
-      result = tool.call(project_id: project.id, title: "Test issue", assignees: %w[octocat])
+      result = tool.call(project_id: project.id, title: "Test issue", assignees: %w[octocat], confirmed: true)
 
       expect(github_client).to have_received(:create_issue).with(
         project.full_name, title: "Test issue", body: "", labels: [], assignees: %w[octocat]
@@ -85,7 +95,7 @@ RSpec.describe Tools::CreateIssue do
 
     it "records an audit event" do
       expect do
-        tool.call(project_id: project.id, title: "Test issue")
+        tool.call(project_id: project.id, title: "Test issue", confirmed: true)
       end.to change(AccountActivityEvent, :count).by(1)
 
       event = AccountActivityEvent.last
@@ -97,7 +107,7 @@ RSpec.describe Tools::CreateIssue do
 
     it "rejects unknown labels" do
       expect do
-        tool.call(project_id: project.id, title: "Test issue", labels: %w[nonexistent])
+        tool.call(project_id: project.id, title: "Test issue", labels: %w[nonexistent], confirmed: true)
       end.to raise_error(ArgumentError, /Unknown labels: nonexistent/)
     end
 
@@ -105,7 +115,7 @@ RSpec.describe Tools::CreateIssue do
       other_project = create(:project)
 
       expect do
-        tool.call(project_id: other_project.id, title: "Test issue")
+        tool.call(project_id: other_project.id, title: "Test issue", confirmed: true)
       end.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -115,7 +125,7 @@ RSpec.describe Tools::CreateIssue do
       other_tool = described_class.new(user: other_user, session:)
 
       expect do
-        other_tool.call(project_id: project.id, title: "Test issue")
+        other_tool.call(project_id: project.id, title: "Test issue", confirmed: true)
       end.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -123,7 +133,7 @@ RSpec.describe Tools::CreateIssue do
       allow(github_client).to receive(:create_issue).and_raise(GithubClient::Error, "API error")
 
       expect do
-        tool.call(project_id: project.id, title: "Test issue")
+        tool.call(project_id: project.id, title: "Test issue", confirmed: true)
       end.to raise_error(GithubClient::Error, "API error")
     end
 
@@ -131,7 +141,7 @@ RSpec.describe Tools::CreateIssue do
       allow(github_client).to receive(:labels).and_raise(GithubClient::Error, "rate limited")
 
       expect do
-        tool.call(project_id: project.id, title: "Test issue", labels: %w[bug])
+        tool.call(project_id: project.id, title: "Test issue", labels: %w[bug], confirmed: true)
       end.to raise_error(GithubClient::Error, "rate limited")
     end
 
@@ -157,7 +167,8 @@ RSpec.describe Tools::CreateIssue do
         result = tool.call(
           project_id: project.id,
           title: "Test issue",
-          body: "Depends on viamin/foo#42"
+          body: "Depends on viamin/foo#42",
+          confirmed: true
         )
 
         expect(result[:number]).to eq(42)
@@ -180,7 +191,7 @@ RSpec.describe Tools::CreateIssue do
       end
 
       it "creates an issue using the installation credential" do
-        result = tool.call(project_id: project.id, title: "Test issue")
+        result = tool.call(project_id: project.id, title: "Test issue", confirmed: true)
 
         expect(github_client).to have_received(:create_issue).with(
           project.full_name, title: "Test issue", body: "", labels: [], assignees: []

--- a/spec/mcp/tools/edit_issue_spec.rb
+++ b/spec/mcp/tools/edit_issue_spec.rb
@@ -54,8 +54,18 @@ RSpec.describe Tools::EditIssue do
       ])
     end
 
+    # @spec CHAT-TOOL-CONFIRMATION-001
+    it "raises when not confirmed" do
+      expect do
+        tool.call(project_id: project.id, issue_number: 42, title: "Updated title", confirmed: false)
+      end.to raise_error(ArgumentError, /Confirmation required/)
+
+      expect(github_client).not_to have_received(:update_issue)
+    end
+
+    # @spec CHAT-TOOL-CONFIRMATION-001
     it "updates the issue title" do
-      result = tool.call(project_id: project.id, issue_number: 42, title: "Updated title")
+      result = tool.call(project_id: project.id, issue_number: 42, title: "Updated title", confirmed: true)
 
       expect(github_client).to have_received(:update_issue).with(project.full_name, 42, title: "Updated title")
       expect(Issues::UpsertFromGithub).to have_received(:call).with(project:, github_issue: updated_issue)
@@ -63,21 +73,21 @@ RSpec.describe Tools::EditIssue do
     end
 
     it "updates the issue body" do
-      tool.call(project_id: project.id, issue_number: 42, body: "New body")
+      tool.call(project_id: project.id, issue_number: 42, body: "New body", confirmed: true)
 
       expect(github_client).to have_received(:update_issue).with(project.full_name, 42, body: "New body")
       expect(Issues::ParseDependencies).to have_received(:call).with(issue: local_issue)
     end
 
     it "updates the issue state" do
-      tool.call(project_id: project.id, issue_number: 42, state: "closed")
+      tool.call(project_id: project.id, issue_number: 42, state: "closed", confirmed: true)
 
       expect(github_client).to have_received(:update_issue).with(project.full_name, 42, state: "closed")
       expect(Issues::ParseDependencies).not_to have_received(:call)
     end
 
     it "updates multiple fields at once" do
-      tool.call(project_id: project.id, issue_number: 42, title: "X", body: "Y", state: "closed")
+      tool.call(project_id: project.id, issue_number: 42, title: "X", body: "Y", state: "closed", confirmed: true)
 
       expect(github_client).to have_received(:update_issue).with(
         project.full_name, 42, title: "X", body: "Y", state: "closed"
@@ -85,26 +95,26 @@ RSpec.describe Tools::EditIssue do
     end
 
     it "validates labels when present" do
-      tool.call(project_id: project.id, issue_number: 42, labels: %w[bug])
+      tool.call(project_id: project.id, issue_number: 42, labels: %w[bug], confirmed: true)
 
       expect(github_client).to have_received(:update_issue).with(project.full_name, 42, labels: %w[bug])
     end
 
     it "rejects unknown labels" do
       expect do
-        tool.call(project_id: project.id, issue_number: 42, labels: %w[nonexistent])
+        tool.call(project_id: project.id, issue_number: 42, labels: %w[nonexistent], confirmed: true)
       end.to raise_error(ArgumentError, /Unknown labels: nonexistent/)
     end
 
     it "raises when no fields are provided" do
       expect do
-        tool.call(project_id: project.id, issue_number: 42)
+        tool.call(project_id: project.id, issue_number: 42, confirmed: true)
       end.to raise_error(ArgumentError, "No fields to update")
     end
 
     it "records an audit event" do
       expect do
-        tool.call(project_id: project.id, issue_number: 42, title: "Updated title")
+        tool.call(project_id: project.id, issue_number: 42, title: "Updated title", confirmed: true)
       end.to change(AccountActivityEvent, :count).by(1)
 
       event = AccountActivityEvent.last
@@ -119,7 +129,7 @@ RSpec.describe Tools::EditIssue do
       other_project = create(:project)
 
       expect do
-        tool.call(project_id: other_project.id, issue_number: 42, title: "X")
+        tool.call(project_id: other_project.id, issue_number: 42, title: "X", confirmed: true)
       end.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -129,7 +139,7 @@ RSpec.describe Tools::EditIssue do
       other_tool = described_class.new(user: other_user, session:)
 
       expect do
-        other_tool.call(project_id: project.id, issue_number: 42, title: "X")
+        other_tool.call(project_id: project.id, issue_number: 42, title: "X", confirmed: true)
       end.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -137,7 +147,7 @@ RSpec.describe Tools::EditIssue do
       allow(github_client).to receive(:update_issue).and_raise(GithubClient::Error, "API error")
 
       expect do
-        tool.call(project_id: project.id, issue_number: 42, title: "X")
+        tool.call(project_id: project.id, issue_number: 42, title: "X", confirmed: true)
       end.to raise_error(GithubClient::Error, "API error")
     end
 
@@ -145,7 +155,7 @@ RSpec.describe Tools::EditIssue do
       allow(github_client).to receive(:labels).and_raise(GithubClient::Error, "rate limited")
 
       expect do
-        tool.call(project_id: project.id, issue_number: 42, labels: %w[bug])
+        tool.call(project_id: project.id, issue_number: 42, labels: %w[bug], confirmed: true)
       end.to raise_error(GithubClient::Error, "rate limited")
     end
 
@@ -157,7 +167,7 @@ RSpec.describe Tools::EditIssue do
       end
 
       it "edits an issue using the installation credential" do
-        result = tool.call(project_id: project.id, issue_number: 42, title: "Updated title")
+        result = tool.call(project_id: project.id, issue_number: 42, title: "Updated title", confirmed: true)
 
         expect(github_client).to have_received(:update_issue).with(
           project.full_name, 42, title: "Updated title"

--- a/spec/mcp/tools/set_labels_spec.rb
+++ b/spec/mcp/tools/set_labels_spec.rb
@@ -51,6 +51,16 @@ RSpec.describe Tools::SetLabels do
   end
 
   describe "#call" do
+    # @spec CHAT-TOOL-CONFIRMATION-001
+    it "raises when not confirmed" do
+      expect do
+        tool.call(project_id: project.id, issue_number: 42, labels: %w[bug], confirmed: false)
+      end.to raise_error(ArgumentError, /Confirmation required/)
+
+      expect(github_client).not_to have_received(:add_labels_to_issue)
+      expect(github_client).not_to have_received(:remove_labels_from_issue)
+    end
+
     context "when setting labels on an issue with no existing labels" do
       before do
         bare_issue = Struct.new(:number, :labels).new(42, [])
@@ -63,7 +73,7 @@ RSpec.describe Tools::SetLabels do
 
       it "adds all requested labels" do
         result = tool.call(project_id: project.id, issue_number: 42,
-                           labels: %w[bug enhancement])
+                           labels: %w[bug enhancement], confirmed: true)
 
         expect(github_client).to have_received(:add_labels_to_issue).with(
           project.full_name, 42, %w[bug enhancement]
@@ -94,7 +104,7 @@ RSpec.describe Tools::SetLabels do
 
       it "adds new labels and removes unwanted ones" do
         result = tool.call(project_id: project.id, issue_number: 42,
-                           labels: %w[bug enhancement])
+                           labels: %w[bug enhancement], confirmed: true)
 
         expect(github_client).to have_received(:add_labels_to_issue).with(
           project.full_name, 42, %w[enhancement]
@@ -124,7 +134,7 @@ RSpec.describe Tools::SetLabels do
 
       it "makes no API calls for add or remove" do
         result = tool.call(project_id: project.id, issue_number: 42,
-                           labels: %w[bug enhancement])
+                           labels: %w[bug enhancement], confirmed: true)
 
         expect(github_client).not_to have_received(:add_labels_to_issue)
         expect(github_client).not_to have_received(:remove_labels_from_issue)
@@ -148,7 +158,7 @@ RSpec.describe Tools::SetLabels do
         .with(project.full_name, 42, %w[documentation])
         .and_return({ removed: [], failed: [ { label: "documentation", error: "still present" } ] })
 
-      result = tool.call(project_id: project.id, issue_number: 42, labels: %w[bug enhancement])
+      result = tool.call(project_id: project.id, issue_number: 42, labels: %w[bug enhancement], confirmed: true)
 
       expect(result[:failed]).to contain_exactly({ label: "documentation", error: "still present" })
       expect(result[:current_labels]).to match_array(%w[bug enhancement documentation])
@@ -157,7 +167,7 @@ RSpec.describe Tools::SetLabels do
 
     it "rejects unknown labels" do
       expect do
-        tool.call(project_id: project.id, issue_number: 42, labels: %w[nonexistent])
+        tool.call(project_id: project.id, issue_number: 42, labels: %w[nonexistent], confirmed: true)
       end.to raise_error(ArgumentError, /Unknown labels: nonexistent/)
     end
 
@@ -168,7 +178,7 @@ RSpec.describe Tools::SetLabels do
       allow(github_client).to receive(:issue).and_return(labeled_issue)
 
       expect do
-        tool.call(project_id: project.id, issue_number: 42, labels: %w[enhancement])
+        tool.call(project_id: project.id, issue_number: 42, labels: %w[enhancement], confirmed: true)
       end.to change(AccountActivityEvent, :count).by(1)
 
       event = AccountActivityEvent.last
@@ -184,7 +194,7 @@ RSpec.describe Tools::SetLabels do
       other_project = create(:project)
 
       expect do
-        tool.call(project_id: other_project.id, issue_number: 42, labels: %w[bug])
+        tool.call(project_id: other_project.id, issue_number: 42, labels: %w[bug], confirmed: true)
       end.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -194,7 +204,7 @@ RSpec.describe Tools::SetLabels do
       other_tool = described_class.new(user: other_user, session:)
 
       expect do
-        other_tool.call(project_id: project.id, issue_number: 42, labels: %w[bug])
+        other_tool.call(project_id: project.id, issue_number: 42, labels: %w[bug], confirmed: true)
       end.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -202,7 +212,7 @@ RSpec.describe Tools::SetLabels do
       allow(github_client).to receive(:issue).and_raise(GithubClient::Error, "API error")
 
       expect do
-        tool.call(project_id: project.id, issue_number: 42, labels: %w[bug])
+        tool.call(project_id: project.id, issue_number: 42, labels: %w[bug], confirmed: true)
       end.to raise_error(GithubClient::Error, "API error")
     end
 
@@ -210,7 +220,7 @@ RSpec.describe Tools::SetLabels do
       allow(github_client).to receive(:labels).and_raise(GithubClient::Error, "rate limited")
 
       expect do
-        tool.call(project_id: project.id, issue_number: 42, labels: %w[bug])
+        tool.call(project_id: project.id, issue_number: 42, labels: %w[bug], confirmed: true)
       end.to raise_error(GithubClient::Error, "rate limited")
     end
 
@@ -224,7 +234,7 @@ RSpec.describe Tools::SetLabels do
       end
 
       it "sets labels using the installation credential" do
-        tool.call(project_id: project.id, issue_number: 42, labels: %w[bug])
+        tool.call(project_id: project.id, issue_number: 42, labels: %w[bug], confirmed: true)
 
         expect(github_client).to have_received(:add_labels_to_issue).with(
           project.full_name, 42, %w[bug]

--- a/spec/services/github_client_spec.rb
+++ b/spec/services/github_client_spec.rb
@@ -627,15 +627,13 @@ RSpec.describe GithubClient do
     let(:repo) { "owner/repo" }
 
     before do
-      stub_request(:get, "#{api_base}/repos/#{repo}/labels")
-        .to_return(
-          status: 200,
-          body: [
-            { id: 1, name: "bug", color: "d73a4a" },
-            { id: 2, name: "enhancement", color: "a2eeef" }
-          ].to_json,
-          headers: { "Content-Type" => "application/json" }
-        )
+      stub_labels_page(
+        query: hash_including("per_page" => "100"),
+        labels: [
+          { id: 1, name: "bug", color: "d73a4a" },
+          { id: 2, name: "enhancement", color: "a2eeef" }
+        ]
+      )
     end
 
     it "returns list of labels" do
@@ -643,6 +641,39 @@ RSpec.describe GithubClient do
 
       expect(result.size).to eq(2)
       expect(result.first.name).to eq("bug")
+    end
+
+    it "follows pagination so labels beyond the first page are visible" do
+      stub_labels_page(
+        query: { "per_page" => "100" },
+        labels: [ { id: 1, name: "bug", color: "d73a4a" } ],
+        link: %(<#{api_base}/repos/#{repo}/labels?per_page=100&page=2>; rel="next")
+      )
+      stub_labels_page(
+        query: { "per_page" => "100", "page" => "2" },
+        labels: [ { id: 2, name: "P2", color: "ff9800" } ]
+      )
+
+      result = client.labels(repo)
+
+      expect(result.map(&:name)).to eq(%w[bug P2])
+    end
+
+    it "temporarily enables auto_paginate and restores it" do
+      expect(client.client.auto_paginate).to be false
+
+      client.labels(repo)
+
+      expect(client.client.auto_paginate).to be false
+    end
+
+    def stub_labels_page(query:, labels:, link: nil)
+      headers = { "Content-Type" => "application/json" }
+      headers["Link"] = link if link
+
+      stub_request(:get, "#{api_base}/repos/#{repo}/labels")
+        .with(query: query)
+        .to_return(status: 200, body: labels.to_json, headers: headers)
     end
   end
 


### PR DESCRIPTION
## Summary

- Require `confirmed: true` for chat-exposed GitHub issue write tools: `create_issue`, `edit_issue`, and `set_labels`.
- Fix GitHub label fetching to auto-paginate so labels beyond the first page, such as priority labels, validate correctly.
- Add LID intent docs and regression coverage for write-tool confirmation and paginated label reads.

## Root Cause

Chat approval injects `confirmed: true` into pre-dispatch write tools, but the GitHub issue tools did not all accept that keyword. `create_issue` failed with `unknown keyword: :confirmed`, and review found `edit_issue` and `set_labels` would fail the same way. Label validation also only saw GitHub's first labels page, which could reject valid labels like `P2`.

## Validation

- `bin/rspec spec/mcp/tools/create_issue_spec.rb spec/mcp/tools/edit_issue_spec.rb spec/mcp/tools/set_labels_spec.rb spec/services/github_client_spec.rb:626 spec/mcp/tools/registry_spec.rb spec/services/chat_sessions/resolve_tool_call_spec.rb`
- `bin/rubocop app/mcp/tools/create_issue.rb app/mcp/tools/edit_issue.rb app/mcp/tools/set_labels.rb app/services/github_client.rb spec/mcp/tools/create_issue_spec.rb spec/mcp/tools/edit_issue_spec.rb spec/mcp/tools/set_labels_spec.rb spec/services/github_client_spec.rb`
- `git diff --check`
- `bin/coherence-check.mjs`

Note: coherence still reports two pre-existing reverse-orphan IDs (`A-Z0-9`, `LID-RUN-001`) unrelated to this change.
