### PR TITLE
fix(db): canonicalize schema dump metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,6 +345,11 @@ jobs:
       - name: Replay migrations
         run: bin/rails db:create db:migrate
 
+      - name: Verify canonical schema dump
+        run: |
+          bin/rails db:schema:dump
+          git diff --exit-code db/schema.rb
+
   fasterer:
     if: >-
       github.event_name != 'pull_request'

--- a/db/functions/paid_current_account_id_v01.sql
+++ b/db/functions/paid_current_account_id_v01.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE FUNCTION public.paid_current_account_id() RETURNS bigint AS $body$
+  -- @spec POSTGRESQL-PERSISTENCE-007
+  -- version: 1
+  SELECT NULLIF(current_setting('paid.current_account_id', true), '')::bigint
+$body$
+LANGUAGE sql
+STABLE;

--- a/db/functions/paid_tenant_bypass_v01.sql
+++ b/db/functions/paid_tenant_bypass_v01.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE FUNCTION public.paid_tenant_bypass() RETURNS boolean AS $body$
+  -- @spec POSTGRESQL-PERSISTENCE-007
+  -- version: 1
+  SELECT current_setting('paid.bypass_tenant_rls', true) = 'true'
+$body$
+LANGUAGE sql
+STABLE;

--- a/db/migrate/20260805002623_canonicalize_schema_dump_metadata.rb
+++ b/db/migrate/20260805002623_canonicalize_schema_dump_metadata.rb
@@ -13,8 +13,38 @@ class CanonicalizeSchemaDumpMetadata < ActiveRecord::Migration[8.1]
   end
 
   def down
+    restore_legacy_helper_functions
+
     return unless column_exists?(:chat_sessions, :clone_manifest)
 
     change_column_comment :chat_sessions, :clone_manifest, LEGACY_CLONE_MANIFEST_COMMENT
+  end
+
+  private
+
+  # Restore the pre-fx, unmanaged bodies so a rolled-back schema dump matches
+  # the schema.rb checked in before this migration. fx exposes no helper to
+  # revert a function to a prior unmanaged body, so CREATE OR REPLACE is used.
+  def restore_legacy_helper_functions
+    safety_assured do
+      execute <<~SQL
+        CREATE OR REPLACE FUNCTION paid_current_account_id()
+        RETURNS bigint
+        LANGUAGE sql
+        STABLE
+        AS $$
+          SELECT NULLIF(current_setting('paid.current_account_id', true), '')::bigint
+        $$;
+      SQL
+      execute <<~SQL
+        CREATE OR REPLACE FUNCTION paid_tenant_bypass()
+        RETURNS boolean
+        LANGUAGE sql
+        STABLE
+        AS $$
+          SELECT current_setting('paid.bypass_tenant_rls', true) = 'true'
+        $$;
+      SQL
+    end
   end
 end

--- a/db/migrate/20260805002623_canonicalize_schema_dump_metadata.rb
+++ b/db/migrate/20260805002623_canonicalize_schema_dump_metadata.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CanonicalizeSchemaDumpMetadata < ActiveRecord::Migration[8.1]
+  # @spec POSTGRESQL-PERSISTENCE-007
+  CLONE_MANIFEST_COMMENT = "Persisted clone metadata used to reopen a reaped multi-repo chat workspace."
+  LEGACY_CLONE_MANIFEST_COMMENT = "Manifest of repos cloned into the chat workspace for container-backed tools"
+
+  def up
+    change_column_comment :chat_sessions, :clone_manifest, CLONE_MANIFEST_COMMENT if column_exists?(:chat_sessions, :clone_manifest)
+
+    create_function :paid_current_account_id, version: 1
+    create_function :paid_tenant_bypass, version: 1
+  end
+
+  def down
+    return unless column_exists?(:chat_sessions, :clone_manifest)
+
+    change_column_comment :chat_sessions, :clone_manifest, LEGACY_CLONE_MANIFEST_COMMENT
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_04_144228) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_05_002623) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -2779,7 +2779,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_04_144228) do
     t.datetime "updated_at", null: false
     t.jsonb "worker_settings", default: {}, null: false
     t.index ["account_id"], name: "index_tenant_settings_on_account_id", unique: true
-    t.check_constraint "queue_fairness_mode::text = ANY (ARRAY['fair_share'::character varying, 'strict_priority'::character varying]::text[])", name: "chk_queue_fairness_mode"
+    t.check_constraint "queue_fairness_mode::text = ANY (ARRAY['fair_share'::character varying::text, 'strict_priority'::character varying::text])", name: "chk_queue_fairness_mode"
   end
 
   create_table "token_usages", force: :cascade do |t|
@@ -3983,6 +3983,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_04_144228) do
        LANGUAGE sql
        STABLE
       AS $function$
+        -- @spec POSTGRESQL-PERSISTENCE-007
+        -- version: 1
         SELECT NULLIF(current_setting('paid.current_account_id', true), '')::bigint
       $function$
   SQL
@@ -3993,6 +3995,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_04_144228) do
        LANGUAGE sql
        STABLE
       AS $function$
+        -- @spec POSTGRESQL-PERSISTENCE-007
+        -- version: 1
         SELECT current_setting('paid.bypass_tenant_rls', true) = 'true'
       $function$
   SQL

--- a/docs/intent/postgresql-persistence/postgresql-persistence-design.md
+++ b/docs/intent/postgresql-persistence/postgresql-persistence-design.md
@@ -19,8 +19,10 @@ indexing features.
 
 The application schema uses PostgreSQL features directly: JSONB columns, GIN and
 trigram indexes, full-text search, row-level security, and database-backed job
-infrastructure. Rails remains on `db/schema.rb`, with PostgreSQL functions and
-triggers handled through `fx` where applicable.
+infrastructure. Rails remains on `db/schema.rb`, which is the canonical schema
+artifact. PostgreSQL functions and triggers are handled through versioned `fx`
+definitions, and CI rejects migration paths that dump a different `schema.rb`
+than the checked-in canonical copy.
 
 Tenant isolation is enforced in PostgreSQL with helper functions driven by
 `paid.current_account_id` and `paid.bypass_tenant_rls`. The application also

--- a/docs/intent/postgresql-persistence/postgresql-persistence-specs.md
+++ b/docs/intent/postgresql-persistence/postgresql-persistence-specs.md
@@ -43,3 +43,14 @@
 - [D] **POSTGRESQL-PERSISTENCE-005** — When operational scale thresholds are
   reached, the persistence layer SHALL document the shipped partitioning,
   retention, replica, and query-observability strategy in this segment.
+
+## Canonical Schema Dump
+
+- [x] **POSTGRESQL-PERSISTENCE-007** — Replaying migrations in CI SHALL dump a
+  `db/schema.rb` identical to the checked-in canonical schema, and PostgreSQL
+  helper functions included in the schema dump SHALL be backed by versioned
+  `fx` definitions instead of unmanaged auto-discovery.
+  *Tests:* `spec/config/ci_database_workflow_file_spec.rb`,
+  `spec/migrations/canonicalize_schema_dump_metadata_spec.rb`.
+  *Code:* `CanonicalizeSchemaDumpMetadata`, `db/functions/paid_current_account_id_v01.sql`,
+  `db/functions/paid_tenant_bypass_v01.sql`.

--- a/spec/config/ci_database_workflow_file_spec.rb
+++ b/spec/config/ci_database_workflow_file_spec.rb
@@ -142,11 +142,14 @@ RSpec.describe CiDatabaseWorkflowFile, :no_db do
       end
 
       if workflow_path == ".github/workflows/ci.yml"
+        # @spec POSTGRESQL-PERSISTENCE-007
         it "replays migrations in a dedicated CI job" do
           job = workflow.fetch("jobs").fetch("migrations")
           setup_step = job.fetch("steps").find { |step| step["name"] == "Replay migrations" }
+          drift_step = job.fetch("steps").find { |step| step["name"] == "Verify canonical schema dump" }
 
           expect(setup_step).not_to be_nil, "expected migrations job to include a Replay migrations step"
+          expect(drift_step).not_to be_nil, "expected migrations job to verify schema dump drift"
           expect(job.fetch("env")).to include(
             "PAID_TEST_DATABASE" => "paid_test",
             "RAILS_TEST_KEY" => "${{ secrets.RAILS_TEST_KEY }}",
@@ -154,6 +157,7 @@ RSpec.describe CiDatabaseWorkflowFile, :no_db do
             "DB_PASSWORD" => "postgres"
           )
           expect(setup_step.fetch("run")).to eq("bin/rails db:create db:migrate")
+          expect(drift_step.fetch("run").strip).to eq("bin/rails db:schema:dump\ngit diff --exit-code db/schema.rb")
         end
       end
     end

--- a/spec/migrations/canonicalize_schema_dump_metadata_spec.rb
+++ b/spec/migrations/canonicalize_schema_dump_metadata_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require Rails.root.join("db/migrate/20260805002623_canonicalize_schema_dump_metadata")
+
+RSpec.describe CanonicalizeSchemaDumpMetadata, :aggregate_failures do
+  let(:migration) { described_class.new }
+
+  # @spec POSTGRESQL-PERSISTENCE-007
+  it "records canonical metadata for schema dumps" do
+    migration.up
+
+    comment = ActiveRecord::Base.connection.select_value(<<~SQL.squish)
+      SELECT col_description('chat_sessions'::regclass, ordinal_position)
+      FROM information_schema.columns
+      WHERE table_name = 'chat_sessions'
+        AND column_name = 'clone_manifest'
+    SQL
+    function_names = ActiveRecord::Base.connection.select_values(<<~SQL.squish)
+      SELECT proname
+      FROM pg_proc
+      JOIN pg_namespace ON pg_namespace.oid = pg_proc.pronamespace
+      WHERE pg_namespace.nspname = 'public'
+        AND proname IN ('paid_current_account_id', 'paid_tenant_bypass')
+      ORDER BY proname
+    SQL
+
+    expect(comment).to eq(described_class::CLONE_MANIFEST_COMMENT)
+    expect(function_names).to eq(%w[paid_current_account_id paid_tenant_bypass])
+  end
+end

--- a/spec/migrations/canonicalize_schema_dump_metadata_spec.rb
+++ b/spec/migrations/canonicalize_schema_dump_metadata_spec.rb
@@ -5,18 +5,44 @@ require Rails.root.join("db/migrate/20260805002623_canonicalize_schema_dump_meta
 
 RSpec.describe CanonicalizeSchemaDumpMetadata, :aggregate_failures do
   let(:migration) { described_class.new }
+  let(:connection) { ActiveRecord::Base.connection }
 
   # @spec POSTGRESQL-PERSISTENCE-007
   it "records canonical metadata for schema dumps" do
     migration.up
 
-    comment = ActiveRecord::Base.connection.select_value(<<~SQL.squish)
+    expect(clone_manifest_comment).to eq(described_class::CLONE_MANIFEST_COMMENT)
+    expect(managed_function_names).to eq(%w[paid_current_account_id paid_tenant_bypass])
+    expect(function_source("paid_current_account_id")).to include("POSTGRESQL-PERSISTENCE-007")
+    expect(function_source("paid_tenant_bypass")).to include("POSTGRESQL-PERSISTENCE-007")
+  end
+
+  # @spec POSTGRESQL-PERSISTENCE-007
+  it "restores the prior unmanaged function bodies and comment on rollback" do
+    migration.up
+    migration.down
+
+    expect(clone_manifest_comment).to eq(described_class::LEGACY_CLONE_MANIFEST_COMMENT)
+    expect(managed_function_names).to eq(%w[paid_current_account_id paid_tenant_bypass])
+    expect(function_source("paid_current_account_id")).not_to include("POSTGRESQL-PERSISTENCE-007")
+    expect(function_source("paid_tenant_bypass")).not_to include("POSTGRESQL-PERSISTENCE-007")
+    expect(function_source("paid_current_account_id")).to include("current_setting('paid.current_account_id'")
+    expect(function_source("paid_tenant_bypass")).to include("current_setting('paid.bypass_tenant_rls'")
+  ensure
+    migration.up
+  end
+
+  def clone_manifest_comment
+    connection.select_value(<<~SQL.squish)
       SELECT col_description('chat_sessions'::regclass, ordinal_position)
       FROM information_schema.columns
       WHERE table_name = 'chat_sessions'
         AND column_name = 'clone_manifest'
     SQL
-    function_names = ActiveRecord::Base.connection.select_values(<<~SQL.squish)
+  end
+
+  def managed_function_names
+    connection.select_values(<<~SQL.squish)
       SELECT proname
       FROM pg_proc
       JOIN pg_namespace ON pg_namespace.oid = pg_proc.pronamespace
@@ -24,8 +50,15 @@ RSpec.describe CanonicalizeSchemaDumpMetadata, :aggregate_failures do
         AND proname IN ('paid_current_account_id', 'paid_tenant_bypass')
       ORDER BY proname
     SQL
+  end
 
-    expect(comment).to eq(described_class::CLONE_MANIFEST_COMMENT)
-    expect(function_names).to eq(%w[paid_current_account_id paid_tenant_bypass])
+  def function_source(name)
+    connection.select_value(<<~SQL.squish)
+      SELECT prosrc
+      FROM pg_proc
+      JOIN pg_namespace ON pg_namespace.oid = pg_proc.pronamespace
+      WHERE pg_namespace.nspname = 'public'
+        AND proname = #{connection.quote(name)}
+    SQL
   end
 end


### PR DESCRIPTION
## Summary

- Canonicalizes schema dump metadata so local migration replay stops producing recurring `db/schema.rb` noise.
- Registers tenant RLS helper functions through versioned `fx` SQL definitions.
- Adds a CI migration replay guard that fails when `db:schema:dump` differs from the checked-in schema.
- Updates PostgreSQL persistence intent and focused specs for the new guarantee.

## Validation

- `bin/rspec spec/migrations/canonicalize_schema_dump_metadata_spec.rb spec/config/ci_database_workflow_file_spec.rb`
- `bin/coherence-check.mjs`
- `bin/lint --changed`
- `bin/rubocop db/migrate/20260805002623_canonicalize_schema_dump_metadata.rb spec/migrations/canonicalize_schema_dump_metadata_spec.rb spec/config/ci_database_workflow_file_spec.rb`
- `bin/rails db:schema:dump` stability check
- Pre-commit hook: secret scan, RuboCop, ESLint, markdownlint, ShellCheck, Herb
