### PR TITLE
fix(ui): repair turbo-frame "Content missing" links and deterministic back navigation

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -495,18 +495,20 @@ module ApplicationHelper
     AGENT_RUN_GOAL_LABELS.fetch(run.goal, run.goal.to_s.titleize)
   end
 
-  # Returns the best "back" URL: checks params[:return_to] first, then
-  # request.referer, then falls back to the provided default path.
-  # Only internal (same-host, path-only) URLs are accepted to prevent open redirects.
+  # Destination for a "Back to X" link. Deterministic by default: the link
+  # navigates to +default_path+ (the page its label names), so a link labeled
+  # "Back to Projects" always lands on the projects index. An explicit,
+  # same-host params[:return_to] is still honored when a controller sets one
+  # intentionally (e.g. deep-linking back into a project after a sub-flow).
+  # Only internal (path-only) URLs are accepted to prevent open redirects.
+  #
+  # The previous request.referer fallback was removed because it routed users
+  # to whatever page they happened to arrive from, so "Back to Projects" could
+  # land on the Dashboard (or anywhere) — the link never did what its label
+  # promised.
   def back_link_path(default_path)
     return_to = params[:return_to].to_s if params[:return_to].present?
-    if return_to.present? && safe_return_path?(return_to)
-      return_to
-    elsif request.referer.present? && safe_referer?(request.referer)
-      request.referer
-    else
-      default_path
-    end
+    (return_to.present? && safe_return_path?(return_to)) ? return_to : default_path
   end
 
   def safe_return_path_or(path, fallback)
@@ -804,10 +806,6 @@ module ApplicationHelper
     return false unless path.start_with?("/") && !path.start_with?("//")
 
     safe_url_from(path).present?
-  end
-
-  def safe_referer?(url)
-    safe_url_from(url.to_s).present?
   end
 
   def priority_tier_for_label(project, label)

--- a/app/views/chat_sessions/_sidebar_list.html.erb
+++ b/app/views/chat_sessions/_sidebar_list.html.erb
@@ -19,7 +19,7 @@
   </div>
 
   <% if has_more && sidebar_next_frame_id && sidebar_next_params %>
-    <%= turbo_frame_tag sidebar_next_frame_id, src: sidebar_page_chat_sessions_path(sidebar_next_params), loading: :lazy do %>
+    <%= turbo_frame_tag sidebar_next_frame_id, src: sidebar_page_chat_sessions_path(sidebar_next_params), loading: :lazy, target: "_top" do %>
       <p class="py-3 text-center text-xs text-gray-400">Loading more...</p>
     <% end %>
   <% end %>

--- a/app/views/chat_sessions/_sidebar_page.html.erb
+++ b/app/views/chat_sessions/_sidebar_page.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag frame_id do %>
+<%= turbo_frame_tag frame_id, target: "_top" do %>
   <% sessions.each do |sidebar_session| %>
     <%= render "session_card", chat_session: sidebar_session %>
   <% end %>

--- a/app/views/dashboard/_auth_health_banner.html.erb
+++ b/app/views/dashboard/_auth_health_banner.html.erb
@@ -10,7 +10,7 @@
           Review Runner Auth Setup before the next run fails with <code>auth_expired</code>.
         </p>
       </div>
-      <%= link_to "Review runners", runners_path, class: "inline-flex items-center rounded-md bg-amber-100 px-3 py-2 text-sm font-semibold text-amber-900 hover:bg-amber-200" %>
+      <%= link_to "Review runners", runners_path, class: "inline-flex items-center rounded-md bg-amber-100 px-3 py-2 text-sm font-semibold text-amber-900 hover:bg-amber-200", data: { turbo_frame: "_top" } %>
     </div>
 
     <div class="mt-4 flow-root">

--- a/app/views/dashboard/_eligibility_breakdown.html.erb
+++ b/app/views/dashboard/_eligibility_breakdown.html.erb
@@ -13,7 +13,8 @@
           <div class="py-3">
             <div class="flex items-center justify-between gap-4">
               <%= link_to bd.project.full_name, project_member_path(bd.project),
-                class: "text-sm font-medium text-gray-900 hover:text-indigo-600" %>
+                class: "text-sm font-medium text-gray-900 hover:text-indigo-600",
+                data: { turbo_frame: "_top" } %>
               <span class="text-xs text-gray-400"><%= pluralize(bd.total_open, "open issue") %></span>
             </div>
             <div class="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">

--- a/app/views/dashboard/_knowledge_widget.html.erb
+++ b/app/views/dashboard/_knowledge_widget.html.erb
@@ -272,7 +272,7 @@
   <% end %>
 
   <div class="mt-4">
-    <%= link_to "Search Knowledge Base", knowledge_search_path, class: "text-sm font-medium text-indigo-600 hover:text-indigo-500" %>
+    <%= link_to "Search Knowledge Base", knowledge_search_path, class: "text-sm font-medium text-indigo-600 hover:text-indigo-500", data: { turbo_frame: "_top" } %>
   </div>
 </div>
 <% end %>

--- a/app/views/dashboard/_queue_preview_row.html.erb
+++ b/app/views/dashboard/_queue_preview_row.html.erb
@@ -1,12 +1,12 @@
 <tr id="<%= dom_id(entry.run, :queue_preview_row) %>">
   <td class="whitespace-nowrap py-3 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-0"><%= entry.position %></td>
-  <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-900"><%= link_to entry.run.project.full_name, project_member_path(entry.run.project), class: "hover:text-indigo-600", data: { turbo: false } %></td>
+  <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-900"><%= link_to entry.run.project.full_name, project_member_path(entry.run.project), class: "hover:text-indigo-600", data: { turbo_frame: "_top" } %></td>
   <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500"><%= agent_run_priority_badge(entry.run) %></td>
   <td class="whitespace-nowrap px-3 py-3 text-sm text-gray-500"><%= goal_label(entry.run.goal) %></td>
   <td class="px-3 py-3 text-sm text-gray-500"><%= agent_run_context_display(entry.run) %></td>
   <td class="whitespace-nowrap px-3 py-3 text-right text-sm">
     <div class="inline-flex items-center gap-2">
-      <%= link_to "View", project_agent_run_member_path(entry.run.project, entry.run), class: "text-indigo-600 hover:text-indigo-900" %>
+      <%= link_to "View", project_agent_run_member_path(entry.run.project, entry.run), class: "text-indigo-600 hover:text-indigo-900", data: { turbo_frame: "_top" } %>
       <% if policy(entry.run).cancel? && entry.run.cancellable? %>
         <%= button_to "Cancel", dashboard_cancel_agent_run_member_path(entry.run),
           method: :post,

--- a/app/views/knowledge/search/_results.html.erb
+++ b/app/views/knowledge/search/_results.html.erb
@@ -21,7 +21,7 @@
                 <% if result[:identifier].present? %>
                   <span class="text-sm font-medium text-gray-900">
                     <% if result[:artifact_id] %>
-                      <%= link_to result[:identifier], knowledge_artifact_path(result[:artifact_id]), class: "hover:text-indigo-600" %>
+                      <%= link_to result[:identifier], knowledge_artifact_path(result[:artifact_id]), class: "hover:text-indigo-600", data: { turbo_frame: "_top" } %>
                     <% else %>
                       <%= result[:identifier] %>
                     <% end %>

--- a/spec/helpers/application_helper_back_link_spec.rb
+++ b/spec/helpers/application_helper_back_link_spec.rb
@@ -38,25 +38,16 @@ RSpec.describe ApplicationHelper do
       end
     end
 
-    context "when return_to is absent but referer is a same-host URL" do
-      it "returns the referer" do
+    context "when params[:return_to] is absent" do
+      it "returns the default path regardless of referer (deterministic)" do
         allow(helper).to receive(:params).and_return(ActionController::Parameters.new({}))
         allow(helper.request).to receive_messages(referer: "http://test.host/agent_runs", host: "test.host")
-
-        expect(helper.back_link_path(default_path)).to eq("http://test.host/agent_runs")
-      end
-    end
-
-    context "when referer is from a different host" do
-      it "falls back to default" do
-        allow(helper).to receive(:params).and_return(ActionController::Parameters.new({}))
-        allow(helper.request).to receive_messages(referer: "https://other.com/page", host: "test.host")
 
         expect(helper.back_link_path(default_path)).to eq(default_path)
       end
     end
 
-    context "when neither return_to nor referer is available" do
+    context "when neither return_to nor a referer is available" do
       it "returns the default path" do
         allow(helper).to receive(:params).and_return(ActionController::Parameters.new({}))
         allow(helper.request).to receive(:referer).and_return(nil)
@@ -66,7 +57,7 @@ RSpec.describe ApplicationHelper do
     end
 
     context "when both return_to and referer are present" do
-      it "uses return_to over referer" do
+      it "uses return_to and ignores referer" do
         allow(helper).to receive(:params).and_return(ActionController::Parameters.new(return_to: "/specific_page"))
         allow(helper.request).to receive_messages(referer: "http://test.host/other_page", host: "test.host")
 

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -288,6 +288,29 @@ RSpec.describe "Dashboard" do
         expect(banner.text).to include("Session expired")
       end
 
+      it "escapes the deferred frame for the Review runners link in the auth-health banner" do
+        allow(Runners::AuthHealth).to receive(:call).and_return([
+          Runners::AuthHealth::Result.new(
+            runner: "Claude",
+            runner_key: "claude",
+            owner_name: user.name,
+            owner_email: user.email,
+            valid: false,
+            expires_at: 1.hour.ago,
+            source: :host_forwarded,
+            error: "Session expired"
+          )
+        ])
+
+        get dashboard_auth_health_path
+
+        document = Nokogiri::HTML(response.body)
+        review_link = document.at_css(%([data-testid='dashboard-auth-health-banner'] a[href="#{runners_path}"]))
+
+        expect(review_link).to be_present
+        expect(review_link["data-turbo-frame"]).to eq("_top")
+      end
+
       it "shows live metrics section with active runs" do
         create(:agent_run, project: project, status: "running", started_at: 5.minutes.ago)
         create(:agent_run, project: project, status: "completed", completed_at: 1.minute.ago, duration_seconds: 42)
@@ -378,7 +401,7 @@ RSpec.describe "Dashboard" do
         expect(cancel_form.at_css("button")&.text).to include("Cancel")
       end
 
-      it "disables Turbo navigation for the project link in the upcoming queue" do
+      it "escapes the dashboard frame for the project link in the upcoming queue" do
         issue = create(:issue, project: project, github_number: 92, title: "Navigate from the queue")
         run = create(:agent_run, :queued, project: project, issue: issue, created_at: 2.minutes.ago)
 
@@ -390,7 +413,7 @@ RSpec.describe "Dashboard" do
         project_link = row.at_css(%(a[href="#{project_path(project)}"]))
 
         expect(project_link).to be_present
-        expect(project_link["data-turbo"]).to eq("false")
+        expect(project_link["data-turbo-frame"]).to eq("_top")
       end
 
       it "does not render a Cancel button in the upcoming queue for users who cannot run agents" do


### PR DESCRIPTION
## Summary

Fixes two classes of broken links surfaced by a UI audit.

### 1. "Content missing" on links inside turbo frames
Navigational links rendered inside lazy-loaded `<turbo-frame>`s lacked `data-turbo-frame="_top"`, so Turbo tried to render the destination *inside* the frame and showed **"Content missing"** instead of navigating. Each now forces a full-page Turbo Drive visit (matching the pattern already used correctly in the notifications bell and dashboard filter buttons):

| File | Link | Frame |
|---|---|---|
| `dashboard/_eligibility_breakdown` | project name | `dashboard-eligibility-breakdown` |
| `dashboard/_queue_preview_row` | project name + "View" run | `dashboard-queue-preview` |
| `dashboard/_knowledge_widget` | "Search Knowledge Base" | `dashboard-knowledge-stats` |
| `dashboard/_auth_health_banner` | "Review runners" | `dashboard-auth-health` |
| `knowledge/search/_results` | artifact identifier | `search-results` |
| `chat_sessions/_sidebar_page` + `_sidebar_list` | session cards | lazy pagination frames (`target: "_top"`) |

### 2. Back links that didn't go where their label promised
~37 "Back to X" links used `ApplicationHelper#back_link_path`, which returned `request.referer` — so "Back to Projects" could land on the Dashboard (or anywhere). Made it **deterministic**: it now navigates to the labeled default, while still honoring an explicit controller-set `params[:return_to]` (used for intentional deep-links like the clarifying-questions flow). Removed the now-dead `safe_referer?`.

## Security
Open-redirect protection intact: `return_to` is still validated by `safe_return_path?` (path-only, rejects `//` and external URLs).

## Test plan
- Updated `application_helper_back_link_spec.rb` to the deterministic behavior.
- Updated the dashboard queue-preview spec (project link now `data-turbo-frame="_top"` instead of `data-turbo="false"`).
- Added a focused spec for the auth-health "Review runners" link escaping its frame.
- `herb lint` clean on all changed views; `rubocop` clean on changed Ruby.
- Local specs green: 168 examples, 0 failures across helper / dashboard / chat_sessions suites.

## Notes
- `db/schema.rb` shows a pre-existing unrelated diff in the working tree (PostgreSQL-version ARRAY/function serialization); it was **not** included in this PR.