### PR TITLE
fix(chat): guard missing scroll container target

### DIFF
--- a/app/javascript/controllers/chat_controller.js
+++ b/app/javascript/controllers/chat_controller.js
@@ -84,6 +84,8 @@ export default class extends Controller {
   }
 
   handleScroll() {
+    if (!this.hasContainerTarget) return
+
     const threshold = 48
     const distanceFromBottom = this.containerTarget.scrollHeight - this.containerTarget.scrollTop - this.containerTarget.clientHeight
     this.autoScroll = distanceFromBottom <= threshold
@@ -554,6 +556,7 @@ export default class extends Controller {
   // A requestAnimationFrame loop that sets scrollTop directly works on every
   // browser because scrollTop assignment is universally supported.
   smoothScrollTo(target) {
+    if (!this.hasContainerTarget) return
     if (this.scrollAnimationId) cancelAnimationFrame(this.scrollAnimationId)
 
     const container = this.containerTarget

--- a/app/javascript/controllers/chat_controller.js
+++ b/app/javascript/controllers/chat_controller.js
@@ -533,6 +533,7 @@ export default class extends Controller {
   }
 
   scrollToBottom() {
+    if (!this.hasContainerTarget) return
     if (!this.autoScroll) return
 
     const streamController = this.application.getControllerForElementAndIdentifier(this.containerTarget, "chat-stream")
@@ -548,6 +549,7 @@ export default class extends Controller {
   }
 
   scrollToInput() {
+    if (!this.hasContainerTarget) return
     this.smoothScrollTo(this.containerTarget.scrollHeight)
   }
 

--- a/spec/lib/chat_controller_node_harness_spec.rb
+++ b/spec/lib/chat_controller_node_harness_spec.rb
@@ -41,6 +41,14 @@ class ChatControllerNodeHarness
 
       Object.assign(controller, overrides);
 
+      // Stimulus sets hasContainerTarget to true when the container element
+      // exists in the DOM. Mirror that so the defensive guards in handleScroll,
+      // scrollToBottom, scrollToInput, and smoothScrollTo exercise their real
+      // path whenever a containerTarget is provided.
+      if ("containerTarget" in controller) {
+        controller.hasContainerTarget = true;
+      }
+
       return { controller, appended, statusMessages };
     }
 

--- a/spec/services/runners/refresh_quota_snapshots_spec.rb
+++ b/spec/services/runners/refresh_quota_snapshots_spec.rb
@@ -74,10 +74,10 @@ RSpec.describe Runners::RefreshQuotaSnapshots do
 
     it "uses provider check_quota for subscription runners when available" do
       provider_name = RunnerSupport.harness_runner_key_for("claude").to_sym
-      status = Struct.new(:remaining, :limit, :reset_at, :unit) do
+      checked_at = 5.minutes.ago
+      status = Struct.new(:remaining, :limit, :reset_at, :unit, :checked_at) do
         def available? = true
-        def checked_at = 5.minutes.ago
-      end.new(600, 1000, 1.hour.from_now, "requests")
+      end.new(600, 1000, 1.hour.from_now, "requests", checked_at)
       provider = double(subscription_unset_vars: [], check_quota: status)
 
       allow(AgentHarness).to receive(:provider).with(provider_name).and_return(provider)
@@ -92,7 +92,7 @@ RSpec.describe Runners::RefreshQuotaSnapshots do
         "available" => true,
         "source" => "provider"
       )
-      expect(Time.iso8601(snapshot.fetch("checked_at"))).to be_within(1.second).of(5.minutes.ago)
+      expect(Time.iso8601(snapshot.fetch("checked_at"))).to be_within(1.second).of(checked_at)
     end
 
     # @spec RUNNER-QUOTA-001


### PR DESCRIPTION
## Summary

Adds defensive guards in the chat Stimulus controller before reading the scroll container target.

## Root Cause

Some chat controller scopes can connect without a `container` target, but `handleScroll()` and smooth scrolling assumed it was always present. That can throw on connect or scroll helper calls and break the chat UI.

## Validation

- `bin/rspec spec/requests/chat_sessions_spec.rb:268`
- `PATH=/workspaces/paid/node_modules/.bin:$PATH yarn build`