### PR TITLE
Organize project pre-commit settings

### DIFF
--- a/app/controllers/projects/pre_commit_requirements_controller.rb
+++ b/app/controllers/projects/pre_commit_requirements_controller.rb
@@ -7,7 +7,7 @@ module Projects
 
     def index
       authorize @project, :show?
-      @pre_commit_requirements = @project.pre_commit_requirements.ordered
+      load_requirements
 
       respond_to do |format|
         format.html
@@ -32,8 +32,8 @@ module Projects
         redirect_to project_pre_commit_requirements_path(@project),
           notice: "Pre-commit requirement created."
       else
-        @pre_commit_requirements = @project.pre_commit_requirements.ordered
-        @new_requirement = @pre_commit_requirement
+        load_requirements
+        assign_failed_requirement
         render :index, status: :unprocessable_content
       end
     end
@@ -45,8 +45,8 @@ module Projects
         redirect_to project_pre_commit_requirements_path(@project),
           notice: "Pre-commit requirement updated."
       else
-        @pre_commit_requirements = @project.pre_commit_requirements.ordered
-        @new_requirement = @pre_commit_requirement
+        load_requirements
+        assign_failed_requirement
         render :index, status: :unprocessable_content
       end
     end
@@ -66,6 +66,33 @@ module Projects
 
     def set_pre_commit_requirement
       @pre_commit_requirement = @project.pre_commit_requirements.find(params[:id])
+    end
+
+    def load_requirements
+      @pre_commit_requirements = @project.pre_commit_requirements.ordered
+      @mutation_requirement = mutation_requirement_for_form
+      @can_manage_pre_commit_requirements = policy(@project).update?
+    end
+
+    def assign_failed_requirement
+      return if @pre_commit_requirement.check_type == "mutation_test"
+
+      @new_requirement = @pre_commit_requirement
+    end
+
+    def mutation_requirement_for_form
+      return @pre_commit_requirement if @pre_commit_requirement&.check_type == "mutation_test"
+
+      @project.pre_commit_requirements.find_by(check_type: "mutation_test") ||
+        @project.pre_commit_requirements.build(
+          account: @project.account,
+          name: "mutation_test",
+          check_type: "mutation_test",
+          command: PreCommitRequirement::MUTATION_TEST_DEFAULT_COMMAND,
+          failure_behavior: "warn",
+          position: 0,
+          enabled: false
+        )
     end
 
     def pre_commit_requirement_params

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -144,7 +144,6 @@ class ProjectsController < ApplicationController
     @available_service_containers = policy_scope(ServiceContainer).where.not(id: @project.service_container_ids).order(:name)
     @available_mcp_server_definitions = policy_scope(McpServerDefinition).where.not(id: @project.mcp_server_definition_ids).order(:name)
     @project_mcp_servers = @project.project_mcp_servers.includes(:mcp_server_definition).to_a
-    @mutation_req = @project.pre_commit_requirements.find_by(check_type: "mutation_test")
     load_screenshot_settings_context
   end
 
@@ -176,26 +175,15 @@ class ProjectsController < ApplicationController
 
     assign_selected_github_credential(@project, update_params)
     update_params = update_params.except(:github_auth_source, :github_token_id, :github_installation_id)
-    @mutation_req = @project.pre_commit_requirements.find_by(check_type: "mutation_test")
 
     Project.transaction do
       @project.update!(update_params)
-      @mutation_req = upsert_mutation_test_requirement!
       redetect_lid_mode! if redetect_lid_mode_requested?
     end
 
     audit_event("project.updated", metadata: { name: @project.name, changed_fields: @project.saved_changes.except("updated_at").keys })
     redirect_to @project, notice: "Project was successfully updated."
-  rescue ActiveRecord::RecordInvalid => e
-    if e.record.is_a?(PreCommitRequirement)
-      @mutation_req = e.record
-      e.record.errors.each do |error|
-        @project.errors.add(:base, error.full_message)
-      end
-    elsif mutation_test_params
-      @mutation_req = mutation_test_requirement_for_form
-    end
-
+  rescue ActiveRecord::RecordInvalid
     ensure_github_app_installation_error
     @available_service_containers = policy_scope(ServiceContainer).where.not(id: @project.service_container_ids).order(:name)
     @available_mcp_server_definitions = policy_scope(McpServerDefinition).where.not(id: @project.mcp_server_definition_ids).order(:name)
@@ -709,56 +697,6 @@ class ProjectsController < ApplicationController
       "service_dependencies" => Array(raw[:service_dependencies]).map(&:to_s).map(&:strip).reject(&:blank?).uniq,
       "setup_commands" => raw[:setup_commands_text].to_s.lines.map(&:strip).reject(&:blank?).uniq
     )
-  end
-
-  def mutation_test_params
-    params.permit(mutation_test: [ :enabled, :command, :failure_behavior ]).fetch(:mutation_test, nil)
-  end
-
-  def upsert_mutation_test_requirement!
-    mutation_params = mutation_test_params
-    return @mutation_req unless mutation_params
-
-    if @mutation_req
-      @mutation_req.assign_attributes(mutation_test_requirement_attributes(mutation_params))
-      @mutation_req.save!
-      @mutation_req
-    elsif mutation_test_enabled?(mutation_params)
-      @project.pre_commit_requirements.create!(mutation_test_requirement_attributes(mutation_params))
-    end
-  end
-
-  def mutation_test_requirement_for_form
-    return @mutation_req unless mutation_test_params
-
-    requirement = @mutation_req || @project.pre_commit_requirements.new(
-      account: @project.account,
-      name: "mutation_test",
-      check_type: "mutation_test",
-      position: 0
-    )
-    requirement.assign_attributes(mutation_test_requirement_attributes(mutation_test_params))
-    requirement
-  end
-
-  def mutation_test_requirement_attributes(mutation_params)
-    {
-      account: @project.account,
-      name: "mutation_test",
-      check_type: "mutation_test",
-      command: mutation_params[:command].presence || PreCommitRequirement::MUTATION_TEST_DEFAULT_COMMAND,
-      failure_behavior: mutation_failure_behavior(mutation_params[:failure_behavior]),
-      position: 0,
-      enabled: mutation_test_enabled?(mutation_params)
-    }
-  end
-
-  def mutation_failure_behavior(value)
-    PreCommitRequirement::FAILURE_BEHAVIORS.include?(value) ? value : "warn"
-  end
-
-  def mutation_test_enabled?(mutation_params)
-    ActiveModel::Type::Boolean.new.cast(mutation_params[:enabled])
   end
 
   def screenshot_settings_for_action

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -104,6 +104,8 @@
                      data-dropdown-target="menu">
                   <%= link_to "Quality", quality_dashboard_path, class: nav_menu_item_class, role: "menuitem", data: { action: "dropdown#close" } %>
                   <%= link_to "Prompts", prompts_path, class: nav_menu_item_class, role: "menuitem", data: { action: "dropdown#close" } %>
+                  <%= link_to "Prompt Reviews", prompt_reviews_queue_path, class: nav_menu_item_class, role: "menuitem", data: { action: "dropdown#close" } %>
+                  <%= link_to "Plan Reviews", plan_reviews_path, class: nav_menu_item_class, role: "menuitem", data: { action: "dropdown#close" } %>
                   <%= link_to "Knowledge", knowledge_search_path, class: nav_menu_item_class, role: "menuitem", data: { action: "dropdown#close" } %>
                 </div>
               </div>
@@ -133,6 +135,9 @@
                     <%= link_to "Services", service_containers_path, class: nav_menu_item_class, role: "menuitem", data: { action: "dropdown#close" } %>
                   <% end %>
                   <%= link_to "Integrations", integrations_path, class: nav_menu_item_class, role: "menuitem", data: { action: "dropdown#close" } %>
+                  <% if policy(CodexLoginSession.new(account: current_account)).new? %>
+                    <%= link_to "Codex Login", new_codex_login_session_path, class: nav_menu_item_class, role: "menuitem", data: { action: "dropdown#close" } %>
+                  <% end %>
                   <% if policy(ExceptionIncident).index? %>
                     <%= link_to "Exception incidents", exception_incidents_path, class: nav_menu_item_class, role: "menuitem", data: { action: "dropdown#close" } %>
                   <% end %>
@@ -234,6 +239,8 @@
             <p class="<%= mobile_heading_class %>">Insights</p>
             <%= link_to "Quality", quality_dashboard_path, data: { action: "mobile-menu#close" }, class: mobile_link_class %>
             <%= link_to "Prompts", prompts_path, data: { action: "mobile-menu#close" }, class: mobile_link_class %>
+            <%= link_to "Prompt Reviews", prompt_reviews_queue_path, data: { action: "mobile-menu#close" }, class: mobile_link_class %>
+            <%= link_to "Plan Reviews", plan_reviews_path, data: { action: "mobile-menu#close" }, class: mobile_link_class %>
             <%= link_to "Knowledge", knowledge_search_path, data: { action: "mobile-menu#close" }, class: mobile_link_class %>
 
             <p class="<%= mobile_heading_class %>">Operations</p>
@@ -242,6 +249,9 @@
               <%= link_to "Services", service_containers_path, data: { action: "mobile-menu#close" }, class: mobile_link_class %>
             <% end %>
             <%= link_to "Integrations", integrations_path, data: { action: "mobile-menu#close" }, class: mobile_link_class %>
+            <% if policy(CodexLoginSession.new(account: current_account)).new? %>
+              <%= link_to "Codex Login", new_codex_login_session_path, data: { action: "mobile-menu#close" }, class: mobile_link_class %>
+            <% end %>
             <% if policy(ExceptionIncident).index? %>
               <%= link_to "Exception incidents", exception_incidents_path, data: { action: "mobile-menu#close", testid: "mobile-exception-incidents-link" }, class: mobile_link_class %>
             <% end %>

--- a/app/views/projects/edit.html.erb
+++ b/app/views/projects/edit.html.erb
@@ -126,6 +126,14 @@
         <% end %>
 
         <div class="space-y-6">
+          <div>
+            <div class="flex items-center">
+              <%= form.check_box :active, class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" %>
+              <%= form.label :active, "Active", class: "ml-3 block text-sm font-medium leading-6 text-gray-900" %>
+            </div>
+            <p class="mt-1 ml-7 text-xs text-gray-500">When inactive, the project will not be polled for new issues.</p>
+          </div>
+
           <div class="rounded-md bg-gray-50 p-4">
             <div class="flex">
               <div class="flex-shrink-0">
@@ -811,14 +819,6 @@
             </div>
           </fieldset>
 
-          <%= render "screenshot_settings", form: form,
-                screenshot_settings: @screenshot_settings,
-                screenshot_service_options: @screenshot_service_options,
-                screenshot_status: @screenshot_status,
-                screenshot_repo_config_result: @screenshot_repo_config_result,
-                screenshot_preview_config: @screenshot_preview_config,
-                screenshot_conflicts: @screenshot_conflicts %>
-
           <fieldset id="auto-release" class="space-y-4">
             <legend class="text-sm font-semibold leading-6 text-gray-900">Auto-Merge &amp; Auto-Release</legend>
 
@@ -875,80 +875,22 @@
             </div>
           </fieldset>
 
-          <div class="flex items-center">
-            <%= form.check_box :active, class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" %>
-            <%= form.label :active, "Active", class: "ml-3 block text-sm font-medium leading-6 text-gray-900" %>
-          </div>
-          <p class="-mt-4 ml-7 text-xs text-gray-500">When inactive, the project will not be polled for new issues.</p>
-        </div>
+          <%= render "screenshot_settings", form: form,
+                screenshot_settings: @screenshot_settings,
+                screenshot_service_options: @screenshot_service_options,
+                screenshot_status: @screenshot_status,
+                screenshot_repo_config_result: @screenshot_repo_config_result,
+                screenshot_preview_config: @screenshot_preview_config,
+                screenshot_conflicts: @screenshot_conflicts %>
 
-          <%# Mutation Testing section %>
-          <fieldset id="mutation-testing" class="space-y-4 rounded-md border border-gray-200 p-4">
-            <legend class="px-1 text-sm font-semibold text-gray-900">Mutation Testing</legend>
+          <fieldset id="pre-commit-requirements" class="space-y-3 rounded-md border border-gray-200 p-4">
+            <legend class="px-1 text-sm font-semibold text-gray-900">Pre-Commit Requirements</legend>
             <p class="text-sm text-gray-600">
-              Run mutation tests before committing to catch inadequate test coverage.
-              Uses <a href="https://github.com/viamin/mutant" class="text-indigo-600 hover:text-indigo-500" target="_blank" rel="noopener noreferrer">viamin/mutant</a> via <code class="rounded bg-gray-100 px-1 text-xs">bundle exec mutant</code>.
+              Configure checks that run before Paid commits agent changes, including mutation testing.
             </p>
-
-            <div data-controller="collapsible-panel">
-              <div class="flex items-center">
-                <input type="hidden" name="mutation_test[enabled]" value="0">
-                <input type="checkbox" name="mutation_test[enabled]" value="1"
-                  id="mutation_test_enabled"
-                  <% if @mutation_req&.enabled? %>checked<% end %>
-                  aria-controls="mutation_test_settings"
-                  class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
-                  data-action="change->collapsible-panel#toggle"
-                  data-collapsible-panel-target="checkbox">
-                <label for="mutation_test_enabled" class="ml-3 block text-sm font-medium leading-6 text-gray-900">Enable mutation testing</label>
-                <% if @mutation_req&.enabled? %>
-                  <span class="ml-2 inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">Active</span>
-                <% end %>
-              </div>
-
-              <div id="mutation_test_settings"
-                class="space-y-4 transition-all duration-200 ease-in-out <%= @mutation_req&.enabled? ? 'max-h-[2000px] opacity-100' : 'max-h-0 overflow-hidden opacity-0' %>"
-                <% unless @mutation_req&.enabled? %>inert<% end %>
-                data-collapsible-panel-target="panel">
-                <div>
-                  <label for="mutation_test_command" class="block text-sm font-medium leading-6 text-gray-900">Command</label>
-                  <div class="mt-1">
-                    <input type="text" name="mutation_test[command]" id="mutation_test_command"
-                      value="<%= @mutation_req&.command || PreCommitRequirement::MUTATION_TEST_DEFAULT_COMMAND %>"
-                      autocomplete="off"
-                      required
-                      class="block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
-                  </div>
-                  <p class="mt-1 text-xs text-gray-500">
-                    Default: <code class="rounded bg-gray-100 px-1"><%= PreCommitRequirement::MUTATION_TEST_DEFAULT_COMMAND %></code>
-                  </p>
-                </div>
-
-                <div>
-                  <label for="mutation_test_failure_behavior" class="block text-sm font-medium leading-6 text-gray-900">Failure behavior</label>
-                  <div class="mt-1">
-                    <select name="mutation_test[failure_behavior]" id="mutation_test_failure_behavior"
-                      class="block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6">
-                      <%= options_for_select(
-                        [
-                          [ "Warn (log result, do not block)", "warn" ],
-                          [ "Block (fail the pre-commit check)", "block" ]
-                        ],
-                        @mutation_req&.failure_behavior || "warn"
-                      ) %>
-                    </select>
-                  </div>
-                  <p class="mt-1 text-xs text-gray-500">Choose <strong>Warn</strong> to start with, then switch to <strong>Block</strong> once your kill rate is stable.</p>
-                </div>
-              </div>
-            </div>
-
-            <% if @mutation_req&.updated_at %>
-              <div class="pt-2">
-                <span class="text-xs text-gray-500">Last updated: <%= @mutation_req.updated_at.strftime("%b %-d, %Y") %></span>
-              </div>
-            <% end %>
+            <%= link_to "Manage pre-commit requirements", project_pre_commit_requirements_path(@project), class: "inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" %>
           </fieldset>
+        </div>
 
         <div class="mt-6 flex items-center justify-end gap-x-4">
           <%= link_to "Cancel", project_path(@project), class: "text-sm font-semibold leading-6 text-gray-900 hover:text-gray-700" %>

--- a/app/views/projects/pre_commit_requirements/_requirement.html.erb
+++ b/app/views/projects/pre_commit_requirements/_requirement.html.erb
@@ -1,3 +1,5 @@
+<% can_manage = local_assigns.fetch(:can_manage, true) %>
+
 <div class="rounded-md border border-gray-200 p-4">
   <div class="flex items-start justify-between">
     <div>
@@ -11,9 +13,11 @@
         <span class="inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10">Disabled</span>
       <% end %>
       <span class="inline-flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700"><%= requirement.failure_behavior %></span>
-      <%= button_to "Delete", project_pre_commit_requirement_path(project, requirement), method: :delete,
-        class: "text-red-600 hover:text-red-900 text-sm font-medium",
-        data: { turbo_confirm: "Remove this requirement?" } %>
+      <% if can_manage %>
+        <%= button_to "Delete", project_pre_commit_requirement_path(project, requirement), method: :delete,
+          class: "text-red-600 hover:text-red-900 text-sm font-medium",
+          data: { turbo_confirm: "Remove this requirement?" } %>
+      <% end %>
     </div>
   </div>
   <div class="mt-2">

--- a/app/views/projects/pre_commit_requirements/index.html.erb
+++ b/app/views/projects/pre_commit_requirements/index.html.erb
@@ -17,23 +17,109 @@
         Configure checks that run before every commit.
       </p>
 
+      <fieldset id="mutation-testing" class="mt-6 space-y-4 rounded-md border border-gray-200 p-4">
+        <legend class="px-1 text-sm font-semibold text-gray-900">Mutation Testing</legend>
+        <p class="text-sm text-gray-600">
+          Run mutation tests before committing to catch inadequate test coverage.
+          Uses <a href="https://github.com/viamin/mutant" class="text-indigo-600 hover:text-indigo-500" target="_blank" rel="noopener noreferrer">viamin/mutant</a> via <code class="rounded bg-gray-100 px-1 text-xs">bundle exec mutant</code>.
+        </p>
+
+        <% if @can_manage_pre_commit_requirements %>
+          <% if @mutation_requirement.errors.any? %>
+            <div class="rounded-md bg-red-50 p-4">
+              <h3 class="text-sm font-medium text-red-800"><%= pluralize(@mutation_requirement.errors.count, "error") %> prevented mutation testing from being saved:</h3>
+              <ul class="mt-2 list-disc pl-5 text-sm text-red-700">
+                <% @mutation_requirement.errors.full_messages.each do |msg| %>
+                  <li><%= msg %></li>
+                <% end %>
+              </ul>
+            </div>
+          <% end %>
+
+          <%= form_with model: [ @project, @mutation_requirement ], class: "space-y-4" do |f| %>
+            <%= f.hidden_field :name, value: "mutation_test" %>
+            <%= f.hidden_field :check_type, value: "mutation_test" %>
+            <%= f.hidden_field :position, value: @mutation_requirement.position || 0 %>
+
+            <div class="flex items-center">
+              <%= f.check_box :enabled, id: "mutation_test_enabled", class: "h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600" %>
+              <%= f.label :enabled, "Enable mutation testing", for: "mutation_test_enabled", class: "ml-3 block text-sm font-medium leading-6 text-gray-900" %>
+              <% if @mutation_requirement.enabled? %>
+                <span class="ml-2 inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">Active</span>
+              <% end %>
+            </div>
+
+            <div>
+              <%= f.label :command, "Command", for: "mutation_test_command", class: "block text-sm font-medium leading-6 text-gray-900" %>
+              <div class="mt-1">
+                <%= f.text_field :command, id: "mutation_test_command", value: @mutation_requirement.command.presence || PreCommitRequirement::MUTATION_TEST_DEFAULT_COMMAND, required: true, autocomplete: "off", class: "block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
+              </div>
+              <p class="mt-1 text-xs text-gray-500">
+                Default: <code class="rounded bg-gray-100 px-1"><%= PreCommitRequirement::MUTATION_TEST_DEFAULT_COMMAND %></code>
+              </p>
+            </div>
+
+            <div>
+              <%= f.label :failure_behavior, "Failure behavior", for: "mutation_test_failure_behavior", class: "block text-sm font-medium leading-6 text-gray-900" %>
+              <div class="mt-1">
+                <%= f.select :failure_behavior,
+                  options_for_select(
+                    [
+                      [ "Warn (log result, do not block)", "warn" ],
+                      [ "Block (fail the pre-commit check)", "block" ]
+                    ],
+                    @mutation_requirement.failure_behavior.presence || "warn"
+                  ),
+                  {},
+                  id: "mutation_test_failure_behavior",
+                  class: "block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
+              </div>
+              <p class="mt-1 text-xs text-gray-500">Choose <strong>Warn</strong> to start with, then switch to <strong>Block</strong> once your kill rate is stable.</p>
+            </div>
+
+            <% if @mutation_requirement.updated_at %>
+              <p class="text-xs text-gray-500">Last updated: <%= @mutation_requirement.updated_at.strftime("%b %-d, %Y") %></p>
+            <% end %>
+
+            <%= f.submit "Save Mutation Testing", class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 cursor-pointer" %>
+          <% end %>
+        <% elsif @mutation_requirement.persisted? %>
+          <div class="space-y-3 text-sm">
+            <div class="flex items-center gap-x-2">
+              <% if @mutation_requirement.enabled? %>
+                <span class="inline-flex items-center rounded-md bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20">Enabled</span>
+              <% else %>
+                <span class="inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10">Disabled</span>
+              <% end %>
+              <span class="inline-flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700"><%= @mutation_requirement.failure_behavior %></span>
+            </div>
+            <code class="block rounded bg-gray-50 px-3 py-2 text-sm text-gray-700"><%= @mutation_requirement.command %></code>
+          </div>
+        <% else %>
+          <p class="text-sm text-gray-500">Mutation testing has not been configured.</p>
+        <% end %>
+      </fieldset>
+
+      <% listed_requirements = @pre_commit_requirements.reject { |requirement| requirement.check_type == "mutation_test" } %>
       <div class="mt-6 space-y-6">
         <%= render partial: "projects/pre_commit_requirements/requirement",
-          collection: @pre_commit_requirements,
+          collection: listed_requirements,
           as: :requirement,
-          locals: { project: @project } %>
+          locals: { project: @project, can_manage: @can_manage_pre_commit_requirements } %>
 
-        <% if @pre_commit_requirements.empty? %>
-          <p class="text-sm text-gray-500">No pre-commit requirements configured.</p>
+        <% if listed_requirements.empty? %>
+          <p class="text-sm text-gray-500">No other pre-commit requirements configured.</p>
         <% end %>
       </div>
 
-      <div class="mt-8 border-t border-gray-200 pt-6">
-        <h2 class="text-lg font-medium text-gray-900">Add Requirement</h2>
-        <%= render "projects/pre_commit_requirements/form",
-          pre_commit_requirement: @new_requirement || PreCommitRequirement.new,
-          project: @project %>
-      </div>
+      <% if @can_manage_pre_commit_requirements %>
+        <div class="mt-8 border-t border-gray-200 pt-6">
+          <h2 class="text-lg font-medium text-gray-900">Add Requirement</h2>
+          <%= render "projects/pre_commit_requirements/form",
+            pre_commit_requirement: @new_requirement || PreCommitRequirement.new,
+            project: @project %>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/spec/requests/projects/pre_commit_requirements_spec.rb
+++ b/spec/requests/projects/pre_commit_requirements_spec.rb
@@ -45,6 +45,16 @@ RSpec.describe "Projects::PreCommitRequirements" do
         get project_pre_commit_requirements_path(project)
         expect(response).to have_http_status(:ok)
       end
+
+      it "does not render management controls" do
+        create(:pre_commit_requirement, account: account, project: project, name: "lint")
+
+        get project_pre_commit_requirements_path(project)
+
+        expect(response.body).not_to include("Save Mutation Testing")
+        expect(response.body).not_to include("Add Requirement")
+        expect(response.body).not_to include("Delete")
+      end
     end
   end
 
@@ -172,7 +182,24 @@ RSpec.describe "Projects::PreCommitRequirements" do
 
         expect(response).to have_http_status(:unprocessable_content)
         expect(response.body).to include(%(action="#{project_pre_commit_requirement_path(project, requirement)}"))
-        expect(response.body).not_to include(%(action="#{project_pre_commit_requirements_path(project)}"))
+      end
+
+      it "keeps mutation test errors out of the generic requirement form" do
+        mutation_requirement = create(:pre_commit_requirement,
+          account: account,
+          project: project,
+          name: "mutation_test",
+          check_type: "mutation_test",
+          command: PreCommitRequirement::MUTATION_TEST_DEFAULT_COMMAND)
+
+        patch project_pre_commit_requirement_path(project, mutation_requirement),
+          params: { pre_commit_requirement: { command: "" } }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to include("prevented mutation testing from being saved")
+        expect(response.body).to include("Save Mutation Testing")
+        expect(response.body).to include("Add Requirement")
+        expect(response.body).not_to include("Update Requirement")
       end
     end
 

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -1865,18 +1865,11 @@ RSpec.describe "Projects" do
         expect(response.body).to include("Could not load repository screenshot config: GitHub is down")
       end
 
-      it "re-renders the form without crashing when mutation_test params accompany a validation failure" do
+      it "links to project pre-commit requirements from settings" do
         project = create(:project, account: account, github_token: github_token)
+        get edit_project_path(project)
 
-        expect {
-          patch project_path(project), params: {
-            project: { name: "" },
-            mutation_test: { enabled: "1", command: "bundle exec mutant run", failure_behavior: "warn" }
-          }
-        }.not_to raise_error
-
-        expect(response).to have_http_status(:unprocessable_content)
-        expect(response.body).to include("Mutation Testing")
+        expect(response.body).to include(project_pre_commit_requirements_path(project))
       end
 
       it "allows updating priority label names" do

--- a/spec/system/projects/mutation_test_requirements_spec.rb
+++ b/spec/system/projects/mutation_test_requirements_spec.rb
@@ -22,15 +22,15 @@ RSpec.describe "Project mutation testing toggle", system_driver: :rack_test, typ
     Warden.test_reset!
   end
 
-  describe "project edit page" do
+  describe "project pre-commit requirements page" do
     it "renders the mutation testing section" do
-      visit edit_project_path(project)
+      visit project_pre_commit_requirements_path(project)
       expect(page).to have_content("Mutation Testing")
       expect(page).to have_content("Enable mutation testing")
     end
 
     it "shows the default command as a hint" do
-      visit edit_project_path(project)
+      visit project_pre_commit_requirements_path(project)
       expect(page).to have_content(PreCommitRequirement::MUTATION_TEST_DEFAULT_COMMAND)
     end
   end
@@ -38,14 +38,14 @@ RSpec.describe "Project mutation testing toggle", system_driver: :rack_test, typ
   describe "toggling mutation testing on" do
     context "when no mutation_test requirement exists" do
       it "creates an enabled requirement" do
-        visit edit_project_path(project)
+        visit project_pre_commit_requirements_path(project)
 
         check "Enable mutation testing"
-        fill_in "mutation_test[command]", with: "bundle exec mutant run --since HEAD~1 --use rspec"
-        select "Warn (log result, do not block)", from: "mutation_test[failure_behavior]"
-        click_button "Save Changes"
+        fill_in "mutation_test_command", with: "bundle exec mutant run --since HEAD~1 --use rspec"
+        select "Warn (log result, do not block)", from: "mutation_test_failure_behavior"
+        click_button "Save Mutation Testing"
 
-        expect(page).to have_content("Project was successfully updated")
+        expect(page).to have_content("Pre-commit requirement created")
 
         req = project.pre_commit_requirements.find_by(check_type: "mutation_test")
         expect(req).to be_present
@@ -62,10 +62,10 @@ RSpec.describe "Project mutation testing toggle", system_driver: :rack_test, typ
       end
 
       it "enables the existing requirement" do
-        visit edit_project_path(project)
+        visit project_pre_commit_requirements_path(project)
 
         check "Enable mutation testing"
-        click_button "Save Changes"
+        click_button "Save Mutation Testing"
 
         requirement.reload
         expect(requirement).to be_enabled
@@ -80,13 +80,13 @@ RSpec.describe "Project mutation testing toggle", system_driver: :rack_test, typ
     end
 
     it "disables the requirement" do
-      visit edit_project_path(project)
+      visit project_pre_commit_requirements_path(project)
 
       expect(page).to have_checked_field("Enable mutation testing")
       uncheck "Enable mutation testing"
-      click_button "Save Changes"
+      click_button "Save Mutation Testing"
 
-      expect(page).to have_content("Project was successfully updated")
+      expect(page).to have_content("Pre-commit requirement updated")
       requirement.reload
       expect(requirement).not_to be_enabled
     end
@@ -99,10 +99,10 @@ RSpec.describe "Project mutation testing toggle", system_driver: :rack_test, typ
     end
 
     it "saves the updated command" do
-      visit edit_project_path(project)
+      visit project_pre_commit_requirements_path(project)
 
-      fill_in "mutation_test[command]", with: "bundle exec mutant run --jobs 4"
-      click_button "Save Changes"
+      fill_in "mutation_test_command", with: "bundle exec mutant run --jobs 4"
+      click_button "Save Mutation Testing"
 
       requirement.reload
       expect(requirement.command).to eq("bundle exec mutant run --jobs 4")


### PR DESCRIPTION
## Summary
- Add navbar links for prompt reviews, plan reviews, and Codex Login.
- Move mutation testing configuration into the project pre-commit requirements page.
- Reorganize project settings so Active is first and screenshots sit below auto-merge/auto-release.
- Make pre-commit requirement management controls permission-aware and keep mutation validation errors out of the generic add form.

## Validation
- bin/rspec spec/requests/projects/pre_commit_requirements_spec.rb spec/system/projects/mutation_test_requirements_spec.rb spec/requests/projects_spec.rb:1868
- bin/lint --changed
- pre-commit hook: staged secret scan and lint
