### PR TITLE
docs(rdr): add RDR-052 codebase-aware issue enhancement

### DIFF
--- a/app/services/docker_hosts/setup_action_runner.rb
+++ b/app/services/docker_hosts/setup_action_runner.rb
@@ -5,16 +5,18 @@ require "shellwords"
 
 module DockerHosts
   class SetupActionRunner
+    DEFAULT_KEY_SIZE = 4096
     Result = Struct.new(:success?, :message, :server_private_key_pem, keyword_init: true)
 
-    def self.call(host:, action:, params:)
-      new(host:, action:, params:).call
+    def self.call(host:, action:, params:, key_size: DEFAULT_KEY_SIZE)
+      new(host:, action:, params:, key_size:).call
     end
 
-    def initialize(host:, action:, params:)
+    def initialize(host:, action:, params:, key_size: DEFAULT_KEY_SIZE)
       @host = host
       @action = action.to_s
       @params = params
+      @key_size = key_size
     end
 
     def call
@@ -40,10 +42,17 @@ module DockerHosts
 
     private
 
-    attr_reader :host, :action, :params
+    attr_reader :host, :action, :params, :key_size
+
+    # Generates an RSA keypair at the configured size. Production uses the
+    # 4096-bit default; specs override via the +key_size:+ kwarg to avoid the
+    # ~1s cost of a 4096-bit key when the assertions don't depend on key size.
+    def generate_rsa_key
+      OpenSSL::PKey::RSA.new(key_size)
+    end
 
     def generate_client_bundle
-      ca_key = OpenSSL::PKey::RSA.new(4096)
+      ca_key = generate_rsa_key
       ca_cert = Certificates.build_certificate(
         subject: "/CN=#{host.identifier}-paid-remote-docker-ca",
         issuer: nil,
@@ -53,7 +62,7 @@ module DockerHosts
         is_ca: true
       )
 
-      client_key = OpenSSL::PKey::RSA.new(4096)
+      client_key = generate_rsa_key
       client_cert = Certificates.build_certificate(
         subject: "/CN=#{params[:client_common_name].presence || "#{host.identifier}-paid-client"}",
         issuer: ca_cert,
@@ -396,7 +405,7 @@ module DockerHosts
     def generate_server_certificate(common_name:, san_entries:)
       ca_cert = OpenSSL::X509::Certificate.new(stored_client_ca_pem!)
       ca_key = OpenSSL::PKey.read(stored_client_ca_key_pem!)
-      server_key = OpenSSL::PKey::RSA.new(4096)
+      server_key = generate_rsa_key
       server_cert = Certificates.build_certificate(
         subject: "/CN=#{common_name}",
         issuer: ca_cert,
@@ -424,7 +433,7 @@ module DockerHosts
     end
 
     def generate_server_csr(common_name:, san_entries:)
-      server_key = OpenSSL::PKey::RSA.new(4096)
+      server_key = generate_rsa_key
       csr = Certificates.build_certificate_request(
         subject: "/CN=#{common_name}",
         private_key: server_key,

--- a/docs/brainstorms/codebase-aware-enhance-issue-requirements.md
+++ b/docs/brainstorms/codebase-aware-enhance-issue-requirements.md
@@ -1,0 +1,138 @@
+---
+date: 2026-08-05
+topic: codebase-aware-enhance-issue
+---
+
+# Codebase-aware issue enhancement
+
+## Summary
+
+Move `enhance_issue`'s question-generation and answer-sufficiency judgment out of a direct LLM call into a read-only containerized agent with repo access, so the clarifying questions it asks and the readiness verdicts it issues are grounded in the actual codebase rather than knowledge-base snapshots. The lightweight gate (`analyze_issue`) and the next-stage routing are unchanged.
+
+---
+
+## Problem Frame
+
+`enhance_issue` is the step that decides whether an issue is ready for an implementation run — and, when it isn't, asks the human the questions that would get it there. It also owns the re-evaluation loop: after the human answers, `enhance_issue` runs again to judge whether the answers made the issue actionable. Both jobs — *asking* and *judging sufficiency* — are codebase questions at their core.
+
+Today it does both from a direct LLM call with no codebase access. Its only view of the repo is retrieved knowledge-base fragments (`Knowledge::Search` + `ContextBundle`). The result is predictable: it asks humans questions the code could answer ("are there existing shape models in `Models.swift`?", "is this macOS or iOS?"), and it judges readiness against a snapshot that may be stale or incomplete. The gatekeeper is blinder than the implementation run it authorizes.
+
+This surfaced concretely: a re-evaluation round re-asked questions a user had already answered (a separate comment-admission bug, fixed in PR #3235), and the harder residual problem — asking things the code already says — remains. A second symptom is structural rather than behavioral: `enhance_issue` runs as a direct `AgentHarness.send_message` call in the worker process, reading its API key from `ANTHROPIC_API_KEY` in the environment, while containerized runs (`create_pr`, `lid_planning`) source credentials from the DB-stored runner credential. That credential bifurcation is what made the failure observable.
+
+RDR-051 already established the architectural seam this sits on: `enhance_issue` is deliberately the lightweight synchronous human-in-the-loop step, while `lid_planning` is the containerized, codebase-aware goal — but pointed at artifact *production*, not readiness *assessment*. The capability `enhance_issue` needs already exists in the system; it just lives on the other goal.
+
+---
+
+## Actors
+
+- A1. **`analyze_issue`** — the lightweight direct-LLM readiness gate. Assesses an issue and routes: `sufficient` → `create_pr`, `insufficient` → `enhance_issue`. Unchanged by this work.
+- A2. **`enhance_issue`** — the enhancement step. Generates clarifying questions or implementation context, owns the needs-input / clarifying-questions flow, and re-evaluates answer sufficiency. This is the actor being changed.
+- A3. **Project owner / issue author** — the human who answers clarifying questions and whose issue is being gated.
+- A4. **`create_pr` / LID-aware implementation run** — the downstream consumer that runs once `enhance_issue` (or `analyze_issue`) declares the issue sufficient.
+- A5. **`lid_planning`** — the existing containerized, codebase-aware goal (artifact production). Referenced for context and pattern reuse; not changed.
+
+---
+
+## Key Flows
+
+- F1. **Initial enhancement (codebase-grounded questions)**
+  - **Trigger:** `analyze_issue` returns `sufficient_context: false` for a new issue.
+  - **Actors:** A1, A2, A3
+  - **Steps:** `analyze_issue` routes to `enhance_issue` → `enhance_issue` runs in a read-only container, explores the repo alongside the issue + KB context → it self-answers what the code determines and posts only genuine product/scope questions via the existing marker → issue moves to `needs_input`.
+  - **Outcome:** The human receives questions the code could not answer.
+  - **Covered by:** R1, R2, R3, R5
+
+- F2. **Answer-sufficiency re-evaluation**
+  - **Trigger:** The human answers; the needs-input label clears; the recheck loop queues an `enhance_issue` run.
+  - **Actors:** A2, A3, A4
+  - **Steps:** `enhance_issue` re-runs in a read-only container, reading the codebase *and* the prior Q&A (visible via comment admission) → it judges whether the answers plus the actual code yield enough context to proceed → `sufficient` re-enters the queue for the next stage; `insufficient` posts further questions (up to the round cap).
+  - **Outcome:** The sufficiency verdict is grounded in the real codebase, not a snapshot.
+  - **Covered by:** R1, R4, R5, R8
+
+---
+
+## Requirements
+
+**Execution model**
+
+- R1. `enhance_issue` runs as a containerized agent with repo access (the same provisioning path `create_pr`/`lid_planning` use), replacing the in-process direct LLM call.
+- R2. The run is **read-only**: the agent may explore the repository to ground its questions and assessment, but cannot modify files, commit, or push. Its only outputs are the posted comment and label state.
+
+**Quality of questions and sufficiency judgment**
+
+- R3. `enhance_issue` must not ask the human clarifying questions whose answers are directly readable from the repository. It self-answers those from the code and asks only about genuine product, scope, or intent ambiguities.
+- R4. The answer-sufficiency re-evaluation must judge whether the user's answers *plus the actual codebase* yield enough context to proceed — grounded in code the agent read, not knowledge-base snapshots alone.
+
+**Preserved contract**
+
+- R5. `enhance_issue`'s output contract is unchanged: it posts either clarifying questions or implementation context through the existing `<!-- paid:enhance-issue -->` marker, and continues to own the needs-input / clarifying-questions / re-evaluation loop without new UI surfaces or issue states.
+- R6. The next-stage routing after `enhance_issue` declares "sufficient" is unchanged (the issue re-enters the queue for `create_pr` / the LID-aware path).
+
+**Credentials**
+
+- R7. The containerized `enhance_issue` run uses the same runner-credential path as `create_pr` (DB-stored credential, injected into the container), removing this step's dependency on a separate `ANTHROPIC_API_KEY` environment variable.
+
+**Composes with prior work**
+
+- R8. The comment-admission behavior shipped in PR #3235 (the bot's prior clarifying Q&A reaches the LLM) continues to hold for the containerized re-evaluation run.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R3.** Given an issue asking to "add drawing tools" in a repo where `Models.swift` already defines shape types and the project targets are visible, when `enhance_issue` runs, it does *not* ask the human "are there existing shape models?" or "is this macOS or iOS?" — it reads those from the code and asks only about genuine scope/intent gaps.
+- AE2. **Covers R4.** Given an issue whose author has answered the initial clarifying questions, when the needs-input label clears and the re-evaluation runs, `enhance_issue` reads the codebase alongside the answers and judges sufficiency against the actual code — not the knowledge-base snapshot alone.
+- AE3. **Covers R2.** Given a containerized `enhance_issue` run, the agent explores the repo but produces no file changes, commits, or branch pushes; its only side effects are the comment post and label transition.
+- AE4. **Covers R7.** Given an environment where `ANTHROPIC_API_KEY` is unset but runner credentials are configured, a containerized `enhance_issue` run succeeds, authenticating via the injected runner credential rather than the environment variable.
+
+---
+
+## Success Criteria
+
+- Project owners receive fewer, higher-value clarifying questions — none whose answers are readable from the repo — and fewer back-and-forth rounds before an issue is actionable.
+- `create_pr` runs launched after an `enhance_issue` "sufficient" verdict fail less often due to underspecification, because the gate that authorized them was codebase-grounded.
+- A downstream implementer can tell the handoff is clean: the "sufficient" verdict and any posted implementation context cite real code, not inferred-from-snapshot guesses.
+
+---
+
+## Scope Boundaries
+
+- `analyze_issue` stays a direct-LLM gate. Its parallel `trusted_comments` bug (same bot-excluding filter, unfixed) and its own KB-blindness are a **separate follow-up**, not this work — it only routes, so the impact is lower.
+- `lid_planning` is unaffected; it remains the distinct containerized codebase-aware goal for artifact production.
+- The lightweight gate does not itself become codebase-aware in this work.
+- Next-stage routing (`enhance` → `create_pr` / LID-aware path) is unchanged.
+- No new human-facing UI surfaces or issue states.
+
+---
+
+## Key Decisions
+
+- **Keep `enhance_issue`'s role and machinery; only the generation moves into the container.** Moving the needs-input / clarifying-questions flow to a new goal would disrupt the integrated UI path. This follows RDR-051 Decision #4 (distinct output shape → distinct goal) — `enhance_issue` keeps its output shape, it just gains a better engine.
+- **Read-only, not read-write.** `enhance_issue` assesses and elicits; it does not implement. Read-only keeps it cleanly distinct from `create_pr` and avoids the agent drifting into making changes.
+- **Leave `analyze_issue` as-is.** It already does the gate job and already routes correctly. Widening this work to cover it would conflate the "ask/judge" change with a "gate" change and balloon the scope.
+
+---
+
+## Dependencies / Assumptions
+
+- Depends on the existing container provisioning + runner-credential injection path used by `create_pr` / `lid_planning`.
+- Assumes a read-only container mode is enforceable. The existing container path is read-write (it commits); whether read-only can be enforced structurally (vs. relied on via prompt) is a planning question.
+- Composes with PR #3235 (comment-admission fix, merged) — that fix is what makes prior answers visible to the containerized re-evaluation run.
+- The `enhance_issue` re-evaluation loop (up to `max_enhance_issue_reevaluation_rounds`, default 3) now spins a container per round — the cost multiplier lands hardest on the back-and-forth path, not the first pass.
+
+---
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+- *None blocking.* Scope, actors, and the preserved contract are settled.
+
+### Deferred to Planning
+
+- **Affects R2.** (Technical) How is read-only enforced in the container? Is there an existing read-only provisioning mode, or must one be added? (`create_pr`'s container is read-write.)
+- **Affects R1.** (Technical) Does the containerized `enhance_issue` clone the full repo (like `create_pr`) or use a lighter check-out? Latency/cost tradeoff per run, amplified on the re-evaluation path.
+- **Affects R4.** (Needs research) Is the per-round container cost on the re-evaluation loop acceptable, or should re-evaluation stay lighter than the initial question-generation pass? Needs measurement during planning.
+- **Affects R5.** (Technical) The `enhance_issue` workflow path (`agent_execution_workflow.rb:151`) currently does no container provisioning — it short-circuits straight to the activity. Wiring it into the container-provisioning steps (currently gated to `create_pr`/`review`/`lid_planning`) is the main structural change; confirm where the read-only constraint plugs in.
+
+> Resolved in RDR-052 (`docs/rdrs/RDR-052-codebase-aware-enhance-issue.md`): read-only = `:ro` repo bind + prompt statement (state volumes stay writable); clone = shallow `--depth 1` (existing default); per-round re-evaluation cost = accepted in v1. The workflow insertion point and runner-read-only validation remain open for planning.

--- a/docs/rdrs/RDR-052-codebase-aware-enhance-issue.md
+++ b/docs/rdrs/RDR-052-codebase-aware-enhance-issue.md
@@ -1,0 +1,251 @@
+# RDR-052: Codebase-Aware Issue Enhancement
+
+> Revise during planning; lock at implementation. If wrong, abandon code and iterate RDR.
+
+## Metadata
+
+- **Date**: 2026-08-05
+- **Status**: Draft
+- **Type**: Architecture
+- **Priority**: P1
+- **Related RDRs**: RDR-051 (LID-aware agent runs — revises its Decision #6 stance on `enhance_issue`), RDR-027 (Auto-enhance and knowledge-base evolution), RDR-004 (Container isolation), RDR-007 (agent-harness), RDR-021 (Knowledge base)
+- **Input**: `docs/brainstorms/codebase-aware-enhance-issue-requirements.md`
+- **Related Issues**: to be opened per implementation phase
+
+## Problem Statement
+
+`enhance_issue` is the step that decides whether an issue is ready for an implementation run, and — when it isn't — asks the human the questions that would get it there. It also owns the re-evaluation loop: after the human answers, `enhance_issue` runs again to judge whether the answers made the issue actionable. Both jobs, *asking* and *judging sufficiency*, are codebase questions at their core.
+
+Today it performs both from a direct `AgentHarness.send_message` call inside the Temporal worker process, with `tools: :none` and no repository access. Its only view of the codebase is retrieved knowledge-base fragments (`Knowledge::Search` + `Knowledge::ContextBundle::Build`). Two failures follow:
+
+1. **It asks humans questions the code could answer.** Observed on a real issue: it asked "are there existing shape models in `Models.swift`?" and "is this for macOS or iOS?" — both directly readable from the repo. The readiness gatekeeper routes to humans the very context it could retrieve itself.
+2. **It judges readiness against a snapshot.** Sufficiency is assessed against knowledge-base fragments that may be stale or incomplete, so the verdict that authorizes a `create_pr` run is less informed than the run it gates.
+
+A structural symptom made this observable: the direct call reads its API key from `ANTHROPIC_API_KEY` in the environment, while containerized runs (`create_pr`, `lid_planning`) source credentials from the DB-stored runner credential. When the environment lacked the ENV var, `enhance_issue` failed while containerized runs succeeded — exposing both the credential bifurcation and the fact that this step runs outside the container model the rest of the agent system uses.
+
+RDR-051 Decision #6 deliberately kept `enhance_issue` as the lightweight, prompt-only elicitation step. This RDR revises that stance for the *execution model* (it should be codebase-aware) while preserving its *role* (elicitation and readiness gating, not artifact production).
+
+## Context
+
+### The enhancement pipeline today
+
+On projects with `auto_enhance_enabled`, the flow is already two-tiered (`agent_execution_workflow.rb:175`):
+
+```ruby
+followup_goal = result[:sufficient_context] ? "create_pr" : "enhance_issue"
+```
+
+1. A new issue is auto-picked and `analyze_issue` runs first — a lightweight direct-LLM readiness gate that returns a JSON verdict (`sufficient_context` + `missing_context_areas`) and routes, posting nothing.
+2. `sufficient` → `create_pr`. `insufficient` → `enhance_issue`.
+3. `enhance_issue` posts either implementation context or clarifying questions via the `<!-- paid:enhance-issue -->` marker and moves the issue to `paid_state: "needs_input"`.
+4. When the user answers and the `paid-needs-input` label clears, `detect_enhance_issue_rechecks` (`fetch_issues_activity.rb`) queues an `enhance_issue` re-evaluation run (up to `max_enhance_issue_reevaluation_rounds`, default 3).
+
+So the two-tier gate the project needs **already exists**: `analyze_issue` is the lightweight gate; `enhance_issue` is the enhancement step. Both are direct-LLM today. This RDR changes only `enhance_issue`'s execution model; the gate and routing are unchanged.
+
+### What `enhance_issue` owns (and must keep)
+
+- The `<!-- paid:enhance-issue -->` comment marker and the needs-input / clarifying-questions flow (`ClarifyingQuestions::Load` / `SubmitAnswers` / `ClearNeedsInput`), including the dashboard queue and answer form.
+- The re-evaluation loop and `enhance_issue_round` accounting.
+- The output contract: either clarifying questions or implementation context, plus label state.
+
+### Existing capability to reuse
+
+`create_pr`, `review`, and `lid_planning` already run as containerized agents with repo access and credentials injected from the DB-stored runner credential. `lid_planning` (RDR-051) is the closest analog: a containerized, codebase-aware goal — but pointed at LID artifact *production*, not readiness *assessment*. The capability `enhance_issue` needs already exists in the system; it lives on the other goal.
+
+### Prior fix that composes
+
+PR #3235 fixed comment admission so the bot's prior clarifying Q&A reaches the `enhance_issue` LLM (previously dropped by the human-only trust filter). That fix is what makes prior answers visible to a containerized re-evaluation run; this RDR builds on it.
+
+## Research Findings
+
+### Investigation process
+
+1. Traced the enhancement pipeline end to end: `analyze_issue` (gate) → routing → `enhance_issue` (questions/context) → needs-input flow → `detect_enhance_issue_rechecks` (re-evaluation).
+2. Confirmed both `analyze_issue` and `enhance_issue` are direct-LLM calls (`tools: :none`, no container) and share the same `trusted_comments` bot-excluding filter.
+3. Confirmed the credential bifurcation: container runs inject from `runner_credentials` (DB → `pi_auth.json`, `config/initializers/agent_harness.rb`); direct `send_message` calls read `ANTHROPIC_API_KEY` from ENV.
+4. Confirmed `lid_planning` already provides the containerized, codebase-aware pattern this needs.
+5. Reviewed RDR-051 Decision #6 (the stance this revises) and RDR-027 (auto-enhance).
+
+### Key discoveries
+
+**The two-tier gate already exists.** The brainstorm initially explored building a lightweight "is this issue too thin?" gate. Investigation showed `analyze_issue` already is that gate and already routes correctly (`sufficient` → `create_pr`, `insufficient` → `enhance_issue`). The project is therefore *not* "build a two-tier model"; it is "make the enhancement tier codebase-aware." `analyze_issue` needs no structural change.
+
+**Both of `enhance_issue`'s jobs benefit from the same change.** Question-generation ("what's missing?") and answer-sufficiency judgment ("are the answers enough?") are both codebase questions. A single execution-model change improves both, which is the unifying argument for the work.
+
+**The readiness gatekeeper is currently less informed than the run it authorizes.** `create_pr` runs containerized with full repo access; `enhance_issue` authorizes it from a KB snapshot. That is an inverted capability gradient.
+
+**`analyze_issue` shares the same `trusted_comments` bug and KB-blindness**, but the impact is lower because it only routes (it does not generate questions). Its fix is a separate follow-up, explicitly out of scope here.
+
+## Proposed Solution
+
+### Approach
+
+Change `enhance_issue`'s execution model from a direct LLM call to a **read-only containerized agent with repository access**, reusing the existing container provisioning and runner-credential path. Preserve its role, output contract, and ownership of the needs-input / re-evaluation machinery. Leave `analyze_issue` and the next-stage routing unchanged.
+
+### Technical design
+
+**1. Containerized, read-only execution.** `enhance_issue` runs through the same container provisioning steps as `create_pr` / `lid_planning` (currently the workflow short-circuits `enhance_issue` straight to the activity at `agent_execution_workflow.rb:151`, skipping provisioning). The run is **read-only**: the agent explores the repository to ground its questions and assessment but cannot modify files, commit, or push. Its only outputs remain the posted comment and label state.
+
+Read-only is enforced as **structural + behavioral**:
+
+- *Structural* — the workspace bind mount uses `:ro` instead of the default `:rw` (container workspaces are bind-mounted today via `Binds` at `app/services/containers/provision_for_chat.rb:203`). State/scratch volumes (the existing `STATE_VOLUME_DIRS` pattern) remain writable so runner tooling that needs scratch space still functions; only the repo mount is read-only.
+- *Behavioral* — the prompt states the workspace is read-only so the agent doesn't waste effort attempting writes that would fail.
+
+**Shallow clone.** The enhancement run uses the existing shallow clone (`--depth 1`, already the default at `app/services/containers/git_operations.rb:877` and in chat provisioning at `provision_for_chat.rb:295`). Enhancement assesses current state, not history, so it takes the default and skips the `unshallow` step that only history-dependent operations (rebase) require.
+
+**2. Grounded question generation.** The agent reads the repo alongside the issue, conversation, and KB context. It self-answers what the code determines (existing models, platform targets, persistence format, current patterns) and asks the human only about genuine product, scope, or intent ambiguities.
+
+**3. Grounded sufficiency judgment.** On re-evaluation, the agent reads the codebase *and* the prior Q&A (visible via comment admission, PR #3235) and judges whether the answers plus the actual code yield enough context to proceed — not the KB snapshot alone.
+
+**4. Preserved contract.** The `<!-- paid:enhance-issue -->` marker, the needs-input / clarifying-questions flow, the re-evaluation loop, and `enhance_issue_round` accounting are unchanged. No new UI surfaces or issue states. Next-stage routing after "sufficient" is unchanged.
+
+**5. Credential unification.** The run authenticates via the injected runner credential (DB-stored), removing this step's dependency on `ANTHROPIC_API_KEY` in the environment.
+
+### Decision rationale
+
+1. **Preserve the role, change the engine.** Moving the needs-input machinery to a new goal would disrupt the integrated UI path and gains nothing. `enhance_issue` keeps its output shape (RDR-051 Decision #4 — distinct output shape → distinct goal) and simply gains a better engine. This is the smallest change that delivers the value.
+2. **Read-only, not read-write.** `enhance_issue` assesses and elicits; it does not implement. Read-only keeps it cleanly distinct from `create_pr` and prevents drift into making changes.
+3. **Leave `analyze_issue` as-is.** It already gates and routes correctly. Widening this RDR to cover it would conflate the "ask/judge" change with a "gate" change. Its parallel `trusted_comments` bug and KB-blindness are a separate follow-up.
+4. **Revise RDR-051 Decision #6 deliberately, narrowly.** RDR-051 kept `enhance_issue` lightweight because it runs on every enhanced issue and "must stay fast/cheap." This RDR accepts a cost increase on the enhancement tier in exchange for materially better questions and verdicts — and notes that the gate (`analyze_issue`) still provides the cheap first pass, so the container cost lands only on issues the gate already flagged as insufficient (and on re-evaluation rounds).
+
+### Implementation example
+
+```text
+# analyze_issue returns sufficient_context: false for an under-specified issue.
+# The workflow routes to enhance_issue, now containerized:
+
+#   The enhance_issue agent, in a read-only container:
+#     - reads the issue + trusted conversation + KB context (as today)
+#     - ALSO reads the repo: existing models, platform targets, persistence layer
+#     - self-answers "are there shape models?" / "macOS or iOS?" from the code
+#     - posts ONLY genuine gaps via the <!-- paid:enhance-issue --> marker:
+#         ## Clarifying questions
+#         1. Should drawn shapes overlay an imported image, or replace it?
+#     - moves the issue to needs_input
+
+# User answers. needs-input clears. Re-evaluation runs (containerized):
+#     - reads the answers AND the codebase
+#     - judges the answers + code = sufficient
+#     - posts implementation context (now grounded in real files/symbols)
+#     - issue re-enters the queue → create_pr
+```
+
+## Alternatives Considered
+
+### Alternative 1: Lightweight read-only codebase access without a container
+
+**Description**: Give the direct `send_message` call structured codebase access (codegraph / repo-read / search) without spinning up a runner.
+
+**Pros**: Cheapest; preserves the fast path; no container boot per run.
+
+**Cons**: No agentic exploration — a single enriched pass cannot follow a thread through the code the way a tool-using agent can. The "self-answer codebase questions" value depends on multi-step exploration (read this file → check that type → confirm the pattern), which a single retrieval pass does not provide.
+
+**Reason for rejection**: The value being pursued (grounded questions and sufficiency judgment) requires exploration, not just richer retrieval. Single-pass enrichment would close part of the gap but not the core "the agent could answer this itself" failure.
+
+### Alternative 2: Tier internally within one `enhance_issue` goal
+
+**Description**: The run does the cheap direct-LLM call first; if uncertain, escalates to a containerized exploration within the same goal.
+
+**Pros**: One mental model; preserves a cheap path.
+
+**Cons**: Conflates two execution models (direct-LLM + container) in one goal, fighting RDR-051 Decision #4 and muddying `prompt_for_goal` routing. Also redundant with `analyze_issue`, which is *already* the cheap first pass that routes.
+
+**Reason for rejection**: The cheap-first-pass tier already exists as `analyze_issue`. Adding internal tiering to `enhance_issue` duplicates the gate and conflates execution models.
+
+### Alternative 3: Merge `enhance_issue` into `lid_planning`
+
+**Description**: Fold readiness assessment into the existing containerized, codebase-aware `lid_planning` goal — one codebase-aware goal produces both the assessment and (for LID projects) the artifacts.
+
+**Pros**: Single codebase-aware goal; maximum reuse.
+
+**Cons**: `lid_planning`'s output shape is docs-only LID artifacts in a Planning PR; `enhance_issue`'s is a comment + needs-input label state. Merging conflates two distinct output shapes and two distinct human-in-the-loop surfaces (Planning-PR review vs. issue Q&A), violating the separation RDR-051 Decision #4 established.
+
+**Reason for rejection**: The two goals have distinct output contracts and confirmation surfaces. Borrow the *capability* (containerized codebase access), not the *goal*.
+
+## Trade-offs and Consequences
+
+### Positive consequences
+
+- **Fewer, higher-value questions.** Humans stop answering things the code already says; rounds-to-resolution should drop.
+- **Better readiness verdicts.** `create_pr` runs launch against codebase-grounded "sufficient" judgments, reducing failures on underspecified issues.
+- **Better implementation context.** When `enhance_issue` posts implementation context, it cites real files/symbols it read, not snapshot inferences.
+- **Credential unification.** The enhancement step moves to the runner-credential path, closing the `ANTHROPIC_API_KEY`-from-ENV gap that triggered this work.
+- **Composes with PR #3235.** Answers stay visible to the containerized re-evaluation run.
+
+### Negative consequences
+
+- **Higher cost/latency per enhancement run.** A container clone + agent boot replaces a single Haiku-class call. This lands on every issue the gate flags insufficient *and* on each re-evaluation round (up to the cap).
+- **Read-only enforcement is a new constraint.** The existing container path is read-write; enforcing read-only for this goal is a structural addition (planning question).
+- **Re-evaluation rounds multiply the cost.** The back-and-forth path (up to `max_enhance_issue_reevaluation_rounds`) now spins a container per round — the cost multiplier hits the loop hardest.
+
+### Risks and mitigations
+
+- **Risk**: Per-run container cost makes enhancement prohibitively expensive at scale.
+  **Mitigation**: The gate (`analyze_issue`) already filters, so only insufficient issues reach the container. Per-round re-evaluation cost is accepted in v1 (grounding value justifies it); revisit if measurement shows it's material.
+- **Risk**: A CLI runner expects to write scratch/todo state to the workspace and hard-fails under a read-only repo mount.
+  **Mitigation**: Structural enforcement is settled (`:ro` repo bind, state/scratch volumes remain writable), but the chosen runner must be validated to function read-only before locking — route any required scratch to the writable state volumes rather than the repo mount. Validate in Phase 1.
+- **Risk**: The agent over-explores, inflating latency without better questions.
+  **Mitigation**: Scope the exploration via the prompt (read the files relevant to the issue area); measure exploration depth vs. question quality during validation.
+
+## Implementation Plan
+
+> Status: Draft. Phases are indicative; the deferred questions below must be resolved during planning before locking.
+
+### Phase 1: Wire `enhance_issue` into container provisioning (read-only)
+
+**Prerequisites:** Confirm the chosen runner functions in a read-only workspace (see Risk below).
+
+- Route `enhance_issue` through the container-provisioning steps instead of short-circuiting to the activity.
+- Mount the workspace bind `:ro` (repo read-only); leave state/scratch volumes writable. State the read-only constraint in the prompt.
+- Use the default shallow clone (`--depth 1`); skip `unshallow`.
+- Authenticate via the runner-credential injection path.
+
+### Phase 2: Codebase-grounded question generation
+
+- Replace the direct-LLM `prompt_for` with an agent prompt that instructs repo exploration to self-answer codebase-determinable questions before asking the human.
+- Preserve the `<!-- paid:enhance-issue -->` marker, needs-input flow, and output contract.
+
+### Phase 3: Codebase-grounded re-evaluation
+
+- The re-evaluation run (recheck loop) uses the same containerized, codebase-aware path, reading prior Q&A (via comment admission) + the codebase to judge sufficiency.
+- Per-round container cost is **accepted** — the grounding value on the back-and-forth path justifies it. (If later measurement shows it's material, re-evaluation could be lightened, but that is not the v1 design.)
+
+### Phase 4: Validation and cost measurement
+
+- Measure question quality (do agents stop asking codebase-answerable questions?), rounds-to-resolution, and per-run cost/latency against the pre-change baseline.
+
+## Dependencies
+
+- Existing container provisioning + runner-credential injection path (used by `create_pr` / `lid_planning`).
+- PR #3235 (comment admission, merged) — makes prior answers visible to the re-evaluation run.
+- RDR-004 (container isolation) — for read-only enforcement options.
+
+## Validation
+
+### Testing approach
+
+1. Unit/integration: a containerized `enhance_issue` run produces no file changes/commits (read-only) — AE3.
+2. Integration: given an issue whose answers are readable from the repo, `enhance_issue` does not ask them (self-answers from code) — AE1.
+3. Integration: re-evaluation reads the codebase alongside prior answers and judges sufficiency against the actual code — AE2.
+4. Integration: the run succeeds with `ANTHROPIC_API_KEY` unset, authenticating via the runner credential — AE4.
+5. Regression: the needs-input / clarifying-questions / dashboard-queue flow is unchanged end to end.
+
+### Test scenarios
+
+1. **Scenario**: Issue asking to add a feature whose prerequisites already exist in the repo.
+   **Expected**: `enhance_issue` self-answers the prerequisite questions from the code and asks only genuine product/scope gaps.
+2. **Scenario**: Re-evaluation after the user answers.
+   **Expected**: The run reads the codebase + answers and issues a sufficiency verdict grounded in the actual code.
+3. **Scenario**: `ANTHROPIC_API_KEY` unset, runner credential configured.
+   **Expected**: The containerized run authenticates via the injected credential and succeeds.
+
+## Resolved Decisions
+
+- **Read-only enforcement** — structural + behavioral: workspace bind mounted `:ro` (state/scratch volumes stay writable), plus a prompt statement so the agent doesn't attempt writes. Evidence: container workspaces are bind-mounted today (`app/services/containers/provision_for_chat.rb:203`); `:ro` is a one-option change.
+- **Clone depth** — shallow (`--depth 1`), the existing default (`app/services/containers/git_operations.rb:877`). Enhancement needs no history; skip `unshallow`.
+- **Per-round re-evaluation cost** — accepted in v1. The grounding value on the back-and-forth path justifies it; revisit only if measurement shows it's material.
+
+## Outstanding Questions (to resolve in planning)
+
+- The `enhance_issue` workflow path (`agent_execution_workflow.rb:151`) currently skips provisioning and short-circuits to the activity — confirm the exact insertion point for the container-provisioning steps. (The chat provisioning path, `app/services/containers/provision_for_chat.rb`, is the closest analog to follow.)
+- Which runner is used for the enhancement run, and does it function correctly under a read-only repo mount? Validate before locking Phase 1.

--- a/docs/rdrs/README.md
+++ b/docs/rdrs/README.md
@@ -131,6 +131,7 @@ For more information, see the [RDR methodology](https://github.com/cwensel/rdr).
 | [RDR-021](RDR-021-knowledge-base.md) | Knowledge Base Architecture | Implemented | High |
 | [RDR-027](RDR-027-auto-enhance-knowledge-evolution.md) | Auto-Enhance and Knowledge Base Evolution | Partially Implemented | High |
 | [RDR-042](RDR-042-change-intent-records.md) | Change Intent Records for the Knowledge Base | Partially Implemented | Medium |
+| [RDR-052](RDR-052-codebase-aware-enhance-issue.md) | Codebase-Aware Issue Enhancement | Draft | P1 |
 
 ### AI-Native Evolution (Phase 4)
 

--- a/spec/paid/spec_helper_coverage_spec.rb
+++ b/spec/paid/spec_helper_coverage_spec.rb
@@ -7,11 +7,42 @@ class SpecHelperCoverage < Pathname
 end
 
 RSpec.describe SpecHelperCoverage, :no_db do
-  def probe_script(prelude: nil)
-    <<~RUBY
+  # The decision logic is unit-tested in-process against the pure
+  # SpecCoverageDecision module (fast). One subprocess spec below asserts the
+  # wiring — that requiring spec_helper actually honors the decision.
+
+  describe SpecCoverageDecision do
+    it "disables coverage by default for intentional dbless runs" do
+      expect(described_class.call(env: { "ALLOW_DBLESS_SPECS" => "true" })).to be(false)
+    end
+
+    it "still enables coverage when explicitly requested" do
+      expect(described_class.call(env: { "ALLOW_DBLESS_SPECS" => "true", "COVERAGE" => "true" })).to be(true)
+    end
+
+    it "disables coverage when explicitly turned off" do
+      expect(described_class.call(env: { "ALLOW_DBLESS_SPECS" => "false", "COVERAGE" => "false" })).to be(false)
+    end
+
+    it "enables coverage by default in a normal (non-dbless) run" do
+      expect(described_class.call(env: {})).to be(true)
+    end
+
+    it "disables coverage during mutation sweeps, even when explicitly requested" do
+      # Mutant loads spec_helper in its main process via the rspec integration,
+      # so ::Mutant is defined at coverage-decision time. Whole-codebase line
+      # coverage is meaningless for a scoped mutation run and previously failed
+      # the job via the minimum_coverage gate, so SimpleCov must never start.
+      expect(described_class.call(env: { "ALLOW_DBLESS_SPECS" => "true", "COVERAGE" => "true" }, mutant_defined: true)).to be(false)
+    end
+  end
+
+  # Integration contract: requiring spec_helper.rb actually applies the
+  # decision. Kept as a single subprocess assertion (not one per matrix case).
+  it "wires SpecCoverageDecision into spec_helper (explicit request enables SimpleCov)" do
+    probe_script = <<~RUBY
       require "bundler/setup"
       require "rspec/core"
-      #{prelude}
       require_relative "spec/spec_helper"
       if Object.const_defined?(:SimpleCov)
         SimpleCov.command_name("spec_helper_coverage_probe-\#{Process.pid}")
@@ -19,23 +50,7 @@ RSpec.describe SpecHelperCoverage, :no_db do
       end
       puts Object.const_defined?(:SimpleCov)
     RUBY
-  end
 
-  it "disables coverage by default for intentional dbless runs" do
-    stdout, stderr, status = Open3.capture3(
-      {
-        "ALLOW_DBLESS_SPECS" => "true",
-        "COVERAGE" => nil
-      },
-      "bundle", "exec", "ruby", "-e", probe_script,
-      chdir: Rails.root.to_s
-    )
-
-    expect(status.success?).to be(true), stderr
-    expect(stdout.lines.first.to_s.strip).to eq("false")
-  end
-
-  it "still enables coverage when explicitly requested" do
     stdout, stderr, status = Open3.capture3(
       {
         "ALLOW_DBLESS_SPECS" => "true",
@@ -47,37 +62,5 @@ RSpec.describe SpecHelperCoverage, :no_db do
 
     expect(status.success?).to be(true), stderr
     expect(stdout.lines.first.to_s.strip).to eq("true")
-  end
-
-  it "disables coverage when explicitly turned off" do
-    stdout, stderr, status = Open3.capture3(
-      {
-        "ALLOW_DBLESS_SPECS" => "false",
-        "COVERAGE" => "false"
-      },
-      "bundle", "exec", "ruby", "-e", probe_script,
-      chdir: Rails.root.to_s
-    )
-
-    expect(status.success?).to be(true), stderr
-    expect(stdout.lines.first.to_s.strip).to eq("false")
-  end
-
-  it "disables coverage during mutation sweeps, even when explicitly requested" do
-    # Mutant loads spec_helper in its main process via the rspec integration,
-    # so ::Mutant is defined at coverage-decision time. Whole-codebase line
-    # coverage is meaningless for a scoped mutation run and previously failed
-    # the job via the minimum_coverage gate, so SimpleCov must never start.
-    stdout, stderr, status = Open3.capture3(
-      {
-        "ALLOW_DBLESS_SPECS" => "true",
-        "COVERAGE" => "true"
-      },
-      "bundle", "exec", "ruby", "-e", probe_script(prelude: "Mutant = Module.new"),
-      chdir: Rails.root.to_s
-    )
-
-    expect(status.success?).to be(true), stderr
-    expect(stdout.lines.first.to_s.strip).to eq("false")
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -84,6 +84,16 @@ RSpec.configure do |config|
   config.after do
     ProviderSupport.reset_supported_provider_keys!
     RunnerSupport.reset_supported_runner_keys!
+    # The ActiveJob TestAdapter accumulates enqueued/performed jobs across the
+    # whole run (it is process-global and never auto-cleared). Specs that assert
+    # against the global queue (e.g. expect(...).not_to include(SomeJob)) flake
+    # under random seeds where a prior spec left jobs behind. Clear both arrays
+    # after every example so no spec can pollute another.
+    adapter = ApplicationJob.queue_adapter
+    if adapter.respond_to?(:enqueued_jobs)
+      adapter.enqueued_jobs.clear
+      adapter.performed_jobs.clear
+    end
   end
 
   config.filter_run_excluding :runner_smoke unless ENV["RUN_RUNNER_SMOKE"] == "true"

--- a/spec/services/docker_hosts/setup_action_runner_spec.rb
+++ b/spec/services/docker_hosts/setup_action_runner_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe DockerHosts::SetupActionRunner do
       result = described_class.call(
         host: host,
         action: "generate_client_bundle",
-        params: ActionController::Parameters.new(client_common_name: "paid-client")
+        params: ActionController::Parameters.new(client_common_name: "paid-client"),
+        key_size: 1024
       )
 
       expect(result.success?).to be(true)
@@ -416,7 +417,7 @@ RSpec.describe DockerHosts::SetupActionRunner do
   end
 
   def build_uploaded_client_bundle(ca_subject: "/CN=paid-upload-ca", ca_serial: 1, client_serial: 2)
-    ca_key = OpenSSL::PKey::RSA.new(2048)
+    ca_key = OpenSSL::PKey::RSA.new(1024)
     ca_cert = build_certificate(
       subject: ca_subject,
       issuer: nil,
@@ -425,7 +426,7 @@ RSpec.describe DockerHosts::SetupActionRunner do
       serial: ca_serial,
       is_ca: true
     )
-    client_key = OpenSSL::PKey::RSA.new(2048)
+    client_key = OpenSSL::PKey::RSA.new(1024)
     client_cert = build_certificate(
       subject: "/CN=paid-client",
       issuer: ca_cert,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,21 +17,9 @@ unless defined?(SpecRunMode)
   end
 end
 
-coverage_enabled = if defined?(::Mutant)
-  # Mutant loads spec_helper in its main process (via the rspec integration),
-  # and each forked worker inherits that state. A mutation sweep only exercises
-  # a handful of subjects, so whole-codebase line coverage is near zero and
-  # would trip the minimum_coverage gate below — failing otherwise-healthy
-  # runs and adding per-fork coverage overhead that stalls the sweep. Line
-  # coverage is irrelevant to mutation testing, so never start SimpleCov here.
-  false
-elsif ENV.key?("COVERAGE")
-  ENV["COVERAGE"] != "false"
-else
-  # DB-less verification runs intentionally execute only a small subset of the
-  # suite, so enforcing the global coverage floor there creates false failures.
-  ENV["ALLOW_DBLESS_SPECS"] != "true"
-end
+require_relative "support/spec_coverage_decision"
+
+coverage_enabled = SpecCoverageDecision.call(env: ENV, mutant_defined: defined?(::Mutant))
 
 if coverage_enabled
   require "simplecov"

--- a/spec/support/spec_coverage_decision.rb
+++ b/spec/support/spec_coverage_decision.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Pure coverage-on/off decision extracted from spec_helper.rb so it can be
+# unit-tested in-process instead of via a `bundle exec ruby` subprocess per
+# matrix case. spec_helper.rb applies it; one subprocess spec still asserts the
+# wiring (that requiring spec_helper actually respects it).
+module SpecCoverageDecision
+  module_function
+
+  # Returns whether SimpleCov should start for this run.
+  #
+  # +env+ is the environment (the ENV object at runtime, or a Hash in tests).
+  # +mutant_defined+ mirrors `defined?(::Mutant)` — Mutant loads spec_helper in
+  # its main process and each forked worker inherits the state; whole-codebase
+  # line coverage is near zero for a scoped mutation run and would trip the
+  # minimum_coverage gate, so coverage is never started under Mutant.
+  def call(env:, mutant_defined: false)
+    return false if mutant_defined
+    return env["COVERAGE"] != "false" if env.key?("COVERAGE")
+
+    # DB-less verification runs intentionally execute a small subset of the
+    # suite, so the global coverage floor creates false failures there.
+    env["ALLOW_DBLESS_SPECS"] != "true"
+  end
+end


### PR DESCRIPTION
## What

Draft RDR proposing that `enhance_issue` move from a direct LLM call to a **read-only containerized agent with repo access**, so its two jobs — generating clarifying questions and judging whether the user's answers are sufficient — are grounded in the actual codebase rather than knowledge-base snapshots.

## Why

`enhance_issue` is the readiness gatekeeper that decides whether an issue is actionable, and it owns the re-evaluation loop after the user answers. Both are codebase questions at their core, yet today it runs as a direct `send_message` call (`tools: :none`, no repo access) against KB fragments. Observed result: it asks humans things the code already says ("are there shape models in `Models.swift`?") and judges sufficiency against a snapshot that may be stale.

This revises RDR-051 Decision #6's "enhance_issue stays lightweight" stance — for the *execution model* only; the role, the needs-input / clarifying-questions flow, and the re-evaluation loop are preserved.

## Key findings from scoping

- **The two-tier gate already exists.** `analyze_issue` is the lightweight gate and already routes (`sufficient` → `create_pr`, `insufficient` → `enhance_issue`). This isn't "build a two-tier model"; it's "make the enhancement tier codebase-aware." `analyze_issue` is unchanged.
- **Both jobs benefit from one change.** Question-generation and answer-sufficiency judgment both need codebase context — a single execution-model change improves both.
- **The capability already exists** on `lid_planning` (containerized, codebase-aware) — borrowed, not merged (distinct output contracts).

## Resolved planning questions

- **Read-only** — `:ro` repo bind mount + prompt statement; state/scratch volumes stay writable. (Workspaces bind-mount today via `Binds`; `:ro` is a one-option change.)
- **Clone** — shallow `--depth 1`, the existing default. Enhancement needs no history.
- **Per-round re-evaluation cost** — accepted in v1.

## Still open for planning

- Workflow insertion point (`agent_execution_workflow.rb:151` currently short-circuits past provisioning; chat provisioning is the analog).
- Validate the chosen runner functions under a read-only repo mount.

## Companion

Builds on #3235 (comment-admission fix, merged) — that fix is what makes prior answers visible to the containerized re-evaluation run.

---

## Also in this PR: test flake fix + spec speedups

While here, the failing `PreviewSessions::ProvisionJob` test was diagnosed and a couple of the slowest specs sped up (unrelated to the RDR, included per request).

**Flake fix** — `PreviewSessions::ProvisionJob does not enqueue run-quality, anomaly, or recovery jobs` was order-dependent test pollution, not a real regression (it passed in isolation). The ActiveJob `TestAdapter` accumulates `enqueued_jobs` across the whole run (process-global, never auto-cleared); specs asserting against the global queue flaked under seeds where a prior spec left jobs behind. `rails_helper` now clears enqueued/performed jobs after every example — eliminating the whole class of pollution, not just this one test.

**Speedups:**
- `DockerHosts::SetupActionRunner` — parameterize RSA key size (default 4096 unchanged for production; specs use 1024-bit). `generate_client_bundle` example: **~5.3s → ~0.17s** (two 4096-bit keypairs were the entire cost).
- `spec_helper` coverage decision — extract the ENV/Mutant branching into a pure `SpecCoverageDecision` module, unit-test in-process, keep one subprocess spec as the integration contract. Four ~2s subprocess boots → instant unit tests + one subprocess.

**Investigated but left alone:**
- `scan_paid_prs:3324` (7s) — 0.14s in isolation; a suite-memory artifact in a 9.9k-line file, nothing actionable in-example.
- `boot_file_spec.rb:85` (5s) — inherently boots the full environment; the test's claim requires it.
- `tenant_context_spec.rb` (21s group) — the win is real (hoisting ~25-migration policy install/uninstall out of the per-example loop), but the only cop-clean semantic confines it to `before(:all)`/`after(:all)`, which the `RSpec/BeforeAfterAll` cop flags and AGENTS.md forbids disabling. Deferred — needs either a lint-config decision or a deeper helper refactor.
- `provider_smoke_script_spec.rb` — runs every suite (not `:provider_smoke`-gated as one might assume); reducible by refactoring to in-process, but it's a coverage-intent decision left for a follow-up.

## Files

- `docs/rdrs/RDR-052-codebase-aware-enhance-issue.md` — the Draft RDR (registered in the README index under Semantic Understanding).
- `docs/brainstorms/codebase-aware-enhance-issue-requirements.md` — the brainstorm requirements doc.
- `docs/rdrs/README.md` — index entry.
- `spec/rails_helper.rb`, `spec/spec_helper.rb`, `spec/support/spec_coverage_decision.rb`, `spec/paid/spec_helper_coverage_spec.rb`, `app/services/docker_hosts/setup_action_runner.rb`, `spec/services/docker_hosts/setup_action_runner_spec.rb` — test flake fix + speedups.