### PR TITLE
fix(agent-runs): stop one invalid agent_type from stalling the dispatch queue

### DIFF
--- a/app/jobs/process_run_queue_job.rb
+++ b/app/jobs/process_run_queue_job.rb
@@ -256,7 +256,19 @@ class ProcessRunQueueJob < ApplicationJob
         # claim_next_queued_run returns nil if another process claimed or
         # transitioned this run between peek and claim. Skip it and continue
         # processing the queue rather than stopping entirely.
-        agent_run = AgentRun.claim_next_queued_run(target_id: next_run.id)
+        begin
+          agent_run = AgentRun.claim_next_queued_run(target_id: next_run.id)
+        rescue ActiveRecord::RecordInvalid => e
+          # The run is in a state that can never pass validation (e.g. an
+          # agent_type that drifted out of AGENT_TYPES), so claiming it — which
+          # calls update! and re-validates — raises RecordInvalid. Force-fail it
+          # so it leaves the queue instead of stalling every dispatch tick
+          # behind one unclaimable run.
+          force_fail_run(next_run, error: "Unclaimable run: #{e.record.errors.full_messages.to_sentence}")
+          skipped_ids.add(next_run.id)
+          next
+        end
+
         unless agent_run
           skipped_ids.add(next_run.id)
           next

--- a/app/models/agent_run.rb
+++ b/app/models/agent_run.rb
@@ -16,7 +16,14 @@ class AgentRun < ApplicationRecord
     [ /(Bearer\s)[A-Za-z0-9\-._~+\/]+=*/i, "\\1[REDACTED]" ]
   ].freeze
   STATUSES = %w[queued running paused completed no_output failed cancelled timeout token_budget_exceeded retried auth_expired rate_limited].freeze
-  AGENT_TYPES = %w[claude_code cursor codex copilot gemini opencode kilocode pi api devin factory internal_agent].freeze
+  # Must include every value RunnerSupport.agent_type_for produces for a
+  # container-executable runner key (RunnerSupport::CONTAINER_EXECUTABLE_RUNNER_KEYS),
+  # otherwise dequeue-time runner binding writes an agent_type that can never be
+  # re-validated — poisoning the dispatch queue. The invariant is enforced by
+  # spec/lib/runner_support_spec.rb ("returns a valid agent type for every
+  # container-executable runner key"). When you add a runner key, add its
+  # agent_type here too.
+  AGENT_TYPES = %w[claude_code cursor codex copilot gemini opencode openrouter_free openrouter_pareto kilocode pi omp api devin factory internal_agent].freeze
   FOCUSES = %w[general ci_fix review_feedback merge_conflict conversation issue_implementation label_action].freeze # @spec FOCUSED-RUN-001
   # analyze_issue is automation-only (triggered via Automation::Decision), not exposed in the manual run form.
   GOALS = %w[create_pr create_issue review enhance_issue analyze_issue lid_planning].freeze

--- a/app/services/agent_runs/bind_runner.rb
+++ b/app/services/agent_runs/bind_runner.rb
@@ -54,6 +54,19 @@ module AgentRuns
 
       apply_resolution!(runner, resolved_agent_type)
       runner
+    rescue ActiveRecord::RecordInvalid => e
+      # The resolved runner/agent_type failed model validation (e.g. an
+      # agent_type that drifted out of AGENT_TYPES). Persisting it would write
+      # an unclaimable run that later raises RecordInvalid on claim and stalls
+      # the queue. Return nil so the run is parked/skipped like any other
+      # unbindable run instead.
+      Rails.logger.error(
+        message: "bind_runner.invalid_resolution",
+        agent_run_id: agent_run.id,
+        runner_id: runner&.id,
+        error: e.message
+      )
+      nil
     end
 
     private
@@ -68,7 +81,7 @@ module AgentRuns
       updates = { runner_id: runner.id }
       updates[:agent_type] = target_agent_type unless target_agent_type == agent_run.agent_type
 
-      agent_run.update_columns(updates) if updates.any?
+      agent_run.update!(updates) if updates.any?
     end
   end
 end

--- a/spec/jobs/process_run_queue_job_spec.rb
+++ b/spec/jobs/process_run_queue_job_spec.rb
@@ -994,6 +994,33 @@ RSpec.describe ProcessRunQueueJob do
       expect(started_ids).to eq([ eligible_run.id ])
     end
 
+    it "force-fails an unclaimable run at the queue head and continues dispatching the rest" do
+      project = create(:project)
+      user = project.created_by
+      user.settings.update!(max_concurrent_runs: 2)
+
+      # Reproduce the production scenario: a bound run whose agent_type drifted
+      # out of AgentRun::AGENT_TYPES (written via a validation-bypassing path).
+      # It is already bound to a runner, so BindRunner does not overwrite the
+      # bad value. Claiming calls update!, which re-validates and raises
+      # RecordInvalid — without the rescue this stalls every dispatch tick.
+      poisoned = create(:agent_run, :queued, project: project, created_at: 3.minutes.ago)
+      poisoned.update_columns(agent_type: "bogus_invalid_type", runner_id: create(:runner, user: user).id)
+      eligible = create(:agent_run, :queued, project: project, created_at: 1.minute.ago)
+
+      started_ids = []
+      allow(temporal_client).to receive(:start_workflow) do |_wf, input, **_opts|
+        started_ids << input[:agent_run_id]
+        workflow_handle
+      end
+
+      expect { described_class.new.perform }.not_to raise_error
+
+      expect(poisoned.reload.status).to eq("failed")
+      expect(poisoned.reload.error_message).to match(/Agent type/i)
+      expect(started_ids).to include(eligible.id)
+    end
+
     it "does not start queued runs when user is at capacity" do
       project = create(:project, auto_pick_enabled: true)
       user = project.created_by

--- a/spec/lib/runner_support_spec.rb
+++ b/spec/lib/runner_support_spec.rb
@@ -143,6 +143,31 @@ RSpec.describe RunnerSupport do
     end
   end
 
+  describe ".agent_type_for" do
+    it "maps claude to claude_code" do
+      expect(described_class.agent_type_for("claude")).to eq("claude_code")
+    end
+
+    it "passes through other runner keys unchanged" do
+      expect(described_class.agent_type_for("codex")).to eq("codex")
+      expect(described_class.agent_type_for("omp")).to eq("omp")
+    end
+
+    # Guards against the drift that poisoned the dispatch queue: a runner key
+    # was added to CONTAINER_EXECUTABLE_RUNNER_KEYS without also being added to
+    # AgentRun::AGENT_TYPES, so agent_type_for returned a value the model could
+    # never validate. Every container-executable runner must map to a valid
+    # agent type so dequeue-time binding can never write an unclaimable run.
+    it "returns a valid agent type for every container-executable runner key" do
+      described_class::CONTAINER_EXECUTABLE_RUNNER_KEYS.each do |runner_key|
+        agent_type = described_class.agent_type_for(runner_key)
+        expect(AgentRun::AGENT_TYPES).to include(agent_type),
+          "#{runner_key.inspect} maps to #{agent_type.inspect}, which is not in AgentRun::AGENT_TYPES. " \
+          "Add it to the constant."
+      end
+    end
+  end
+
   describe "API_SERVICE_TYPES" do
     it "includes the expected service types" do
       expect(described_class::API_SERVICE_TYPES).to include(

--- a/spec/models/agent_run_spec.rb
+++ b/spec/models/agent_run_spec.rb
@@ -3217,7 +3217,7 @@ RSpec.describe AgentRun do
     end
 
     it "defines valid AGENT_TYPES" do
-      expect(described_class::AGENT_TYPES).to eq(%w[claude_code cursor codex copilot gemini opencode kilocode pi api devin factory internal_agent])
+      expect(described_class::AGENT_TYPES).to eq(%w[claude_code cursor codex copilot gemini opencode openrouter_free openrouter_pareto kilocode pi omp api devin factory internal_agent])
     end
 
     it "defines valid GOALS" do

--- a/spec/services/agent_runs/bind_runner_spec.rb
+++ b/spec/services/agent_runs/bind_runner_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AgentRuns::BindRunner do
+  describe ".call" do
+    let(:project) { create(:project) }
+    let(:owner) { project.created_by }
+    let(:run) { create(:agent_run, :queued, project: project) }
+
+    before do
+      allow(AgentRuns::RunnerResolver).to receive(:call).and_return([ runner.id, resolved_agent_type ])
+    end
+
+    context "when the resolved agent type is valid" do
+      let(:runner) { create(:runner, runner_key: "codex", user: owner) }
+      let(:resolved_agent_type) { "codex" }
+
+      it "persists the resolved runner and agent_type through validation" do
+        result = described_class.call(agent_run: run)
+
+        expect(result).to eq(runner)
+        run.reload
+        expect(run.runner_id).to eq(runner.id)
+        expect(run.agent_type).to eq("codex")
+        expect(run).to be_valid
+      end
+    end
+
+    context "when the resolved agent type is invalid" do
+      let(:runner) { create(:runner, runner_key: "codex", user: owner) }
+      let(:resolved_agent_type) { "bogus_invalid_type" }
+
+      it "returns nil instead of persisting an unclaimable agent_type" do
+        result = described_class.call(agent_run: run)
+
+        expect(result).to be_nil
+        run.reload
+        expect(run.runner_id).to be_nil
+        expect(run.agent_type).to eq("claude_code")
+      end
+
+      it "logs the invalid resolution" do
+        expect(Rails.logger).to receive(:error).with(
+          hash_including(message: "bind_runner.invalid_resolution")
+        )
+        described_class.call(agent_run: run)
+      end
+    end
+
+    context "when the run already has a pinned runner" do
+      let(:runner) { create(:runner, runner_key: "codex", user: owner) }
+      let(:resolved_agent_type) { "codex" }
+
+      it "returns nil without invoking the resolver" do
+        run.update!(runner_id: runner.id, agent_type: "codex")
+
+        expect(AgentRuns::RunnerResolver).not_to receive(:call)
+
+        expect(described_class.call(agent_run: run)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

A single queued run whose `agent_type` fell outside `AgentRun::AGENT_TYPES` (e.g. `"omp"`) stalled the **entire** dispatch queue. `ProcessRunQueueJob` (cron, every 5 min) claims the queue head via `AgentRun.claim_next_queued_run`, which calls `update!` — that re-validates and raised `ActiveRecord::RecordInvalid`. The exception wasn't rescued inside the dispatch loop, so it aborted every tick without ever adding the poisoned run to the skip set. It was re-picked as head 5 minutes later → same crash. Result: zero runs dispatched while plenty of eligible issues sat queued.

## Root cause (three layered bugs)

| # | Bug | Location |
|---|-----|----------|
| A | `omp` / `openrouter_free` / `openrouter_pareto` are valid, container-executable runner keys but were never added to `AGENT_TYPES`. Commit that added the omp runner key updated `CONTAINER_EXECUTABLE_RUNNER_KEYS` but not the validation constant. | `app/models/agent_run.rb` |
| B | `BindRunner` wrote `agent_type` via `update_columns`, bypassing validation — so it silently persisted an unclaimable value (write/read asymmetry: it could write a value the model could never re-validate). | `app/services/agent_runs/bind_runner.rb` |
| C | `ProcessRunQueueJob` had no `rescue` around the claim, so one unvalidatable run aborted the whole tick and stalled the queue indefinitely. | `app/jobs/process_run_queue_job.rb` |

## Fix

- **A** — Added `openrouter_free openrouter_pareto omp` to `AGENT_TYPES`, with a comment cross-referencing `RunnerSupport::CONTAINER_EXECUTABLE_RUNNER_KEYS`. Downstream routing already handled them via passthrough (`AGENT_TYPE_TO_RUNNER` only special-cases `claude_code`); only the stale validation constant blocked them.
- **B** — `BindRunner` now persists via `update!`; on `RecordInvalid` it logs `bind_runner.invalid_resolution` and returns `nil` (graceful skip), so it can never write an unclaimable run or stall dispatch.
- **C** — `ProcessRunQueueJob` rescues `RecordInvalid` from the claim, force-fails the unclaimable run with a descriptive error, and continues — so one bad run can never block the rest of the queue.

## Tests

- `spec/lib/runner_support_spec.rb` — invariant: every container-executable runner key maps to a valid agent type (regression guard against future drift).
- `spec/services/agent_runs/bind_runner_spec.rb` (new) — valid binding persists through validation; invalid binding returns `nil` without persisting and logs; pinned-runner no-op.
- `spec/jobs/process_run_queue_job_spec.rb` — reproduces the bound poisoned-run scenario: the poisoned run is force-failed while the next queued run still dispatches.

## Verification

1,054+ specs green across affected areas (model 529, controller/request/MCP/helper 285, runner/bind/job 201, resolver/followup 39); RuboCop clean on all changed files.