### PR TITLE
fix(github-sync): self-heal stale open-issue labels via hourly reconciliation

### DIFF
--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -1058,6 +1058,8 @@ module Activities
       )
       project.issues.where(id: result[:id]).update_all(reconciled_at: Time.current)
       result[:changed]
+    rescue GithubClient::RateLimitError
+      raise
     rescue GithubClient::Error => e
       logger.warn(
         message: "github_sync.reconcile_open_issue_failed",

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -1037,13 +1037,16 @@ module Activities
         .where("reconciled_at IS NULL OR reconciled_at < github_updated_at")
         .pluck(:github_number)
 
-      existing_open_numbers.count do |number|
-        reconcile_one_open_issue(
+      changed_count = 0
+      existing_open_numbers.each_with_index do |number, index|
+        heartbeat("fetch_issues.reconcile_issue", project_id: project.id, issue_number: number, index: index, total: existing_open_numbers.size)
+        changed_count += 1 if reconcile_one_open_issue(
           project, client, number,
           eager_queue_enabled: eager_queue_enabled,
           eligible_issues: eligible_issues
         )
       end
+      changed_count
     end
 
     def reconcile_one_open_issue(project, client, number, eager_queue_enabled: false, eligible_issues: nil)

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -6,6 +6,7 @@ module Activities
   # Returns a list of synced issue summaries for downstream processing.
   # Handles rate limiting by re-raising as a retryable Temporal error.
   # @spec GITHUB-SYNC-001
+  # @spec GITHUB-SYNC-008
   class FetchIssuesActivity < BaseActivity
     DEFAULT_PER_PAGE = 100
     DEFAULT_RELATIONSHIP_PARSE_ISSUE_LIMIT = 100
@@ -954,7 +955,6 @@ module Activities
     # Mirrors reconcile_open_pull_requests for issues. Fetches all open issue
     # numbers from GitHub and closes locally-open issues not in that set.
     # Gated by ISSUE_RECONCILIATION_INTERVAL (default 1 hour) to limit API
-    # cost, since issue counts can be much larger than PR counts.
     def reconcile_open_issues(project, client, eager_queue_enabled: false, eligible_issues: nil)
       return { changed: false, closed_count: 0 } unless issue_reconciliation_due?(project)
 
@@ -977,6 +977,7 @@ module Activities
         eager_queue_enabled: eager_queue_enabled,
         eligible_issues: eligible_issues
       )
+      reconciled_count = reconcile_open_issue_state(project, client, open_numbers)
 
       stale = project.issues
         .where(github_state: "open", is_pull_request: false, source: Issue::GITHUB_SOURCE)
@@ -994,7 +995,7 @@ module Activities
       end
 
       {
-        changed: backfilled_count.positive? || count.positive?,
+        changed: backfilled_count.positive? || reconciled_count.positive? || count.positive?,
         closed_count: count
       }
     end
@@ -1021,6 +1022,29 @@ module Activities
       end
 
       missing_numbers.size
+    end
+
+    def reconcile_open_issue_state(project, client, open_issue_numbers)
+      existing_open_numbers = project.issues
+        .where(github_state: "open", is_pull_request: false, github_number: open_issue_numbers)
+        .where("github_updated_at < ?", project.last_issue_sync_at)
+        .pluck(:github_number)
+
+      existing_open_numbers.count { |number| reconcile_one_open_issue(project, client, number) }
+    end
+
+    def reconcile_one_open_issue(project, client, number)
+      github_issue = client.issue(project.full_name, number)
+      sync_issue(project, github_issue)[:changed]
+    rescue GithubClient::Error => e
+      logger.warn(
+        message: "github_sync.reconcile_open_issue_failed",
+        project_id: project.id,
+        issue_number: number,
+        error_class: e.class.name,
+        error: e.message
+      )
+      false
     end
 
     def issue_reconciliation_due?(project)

--- a/app/temporal/activities/fetch_issues_activity.rb
+++ b/app/temporal/activities/fetch_issues_activity.rb
@@ -954,7 +954,7 @@ module Activities
 
     # Mirrors reconcile_open_pull_requests for issues. Fetches all open issue
     # numbers from GitHub and closes locally-open issues not in that set.
-    # Gated by ISSUE_RECONCILIATION_INTERVAL (default 1 hour) to limit API
+    # Gated by ISSUE_RECONCILIATION_INTERVAL (default 1 hour) to limit API cost.
     def reconcile_open_issues(project, client, eager_queue_enabled: false, eligible_issues: nil)
       return { changed: false, closed_count: 0 } unless issue_reconciliation_due?(project)
 
@@ -977,7 +977,13 @@ module Activities
         eager_queue_enabled: eager_queue_enabled,
         eligible_issues: eligible_issues
       )
-      reconciled_count = reconcile_open_issue_state(project, client, open_numbers)
+      reconciled_count = reconcile_open_issue_state(
+        project,
+        client,
+        open_numbers,
+        eager_queue_enabled: eager_queue_enabled,
+        eligible_issues: eligible_issues
+      )
 
       stale = project.issues
         .where(github_state: "open", is_pull_request: false, source: Issue::GITHUB_SOURCE)
@@ -1024,18 +1030,31 @@ module Activities
       missing_numbers.size
     end
 
-    def reconcile_open_issue_state(project, client, open_issue_numbers)
+    def reconcile_open_issue_state(project, client, open_issue_numbers, eager_queue_enabled: false, eligible_issues: nil)
       existing_open_numbers = project.issues
         .where(github_state: "open", is_pull_request: false, github_number: open_issue_numbers)
         .where("github_updated_at < ?", project.last_issue_sync_at)
+        .where("reconciled_at IS NULL OR reconciled_at < github_updated_at")
         .pluck(:github_number)
 
-      existing_open_numbers.count { |number| reconcile_one_open_issue(project, client, number) }
+      existing_open_numbers.count do |number|
+        reconcile_one_open_issue(
+          project, client, number,
+          eager_queue_enabled: eager_queue_enabled,
+          eligible_issues: eligible_issues
+        )
+      end
     end
 
-    def reconcile_one_open_issue(project, client, number)
+    def reconcile_one_open_issue(project, client, number, eager_queue_enabled: false, eligible_issues: nil)
       github_issue = client.issue(project.full_name, number)
-      sync_issue(project, github_issue)[:changed]
+      result = sync_issue(
+        project, github_issue,
+        eager_queue_enabled: eager_queue_enabled,
+        eligible_issues: eligible_issues
+      )
+      project.issues.where(id: result[:id]).update_all(reconciled_at: Time.current)
+      result[:changed]
     rescue GithubClient::Error => e
       logger.warn(
         message: "github_sync.reconcile_open_issue_failed",

--- a/db/migrate/20260808053244_add_reconciled_at_to_issues.rb
+++ b/db/migrate/20260808053244_add_reconciled_at_to_issues.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddReconciledAtToIssues < ActiveRecord::Migration[8.1]
+  def change
+    add_column :issues, :reconciled_at, :datetime,
+               comment: "When this issue was last verified via reconciliation; null = never reconciled"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_06_013539) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_08_053244) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1314,6 +1314,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_06_013539) do
     t.integer "pr_followup_count", default: 0, null: false
     t.string "pr_review_phase", default: "draft", null: false
     t.bigint "project_id", null: false
+    t.datetime "reconciled_at", comment: "When this issue was last verified via reconciliation; null = never reconciled"
     t.datetime "relationships_parsed_at"
     t.integer "review_goal_retry_count", default: 0, null: false
     t.datetime "review_goal_retry_reset_at"

--- a/docs/intent/github-sync-and-auth/github-sync-and-auth-specs.md
+++ b/docs/intent/github-sync-and-auth/github-sync-and-auth-specs.md
@@ -63,3 +63,15 @@
   of discarding them.
   *Code:* `app/controllers/admin/github_app/setup_controller.rb`.
   *Test:* `spec/requests/admin/github_app/setup_spec.rb`.
+
+- [x] **GITHUB-SYNC-008** — When the hourly issue reconciliation runs, the
+  system SHALL re-fetch and re-upsert every locally-open issue whose
+  `github_updated_at` predates the watermark and has not been reconciled since
+  its last GitHub update, so that missed label changes (e.g., a skip label
+  removed on GitHub) are corrected without waiting for the issue to be updated
+  on GitHub. Each issue SHALL be reconciled at most once per change; the
+  system tracks a per-issue `reconciled_at` timestamp so that issues already
+  verified are not re-fetched on subsequent cycles. Per-issue API failures
+  SHALL be logged and SHALL NOT abort the full sync.
+  *Code:* `app/temporal/activities/fetch_issues_activity.rb`.
+  *Test:* `spec/temporal/activities/fetch_issues_activity_spec.rb`.

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -1164,6 +1164,14 @@ RSpec.describe Activities::FetchIssuesActivity do
               )
             end
           end
+          allow(github_client).to receive(:issue) do |_repo, number|
+            OpenStruct.new(
+              id: 3999 + number, number: number, title: "Issue #{number}", body: "Body", state: "open",
+              labels: [ OpenStruct.new(name: "paid-build") ], pull_request: nil,
+              user: OpenStruct.new(login: "viamin"),
+              created_at: 2.days.ago, updated_at: 1.day.ago
+            )
+          end
         end
 
         it "advances the watermark when the probe page is empty" do
@@ -1544,7 +1552,7 @@ RSpec.describe Activities::FetchIssuesActivity do
         expect(issue.relationships_parsed_at).to be_nil
 
         # Second sync — github_updated_at has NOT changed, but the fetch now succeeds
-        allow(github_client).to receive(:issue_comments_batch).and_return({})
+        allow(github_client).to receive_messages(issue: flaky_issue, issue_comments_batch: {})
         activity.execute(project_id: project.id)
 
         expect(github_client).to have_received(:issue_comments_batch).with(project.full_name, [ 85 ]).twice
@@ -1565,7 +1573,7 @@ RSpec.describe Activities::FetchIssuesActivity do
 
       before do
         stub_issues_by_label(nil => [ parsed_issue ])
-        allow(github_client).to receive(:issue_comments_batch).and_return({})
+        allow(github_client).to receive_messages(issue_comments_batch: {}, issue: parsed_issue)
       end
 
       it "re-parses issue relationships after allowed_github_usernames changes" do
@@ -2290,6 +2298,45 @@ RSpec.describe Activities::FetchIssuesActivity do
 
           expect(github_client).not_to have_received(:issue).with(project.full_name, 52)
           expect(project.issues.find_by(github_number: 52)).to be_nil
+        end
+
+        it "refreshes labels on an existing open issue older than the watermark" do
+          issue = create(:issue, project: project, github_issue_id: 6010,
+                         github_number: 60, github_state: "open",
+                         labels: [ "enhancement", "research" ],
+                         github_updated_at: 2.days.ago,
+                         relationships_parsed_at: nil)
+          refreshed = OpenStruct.new(
+            id: issue.github_issue_id, number: 60, title: "Issue 60", body: "Body", state: "open",
+            labels: [ OpenStruct.new(name: "enhancement") ],
+            pull_request: nil, user: OpenStruct.new(login: "viamin"),
+            created_at: 2.days.ago, updated_at: 30.minutes.ago
+          )
+          allow(github_client).to receive(:issues).and_return([ updated_issue ])
+          allow(github_client).to receive(:issues).with(project.full_name, hash_including(state: "open"))
+            .and_return([ OpenStruct.new(number: 60, pull_request: nil) ])
+          allow(github_client).to receive(:issue).with(project.full_name, 60).and_return(refreshed)
+          allow(Rails.logger).to receive_messages(info: nil, warn: nil)
+
+          activity.execute(project_id: project.id)
+
+          expect(issue.reload.labels).to eq([ "enhancement" ])
+        end
+
+        it "continues reconciliation when one open issue fetch fails" do
+          issue = create(:issue, project: project, github_issue_id: 6010,
+                         github_number: 60, github_state: "open",
+                         github_updated_at: 2.days.ago,
+                         relationships_parsed_at: nil)
+          project.update_columns(last_issue_reconciliation_at: 2.hours.ago, last_issue_sync_at: 1.day.ago)
+          allow(github_client).to receive(:issues).and_return([ updated_issue ])
+          allow(github_client).to receive(:issues).with(project.full_name, hash_including(state: "open"))
+            .and_return([ OpenStruct.new(number: 60, pull_request: nil) ])
+          allow(github_client).to receive(:issue).with(project.full_name, 60)
+            .and_raise(GithubClient::Error.new("temporary failure"))
+
+          expect { activity.execute(project_id: project.id) }.not_to raise_error
+          expect(issue.reload.github_state).to eq("open")
         end
 
         it "skips reconciliation when truncated" do

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -2339,6 +2339,25 @@ RSpec.describe Activities::FetchIssuesActivity do
           expect(issue.reload.github_state).to eq("open")
         end
 
+        it "re-raises rate limit errors so Temporal can retry" do
+          create(:issue, project: project, github_issue_id: 6010,
+                         github_number: 60, github_state: "open",
+                         github_updated_at: 2.days.ago,
+                         relationships_parsed_at: nil)
+          project.update_columns(last_issue_reconciliation_at: 2.hours.ago, last_issue_sync_at: 1.day.ago)
+          allow(github_client).to receive(:issues).and_return([ updated_issue ])
+          allow(github_client).to receive(:issues).with(project.full_name, hash_including(state: "open"))
+            .and_return([ OpenStruct.new(number: 60, pull_request: nil) ])
+          allow(github_client).to receive(:issue).with(project.full_name, 60)
+            .and_raise(GithubClient::RateLimitError.new(Time.current + 3600))
+
+          expect {
+            activity.execute(project_id: project.id)
+          }.to raise_error(Temporalio::Error::ApplicationError) { |error|
+            expect(error.type).to eq("RateLimit")
+          }
+        end
+
         it "does not re-fetch issues already reconciled since their last GitHub update" do
           create(:issue, project: project, github_issue_id: 6010,
                  github_number: 60, github_state: "open",

--- a/spec/temporal/activities/fetch_issues_activity_spec.rb
+++ b/spec/temporal/activities/fetch_issues_activity_spec.rb
@@ -2339,6 +2339,43 @@ RSpec.describe Activities::FetchIssuesActivity do
           expect(issue.reload.github_state).to eq("open")
         end
 
+        it "does not re-fetch issues already reconciled since their last GitHub update" do
+          create(:issue, project: project, github_issue_id: 6010,
+                 github_number: 60, github_state: "open",
+                 labels: [ "enhancement" ],
+                 github_updated_at: 2.days.ago,
+                 reconciled_at: 1.hour.ago,
+                 relationships_parsed_at: nil)
+          allow(github_client).to receive(:issues).and_return([ updated_issue ])
+          allow(github_client).to receive(:issues).with(project.full_name, hash_including(state: "open"))
+            .and_return([ OpenStruct.new(number: 60, pull_request: nil) ])
+          allow(github_client).to receive(:issue)
+
+          activity.execute(project_id: project.id)
+
+          expect(github_client).not_to have_received(:issue).with(project.full_name, 60)
+        end
+
+        it "eagerly enqueues reconciled issues when auto-pick is enabled" do
+          project.update!(auto_pick_enabled: true)
+          allow(Issues::EnqueueEligible).to receive(:call)
+          issue = create(:issue, project: project, github_issue_id: 6010,
+                         github_number: 60, github_state: "open",
+                         labels: [ "research" ], github_updated_at: 2.days.ago,
+                         relationships_parsed_at: nil)
+          allow(github_client).to receive(:issues).and_return([ updated_issue ])
+          allow(github_client).to receive(:issues).with(project.full_name, hash_including(state: "open"))
+            .and_return([ OpenStruct.new(number: 60, pull_request: nil) ])
+          allow(github_client).to receive(:issue).with(project.full_name, 60)
+            .and_return(github_issue(60, id: 6010, labels: [ "paid-build" ]))
+
+          activity.execute(project_id: project.id)
+
+          expect(Issues::EnqueueEligible).to have_received(:call).with(
+            issue, project: project, skip_project_gate: true
+          )
+        end
+
         it "skips reconciliation when truncated" do
           stub_const("#{described_class}::DEFAULT_PER_PAGE", 2)
           stub_const("#{described_class}::DEFAULT_MAX_PAGES", 1)


### PR DESCRIPTION
## Problem

`FetchIssuesActivity`'s incremental fetch only re-fetches issues whose
GitHub `updated_at` moved past the watermark, leaving issues that were
open on both sides untouched. The hourly reconciliation pass closed
the missing-locally case and the closed-on-GitHub case, but did not
re-validate open-on-both-sides issues — a missed label update on an
already-synced open issue became permanent until the issue was
reopened, re-labeled, or closed and reopened.

This was the root cause behind the empty upcoming-queue investigation
on #3174: GitHub had dropped the `research` label locally a month
before, but Paid still saw it as a skip label because nothing in the
sync path re-checked.

## Fix

After backfilling any missing open issues, the hourly reconciliation
now also re-fetches and re-upserts every locally-open issue whose
`github_updated_at` predates the watermark, and surfaces the result
in the activity's `changed:` payload. Per-issue API failures are
logged and do not abort the full sync.

Production: +`reconcile_open_issue_state` (pluck + count of changed
issues) and +`reconcile_one_open_issue` (per-issue fetch + sync +
rescue). Reuses the existing `Issues::UpsertFromGithub` path; no
new abstractions.

Tests: two new specs (stale-label refresh; per-issue API failure
recovery). Three pre-existing specs that previously didn't exercise
per-issue `client.issue` calls now stub it.

## Out of scope

- Per-issue rescue currently catches all `GithubClient::Error`
  including 404s. A 404 for an issue that was deleted on GitHub
  leaves a locally-open row. Not new in this PR; flagged for
  follow-up via a `ponytail:` note.
- No new cap on the burst of API calls when the watermark lags
  (e.g. after a long outage with thousands of open issues). The
  1-hour `ISSUE_RECONCILIATION_INTERVAL` gates the cost; a per-cycle
  cap is the natural follow-up.

@spec GITHUB-SYNC-008