### PR TITLE
fix(agent-runs): re-admit bot clarifying Q&A in enhance_issue re-evaluation

### DIFF
--- a/app/temporal/activities/enhance_issue_activity.rb
+++ b/app/temporal/activities/enhance_issue_activity.rb
@@ -299,7 +299,13 @@ module Activities
     end
 
     def trusted_comments(project, comments)
-      comments.select { |comment| project.trusted_github_user?(comment.user&.login) }
+      # Admit trusted human collaborators plus Paid's own structured marker
+      # comments (clarifying questions/answers) authored by the project's
+      # GitHub App bot. trusted_github_user? deliberately excludes the bot, so
+      # without this re-admission the re-evaluation LLM never sees the prior
+      # Q&A it posted and re-asks the same questions. See CommentAdmission and
+      # Project#paid_bot_author?.
+      comments.select { |comment| ClarifyingQuestions::CommentAdmission.admissible?(project:, comment:) }
     end
 
     def format_search_results(results)

--- a/docs/intent/issue-enhancement/issue-enhancement-design.md
+++ b/docs/intent/issue-enhancement/issue-enhancement-design.md
@@ -44,6 +44,24 @@ The activity still emits the same markdown shape:
 That preserves the existing parser, `paid_state: "needs_input"` handling,
 dashboard queue, answer form, and answer-ingestion flow.
 
+## Re-evaluation comment admission
+
+When the user answers, the `needs_input` label is cleared and a re-evaluation
+run is queued (see `fetch_issues_activity#detect_enhance_issue_rechecks`). The
+re-evaluation LLM must see the prior clarifying questions and answers to decide
+whether the issue is now actionable.
+
+Both the questions and the captured-answers comments are posted by the
+project's GitHub App bot (`paid-agents[bot]`). The human-only comment trust
+filter (`Project#trusted_github_user?`) deliberately excludes the bot — Paid
+must not feed arbitrary bot comments back into the agent as an untrusted input
+channel. The re-evaluation therefore re-admits only Paid's own structured
+marker comments (`<!-- paid:enhance-issue -->`, `<!-- paid:clarifying-answers -->`)
+via `ClarifyingQuestions::CommentAdmission`, backed by the unspoofable
+`Project#paid_bot_author?` check. This is scoped: it never broadens the comment
+trust used for arbitrary conversation, so a spoofed marker in an attacker's
+comment is still rejected.
+
 ## LID-aware materialization
 
 For non-LID projects, answered clarifying questions only provide better human

--- a/docs/intent/issue-enhancement/issue-enhancement-specs.md
+++ b/docs/intent/issue-enhancement/issue-enhancement-specs.md
@@ -21,6 +21,19 @@
   *Code:* `app/temporal/activities/enhance_issue_activity.rb#prompt_for`,
   `app/services/clarifying_questions/load.rb`.
 
+- [x] **ISSUE-ENHANCEMENT-005** — When issue enhancement re-evaluates an issue
+  after the user answers clarifying questions, the system SHALL include the
+  prior clarifying questions and answers in the conversation context supplied
+  to the LLM, even though those comments are authored by the project's GitHub
+  App bot (which the human-only comment trust filter deliberately excludes).
+  The system SHALL re-admit only Paid's own structured marker comments via
+  comment admission, never arbitrary bot comments, so the re-evaluation
+  considers already-provided answers rather than re-asking them.
+  *Tests:* `spec/temporal/activities/enhance_issue_activity_spec.rb`.
+  *Code:* `app/temporal/activities/enhance_issue_activity.rb#trusted_comments`,
+  `app/services/clarifying_questions/comment_admission.rb`,
+  `app/models/project.rb#paid_bot_author?`.
+
 ## LID-aware prompt materialization
 
 - [x] **ISSUE-ENHANCEMENT-003** — When a project is marked with a non-empty

--- a/spec/temporal/activities/enhance_issue_activity_spec.rb
+++ b/spec/temporal/activities/enhance_issue_activity_spec.rb
@@ -95,6 +95,26 @@ RSpec.describe Activities::EnhanceIssueActivity do
     ]
   end
 
+  # Mirrors the production app-backed path: Paid posts both the clarifying
+  # questions and the captured answers as its own GitHub App bot
+  # (`paid-agents[bot]`), which Project#trusted_github_user? deliberately
+  # excludes. Comment admission re-admits these structured marker comments.
+  def bot_answered_reevaluation_comments
+    bot_login = "paid-agents[bot]"
+    [
+      OpenStruct.new(
+        body: "#{described_class::COMMENT_MARKER}\n## Clarifying questions\n1. Which events should be recorded?",
+        user: OpenStruct.new(login: bot_login),
+        created_at: Time.zone.parse("2026-04-20 12:00:00 UTC")
+      ),
+      OpenStruct.new(
+        body: "#{ClarifyingQuestions::Load::ANSWER_MARKER}\n\n## Clarifying question answers\n\n**Q1: Which events should be recorded?**\n**A1:** Record sign-in, permission, and billing events.",
+        user: OpenStruct.new(login: bot_login),
+        created_at: Time.zone.parse("2026-04-20 13:00:00 UTC")
+      )
+    ]
+  end
+
   describe "#execute" do
     it "posts an implementation context comment" do
       result = activity.execute(agent_run_id: agent_run.id)
@@ -485,6 +505,39 @@ RSpec.describe Activities::EnhanceIssueActivity do
       )
       expect_comment_including("## Implementation context")
       expect(issue.reload.enhance_issue_rounds).to eq(1)
+    end
+
+    context "when the clarifying Q&A comments are authored by the paid-agents bot" do
+      # Production app-backed path: Paid posts both the clarifying questions and
+      # the captured answers as its own GitHub App bot (`paid-agents[bot]`),
+      # which Project#trusted_github_user? deliberately excludes. Only comment
+      # admission re-admits these structured marker comments.
+      let(:project) { create(:project, :with_github_installation) }
+      let(:issue) do
+        create(:issue, :in_progress, project: project, github_number: 42,
+                                      title: "Add audit log", body: "Record user actions")
+      end
+      let(:agent_run) { create(:agent_run, project: project, issue: issue, goal: "enhance_issue") }
+      let(:comments) { bot_answered_reevaluation_comments }
+
+      before do
+        allow(Github::AppInstallation).to receive(:token_for).and_return("fake-app-installation-token")
+      end
+
+      it "re-evaluates using the bot's own marker comments (app-backed project)" do # @spec ISSUE-ENHANCEMENT-005
+        issue.update!(enhance_issue_rounds: 1)
+
+        activity.execute(agent_run_id: agent_run.id)
+
+        expect(AgentHarness).to have_received(:send_message).with(
+          a_string_including(
+            "Which events should be recorded?",
+            "Record sign-in, permission, and billing events."
+          ),
+          hash_including(provider: :claude)
+        )
+        expect_comment_including("## Implementation context")
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem

On app-backed projects, the `enhance_issue` re-evaluation loop re-asked clarifying questions the user had already answered (see [viamin/WiringDiagram#6](https://github.com/viamin/WiringDiagram/issues/6) for a real example: round 2 re-asked platform target, tool palette, and shape-merging behavior that were all answered in round 1).

## Root cause

`EnhanceIssueActivity#trusted_comments` filtered the issue conversation with `Project#trusted_github_user?`, which **deliberately excludes** Paid's own GitHub App bot (its docstring: *"Paid must not feed its own bot's comments back into the agent"*).

Both the clarifying-questions comment *and* the captured-answers comment are posted by `paid-agents[bot]`. So on re-evaluation, **every prior Q&A comment was dropped** before reaching the LLM — the prompt rendered `## Conversation\nNo comments.` and the LLM regenerated near-duplicate questions from the bare issue body.

A canonical, scoped admission filter already existed for exactly this case (`ClarifyingQuestions::CommentAdmission` — trusted humans *plus* Paid's own structured marker comments, backed by the unspoofable `Project#paid_bot_author?` check), and `ClarifyingQuestions::Load` already used it. The activity just hadn't been updated to match.

## Fix

Swap `trusted_comments` to use `ClarifyingQuestions::CommentAdmission.admissible?`. Scoped and safe:
- Only Paid's own bot + marker content (`<!-- paid:enhance-issue -->`, `<!-- paid:clarifying-answers -->`) is re-admitted.
- An attacker cannot spoof the bot login, and a spoofed marker in an attacker's comment is still rejected (the existing `ignores untrusted enhancement-marker comments` test confirms this).

Latent bonus: the round-0 duplicate-comment idempotency guard (`existing_comment && rounds.zero?`) now also works for bot-authored enhancement comments, since `enhancement_comment` searches the same filtered list.

## LID arrow

- **EARS:** added `ISSUE-ENHANCEMENT-005` (the recheck SHALL include prior Q&A, re-admitting only Paid's own marker comments) to `issue-enhancement-specs.md`.
- **LLD:** added a "Re-evaluation comment admission" section to `issue-enhancement-design.md`.
- **Test:** failing-first test (`@spec ISSUE-ENHANCEMENT-005`) using a real app-backed project — verified red before the fix (`No comments.`), green after.

## Verification

- `bin/rspec spec/temporal/activities/enhance_issue_activity_spec.rb spec/services/clarifying_questions` → 97 examples, 0 failures
- `bin/lint --changed` → clean
- `bin/coherence-check.mjs` → no dangling `@spec` references