### PR TITLE
fix(dashboard): prevent dead needs-input answer links

### DIFF
--- a/app/controllers/projects/clarifying_questions_controller.rb
+++ b/app/controllers/projects/clarifying_questions_controller.rb
@@ -89,13 +89,15 @@ module Projects
       params[:queue].to_s
     end
 
+    # Resolves the project whose queue the user was browsing from
+    # +queue_project_id+. It must resolve even when that project's
+    # question-backed queue is momentarily empty (e.g. the last stale
+    # needs-input row was just cleared) so the fallback redirect keeps its
+    # project scope. Accessibility is already enforced by +policy_scope+.
     def queue_project
       return unless queue_mode? && params[:queue_project_id].present?
 
-      @queue_project ||= begin
-        candidate = policy_scope(Project).find_by(id: params[:queue_project_id])
-        candidate if candidate && queue_scope_issues(project: candidate).any?
-      end
+      @queue_project ||= policy_scope(Project).find_by(id: params[:queue_project_id])
     end
 
     def queue_return_to

--- a/app/services/clarifying_questions/clear_needs_input.rb
+++ b/app/services/clarifying_questions/clear_needs_input.rb
@@ -23,10 +23,10 @@ module ClarifyingQuestions
     end
 
     def call
-      return unless issue.needs_input?
+      return unless issue.needs_input? || issue_paid_state_needs_input?
 
       label = project.enhance_issue_needs_input_label_name
-      remove_label(label)
+      remove_label(label) if issue.has_label?(label)
 
       # Check if this issue is associated with a paused create_feature run.
       # If so, assemble the feature brief from the answers and resume the run
@@ -43,6 +43,10 @@ module ClarifyingQuestions
     private
 
     attr_reader :project, :issue
+
+    def issue_paid_state_needs_input?
+      issue.respond_to?(:paid_state) && issue.paid_state == "needs_input"
+    end
 
     def remove_label(label)
       project.client&.remove_label_from_issue(project.full_name, issue.github_number, label)

--- a/app/services/clarifying_questions/extract_answer_pairs.rb
+++ b/app/services/clarifying_questions/extract_answer_pairs.rb
@@ -44,9 +44,7 @@ module ClarifyingQuestions
 
     def find_enhancement_comment
       admitted_comments.reverse.find do |comment|
-        body = comment.body.to_s
-        body.include?(Parse::ENHANCEMENT_MARKER) &&
-          body.include?("## Clarifying questions")
+        Parse.call(comment_body: comment.body).any?
       end
     end
 
@@ -66,7 +64,10 @@ module ClarifyingQuestions
     def current_questions(enhancement_comment)
       return Parse.call(comment_body: enhancement_comment.body.to_s) if enhancement_comment
 
-      Parse.call(comment_body: issue&.body.to_s)
+      questions = Parse.call(comment_body: issue&.body.to_s)
+      return questions if questions.any?
+
+      issue.respond_to?(:needs_input_questions) ? Array(issue.needs_input_questions) : []
     end
 
     def answer_satisfies_latest_questions?(answer_comment:, enhancement_comment:)

--- a/app/services/clarifying_questions/load.rb
+++ b/app/services/clarifying_questions/load.rb
@@ -15,14 +15,17 @@ module ClarifyingQuestions
 
     def call
       body_questions = Parse.call(comment_body: issue.body)
+      stored_questions = issue.respond_to?(:needs_input_questions) ? Array(issue.needs_input_questions).map { |question| question.to_s.strip }.reject(&:blank?) : []
+      current_questions = body_questions.presence || stored_questions
 
-      if body_questions.any?
-        return body_questions unless github_available?
+      if current_questions.any?
+        return current_questions unless github_available?
 
         enhancement_comment = latest_enhancement_comment
-        return reconcile_answered if answered_after_latest_questions?(body_questions:, enhancement_comment:)
+        current_questions = latest_questions(body_questions: current_questions, enhancement_comment:)
+        return reconcile_answered if answered_after_latest_questions?(body_questions: current_questions, enhancement_comment:)
 
-        return body_questions
+        return current_questions
       end
 
       return [] unless github_available?
@@ -33,9 +36,9 @@ module ClarifyingQuestions
 
       Parse.call(comment_body: comment_body(enhancement_comment))
     rescue GithubClient::Error
-      raise if body_questions.empty?
+      raise if current_questions.empty?
 
-      body_questions
+      current_questions
     end
 
     private
@@ -50,8 +53,7 @@ module ClarifyingQuestions
       return unless github_available?
 
       issue_comments.reverse.find do |comment|
-        comment_body(comment).include?(Parse::ENHANCEMENT_MARKER) &&
-          comment_body(comment).include?("## Clarifying questions")
+        Parse.call(comment_body: comment_body(comment)).any?
       end
     end
 
@@ -67,7 +69,10 @@ module ClarifyingQuestions
     end
 
     def latest_questions(body_questions:, enhancement_comment:)
-      return Parse.call(comment_body: comment_body(enhancement_comment)) if enhancement_comment.present?
+      if enhancement_comment.present?
+        questions = Parse.call(comment_body: comment_body(enhancement_comment))
+        return questions if questions.any?
+      end
 
       body_questions
     end

--- a/app/services/clarifying_questions/parse.rb
+++ b/app/services/clarifying_questions/parse.rb
@@ -3,7 +3,7 @@
 module ClarifyingQuestions
   class Parse
     ENHANCEMENT_MARKER = "<!-- paid:enhance-issue -->"
-    CLARIFYING_SECTION_PATTERN = /## Clarifying questions\s*\n(.+?)(?=\n## |\z)/m.freeze
+    CLARIFYING_SECTION_PATTERN = /^##\s+.*clarifying questions[^\n]*\n(.+?)(?=^## |\z)/mi.freeze
 
     def self.call(...)
       new(...).call
@@ -15,7 +15,7 @@ module ClarifyingQuestions
 
     def call
       return [] unless comment_body.include?(ENHANCEMENT_MARKER)
-      return [] unless comment_body.include?("## Clarifying questions")
+      return [] unless comment_body.match?(CLARIFYING_SECTION_PATTERN)
 
       section = extract_clarifying_section
       return [] unless section

--- a/app/services/clarifying_questions/parse.rb
+++ b/app/services/clarifying_questions/parse.rb
@@ -3,7 +3,7 @@
 module ClarifyingQuestions
   class Parse
     ENHANCEMENT_MARKER = "<!-- paid:enhance-issue -->"
-    CLARIFYING_SECTION_PATTERN = /^##\s+.*clarifying questions[^\n]*\n(.+?)(?=^## |\z)/mi.freeze
+    CLARIFYING_SECTION_PATTERN = /^##\s+[^\n]*clarifying questions[^\n]*\n(.+?)(?=^## |\z)/mi.freeze
 
     def self.call(...)
       new(...).call

--- a/app/services/dashboard/eligibility_breakdown.rb
+++ b/app/services/dashboard/eligibility_breakdown.rb
@@ -62,13 +62,13 @@ module Dashboard
       excluded = open.where.not(id: eligible_scope.select(:id))
       row = excluded.pick(
         Arel.sql("COUNT(*)"),
-        Arel.sql("COUNT(*) FILTER (WHERE paid_state = 'needs_input')"),
         Arel.sql("COUNT(*) FILTER (WHERE paid_state = 'in_progress')"),
         Arel.sql("COUNT(*) FILTER (WHERE paid_state = 'completed')"),
         Arel.sql("COUNT(*) FILTER (WHERE paid_state IN ('new','planning','failed','analyzed'))")
-      ) || [ 0, 0, 0, 0, 0 ]
-      excluded_total, needs_input, in_progress, completed, analyzable = row
+      ) || [ 0, 0, 0, 0 ]
+      excluded_total, in_progress, completed, analyzable = row
 
+      needs_input = count_question_backed_needs_input(excluded)
       skip_label = count_skip_labeled(excluded, analyzable, project)
       other = excluded_total - needs_input - in_progress - completed - skip_label
 
@@ -100,6 +100,19 @@ module Dashboard
           labels.map(&:downcase)
         )
         .count
+    end
+
+    def count_question_backed_needs_input(excluded_scope)
+      excluded_scope.where(paid_state: "needs_input")
+        .select(:body, :needs_input_questions)
+        .count { |issue| question_summary_for(issue).any? }
+    end
+
+    def question_summary_for(issue)
+      questions = ClarifyingQuestions::Parse.call(comment_body: issue.body)
+      return questions if questions.any?
+
+      Array(issue.needs_input_questions)
     end
 
     def visible_owner_ids

--- a/app/services/dashboard/needs_input_queue.rb
+++ b/app/services/dashboard/needs_input_queue.rb
@@ -19,20 +19,11 @@ module Dashboard
     end
 
     def call
-      ordered_issues.filter_map do |issue|
-        questions = question_summary_for(issue)
-        next if questions.empty?
-
-        Entry.new(
-          project: issue.project,
-          issue: issue,
-          questions: questions
-        )
-      end
+      queued_entries
     end
 
     def next_issue
-      queue = ordered_issues.to_a
+      queue = queued_entries.map(&:issue)
       return queue.first if after_issue.blank?
 
       current_index = queue.index { |issue| issue.id == after_issue.id }
@@ -44,6 +35,22 @@ module Dashboard
     private
 
     attr_reader :after_issue, :project, :user
+
+    # Question-backed needs-input issues only. Shared by +call+ (dashboard
+    # render) and +next_issue+ (queue navigation) so neither links to a stale
+    # needs-input row that has no parseable questions.
+    def queued_entries
+      @queued_entries ||= ordered_issues.filter_map do |issue|
+        questions = question_summary_for(issue)
+        next if questions.empty?
+
+        Entry.new(
+          project: issue.project,
+          issue: issue,
+          questions: questions
+        )
+      end
+    end
 
     def ordered_issues
       @ordered_issues ||= begin

--- a/app/services/dashboard/needs_input_queue.rb
+++ b/app/services/dashboard/needs_input_queue.rb
@@ -19,11 +19,14 @@ module Dashboard
     end
 
     def call
-      ordered_issues.map do |issue|
+      ordered_issues.filter_map do |issue|
+        questions = question_summary_for(issue)
+        next if questions.empty?
+
         Entry.new(
           project: issue.project,
           issue: issue,
-          questions: question_summary_for(issue)
+          questions: questions
         )
       end
     end

--- a/app/temporal/activities/enhance_issue_activity.rb
+++ b/app/temporal/activities/enhance_issue_activity.rb
@@ -66,11 +66,16 @@ module Activities
     # Build comment, post, apply labels, complete run.
     # @spec ISSUE-ENHANCEMENT-006
     def finish_enhance_issue(agent_run, project, issue, client, parsed)
+      max_rounds_reached = !parsed[:sufficient_context] && max_rounds_reached?(project, issue)
       parsed = stop_after_max_rounds(parsed, project, issue)
       draft = build_change_intent_draft(agent_run, project, issue, parsed)
       comment_body = comment_body_for(parsed, draft)
+      questions = needs_input_questions(parsed, comment_body, max_rounds_reached:)
+      raise_parse_error!(agent_run, "sufficient_context false without clarifying questions") if needs_questions?(parsed, max_rounds_reached) && questions.empty?
+
       gh_comment = client.add_comment(project.full_name, issue.github_number, comment_body)
       label_result = apply_label_state(client, project, issue, parsed)
+      sync_needs_input_questions(issue, questions)
 
       agent_run.log!("stdout", comment_body)
       complete_run!(agent_run, paid_state_for(parsed, project, issue))
@@ -142,14 +147,15 @@ module Activities
     end
 
     def recover_or_raise_parse_error!(agent_run, project, issue, client, comments, detail)
-      return recover_paid_question_comment!(agent_run, project, issue, client, comments) if paid_question_comment?(project, agent_run, comments)
+      comment = paid_question_comment(project, agent_run, comments)
+      return recover_paid_question_comment!(agent_run, project, issue, client, comment) if comment
 
       raise_parse_error!(agent_run, detail)
     end
 
-    def recover_paid_question_comment!(agent_run, project, issue, client, comments)
-      comment = paid_question_comment(project, agent_run, comments)
+    def recover_paid_question_comment!(agent_run, project, issue, client, comment)
       label_result = apply_label_state(client, project, issue, sufficient_context: false)
+      issue.update!(needs_input_questions: paid_comment_questions(comment))
       complete_run!(agent_run, "needs_input")
       ProcessRunQueueJob.perform_later
 
@@ -357,6 +363,20 @@ module Activities
       "needs_input"
     end
 
+    def needs_input_questions(parsed, comment_body, max_rounds_reached:)
+      return [] unless needs_questions?(parsed, max_rounds_reached)
+
+      ClarifyingQuestions::Parse.call(comment_body:)
+    end
+
+    def needs_questions?(parsed, max_rounds_reached)
+      !parsed[:sufficient_context] && !max_rounds_reached
+    end
+
+    def sync_needs_input_questions(issue, questions)
+      issue.update!(needs_input_questions: questions.presence)
+    end
+
     def max_rounds_reached?(project, issue)
       issue.enhance_issue_rounds >= project.max_enhance_issue_reevaluation_rounds
     end
@@ -419,16 +439,20 @@ module Activities
       issue.update!(labels: labels)
     end
 
-    def paid_question_comment?(project, agent_run, comments)
-      paid_question_comment(project, agent_run, comments).present?
-    end
-
     def paid_question_comment(project, agent_run, comments)
       comments.reverse.find do |comment|
         paid_bot_comment?(project, comment) &&
           comment_after_run?(comment, agent_run) &&
-          comment_needs_human_input?(comment.body.to_s)
+          paid_comment_questions(comment).present?
       end
+    end
+
+    def paid_comment_questions(comment)
+      body = comment.body.to_s
+      questions = ClarifyingQuestions::Parse.call(comment_body: body)
+      return questions if questions.any?
+
+      ClarifyingQuestions::Parse.call(comment_body: "#{COMMENT_MARKER}\n#{body}")
     end
 
     def paid_bot_comment?(project, comment)
@@ -438,11 +462,6 @@ module Activities
     def comment_after_run?(comment, agent_run)
       created_at = comment.created_at
       created_at && created_at.to_time >= agent_run.created_at
-    end
-
-    def comment_needs_human_input?(body)
-      body.match?(/^##\s+Clarifying questions\b/i) ||
-        body.match?(/\b(question|decision|confirm|blocked|answer)\b/i)
     end
 
     def github_client(project)

--- a/docs/intent/issue-enhancement/issue-enhancement-specs.md
+++ b/docs/intent/issue-enhancement/issue-enhancement-specs.md
@@ -19,8 +19,9 @@
   marker and `needs_input` flow rather than creating a new state or surface.
   If a containerized enhancement agent posts a Paid-authored clarifying-question
   comment directly but fails to emit parseable structured output, the system
-  SHALL recover by applying the enhance-issue needs-input label and moving the
-  issue to `paid_state: "needs_input"` rather than leaving it auto-pick eligible.
+  SHALL recover only when it can parse and persist the questions, then apply the
+  enhance-issue needs-input label and move the issue to `paid_state:
+  "needs_input"` rather than leaving it auto-pick eligible.
   *Tests:* `spec/temporal/activities/enhance_issue_activity_spec.rb`.
   *Code:* `app/temporal/activities/enhance_issue_activity.rb#enhance_issue_post_run`,
   `app/temporal/activities/enhance_issue_activity.rb#recover_paid_question_comment!`,

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -869,7 +869,7 @@ RSpec.describe "Dashboard" do
     end
 
     it "links the needs-input count to the dashboard queue" do
-      create(:issue, :needs_input, project: project)
+      create(:issue, :needs_input, project: project, needs_input_questions: [ "What should happen?" ])
 
       get dashboard_eligibility_breakdown_path
 

--- a/spec/requests/projects/clarifying_questions_spec.rb
+++ b/spec/requests/projects/clarifying_questions_spec.rb
@@ -95,6 +95,9 @@ RSpec.describe "Projects::ClarifyingQuestions" do
     context "when all answers are provided" do
       let(:questions) { [ "What is the expected behavior?", "Should this be behind a flag?" ] }
       let(:answers) { [ "X is a feature", "Yes, by default" ] }
+      let(:issue) do
+        create(:issue, :needs_input, project: project, body: issue_body, needs_input_questions: questions)
+      end
 
       before do
         allow(github_client).to receive(:issue_comments).and_return([ trusted_comment ])
@@ -135,7 +138,8 @@ RSpec.describe "Projects::ClarifyingQuestions" do
 
       it "redirects to the next queued issue when opened from the dashboard queue" do
         project.update!(auto_pick_enabled: true, active: true)
-        next_issue = create(:issue, :needs_input, project: project, github_number: issue.github_number + 1)
+        next_issue = create(:issue, :needs_input, project: project, github_number: issue.github_number + 1,
+          needs_input_questions: [ "What should happen next?" ])
         return_to = dashboard_needs_input_path(project_id: project.id)
 
         post project_issue_clarifying_questions_path(project, issue), params: {
@@ -218,7 +222,9 @@ RSpec.describe "Projects::ClarifyingQuestions" do
           auto_pick_enabled: true,
           active: true
         )
-        create(:issue, :needs_input, project: other_project, github_number: issue.github_number + 1)
+        create(:issue, :needs_input, project: other_project,
+          github_number: issue.github_number + 1,
+          needs_input_questions: [ "What should happen next?" ])
 
         post project_issue_clarifying_questions_path(project, issue), params: {
           questions: questions,

--- a/spec/services/clarifying_questions/clear_needs_input_spec.rb
+++ b/spec/services/clarifying_questions/clear_needs_input_spec.rb
@@ -15,7 +15,9 @@ RSpec.describe ClarifyingQuestions::ClearNeedsInput do
     let(:issue) do
       double(
         github_number: 1964,
+        paid_state: "needs_input",
         needs_input?: true,
+        has_label?: true,
         labels: [ "paid-needs-input", "P2" ],
         update!: true
       )
@@ -36,12 +38,32 @@ RSpec.describe ClarifyingQuestions::ClearNeedsInput do
     end
 
     context "when the issue is not awaiting input" do
-      let(:issue) { double(needs_input?: false) }
+      let(:issue) { double(paid_state: "new", needs_input?: false) }
 
       it "is a no-op" do
         described_class.call(project: project, issue: issue)
 
         expect(github_client).not_to have_received(:remove_label_from_issue)
+      end
+    end
+
+    context "when the local state is stale and the label is already gone" do
+      let(:issue) do
+        double(
+          github_number: 1964,
+          paid_state: "needs_input",
+          needs_input?: false,
+          has_label?: false,
+          labels: [ "P2" ],
+          update!: true
+        )
+      end
+
+      it "clears local needs_input without calling GitHub" do
+        described_class.call(project: project, issue: issue)
+
+        expect(github_client).not_to have_received(:remove_label_from_issue)
+        expect(issue).to have_received(:update!).with(paid_state: "new", labels: [ "P2" ], needs_input_questions: nil)
       end
     end
 

--- a/spec/services/clarifying_questions/extract_answer_pairs_spec.rb
+++ b/spec/services/clarifying_questions/extract_answer_pairs_spec.rb
@@ -195,4 +195,34 @@ RSpec.describe ClarifyingQuestions::ExtractAnswerPairs do
       expect(result.answer_comment).to be_nil
     end
   end
+
+  context "when the clarifying questions are persisted locally" do
+    let(:stored_issue) do
+      build_stubbed(
+        :issue,
+        body: "Original issue body",
+        needs_input_questions: [
+          "What problem are we solving?",
+          "When the redirect is invalid, what should happen?"
+        ]
+      )
+    end
+
+    it "returns pairs when stored questions match the posted answers" do
+      result = described_class.call(
+        project: project,
+        issue: stored_issue,
+        issue_comments: [ answer_comment ]
+      )
+
+      expect(result.qa_pairs).to eq(
+        [
+          { question: "What problem are we solving?",
+            answer: "Users should never land on a broken redirect." },
+          { question: "When the redirect is invalid, what should happen?",
+            answer: "The system should send them to `/dashboard`." }
+        ]
+      )
+    end
+  end
 end

--- a/spec/services/clarifying_questions/load_spec.rb
+++ b/spec/services/clarifying_questions/load_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe ClarifyingQuestions::Load, :no_db do
       body: issue_body,
       github_number: 1964,
       github_updated_at: 2.minutes.ago,
+      needs_input_questions: nil,
       needs_input?: false
     )
   end
@@ -93,6 +94,49 @@ RSpec.describe ClarifyingQuestions::Load, :no_db do
       end
 
       it "loads questions from the latest enhancement comment" do
+        questions = described_class.call(project: project, issue: issue)
+
+        expect(questions).to eq([
+          "What is the expected behavior?",
+          "Should this be behind a flag?"
+        ])
+      end
+    end
+
+    context "when clarifying questions are persisted locally" do
+      let(:issue) do
+        double(
+          id: 42,
+          body: "Original issue body",
+          github_number: 1964,
+          github_updated_at: 2.minutes.ago,
+          needs_input_questions: [ "Which scope should ship first?" ],
+          needs_input?: true
+        )
+      end
+
+      it "returns the persisted questions" do
+        questions = described_class.call(project: project, issue: issue)
+
+        expect(questions).to eq([ "Which scope should ship first?" ])
+      end
+
+      it "returns persisted questions when GitHub comments cannot be loaded" do
+        allow(github_client).to receive(:issue_comments).and_raise(GithubClient::Error, "GitHub unavailable")
+
+        questions = described_class.call(project: project, issue: issue)
+
+        expect(questions).to eq([ "Which scope should ship first?" ])
+      end
+
+      it "prefers newer questions from GitHub comments" do
+        comment = double(
+          body: comment_body,
+          user: double(login: trusted_login),
+          created_at: 1.minute.ago
+        )
+        allow(github_client).to receive(:issue_comments).and_return([ comment ])
+
         questions = described_class.call(project: project, issue: issue)
 
         expect(questions).to eq([

--- a/spec/services/clarifying_questions/parse_spec.rb
+++ b/spec/services/clarifying_questions/parse_spec.rb
@@ -46,6 +46,19 @@ RSpec.describe ClarifyingQuestions::Parse, :no_db do
         expect(questions[0]).to eq("What is the expected behavior for the edge case where the user has not yet confirmed their email address?")
         expect(questions[1]).to eq("Should this be enabled by default?")
       end
+
+      it "parses heading variants such as remaining clarifying questions" do
+        body = <<~COMMENT
+          <!-- paid:enhance-issue -->
+
+          ## Remaining clarifying questions
+          1. Which scope should ship first?
+        COMMENT
+
+        questions = described_class.call(comment_body: body)
+
+        expect(questions).to eq([ "Which scope should ship first?" ])
+      end
     end
 
     context "when comment has sufficient context (no clarifying questions)" do

--- a/spec/services/clarifying_questions/parse_spec.rb
+++ b/spec/services/clarifying_questions/parse_spec.rb
@@ -59,6 +59,24 @@ RSpec.describe ClarifyingQuestions::Parse, :no_db do
 
         expect(questions).to eq([ "Which scope should ship first?" ])
       end
+
+      it "ignores the phrase clarifying questions repeated in a later section" do
+        body = <<~COMMENT
+          <!-- paid:enhance-issue -->
+
+          ## Clarifying questions
+          1. What is the expected behavior for edge case X?
+
+          ## Notes
+          These are the clarifying questions we still need to resolve.
+
+          Some trailing context.
+        COMMENT
+
+        questions = described_class.call(comment_body: body)
+
+        expect(questions).to eq([ "What is the expected behavior for edge case X?" ])
+      end
     end
 
     context "when comment has sufficient context (no clarifying questions)" do

--- a/spec/services/clarifying_questions/submit_answers_spec.rb
+++ b/spec/services/clarifying_questions/submit_answers_spec.rb
@@ -146,6 +146,7 @@ RSpec.describe ClarifyingQuestions::SubmitAnswers, :no_db do
         double(
           github_number: 1964,
           needs_input?: true,
+          has_label?: true,
           labels: [ "paid-needs-input", "P2" ]
         )
       end

--- a/spec/services/dashboard/eligibility_breakdown_spec.rb
+++ b/spec/services/dashboard/eligibility_breakdown_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Dashboard::EligibilityBreakdown do
     it "returns a breakdown with correct counts" do
       create(:issue, project: project, github_state: "open", paid_state: "new")
       create(:issue, project: project, github_state: "open", paid_state: "new", labels: [ "tracking" ])
-      create(:issue, project: project, github_state: "open", paid_state: "needs_input")
+      create(:issue, project: project, github_state: "open", paid_state: "needs_input", needs_input_questions: [ "What should happen?" ])
       create(:issue, project: project, github_state: "open", paid_state: "in_progress")
       create(:issue, project: project, github_state: "open", paid_state: "completed")
 
@@ -47,6 +47,27 @@ RSpec.describe Dashboard::EligibilityBreakdown do
       expect(bd.completed).to eq(1)
       expect(bd.skip_label).to eq(1)
       expect(bd.other_excluded).to eq(0)
+    end
+
+    it "counts questionless needs-input issues as other excluded" do
+      create(:issue, project: project, github_state: "open", paid_state: "needs_input")
+
+      result = described_class.call(user: user)
+
+      bd = result.first
+      expect(bd.needs_input).to eq(0)
+      expect(bd.other_excluded).to eq(1)
+    end
+
+    it "does not count marker-only needs-input bodies as answerable" do
+      create(:issue, project: project, github_state: "open", paid_state: "needs_input",
+        body: "#{ClarifyingQuestions::Parse::ENHANCEMENT_MARKER}\n\n## Clarifying questions\nNo numbered questions here.")
+
+      result = described_class.call(user: user)
+
+      bd = result.first
+      expect(bd.needs_input).to eq(0)
+      expect(bd.other_excluded).to eq(1)
     end
 
     it "counts dependency-blocked issues in other_excluded" do

--- a/spec/services/dashboard/needs_input_queue_spec.rb
+++ b/spec/services/dashboard/needs_input_queue_spec.rb
@@ -73,5 +73,16 @@ RSpec.describe Dashboard::NeedsInputQueue do
 
       expect(described_class.next_issue(user: user, project: project, after_issue: stale_issue)).to be_nil
     end
+
+    it "skips questionless issues when advancing to the next queued issue" do
+      first_issue
+      questionless = create(:issue, :needs_input, project: project, github_number: 11, body: "Needs manual retry")
+      third_issue = create(:issue, :needs_input, project: project, github_number: 12, body: questions_body)
+
+      entries = described_class.call(user: user, project: project).map(&:issue)
+
+      expect(entries).not_to include(questionless)
+      expect(described_class.next_issue(user: user, project: project, after_issue: first_issue)).to eq(third_issue)
+    end
   end
 end

--- a/spec/services/dashboard/needs_input_queue_spec.rb
+++ b/spec/services/dashboard/needs_input_queue_spec.rb
@@ -20,6 +20,27 @@ RSpec.describe Dashboard::NeedsInputQueue do
   end
 
   describe ".call" do
+    it "excludes needs-input issues without a local or body questionnaire" do
+      stale_issue = create(:issue, :needs_input, project: project, github_number: 9, body: "Needs manual retry")
+      first_issue
+
+      entries = described_class.call(user: user, project: project)
+
+      expect(entries.map(&:issue)).to include(first_issue)
+      expect(entries.map(&:issue)).not_to include(stale_issue)
+    end
+
+    it "excludes issues whose body only looks like a questionnaire" do
+      stale_issue = create(:issue, :needs_input, project: project, github_number: 9,
+        body: "#{ClarifyingQuestions::Parse::ENHANCEMENT_MARKER}\n\n## Clarifying questions\nNo numbered questions here.")
+      first_issue
+
+      entries = described_class.call(user: user, project: project)
+
+      expect(entries.map(&:issue)).to include(first_issue)
+      expect(entries.map(&:issue)).not_to include(stale_issue)
+    end
+
     it "returns clarifying questions persisted locally for create_feature issues without an API round-trip" do
       feature_issue = create(:issue, :needs_input, project: project, github_number: 20,
                              body: "Need dark mode",

--- a/spec/temporal/activities/enhance_issue_activity_spec.rb
+++ b/spec/temporal/activities/enhance_issue_activity_spec.rb
@@ -122,6 +122,7 @@ RSpec.describe Activities::EnhanceIssueActivity do
       expect_label_added(project.enhance_issue_needs_input_label_name)
       expect(issue.reload.paid_state).to eq("needs_input")
       expect(issue.labels).to include(project.enhance_issue_needs_input_label_name)
+      expect(issue.needs_input_questions).to eq([ "Which events should be recorded?" ])
     end
 
     it "fails before moving to needs_input when adding the GitHub label fails" do
@@ -145,6 +146,21 @@ RSpec.describe Activities::EnhanceIssueActivity do
       )
       expect(issue.reload.paid_state).to eq("in_progress")
       expect(issue.reload.labels).not_to include(project.enhance_issue_needs_input_label_name)
+    end
+
+    it "fails before posting when insufficient context has no parseable questions" do
+      log_agent_stdout({
+        sufficient_context: false,
+        comment_body: "## Implementation context\nThis is not actionable yet."
+      }.to_json)
+
+      expect {
+        activity.execute(agent_run_id: agent_run.id)
+      }.to raise_error(Temporalio::Error::ApplicationError) { |error| expect(error.type).to eq("EnhanceIssueUnparseableOutput") }
+
+      expect(client).not_to have_received(:add_comment)
+      expect(issue.reload.paid_state).to eq("in_progress")
+      expect(issue.needs_input_questions).to be_nil
     end
 
     it "fails before completing when adding the enhanced GitHub label fails" do
@@ -366,6 +382,7 @@ RSpec.describe Activities::EnhanceIssueActivity do
       expect(agent_run.reload.status).to eq("completed")
       expect(issue.reload.paid_state).to eq("needs_input")
       expect(issue.labels).to include(project.enhance_issue_needs_input_label_name)
+      expect(issue.needs_input_questions).to eq([ "Which scope should ship first?" ])
     end
 
     it "recovers a Paid-authored question comment when no stdout was captured" do # @spec ISSUE-ENHANCEMENT-002
@@ -378,7 +395,26 @@ RSpec.describe Activities::EnhanceIssueActivity do
 
       expect(result[:recovered_paid_question_comment]).to be true
       expect(issue.reload.paid_state).to eq("needs_input")
+      expect(issue.needs_input_questions).to eq([ "Which scope should ship first?" ])
       expect_label_added(project.enhance_issue_needs_input_label_name)
+    end
+
+    it "does not recover a Paid-authored decision request without parseable questions" do # @spec ISSUE-ENHANCEMENT-002
+      configure_app_backed_project
+      allow(client).to receive(:issue_comments).and_return(comments + [
+        OpenStruct.new(
+          body: "## Decision request\n\nPlease choose the final implementation shape.",
+          user: OpenStruct.new(login: Github::AppRegistry.bot_login),
+          created_at: agent_run.created_at + 1.minute
+        )
+      ])
+      log_agent_stdout("not json")
+
+      expect {
+        activity.execute(agent_run_id: agent_run.id)
+      }.to raise_error(Temporalio::Error::ApplicationError) { |error| expect(error.type).to eq("EnhanceIssueUnparseableOutput") }
+
+      expect(issue.reload.paid_state).to eq("in_progress")
     end
 
     it "does not recover untrusted question-shaped comments" do


### PR DESCRIPTION
## Summary

Fixes the needs-input dashboard flow so the Auto-Pick Eligibility table and Needs Input Queue only link to issues that actually have answerable clarifying questions.

## Root Cause

The dashboard treated every open non-PR issue with `paid_state = "needs_input"` as an answerable questionnaire. Some rows were stale/manual needs-input states or enhancement recovery outputs without parseable questions, so the answer page correctly found no questions and redirected with an error.

## Changes

- Persist parsed clarifying questions from normal and recovered enhancement needs-input flows.
- Require recovered/insufficient-context enhancement output to contain parseable questions before applying needs-input state, except max-round manual-review stops.
- Make question loading and answer ingestion use stored `needs_input_questions` as a fallback.
- Filter dashboard needs-input queue/counts through the actual parser/local-question rule instead of broad state alone.
- Clear stale local needs-input state even when the GitHub label is already gone.
- Broaden clarifying-question parsing to heading variants like `## Remaining clarifying questions`.

## Data Repair Performed Locally

- Backfilled stored questions for answerable needs-input issues.
- Cleared questionless stale rows.
- Ran `AutoPickEligibilitySweepJob.perform_now`.
- Final local check: 57 open non-PR needs-input rows, 0 questionless rows; yupyup blockers are queued/in progress rather than dead-linked.

## Validation

- `bin/rspec spec/services/clarifying_questions/parse_spec.rb spec/services/clarifying_questions/load_spec.rb spec/services/clarifying_questions/clear_needs_input_spec.rb spec/services/clarifying_questions/extract_answer_pairs_spec.rb spec/temporal/activities/enhance_issue_activity_spec.rb spec/services/dashboard/needs_input_queue_spec.rb spec/services/dashboard/eligibility_breakdown_spec.rb spec/requests/dashboard_spec.rb:871 spec/requests/dashboard_spec.rb:885`
- `bin/rubocop app/services/clarifying_questions/parse.rb app/services/clarifying_questions/load.rb app/services/clarifying_questions/clear_needs_input.rb app/services/clarifying_questions/extract_answer_pairs.rb app/services/dashboard/needs_input_queue.rb app/services/dashboard/eligibility_breakdown.rb app/temporal/activities/enhance_issue_activity.rb spec/services/clarifying_questions/parse_spec.rb spec/services/clarifying_questions/load_spec.rb spec/services/clarifying_questions/clear_needs_input_spec.rb spec/services/clarifying_questions/extract_answer_pairs_spec.rb spec/services/dashboard/needs_input_queue_spec.rb spec/services/dashboard/eligibility_breakdown_spec.rb spec/requests/dashboard_spec.rb spec/temporal/activities/enhance_issue_activity_spec.rb`
- `bin/coherence-check.mjs`
- `git diff --check`