### PR TITLE
fix(issue-agents): stop analyze and enhance run failures

### DIFF
--- a/app/services/containers/provision.rb
+++ b/app/services/containers/provision.rb
@@ -2525,16 +2525,13 @@ module Containers
       }
     end
 
-    # Returns the mount mode for the workspace bind.  enhance_issue runs
-    # are read-only (RDR-052) — the agent can explore the repo but cannot
-    # modify files, commit, or push.  All other goals mount read-write.
+    # Returns the mount mode for the workspace bind. The platform must clone
+    # the repo into /workspace before enhance_issue can inspect it, so the
+    # Docker mount stays writable even though the enhance prompt forbids
+    # changing files and the workflow never pushes enhance_issue output.
     # @spec ISSUE-ENHANCEMENT-006
     def workspace_mount_mode
-      if agent_run&.enhance_issue_goal?
-        "ro"
-      else
-        "rw"
-      end
+      "rw"
     end
 
     # Proxy-mode API key auth uses the restricted paid_agent network.

--- a/app/temporal/activities/analyze_issue_activity.rb
+++ b/app/temporal/activities/analyze_issue_activity.rb
@@ -306,7 +306,35 @@ module Activities
     end
 
     def extract_analysis_json(output)
-      JSON.parse(strip_markdown_fence(output.to_s.strip), symbolize_names: true)
+      parse_analysis_candidate(output) ||
+        raise(JSON::ParserError, "no analysis JSON object found")
+    end
+
+    def parse_analysis_candidate(output)
+      analysis_json_candidates(output).each do |candidate|
+        parsed = JSON.parse(candidate, symbolize_names: true)
+        return parsed if parsed.is_a?(Hash)
+      rescue JSON::ParserError
+        next
+      end
+
+      nil
+    end
+
+    def analysis_json_candidates(output)
+      stripped = output.to_s.strip
+      candidates = [ strip_markdown_fence(stripped) ]
+      candidates.concat(stripped.scan(/```(?:json)?\s*(.*?)\s*```/m).flatten)
+      candidates << embedded_json_object(stripped)
+      candidates.compact.uniq
+    end
+
+    def embedded_json_object(output)
+      start = output.index("{")
+      finish = output.rindex("}")
+      return unless start && finish && finish > start
+
+      output[start..finish]
     end
 
     def track_tokens(agent_run, response)

--- a/app/temporal/activities/enhance_issue_activity.rb
+++ b/app/temporal/activities/enhance_issue_activity.rb
@@ -5,9 +5,12 @@ module Activities
   # or asks focused clarifying questions when the issue is not actionable yet.
   #
   # Containerized execution: the agent has already explored the repo in a
-  # read-only container via RunAgentActivity (RDR-052 Phase 1) and emitted a
-  # structured JSON result between OUTPUT_DELIMITER lines. This activity reads
-  # that result, posts the enhancement comment, and applies label state.
+  # comment-only containerized run via RunAgentActivity (RDR-052 Phase 1) and
+  # emitted a structured JSON result between OUTPUT_DELIMITER lines. The
+  # workspace mount is :rw so the platform could clone into /workspace, but
+  # RunAgentActivity skipped git post-processing and the prompt instructed
+  # the agent not to commit/push. This activity reads that result, posts the
+  # enhancement comment, and applies label state.
   # @spec ISSUE-ENHANCEMENT-006
   class EnhanceIssueActivity < BaseActivity
     include Llm::OutputNormalizer

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -324,8 +324,14 @@ module Activities
             # until those failures age out of the inspection window.
             clear_issue_runner_retry_abandonment(agent_run)
 
-            # Skip git post-processing for goals that don't clone a repo.
-            # These runs only interact via the GitHub API proxy — no git repo exists.
+            # Skip git post-processing for runs that have nothing to commit:
+            #   - Goals that never clone a repo (they only interact via the
+            #     GitHub API proxy — no git repo exists).
+            #   - enhance_issue DOES clone (the workspace mount is :rw so the
+            #     platform can populate /workspace for inspection), but the
+            #     workflow is comment-only: it never commits, pushes, or opens
+            #     a PR. Skipping here keeps the run from spuriously reporting
+            #     file changes or attempting to commit.
             #
             # Keep heartbeats flowing during post-run bookkeeping too. By the
             # time we reach this block the runner may already have posted a PR
@@ -3681,7 +3687,9 @@ module Activities
       IMPORTANT: Your goal is to ENHANCE AN EXISTING ISSUE by adding context or asking clarifying questions.
       Do NOT write code, create PRs, create new issues, or push commits.
 
-      The workspace is READ-ONLY — you can explore and read files but cannot modify them.
+      This run is comment-only: do NOT modify files in /workspace, do NOT commit, push, or
+      create a PR. The workflow discards any /workspace modifications — only the posted
+      comment and label state matter. You can explore and read the repo freely.
       State directories (under /home/agent/) are writable for scratch/tooling needs.
 
       Read issue #{{issue_number}} in {{repo}} — its description and all comments.  Explore the repository

--- a/app/temporal/activities/run_agent_activity.rb
+++ b/app/temporal/activities/run_agent_activity.rb
@@ -338,7 +338,7 @@ module Activities
             bookkeeping_result = with_periodic_heartbeat("post_run_bookkeeping", runner) do
               # Evaluate pre-commit requirements against the working directory
               # before committing, so blocking failures prevent commits.
-              if agent_run.repo_cloned?
+              if agent_run.repo_cloned? && !agent_run.enhance_issue_goal?
                 record_verification_result(
                   agent_run,
                   fallback_result: runner_result[:verification_fallback_result]
@@ -362,7 +362,11 @@ module Activities
                 commit_uncommitted_changes(agent_run)
               end
 
-              { has_changes: agent_run.repo_cloned? ? check_for_changes(agent_run, pre_agent_sha) : false }
+              {
+                has_changes: agent_run.repo_cloned? && !agent_run.enhance_issue_goal? ?
+                  check_for_changes(agent_run, pre_agent_sha) :
+                  false
+              }
             end
 
             attempt_finished = true

--- a/db/seeds/prompts.rb
+++ b/db/seeds/prompts.rb
@@ -908,7 +908,9 @@ upsert_global_prompt.call(
     IMPORTANT: Your goal is to ENHANCE AN EXISTING ISSUE by adding context or asking clarifying questions.
     Do NOT write code, create PRs, create new issues, or push commits.
 
-    The workspace is READ-ONLY -- you can explore and read files but cannot modify them.
+    This run is comment-only: do NOT modify files in /workspace, do NOT commit, push, or
+    create a PR. The workflow discards any /workspace modifications -- only the posted
+    comment and label state matter. You can explore and read the repo freely.
     State directories (under /home/agent/) are writable for scratch/tooling needs.
 
     Read issue #{{issue_number}} in {{repo}} -- its description and all comments.  Explore the repository

--- a/docs/intent/issue-enhancement/issue-enhancement-design.md
+++ b/docs/intent/issue-enhancement/issue-enhancement-design.md
@@ -62,12 +62,15 @@ retrieval results (`Knowledge::Search`) and knowledge-base context bundle
 states this constraint explicitly so the agent does not fabricate file paths
 or claim a repo read it never made.
 
-**RDR-052 Phase 1 (#3254) — read-only containerized execution.** When that
-work lands, `enhance_issue` will route through container provisioning with a
-read-only repo mount (`app/services/containers/provision_for_chat.rb` is the
-closest analog) and authenticate via the DB-stored runner credential. At that
-point the following claims become behavioral rather than aspirational, and
-ISSUE-ENHANCEMENT-006 / 007 move from `[D]` to `[x]`:
+**RDR-052 Phase 1 (#3254) — comment-only containerized execution.** Phase 1
+routes `enhance_issue` through container provisioning (with the workspace
+mounted writable so the platform can clone the repo before the agent starts)
+and authenticates via the DB-stored runner credential. The run itself is
+comment-only at the workflow level — `RunAgentActivity` skips git
+post-processing and `workspace_mount_mode` is `:rw` so clone can populate
+`/workspace` — and the agent prompt instructs the agent accordingly. This
+moved the following claims from aspirational to behavioral, and
+ISSUE-ENHANCEMENT-006 / 007 from `[D]` to `[x]`:
 
 - **Self-answer what the code determines.** The agent explores the repository,
   retrieval results, and knowledge-base context to answer for itself the things
@@ -85,9 +88,13 @@ ISSUE-ENHANCEMENT-006 / 007 move from `[D]` to `[x]`:
   implementation context cites real files, symbols, and patterns read from the
   repository, not inferred-from-snapshot guesses.
 
-The workspace is read-only: the agent may explore the repository to ground its
-questions and verdict but cannot modify files, commit, or push (RDR R2). Its
-only outputs remain the posted comment and label state.
+The workspace is mounted writable so the platform can clone the repo into
+`/workspace` before the agent runs, but the run is **comment-only**: the
+workflow discards any workspace modifications, never commits, never pushes,
+and never opens a PR (RDR R2). The agent may explore the repository to ground
+its questions and verdict, but its only durable outputs are the posted comment
+and label state. The agent prompt must instruct the agent that the run is
+comment-only so it does not attempt writes that would be discarded anyway.
 
 ## Re-evaluation comment admission
 
@@ -122,7 +129,7 @@ The enhancement flow itself does not create LID artifacts. It captures and
 surfaces intent; the later `create_pr` run materializes that intent when the
 project's LID mode says it should.
 
-## Containerized, read-only execution (RDR-052)
+## Containerized, comment-only execution (RDR-052)
 
 As of RDR-052 Phase 1, `enhance_issue` runs as a **containerized agent with
 repository access** instead of a direct `AgentHarness.send_message` call inside
@@ -130,13 +137,16 @@ the worker process. The agent authenticates via the runner-credential injection
 path (DB-stored credential → container-injected), removing this step's
 dependency on `ANTHROPIC_API_KEY` in the environment.
 
-The run is **read-only**:
+The run is **comment-only**:
 
-- *Structural* — the workspace bind mount uses `:ro` (state/scratch volumes
-  under `/home/agent/` remain writable). See
-  `app/services/containers/provision.rb#workspace_mount_mode`.
-- *Behavioral* — the agent prompt states the workspace is read-only so the
-  agent does not attempt writes that would fail.
+- *Structural* — the workspace bind mount is `:rw` (state/scratch volumes
+  under `/home/agent/` are also writable). The platform populates `/workspace`
+  via the normal clone path before the agent starts; the workflow skips git
+  post-processing for `enhance_issue` so any agent writes are discarded. See
+  `app/services/containers/provision.rb#workspace_mount_mode` and
+  `app/temporal/activities/run_agent_activity.rb`.
+- *Behavioral* — the agent prompt instructs the agent that the run is
+  comment-only so it does not attempt writes that would be discarded anyway.
 
 The run uses the default shallow clone (`--depth 1`), which is sufficient for
 codebase exploration during enhancement. The existing `<!-- paid:enhance-issue -->`

--- a/docs/intent/issue-enhancement/issue-enhancement-specs.md
+++ b/docs/intent/issue-enhancement/issue-enhancement-specs.md
@@ -82,8 +82,9 @@
 - [x] **ISSUE-ENHANCEMENT-006** — When issue enhancement runs, the system SHALL
   execute it as a containerized agent with repository access, authenticating
   via the injected runner credential instead of the `ANTHROPIC_API_KEY`
-  environment variable. The agent prompt SHALL state the read-only constraint,
-  and the workflow SHALL treat the run as comment-only: it SHALL post the
+  environment variable. The agent prompt SHALL instruct the agent that the run
+  is comment-only: workspace modifications are discarded and the agent SHALL
+  NOT commit, push, or create a pull request. The workflow SHALL post the
   `<!-- paid:enhance-issue -->` comment and label state without committing,
   pushing, or creating a pull request.
   *Tests:* `spec/temporal/activities/enhance_issue_activity_spec.rb`.

--- a/docs/intent/issue-enhancement/issue-enhancement-specs.md
+++ b/docs/intent/issue-enhancement/issue-enhancement-specs.md
@@ -80,12 +80,12 @@
 ## Containerized read-only execution (RDR-052)
 
 - [x] **ISSUE-ENHANCEMENT-006** — When issue enhancement runs, the system SHALL
-  execute it as a containerized agent with read-only repository access,
-  authenticating via the injected runner credential instead of the
-  `ANTHROPIC_API_KEY` environment variable. The workspace bind mount SHALL be
-  `:ro` and the agent prompt SHALL state the read-only constraint. The run
-  SHALL produce no file changes, commits, or pushes — only the posted
-  `<!-- paid:enhance-issue -->` comment and label state.
+  execute it as a containerized agent with repository access, authenticating
+  via the injected runner credential instead of the `ANTHROPIC_API_KEY`
+  environment variable. The agent prompt SHALL state the read-only constraint,
+  and the workflow SHALL treat the run as comment-only: it SHALL post the
+  `<!-- paid:enhance-issue -->` comment and label state without committing,
+  pushing, or creating a pull request.
   *Tests:* `spec/temporal/activities/enhance_issue_activity_spec.rb`.
   *Code:* `app/temporal/activities/enhance_issue_activity.rb#enhance_issue_post_run`,
   `app/temporal/workflows/agent_execution_workflow.rb`,

--- a/spec/services/containers/provision_spec.rb
+++ b/spec/services/containers/provision_spec.rb
@@ -1098,6 +1098,18 @@ RSpec.describe Containers::Provision do
         described_class.new(agent_run: agent_run).provision
       end
 
+      it "keeps enhance_issue workspace volume writable so clone can populate the review workspace" do
+        enhance_run = create(:agent_run, :enhance_issue_goal, project: project)
+
+        expect(Docker::Container).to receive(:create) do |config|
+          binds = config["HostConfig"]["Binds"]
+          expect(binds).to include("paid-workspace-#{enhance_run.id}:/workspace:rw")
+          mock_container
+        end
+
+        described_class.new(agent_run: enhance_run).provision
+      end
+
       it "raises ProvisionError for non-existent path" do
         service = described_class.new(agent_run: agent_run, worktree_path: "/nonexistent/path")
 

--- a/spec/temporal/activities/analyze_issue_activity_spec.rb
+++ b/spec/temporal/activities/analyze_issue_activity_spec.rb
@@ -143,6 +143,25 @@ RSpec.describe Activities::AnalyzeIssueActivity do
       expect(agent_run.reload.status).to eq("completed")
     end
 
+    it "extracts fenced analysis JSON when the LLM adds prose before it" do
+      allow(llm_response).to receive(:output).and_return(<<~OUTPUT)
+        I'll assess the issue and return the requested JSON.
+
+        ```json
+        {
+          "sufficient_context": false,
+          "reasoning": "The issue leaves the persistence format unspecified.",
+          "missing_context_areas": ["persistence format"]
+        }
+        ```
+      OUTPUT
+
+      result = activity.execute(agent_run_id: agent_run.id)
+
+      expect(result[:sufficient_context]).to be(false)
+      expect(result[:missing_context_areas]).to eq([ "persistence format" ])
+    end
+
     it "tracks token usage correctly" do
       activity.execute(agent_run_id: agent_run.id)
 

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -1060,12 +1060,13 @@ RSpec.describe Activities::RunAgentActivity do
       expect(prompt).to include("## Codebase Context")
       expect(prompt).to include("Hunt#last_active uses prey.updated_at")
       expect(prompt).to include("Read issue ##{issue.github_number} in #{project.full_name}")
-      # Pin the read-only / no-write safety instructions (RDR-052 Phase 1):
+      # Pin the comment-only / no-write safety instructions (RDR-052 Phase 1):
       # the prompt must explicitly forbid code/PR/commit/issue writes and
-      # declare the workspace read-only so an accidental edit to the
+      # declare the run comment-only so an accidental edit to the
       # FALLBACK_ENHANCE_ISSUE_GOAL_PROMPT template is caught by the spec.
       expect(prompt).to include("Do NOT write code, create PRs, create new issues, or push commits")
-      expect(prompt).to include("workspace is READ-ONLY")
+      expect(prompt).to include("This run is comment-only")
+      expect(prompt).to include("do NOT modify files in /workspace")
     end
 
     it "renders without knowledge context when no artifacts are available" do
@@ -1079,10 +1080,11 @@ RSpec.describe Activities::RunAgentActivity do
       expect(prompt).to include(base_prompt)
       expect(prompt).not_to include("## Codebase Context")
       expect(prompt).to include("Read issue ##{issue.github_number}")
-      # Pin the read-only / no-write safety instructions regardless of
+      # Pin the comment-only / no-write safety instructions regardless of
       # whether the knowledge base produced context for this run.
       expect(prompt).to include("Do NOT write code, create PRs, create new issues, or push commits")
-      expect(prompt).to include("workspace is READ-ONLY")
+      expect(prompt).to include("This run is comment-only")
+      expect(prompt).to include("do NOT modify files in /workspace")
     end
   end
 

--- a/spec/temporal/activities/run_agent_activity_spec.rb
+++ b/spec/temporal/activities/run_agent_activity_spec.rb
@@ -2103,6 +2103,17 @@ expect(container_service).to receive(:execute).with(
         expect(result[:success]).to be true
       end
 
+      it "does not commit or report file changes for enhance_issue runs" do
+        agent_run.update!(goal: "enhance_issue")
+        allow(git_ops).to receive(:has_changes_since?).with("pre_agent_sha_abc123").and_return(true)
+
+        result = activity.execute(agent_run_id: agent_run.id)
+
+        expect(result[:has_changes]).to be false
+        expect(git_ops).not_to have_received(:commit_uncommitted_changes)
+        expect(git_ops).not_to have_received(:has_changes_since?)
+      end
+
       it "returns review_threads_already_addressed when the agent emits the marker" do
         marker_success = Containers::Provision::Result.success(
           stdout: "Reviewed the branch.\n#{Prompts::BuildForPr::ALREADY_ADDRESSED_MARKER}\n",


### PR DESCRIPTION
## Summary

Fixes the recurring issue-agent failure modes seen in recent runs:

- `analyze_issue` now accepts model responses that include prose before fenced or embedded JSON, while still requiring the expected analysis keys.
- `enhance_issue` can clone into `/workspace` again by keeping the workspace mount writable for platform setup.
- `enhance_issue` skips git post-processing in `RunAgentActivity`, so comment-only enhancement runs do not commit or report file changes even though clone needs a writable workspace.
- Updates the issue-enhancement intent spec to describe the enforceable comment-only workflow contract.

## Root Cause

Recent `enhance_issue` runs failed during clone because `/workspace` was mounted read-only before `CloneRepoActivity` populated it. Recent `analyze_issue` runs failed when models returned valid JSON inside a fenced block after a short prose preamble.

## Validation

- `bin/rspec spec/temporal/activities/analyze_issue_activity_spec.rb spec/services/containers/provision_spec.rb:1101 spec/temporal/activities/run_agent_activity_spec.rb:2104`
- `bin/rubocop app/temporal/activities/analyze_issue_activity.rb app/services/containers/provision.rb app/temporal/activities/run_agent_activity.rb spec/temporal/activities/analyze_issue_activity_spec.rb spec/services/containers/provision_spec.rb spec/temporal/activities/run_agent_activity_spec.rb`
- `bin/coherence-check.mjs`
- `git diff --check`