### PR TITLE
fix(chat): surface missing tool args as invalid

### DIFF
--- a/app/mcp/tools/base_tool.rb
+++ b/app/mcp/tools/base_tool.rb
@@ -169,10 +169,18 @@ module Tools
 
     def run_declared_authorizations!(args)
       self.class.authorization_rules.each do |rule|
-        record = instance_exec(args, &rule[:resolver])
+        record = authorization_record_for(rule, args)
         @preflight_authorization_performed = true
         authorize(record, rule[:query], policy_class: rule[:policy_class])
       end
+    end
+
+    def authorization_record_for(rule, args)
+      instance_exec(args, &rule[:resolver])
+    rescue KeyError => error
+      raise unless error.respond_to?(:receiver) && error.receiver.equal?(args)
+
+      raise ArgumentError, "Missing required argument: #{error.key}"
     end
   end
 end

--- a/docs/intent/chat-tool-confirmation/chat-tool-confirmation-specs.md
+++ b/docs/intent/chat-tool-confirmation/chat-tool-confirmation-specs.md
@@ -31,3 +31,15 @@
   `Tools::BaseTool.auto_approve_eligible?`,
   `Tools::GithubIssueToolSupport` (ClassMethods),
   `Tools::TriggerAgentRun.auto_approve_eligible?`.
+
+- [x] **CHAT-TOOL-CONFIRMATION-003** - When a chat-dispatched tool call is
+  missing a required argument used for preflight authorization, the system SHALL
+  return an `invalid_arguments` tool result that names the missing argument
+  instead of surfacing an `internal_error`, including auto-approved write-tool
+  calls.
+
+  *Tests:* `spec/mcp/tools/base_tool_spec.rb`,
+  `spec/mcp/tools/trigger_agent_run_spec.rb`,
+  `spec/services/chat_sessions/agent_loop_spec.rb`.
+  *Code:* `Tools::BaseTool#authorization_record_for`,
+  `ChatSessions::ToolDispatch#normalize_tool_dispatch_result`.

--- a/spec/mcp/tools/base_tool_spec.rb
+++ b/spec/mcp/tools/base_tool_spec.rb
@@ -49,6 +49,17 @@ RSpec.describe Tools::BaseTool do
         { ok: true }
       end
     end)
+
+    stub_const("Tools::BaseToolNestedKeyErrorSpecTool", Class.new(described_class) do
+      authorize :show?, ->(_args) { {}.fetch(:internal_key) }
+
+      def self.tool_name = "base_tool_nested_key_error_spec"
+      def self.description = "Nested KeyError base tool spec"
+
+      def perform
+        { ok: true }
+      end
+    end)
   end
 
   describe "#dispatch" do
@@ -92,6 +103,22 @@ RSpec.describe Tools::BaseTool do
       expect { tool.dispatch(project_id: project.id) }
         .to raise_error(Tools::UnauthorizedError, "base_tool_post_hoc_authorized_spec must authorize before execution")
       expect(tool.perform_called).to be_nil
+    end
+
+    # @spec CHAT-TOOL-CONFIRMATION-003
+    it "normalizes missing authorization arguments" do
+      tool = Tools::BaseToolAuthorizedSpecTool.new(user: user, session: session)
+
+      expect { tool.dispatch }
+        .to raise_error(ArgumentError, "Missing required argument: project_id")
+    end
+
+    # @spec CHAT-TOOL-CONFIRMATION-003
+    it "does not normalize KeyErrors from inside resolver helpers" do
+      tool = Tools::BaseToolNestedKeyErrorSpecTool.new(user: user, session: session)
+
+      expect { tool.dispatch }
+        .to raise_error(KeyError, /internal_key/)
     end
   end
 end

--- a/spec/mcp/tools/trigger_agent_run_spec.rb
+++ b/spec/mcp/tools/trigger_agent_run_spec.rb
@@ -52,6 +52,13 @@ RSpec.describe Tools::TriggerAgentRun do
       }.to raise_error(ArgumentError, /Confirmation required/)
     end
 
+    # @spec CHAT-TOOL-CONFIRMATION-003
+    it "raises an argument error when project_id is missing" do
+      expect {
+        tool.call(confirmed: true)
+      }.to raise_error(ArgumentError, "Missing required argument: project_id")
+    end
+
     it "raises for project in another account" do
       other_project = create(:project)
       other_issue = create(:issue, project: other_project)

--- a/spec/services/chat_sessions/agent_loop_spec.rb
+++ b/spec/services/chat_sessions/agent_loop_spec.rb
@@ -236,6 +236,25 @@ RSpec.describe ChatSessions::AgentLoop do
         ])
       end
 
+      let(:malformed_auto_approve_client) do
+        Class.new do
+          def initialize
+            @called = false
+          end
+
+          def call(_conversation, tools: nil)
+            @called = !@called
+            return { content: "I need the project id before I can start that run.", tool_calls: [], tokens_input: 5, tokens_output: 2, model: "gpt-4o" } unless @called
+
+            {
+              content: "I'll kick off an agent run.",
+              tool_calls: [ { id: "call_1", name: "trigger_agent_run", arguments: {} } ],
+              tokens_input: 50, tokens_output: 20, model: "gpt-4o"
+            }
+          end
+        end.new
+      end
+
       before do
         allow(Tools::Registry).to receive(:chat_definitions_for).with(user: user, session: anything).and_return(tool_definitions)
         allow(Tools::Registry).to receive(:dispatch).and_return({ "id" => 99, "status" => "queued" })
@@ -315,6 +334,20 @@ RSpec.describe ChatSessions::AgentLoop do
         expect(pending_message.tool_name).to eq("record_change_intent")
         expect(pending_message.tool_result).to include("status" => "draft")
         expect(chat_session.messages.where(tool_status: "approved")).not_to exist
+      end
+
+      # @spec CHAT-TOOL-CONFIRMATION-003
+      it "surfaces malformed auto-approved tool calls as invalid arguments" do
+        allow(Tools::Registry).to receive(:dispatch).and_call_original
+
+        described_class.new(chat_session: chat_session, llm_client: malformed_auto_approve_client).run
+
+        tool_result = chat_session.messages.find_by(role: "tool", tool_call_id: "call_1").tool_result
+        expect(tool_result).to include(
+          "status" => "error",
+          "error" => "invalid_arguments",
+          "message" => "Missing required argument: project_id"
+        )
       end
     end
 


### PR DESCRIPTION
## Summary

- normalize missing preflight authorization arguments into `invalid_arguments` instead of chat-facing `internal_error`
- keep internal `KeyError`s from resolver helpers bubbling so real bugs are not hidden as user input problems
- add LID intent coverage and regression specs for `trigger_agent_run` and auto-approved chat tool calls

## Root Cause

Chat session 31 auto-approved malformed `trigger_agent_run` calls with empty tool arguments. The authorization resolver fetched `:project_id` before method-level keyword validation, raising a raw `KeyError` that the chat dispatch layer classified as an internal error.

## Validation

- `bin/rspec spec/mcp/tools/base_tool_spec.rb spec/mcp/tools/trigger_agent_run_spec.rb spec/services/chat_sessions/agent_loop_spec.rb`
- `bin/rubocop app/mcp/tools/base_tool.rb spec/mcp/tools/base_tool_spec.rb spec/mcp/tools/trigger_agent_run_spec.rb spec/services/chat_sessions/agent_loop_spec.rb`
- `bin/coherence-check.mjs`
- pre-commit checks: staged secret scan, RuboCop, markdownlint, ShellCheck/Herb no-op where applicable
