### PR TITLE
fix(chat): constrain API runner fallback

### DIFF
--- a/app/controllers/chat_sessions_controller.rb
+++ b/app/controllers/chat_sessions_controller.rb
@@ -140,6 +140,7 @@ class ChatSessionsController < ApplicationController
     authorize @chat_session
     project_changed = update_params.key?(:project_id) && update_params[:project_id].to_s != @chat_session.project_id.to_s
     metadata_changed = update_params.key?(:metadata) && update_params[:metadata] != @chat_session.metadata
+    validate_api_chat_runner!(update_params[:runner_id]) if update_params.key?(:runner_id)
     @chat_session.update!(update_params)
     regenerate_system_message! if project_changed || metadata_changed
 
@@ -148,6 +149,12 @@ class ChatSessionsController < ApplicationController
       format.turbo_stream { head :no_content }
       format.html { redirect_to chat_session_path(@chat_session), notice: "Chat session updated." }
       format.json { render json: session_json(@chat_session) }
+    end
+  rescue ArgumentError, ActiveRecord::RecordInvalid => e
+    respond_to do |format|
+      format.turbo_stream { render plain: update_error_message(e), status: :unprocessable_entity }
+      format.html { redirect_to chat_session_path(@chat_session), alert: update_error_message(e) }
+      format.json { render json: { error: update_error_message(e) }, status: :unprocessable_entity }
     end
   end
 
@@ -417,6 +424,21 @@ class ChatSessionsController < ApplicationController
     request.format = :json
   end
 
+  def validate_api_chat_runner!(runner_id)
+    return if runner_id.blank?
+
+    runner = current_user.runners.kept_only.find(runner_id)
+    return if ChatSessions::BuildLlmClient.usable_runner?(runner)
+
+    raise ArgumentError, "runner must be an API-key chat runner with a configured API key"
+  end
+
+  def update_error_message(error)
+    return error.record.errors.full_messages.to_sentence if error.respond_to?(:record) && error.record&.errors&.any?
+
+    error.message
+  end
+
   def load_sidebar_data(active_session: nil)
     archived = sidebar_view_archived?(active_session)
     sidebar = sidebar_batch(archived: archived)
@@ -430,7 +452,10 @@ class ChatSessionsController < ApplicationController
     @sidebar_next_frame_id = sidebar[:next_frame_id]
     @sidebar_next_params = sidebar[:next_params]
     @new_chat_session = ChatSession.new(container_capability: "none", auto_approve: current_user.settings.default_auto_approve)
-    @available_runners = current_user.runners.kept_only.ordered
+    @available_runners = current_user.runners.kept_only.for_chat.api_key
+      .includes(:provider_api_key, :integration_credential)
+      .ordered
+      .select { |runner| ChatSessions::BuildLlmClient.usable_runner?(runner) }
     @available_projects = current_account.projects.order(:name)
     @available_models = LlmModel.active.order(:provider, :display_name)
   end

--- a/app/controllers/chat_sessions_controller.rb
+++ b/app/controllers/chat_sessions_controller.rb
@@ -431,6 +431,8 @@ class ChatSessionsController < ApplicationController
     return if ChatSessions::BuildLlmClient.usable_runner?(runner)
 
     raise ArgumentError, "runner must be an API-key chat runner with a configured API key"
+  rescue ActiveRecord::RecordNotFound
+    raise ArgumentError, "runner must belong to the same account"
   end
 
   def update_error_message(error)

--- a/app/controllers/chat_sessions_controller.rb
+++ b/app/controllers/chat_sessions_controller.rb
@@ -427,7 +427,10 @@ class ChatSessionsController < ApplicationController
   def validate_api_chat_runner!(runner_id)
     return if runner_id.blank?
 
-    runner = current_user.runners.kept_only.find(runner_id)
+    runner = Runner.kept_only.find(runner_id)
+    unless runner.user&.account_id == current_account.id
+      raise ArgumentError, "runner must belong to the same account"
+    end
     return if ChatSessions::BuildLlmClient.usable_runner?(runner)
 
     raise ArgumentError, "runner must be an API-key chat runner with a configured API key"

--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -715,7 +715,11 @@ class Runner < ApplicationRecord
     return unless owner
 
     executable_keys = RunnerSupport.container_executable_runner_keys
-    owner.runners.kept_only.for_chat.where(runner_key: executable_keys).ordered.find do |runner|
+    owner.runners.kept_only.for_chat.api_key
+      .includes(:provider_api_key, :integration_credential)
+      .where(runner_key: executable_keys)
+      .ordered
+      .find do |runner|
       runner.effective_api_secret.present?
     end
   end

--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -704,13 +704,6 @@ class Runner < ApplicationRecord
     owner.runners.kept_only.for_agent_runs.where(runner_key: executable_keys).ordered.first
   end
 
-  def self.first_chat_enabled_for_owner(owner)
-    return unless owner
-
-    executable_keys = RunnerSupport.container_executable_runner_keys
-    owner.runners.kept_only.for_chat.where(runner_key: executable_keys).ordered.first
-  end
-
   def self.first_configured_chat_enabled_for_owner(owner)
     return unless owner
 

--- a/app/services/chat_sessions/build_llm_client.rb
+++ b/app/services/chat_sessions/build_llm_client.rb
@@ -16,6 +16,10 @@ module ChatSessions
       "gpt-4o"
     end
 
+    def self.usable_runner?(runner)
+      runner&.enabled_for_chat? && runner.api_key? && runner.effective_api_secret.present?
+    end
+
     def initialize(chat_session:)
       @chat_session = chat_session
     end
@@ -43,7 +47,8 @@ module ChatSessions
 
     def resolved_runner
       runner = chat_session.runner
-      return runner if runner&.effective_api_secret.present?
+      return runner if self.class.usable_runner?(runner)
+      return runner if runner.present?
 
       fallback_runner = Runner.first_configured_chat_enabled_for_owner(chat_session.created_by)
       return runner unless fallback_runner && fallback_runner != runner

--- a/app/services/chat_sessions/create.rb
+++ b/app/services/chat_sessions/create.rb
@@ -151,6 +151,9 @@ module ChatSessions
             raise ArgumentError, "runner must belong to the same account"
           end
           raise ArgumentError, "runner must be enabled for chat" unless runner.enabled_for_chat?
+          unless ChatSessions::BuildLlmClient.usable_runner?(runner)
+            raise ArgumentError, "runner must be an API-key chat runner with a configured API key"
+          end
         end
       else
         default_runner_for_user
@@ -167,7 +170,7 @@ module ChatSessions
     end
 
     def default_runner_for_user
-      Runner.first_configured_chat_enabled_for_owner(user) || Runner.first_chat_enabled_for_owner(user)
+      Runner.first_configured_chat_enabled_for_owner(user)
     end
   end
 end

--- a/app/services/chat_sessions/create.rb
+++ b/app/services/chat_sessions/create.rb
@@ -158,6 +158,8 @@ module ChatSessions
       else
         default_runner_for_user
       end
+    rescue ActiveRecord::RecordNotFound
+      raise ArgumentError, "runner must belong to the same account"
     end
 
     def resolved_model

--- a/app/services/chat_sessions/fallback_loop.rb
+++ b/app/services/chat_sessions/fallback_loop.rb
@@ -14,6 +14,7 @@ module ChatSessions
     private
 
     def run_with_fallbacks
+      # @spec CHAT-API-006
       attempted_runners = [ chat_session.runner ].compact
 
       loop do

--- a/app/services/chat_sessions/fallback_runners.rb
+++ b/app/services/chat_sessions/fallback_runners.rb
@@ -28,7 +28,9 @@ module ChatSessions
         runner
       end
 
-      automatic_candidates = user.runners.kept_only.for_fallback.where(enabled_for_chat: true).ordered.filter_map do |runner|
+      automatic_candidates = user.runners.kept_only.for_fallback.api_key
+        .includes(:provider_api_key, :integration_credential)
+        .where(enabled_for_chat: true).ordered.filter_map do |runner|
         next unless usable_runner?(runner)
         next if excluded_ids.include?(runner.id)
 

--- a/app/services/chat_sessions/fallback_runners.rb
+++ b/app/services/chat_sessions/fallback_runners.rb
@@ -7,18 +7,35 @@ module ChatSessions
     module_function
 
     def for(chat_session:, excluding: [])
+      # @spec CHAT-API-006
       user = chat_session.created_by
       return [] unless user&.settings
 
       excluded_ids = excluded_runner_ids(excluding)
+      excluded_ids << chat_session.runner_id if excluding.blank? && chat_session.runner_id.present?
+      current_runner = chat_session.reload.runner
+      current_candidates = if usable_runner?(current_runner) && !excluded_ids.include?(current_runner.id)
+        [ current_runner ]
+      else
+        []
+      end
 
-      Array(user.settings.kb_chat_fallback_runners).filter_map do |identifier|
+      configured_candidates = Array(user.settings.kb_chat_fallback_runners).filter_map do |identifier|
         runner = runner_for_identifier(user, identifier, excluding_ids: excluded_ids)
         next unless usable_runner?(runner)
         next if excluded_ids.include?(runner.id)
 
         runner
-      end.uniq
+      end
+
+      automatic_candidates = user.runners.kept_only.for_fallback.where(enabled_for_chat: true).ordered.filter_map do |runner|
+        next unless usable_runner?(runner)
+        next if excluded_ids.include?(runner.id)
+
+        runner
+      end
+
+      (current_candidates + configured_candidates + automatic_candidates).uniq
     end
 
     def switch!(chat_session:, runner:)
@@ -40,17 +57,18 @@ module ChatSessions
     end
 
     def usable_runner?(runner)
-      runner&.enabled_for_chat? && runner.effective_api_secret.present?
+      BuildLlmClient.usable_runner?(runner)
     end
 
     def runner_for_identifier(user, identifier, excluding_ids:)
       if Runner.routing_key?(identifier)
         runner = Runner.for_identifier(user, identifier)
         return nil if runner && excluding_ids.include?(runner.id)
+        return nil unless runner&.enabled_for_fallback?
 
         runner
       else
-        user.runners.kept_only.where(runner_key: identifier).ordered.find do |runner|
+        user.runners.kept_only.for_fallback.where(runner_key: identifier).ordered.find do |runner|
           usable_runner?(runner) && !excluding_ids.include?(runner.id)
         end
       end

--- a/docs/intent/api-mode-chat/api-mode-chat-specs.md
+++ b/docs/intent/api-mode-chat/api-mode-chat-specs.md
@@ -69,3 +69,16 @@
   `TokenUsageTracker.record_per_request_usage`,
   `ChatSessionsController#session_scope_with_token_totals`,
   `ChatSessionsController#session_json`.
+
+- [x] **CHAT-API-006** — When an API-mode chat runner raises a provider error
+  such as a rate limit, the system SHALL retry the turn on a usable API-key
+  backed replacement runner, preferring a runner newly selected on the chat
+  session and then falling back through chat fallback-enabled runners; inline
+  chat runner selectors SHALL only offer runners that can build an API chat
+  client.
+  *Tests:* `spec/services/chat_sessions/fallback_runners_spec.rb`,
+  `spec/jobs/chat_sessions/process_message_job_spec.rb`,
+  `spec/requests/chat_sessions_spec.rb`.
+  *Code:* `ChatSessions::FallbackLoop#run_with_fallbacks`,
+  `ChatSessions::FallbackRunners.for`,
+  `ChatSessionsController#load_sidebar_data`.

--- a/spec/jobs/chat_sessions/process_message_job_spec.rb
+++ b/spec/jobs/chat_sessions/process_message_job_spec.rb
@@ -231,11 +231,7 @@ RSpec.describe ChatSessions::ProcessMessageJob, type: :job do
       .and_return(rate_limited_llm_client, successful_fallback_llm_client)
 
     expect {
-      described_class.perform_now(
-        chat_session_id: chat_session.id,
-        content: "Hello",
-        stream_message_id: stream_message_id
-      )
+      perform_message
     }.to have_broadcasted_to(stream_name)
       .with(hash_including(type: "message_created", role: "assistant",
         fallback_notice: true,
@@ -245,6 +241,23 @@ RSpec.describe ChatSessions::ProcessMessageJob, type: :job do
         html: include("Fallback answer")))
       .and have_broadcasted_to(stream_name)
       .with(hash_including(type: "message_complete", tokens: { input: 10, output: 5 }))
+  end
+
+  it "continues on a runner selected while the rate-limited attempt is running" do
+    # @spec CHAT-API-006
+    fallback_runner = configure_chat_fallback(configured: false)
+    fallback_runner.update!(enabled_for_fallback: false)
+    stub_mid_attempt_runner_switch(fallback_runner)
+
+    expect {
+      perform_message
+    }.to have_broadcasted_to(stream_name)
+      .with(hash_including(type: "message_created", role: "assistant",
+        fallback_notice: true,
+        html: include("Switching to #{fallback_runner.display_name} and continuing.")))
+      .and have_broadcasted_to(stream_name)
+      .with(hash_including(type: "message_created", role: "assistant",
+        html: include("Fallback answer")))
   end
 
   it "broadcasts generic error for unexpected failures" do
@@ -329,14 +342,33 @@ RSpec.describe ChatSessions::ProcessMessageJob, type: :job do
     })
   end
 
-  def configure_chat_fallback
+  def perform_message(content: "Hello")
+    described_class.perform_now(
+      chat_session_id: chat_session.id,
+      content: content,
+      stream_message_id: stream_message_id
+    )
+  end
+
+  def stub_mid_attempt_runner_switch(fallback_runner)
+    build_attempts = 0
+    allow(ChatSessions::BuildLlmClient).to receive(:call)
+      .with(chat_session: chat_session)
+      .and_wrap_original do |_method, chat_session:|
+        build_attempts += 1
+        ChatSession.where(id: chat_session.id).update_all(runner_id: fallback_runner.id)
+        build_attempts == 1 ? rate_limited_llm_client : successful_fallback_llm_client
+      end
+  end
+
+  def configure_chat_fallback(configured: true)
     primary_runner = create(:runner, :api_key, user: user, runner_key: "opencode",
       provider_api_key: create(:provider_api_key, user: user, api_service_type: "openrouter"),
       config: { "opencode" => { "api_provider" => "openrouter", "model" => "moonshotai/kimi-k2" } })
     fallback_runner = create(:runner, :api_key, user: user, runner_key: "claude",
       provider_api_key: create(:provider_api_key, user: user, api_service_type: "anthropic"))
 
-    user.settings.update!(kb_chat_fallback_runners: [ "claude" ])
+    user.settings.update!(kb_chat_fallback_runners: [ "claude" ]) if configured
     chat_session.update!(runner: primary_runner)
     fallback_runner
   end

--- a/spec/requests/chat_sessions_spec.rb
+++ b/spec/requests/chat_sessions_spec.rb
@@ -654,6 +654,32 @@ RSpec.describe "ChatSessions" do
         expect(chat_session.reload.runner_id).not_to eq(runner.id)
       end
 
+      it "accepts an API-key chat runner owned by another user in the same account" do
+        teammate = create(:user, account: account)
+        runner = create(:runner, :api_key, user: teammate, runner_key: "opencode",
+          provider_api_key: create(:provider_api_key, user: teammate, api_service_type: "openrouter"),
+          config: { "opencode" => { "api_provider" => "openrouter", "model" => "moonshotai/kimi-k2" } })
+
+        patch chat_session_path(chat_session, format: :json), params: { runner_id: runner.id }
+
+        expect(response).to have_http_status(:ok)
+        expect(chat_session.reload.runner_id).to eq(runner.id)
+      end
+
+      it "rejects runners from a different account" do
+        other_account = create(:account)
+        other_user = create(:user, account: other_account)
+        runner = create(:runner, :api_key, user: other_user, runner_key: "opencode",
+          provider_api_key: create(:provider_api_key, user: other_user, api_service_type: "openrouter"),
+          config: { "opencode" => { "api_provider" => "openrouter", "model" => "moonshotai/kimi-k2" } })
+
+        patch chat_session_path(chat_session, format: :json), params: { runner_id: runner.id }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["error"]).to include("must belong to the same account")
+        expect(chat_session.reload.runner_id).not_to eq(runner.id)
+      end
+
       it "updates popup metadata context" do
         patch chat_session_path(chat_session, format: :json), params: {
           metadata: {

--- a/spec/requests/chat_sessions_spec.rb
+++ b/spec/requests/chat_sessions_spec.rb
@@ -216,12 +216,21 @@ RSpec.describe "ChatSessions" do
       end
 
       it "accepts provider_id as a legacy alias for runner_id" do
-        runner = create(:runner, user: user)
+        runner = create_api_chat_runner
 
         post chat_sessions_path(format: :json), params: { container_capability: "none", provider_id: runner.id }
 
         expect(response).to have_http_status(:created)
         expect(ChatSession.order(:id).last.runner).to eq(runner)
+      end
+
+      it "rejects inline sessions with non-API chat runners" do
+        runner = create(:runner, user: user, runner_key: "codex", auth_type: "subscription", enabled_for_chat: true)
+
+        post chat_sessions_path(format: :json), params: { container_capability: "none", runner_id: runner.id }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["error"]).to include("API-key chat runner")
       end
 
       it "redirects to the session page for html requests" do
@@ -400,6 +409,21 @@ RSpec.describe "ChatSessions" do
         expect(chat_root).to be_present
         expect(capability_panel).to be_present
         expect(chat_root.at_css("[data-chat-target='capabilityPanel']")).to eq(capability_panel)
+      end
+
+      it "only offers API-key-backed runners in the inline chat runner selector" do
+        # @spec CHAT-API-006
+        create(:runner, user: user, runner_key: "codex", auth_type: "subscription", enabled_for_chat: true)
+        api_runner = create(:runner, :api_key, user: user, runner_key: "opencode", name: "API Chat Runner",
+          provider_api_key: create(:provider_api_key, user: user, api_service_type: "openrouter"),
+          config: { "opencode" => { "api_provider" => "openrouter", "model" => "moonshotai/kimi-k2" } })
+
+        get chat_session_path(chat_session)
+
+        doc = Nokogiri::HTML(response.body)
+        runner_options = doc.css("select[name='chat_session[runner_id]'] option").map(&:text)
+        expect(runner_options).to include(api_runner.display_name)
+        expect(runner_options).not_to include("OpenAI Codex CLI")
       end
 
       it "renders mobile archive controls without expanding the sidebar by default" do
@@ -620,6 +644,16 @@ RSpec.describe "ChatSessions" do
         expect(chat_session.model).to eq("gpt-4.1")
       end
 
+      it "rejects runner updates that cannot build an API chat client" do
+        runner = create(:runner, user: user, runner_key: "codex", auth_type: "subscription", enabled_for_chat: true)
+
+        patch chat_session_path(chat_session, format: :json), params: { runner_id: runner.id }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["error"]).to include("API-key chat runner")
+        expect(chat_session.reload.runner_id).not_to eq(runner.id)
+      end
+
       it "updates popup metadata context" do
         patch chat_session_path(chat_session, format: :json), params: {
           metadata: {
@@ -836,5 +870,11 @@ RSpec.describe "ChatSessions" do
       expect(form["class"]).to include('hidden')
       expect(form["data-chat-capability-stopped-only"]).to be_present
     end
+  end
+
+  def create_api_chat_runner
+    create(:runner, :api_key, user: user, runner_key: "opencode",
+      provider_api_key: create(:provider_api_key, user: user, api_service_type: "openrouter"),
+      config: { "opencode" => { "api_provider" => "openrouter", "model" => "moonshotai/kimi-k2" } })
   end
 end

--- a/spec/services/chat_sessions/build_llm_client_spec.rb
+++ b/spec/services/chat_sessions/build_llm_client_spec.rb
@@ -68,22 +68,16 @@ RSpec.describe ChatSessions::BuildLlmClient, type: :service do
     end
 
     context "with a subscription runner (no API key)" do
-      it "falls back to the creator's configured API key runner" do
+      it "raises a setup error for the selected runner" do
         runner = user.runners.find_or_create_by!(runner_key: "cursor", auth_type: "subscription")
-        api_key_record = create(:provider_api_key, user: user, api_key: "sk-ant-fallback", api_service_type: "anthropic")
-        fallback_runner = create(:runner, :api_key,
-          user: user,
-          runner_key: "kilocode",
-          provider_api_key: api_key_record,
-          config: { "kilocode" => { "api_provider" => "anthropic", "model" => "claude-sonnet-4-20250514" } }
-        )
         chat_session = create(:chat_session, account: account, created_by: user, runner: runner)
 
-        client = described_class.call(chat_session: chat_session)
-
-        expect(client).to be_a(described_class::HttpClient)
-        expect(client.model).to eq("claude-sonnet-4-20250514")
-        expect(fallback_runner.effective_api_secret).to eq("sk-ant-fallback")
+        expect {
+          described_class.call(chat_session: chat_session)
+        }.to raise_error(
+          ChatSessions::LlmClientConfigurationError,
+          "Chat runner #{runner.display_name} is missing an API key. Choose a chat-enabled runner with a configured API key."
+        )
       end
     end
 
@@ -129,15 +123,8 @@ RSpec.describe ChatSessions::BuildLlmClient, type: :service do
     end
 
     context "with an unconfigured runner and another configured chat runner" do
-      it "falls back to the configured runner and persists a compatible model on the session" do
+      it "raises a setup error for the selected runner" do
         unavailable_runner = user.runners.find_or_create_by!(runner_key: "claude", auth_type: "subscription")
-        api_key_record = create(:provider_api_key, user: user, api_key: "sk-openrouter-test", api_service_type: "openrouter")
-        fallback_runner = create(:runner, :api_key,
-          user: user,
-          runner_key: "opencode",
-          provider_api_key: api_key_record,
-          config: { "opencode" => { "api_provider" => "openrouter", "model" => "moonshotai/kimi-k2" } }
-        )
         chat_session = create(:chat_session,
           account: account,
           created_by: user,
@@ -145,12 +132,9 @@ RSpec.describe ChatSessions::BuildLlmClient, type: :service do
           model: "claude-sonnet-4-20250514"
         )
 
-        client = described_class.call(chat_session: chat_session)
-
-        expect(client).to be_a(described_class::HttpClient)
-        expect(chat_session.reload.runner).to eq(fallback_runner)
-        expect(chat_session.model).to eq("moonshotai/kimi-k2")
-        expect(client.model).to eq("moonshotai/kimi-k2")
+        expect {
+          described_class.call(chat_session: chat_session)
+        }.to raise_error(ChatSessions::LlmClientConfigurationError)
       end
     end
 

--- a/spec/services/chat_sessions/create_spec.rb
+++ b/spec/services/chat_sessions/create_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe ChatSessions::Create do
     end
 
     it "resolves and associates a runner" do
-      runner = create(:runner, user: user)
+      runner = create_api_chat_runner
       session = described_class.call(
         account: account,
         user: user,
@@ -66,10 +66,11 @@ RSpec.describe ChatSessions::Create do
       expect(session.model).to eq("gpt-4o")
     end
 
-    it "defaults to the first chat-eligible runner" do
+    it "defaults to the first configured API-key chat runner" do
       non_chat_runner = user.runners.find_by!(runner_key: "claude")
       non_chat_runner.update!(enabled_for_chat: false)
-      chat_runner = create(:runner, user: user, runner_key: "cursor", enabled_for_chat: true)
+      create(:runner, user: user, runner_key: "cursor", enabled_for_chat: true)
+      chat_runner = create_api_chat_runner
 
       session = described_class.call(account: account, user: user)
 
@@ -94,7 +95,7 @@ RSpec.describe ChatSessions::Create do
     end
 
     it "accepts provider_id as a legacy alias for runner_id" do
-      runner = create(:runner, user: user)
+      runner = create_api_chat_runner
       session = described_class.call(
         account: account,
         user: user,
@@ -102,6 +103,14 @@ RSpec.describe ChatSessions::Create do
       )
 
       expect(session.runner).to eq(runner)
+    end
+
+    it "raises when an inline chat runner cannot build an API chat client" do
+      runner = create(:runner, user: user, runner_key: "codex", auth_type: "subscription", enabled_for_chat: true)
+
+      expect {
+        described_class.call(account: account, user: user, runner_id: runner.id)
+      }.to raise_error(ArgumentError, /API-key chat runner/)
     end
 
     it "raises when runner belongs to a different account" do
@@ -246,5 +255,11 @@ RSpec.describe ChatSessions::Create do
         )
       )
     end
+  end
+
+  def create_api_chat_runner
+    create(:runner, :api_key, user: user, runner_key: "opencode",
+      provider_api_key: create(:provider_api_key, user: user, api_service_type: "openrouter"),
+      config: { "opencode" => { "api_provider" => "openrouter", "model" => "moonshotai/kimi-k2" } })
   end
 end

--- a/spec/services/chat_sessions/fallback_runners_spec.rb
+++ b/spec/services/chat_sessions/fallback_runners_spec.rb
@@ -25,6 +25,48 @@ RSpec.describe ChatSessions::FallbackRunners do
     it "returns no fallbacks when the user has no fallback runners configured" do
       expect(described_class.for(chat_session: chat_session, excluding: [ primary_runner ])).to eq([])
     end
+
+    it "does not return the session runner as its own fallback" do
+      expect(described_class.for(chat_session: chat_session)).to eq([])
+    end
+
+    it "prefers a runner selected after the current attempt started" do
+      # @spec CHAT-API-006
+      selected_runner = create_openrouter_runner(name: "Selected")
+      selected_runner.update!(enabled_for_fallback: false)
+      chat_session.runner
+      ChatSession.where(id: chat_session.id).update_all(runner_id: selected_runner.id)
+
+      expect(described_class.for(chat_session: chat_session, excluding: [ primary_runner ])).to eq([ selected_runner ])
+    end
+
+    it "falls back to another enabled chat runner when no explicit fallback is configured" do
+      # @spec CHAT-API-006
+      fallback_runner = create_openrouter_runner(name: "Automatic")
+
+      expect(described_class.for(chat_session: chat_session, excluding: [ primary_runner ])).to eq([ fallback_runner ])
+    end
+
+    it "does not automatically use runners disabled for fallback" do
+      # @spec CHAT-API-006
+      create_openrouter_runner(name: "Disabled").update!(enabled_for_fallback: false)
+
+      expect(described_class.for(chat_session: chat_session, excluding: [ primary_runner ])).to eq([])
+    end
+
+    it "does not use configured runners disabled for fallback" do
+      disabled = create_openrouter_runner(name: "Disabled")
+      disabled.update!(enabled_for_fallback: false)
+      user.settings.update_columns(kb_chat_fallback_runners: [ disabled.routing_key, "opencode" ])
+
+      expect(described_class.for(chat_session: chat_session, excluding: [ primary_runner ])).to eq([])
+    end
+
+    it "does not automatically use subscription runners" do
+      create(:runner, user: user, runner_key: "codex", auth_type: "subscription", enabled_for_chat: true, enabled_for_fallback: true)
+
+      expect(described_class.for(chat_session: chat_session, excluding: [ primary_runner ])).to eq([])
+    end
   end
 
   describe ".notice_for" do


### PR DESCRIPTION
## Summary

Fixes API-mode chat runner switching and fallback so inline chat only selects runners that can actually build an API chat client.

## Root Cause

Inline chat offered subscription CLI runners such as Codex even though `ChatSessions::BuildLlmClient` can only build API-backed chat clients. When a user selected an unusable runner, the client builder could silently fall back to the first API-key chat runner, which made sessions appear to keep using a rate-limited GLM runner.

## Changes

- Restrict inline chat runner selectors, creation, and updates to API-key chat runners with configured secrets.
- Stop silently substituting an explicitly selected unusable runner.
- Retry provider/rate-limit failures on usable replacement runners, including a runner selected mid-chat.
- Keep fallback candidates honest by excluding the current runner and respecting fallback-enabled state.
- Add LID coverage for `CHAT-API-006` and focused specs for runner selection, fallback, and API validation.

## Validation

- `bin/rspec spec/services/chat_sessions/fallback_runners_spec.rb spec/services/chat_sessions/build_llm_client_spec.rb spec/services/chat_sessions/create_spec.rb spec/jobs/chat_sessions/process_message_job_spec.rb spec/requests/chat_sessions_spec.rb`
- `bin/rubocop app/controllers/chat_sessions_controller.rb app/models/runner.rb app/services/chat_sessions/build_llm_client.rb app/services/chat_sessions/create.rb app/services/chat_sessions/fallback_loop.rb app/services/chat_sessions/fallback_runners.rb spec/jobs/chat_sessions/process_message_job_spec.rb spec/requests/chat_sessions_spec.rb spec/services/chat_sessions/build_llm_client_spec.rb spec/services/chat_sessions/create_spec.rb spec/services/chat_sessions/fallback_runners_spec.rb`
- `bin/coherence-check.mjs`
- Pre-commit hook passed staged secret scan, RuboCop, markdownlint, and other staged checks.