### PR TITLE
chore(devcontainer): install ponytail plugin

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -84,7 +84,8 @@
     "setup-signing-key": "bash .devcontainer/setup-signing-key.sh",
     // This single sequential chain is the ordering backbone of devcontainer setup:
     //   bin/setup -> install Claude CLI -> install Compound Engineering plugin
-    //   -> install LID (Linked-Intent Development) plugin -> configure auto-approve mode.
+    //   -> install LID (Linked-Intent Development) plugin -> install Ponytail
+    //   -> configure auto-approve mode.
     // It is chained (not split into parallel entries) for several reasons:
     //  - the Claude CLI install uses `bundle exec`, which needs gems from bin/setup;
     //  - the plugin installs (Compound Engineering, LID) must run after the `claude`
@@ -96,7 +97,7 @@
     // (codex, gemini, opencode, ...) have finished, so their wrappers/config apply.
     // Each added step is `|| echo`-guarded so a plugin failure stays non-fatal;
     // a bin/setup or Claude-install failure still propagates and fails creation.
-    "setup": "corepack enable && corepack prepare yarn@1.22.22 --activate && bin/setup --skip-server && (eval \"$(bundle exec ruby scripts/extract-provider-install-contract.rb claude | sed -n 's/^INSTALL_COMMAND=//p')\" || echo 'WARNING: Claude CLI installation failed (non-fatal)') && (bash .devcontainer/install-compound-engineering.sh || echo 'WARNING: Compound Engineering plugin install incomplete (non-fatal)') && (bash .devcontainer/install-lid.sh || echo 'WARNING: LID plugin install incomplete (non-fatal)') && bash .devcontainer/configure-llm-tools.sh",
+    "setup": "corepack enable && corepack prepare yarn@1.22.22 --activate && bin/setup --skip-server && (eval \"$(bundle exec ruby scripts/extract-provider-install-contract.rb claude | sed -n 's/^INSTALL_COMMAND=//p')\" || echo 'WARNING: Claude CLI installation failed (non-fatal)') && (bash .devcontainer/install-compound-engineering.sh || echo 'WARNING: Compound Engineering plugin install incomplete (non-fatal)') && (bash .devcontainer/install-lid.sh || echo 'WARNING: LID plugin install incomplete (non-fatal)') && (bash .devcontainer/install-ponytail.sh || echo 'WARNING: Ponytail plugin install incomplete (non-fatal)') && bash .devcontainer/configure-llm-tools.sh",
     // LLM CLI Tools - Installation via agent-harness contracts
     // Each tool is installed via scripts/install-from-contract.sh which delegates
     // to scripts/extract-provider-install-contract.rb. This means versions and

--- a/.devcontainer/install-ponytail.sh
+++ b/.devcontainer/install-ponytail.sh
@@ -12,6 +12,28 @@ PONYTAIL_MARKETPLACE="${PONYTAIL_MARKETPLACE:-ponytail}"
 PONYTAIL_PLUGIN="${PONYTAIL_PLUGIN:-ponytail}"
 PONYTAIL_NPM_PACKAGE="${PONYTAIL_NPM_PACKAGE:-@dietrichgebert/ponytail}"
 PONYTAIL_OMP_TARGET="${PONYTAIL_OMP_TARGET:-git:github.com/DietrichGebert/ponytail}"
+STEP_TIMEOUT="${PONYTAIL_STEP_TIMEOUT:-180}"
+
+run_step() {
+  local desc="$1"
+  shift
+
+  if ! timeout -k 10 "$STEP_TIMEOUT" "$@" </dev/null; then
+    echo "WARNING: ${desc} failed or timed out (${STEP_TIMEOUT}s); skipping." >&2
+    return 1
+  fi
+
+  return 0
+}
+
+run_install() {
+  local desc="$1"
+  shift
+
+  if ! "$@"; then
+    echo "WARNING: ${desc} install failed; continuing with remaining Ponytail installs." >&2
+  fi
+}
 
 wait_for_command() {
   local command_name="$1"
@@ -40,13 +62,13 @@ install_claude_ponytail() {
   mkdir -p "$claude_root/marketplaces" "$claude_root/cache"
 
   if [ -d "$marketplace_dir/.git" ]; then
-    git -C "$marketplace_dir" fetch --depth=1 origin main
+    run_step "Claude Ponytail marketplace fetch" git -C "$marketplace_dir" fetch --depth=1 origin main || return 1
     git -C "$marketplace_dir" checkout --quiet FETCH_HEAD
   elif [ -e "$marketplace_dir" ]; then
     echo "WARNING: $marketplace_dir exists but is not a git checkout; skipping Claude Ponytail install." >&2
     return 0
   else
-    git clone --depth=1 "$PONYTAIL_REPO" "$marketplace_dir"
+    run_step "Claude Ponytail marketplace clone" git clone --depth=1 "$PONYTAIL_REPO" "$marketplace_dir" || return 1
   fi
 
   manifest="$marketplace_dir/.claude-plugin/plugin.json"
@@ -114,8 +136,8 @@ install_codex_ponytail() {
     return 0
   fi
 
-  codex plugin marketplace add DietrichGebert/ponytail
-  codex plugin add ponytail@ponytail
+  run_step "Codex Ponytail marketplace add" codex plugin marketplace add DietrichGebert/ponytail || return 1
+  run_step "Codex Ponytail plugin add" codex plugin add ponytail@ponytail || return 1
 }
 
 install_opencode_ponytail() {
@@ -124,7 +146,7 @@ install_opencode_ponytail() {
     return 0
   fi
 
-  opencode plugin --global "$PONYTAIL_NPM_PACKAGE"
+  run_step "OpenCode Ponytail plugin install" opencode plugin --global "$PONYTAIL_NPM_PACKAGE" || return 1
 }
 
 install_omp_ponytail() {
@@ -133,12 +155,12 @@ install_omp_ponytail() {
     return 0
   fi
 
-  omp plugin install "$PONYTAIL_OMP_TARGET"
+  run_step "OMP Ponytail plugin install" omp plugin install "$PONYTAIL_OMP_TARGET" || return 1
 }
 
 echo "Installing Ponytail plugins for devcontainer agent CLIs..."
-install_claude_ponytail
-install_codex_ponytail
-install_opencode_ponytail
-install_omp_ponytail
+run_install "Claude Ponytail" install_claude_ponytail
+run_install "Codex Ponytail" install_codex_ponytail
+run_install "OpenCode Ponytail" install_opencode_ponytail
+run_install "OMP Ponytail" install_omp_ponytail
 echo "Ponytail plugin installation complete."

--- a/.devcontainer/install-ponytail.sh
+++ b/.devcontainer/install-ponytail.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+
+# Install Ponytail for the agent CLIs whose state is persisted in devcontainer
+# named volumes. Native CLI installers are used where available. Claude Code's
+# documented installer is an interactive slash command, so this script mirrors
+# Claude's local marketplace/cache metadata directly.
+
+set -euo pipefail
+
+PONYTAIL_REPO="${PONYTAIL_REPO:-https://github.com/DietrichGebert/ponytail.git}"
+PONYTAIL_MARKETPLACE="${PONYTAIL_MARKETPLACE:-ponytail}"
+PONYTAIL_PLUGIN="${PONYTAIL_PLUGIN:-ponytail}"
+PONYTAIL_NPM_PACKAGE="${PONYTAIL_NPM_PACKAGE:-@dietrichgebert/ponytail}"
+PONYTAIL_OMP_TARGET="${PONYTAIL_OMP_TARGET:-git:github.com/DietrichGebert/ponytail}"
+
+wait_for_command() {
+  local command_name="$1"
+  local tries="${2:-60}"
+
+  while [ "$tries" -gt 0 ]; do
+    if command -v "$command_name" >/dev/null 2>&1; then
+      return 0
+    fi
+
+    tries=$((tries - 1))
+    sleep 2
+  done
+
+  return 1
+}
+
+install_claude_ponytail() {
+  local claude_root="$HOME/.claude/plugins"
+  local marketplace_dir="$claude_root/marketplaces/$PONYTAIL_MARKETPLACE"
+  local manifest
+  local version
+  local cache_dir
+  local commit_sha
+
+  mkdir -p "$claude_root/marketplaces" "$claude_root/cache"
+
+  if [ -d "$marketplace_dir/.git" ]; then
+    git -C "$marketplace_dir" fetch --depth=1 origin main
+    git -C "$marketplace_dir" checkout --quiet FETCH_HEAD
+  elif [ -e "$marketplace_dir" ]; then
+    echo "WARNING: $marketplace_dir exists but is not a git checkout; skipping Claude Ponytail install." >&2
+    return 0
+  else
+    git clone --depth=1 "$PONYTAIL_REPO" "$marketplace_dir"
+  fi
+
+  manifest="$marketplace_dir/.claude-plugin/plugin.json"
+  if [ ! -f "$manifest" ]; then
+    echo "WARNING: Ponytail Claude manifest missing at $manifest; skipping Claude install." >&2
+    return 0
+  fi
+
+  version="$(node -e 'console.log(require(process.argv[1]).version)' "$manifest")"
+  commit_sha="$(git -C "$marketplace_dir" rev-parse HEAD)"
+  cache_dir="$claude_root/cache/$PONYTAIL_MARKETPLACE/$PONYTAIL_PLUGIN/$version"
+
+  mkdir -p "$cache_dir"
+  find "$cache_dir" -mindepth 1 -maxdepth 1 -exec rm -r {} +
+  git -C "$marketplace_dir" archive --format=tar HEAD | tar -x -C "$cache_dir"
+
+  node - "$claude_root" "$PONYTAIL_REPO" "$marketplace_dir" "$cache_dir" "$version" "$commit_sha" <<'NODE'
+const fs = require("fs");
+const path = require("path");
+
+const [root, repoUrl, marketplaceDir, cacheDir, version, commitSha] = process.argv.slice(2);
+const knownPath = path.join(root, "known_marketplaces.json");
+const installedPath = path.join(root, "installed_plugins.json");
+const now = new Date().toISOString();
+
+function readJson(file, fallback) {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    return fallback;
+  }
+}
+
+function writeJson(file, data) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+const known = readJson(knownPath, {});
+known.ponytail = {
+  source: { source: "github", repo: repoUrl.replace(/^https:\/\/github\.com\//, "").replace(/\.git$/, "") },
+  installLocation: marketplaceDir,
+  lastUpdated: now
+};
+writeJson(knownPath, known);
+
+const installed = readJson(installedPath, { version: 2, plugins: {} });
+installed.version ||= 2;
+installed.plugins ||= {};
+installed.plugins["ponytail@ponytail"] = [{
+  scope: "user",
+  installPath: cacheDir,
+  version,
+  installedAt: now,
+  lastUpdated: now,
+  gitCommitSha: commitSha
+}];
+writeJson(installedPath, installed);
+NODE
+}
+
+install_codex_ponytail() {
+  if ! wait_for_command codex; then
+    echo "WARNING: codex command not found; skipping Codex Ponytail install." >&2
+    return 0
+  fi
+
+  codex plugin marketplace add DietrichGebert/ponytail
+  codex plugin add ponytail@ponytail
+}
+
+install_opencode_ponytail() {
+  if ! wait_for_command opencode; then
+    echo "WARNING: opencode command not found; skipping OpenCode Ponytail install." >&2
+    return 0
+  fi
+
+  opencode plugin --global "$PONYTAIL_NPM_PACKAGE"
+}
+
+install_omp_ponytail() {
+  if ! wait_for_command omp; then
+    echo "WARNING: omp command not found; skipping OMP Ponytail install." >&2
+    return 0
+  fi
+
+  omp plugin install "$PONYTAIL_OMP_TARGET"
+}
+
+echo "Installing Ponytail plugins for devcontainer agent CLIs..."
+install_claude_ponytail
+install_codex_ponytail
+install_opencode_ponytail
+install_omp_ponytail
+echo "Ponytail plugin installation complete."

--- a/spec/config/devcontainer_file_spec.rb
+++ b/spec/config/devcontainer_file_spec.rb
@@ -41,7 +41,10 @@ RSpec.describe DevcontainerFile, :no_db do
 
     expect(command).to include("bash .devcontainer/install-ponytail.sh")
     expect(command).to match(/install-lid\.sh.*install-ponytail\.sh.*configure-llm-tools\.sh/)
+    expect(ponytail_installer).to include('STEP_TIMEOUT="${PONYTAIL_STEP_TIMEOUT:-180}"')
+    expect(ponytail_installer).to include('timeout -k 10 "$STEP_TIMEOUT" "$@" </dev/null')
     expect(ponytail_installer).to include("known_marketplaces.json")
+    expect(ponytail_installer).to include('run_install "Claude Ponytail" install_claude_ponytail')
     expect(ponytail_installer).to include("codex plugin marketplace add DietrichGebert/ponytail")
     expect(ponytail_installer).to include('opencode plugin --global "$PONYTAIL_NPM_PACKAGE"')
     expect(ponytail_installer).to include('omp plugin install "$PONYTAIL_OMP_TARGET"')

--- a/spec/config/devcontainer_file_spec.rb
+++ b/spec/config/devcontainer_file_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe DevcontainerFile, :no_db do
   end
 
   let(:oh_my_pi_installer) { Rails.root.join(".devcontainer/install-oh-my-pi.sh").read }
+  let(:ponytail_installer) { Rails.root.join(".devcontainer/install-ponytail.sh").read }
 
   it "installs opencode through the shared contract wrapper" do
     command = devcontainer.fetch("postCreateCommand").fetch("opencode")
@@ -33,6 +34,17 @@ RSpec.describe DevcontainerFile, :no_db do
     expect(oh_my_pi_installer).to include("SHASUMS256.txt")
     expect(oh_my_pi_installer).to include("sha256sum -c -")
     expect(oh_my_pi_installer).not_to include("https://bun.sh/install")
+  end
+
+  it "installs Ponytail for the devcontainer agent CLIs" do
+    command = devcontainer.fetch("postCreateCommand").fetch("setup")
+
+    expect(command).to include("bash .devcontainer/install-ponytail.sh")
+    expect(command).to match(/install-lid\.sh.*install-ponytail\.sh.*configure-llm-tools\.sh/)
+    expect(ponytail_installer).to include("known_marketplaces.json")
+    expect(ponytail_installer).to include("codex plugin marketplace add DietrichGebert/ponytail")
+    expect(ponytail_installer).to include('opencode plugin --global "$PONYTAIL_NPM_PACKAGE"')
+    expect(ponytail_installer).to include('omp plugin install "$PONYTAIL_OMP_TARGET"')
   end
 
   it "re-runs setup on every start to restore the detached dev supervisor" do


### PR DESCRIPTION
## Summary

- Adds a devcontainer Ponytail installer covering Claude Code, Codex, OpenCode, and OMP.
- Wires the installer into the ordered post-create setup chain after LID and before auto-approve config.
- Adds a focused devcontainer config spec so the plugin install remains covered.

## Validation

- `bin/rspec spec/config/devcontainer_file_spec.rb`
- Pre-commit hook: secret scan, RuboCop, ESLint, markdownlint, ShellCheck, Herb
