### PR TITLE
fix(auto-merge): retry dependabot merges with PAT fallback

### DIFF
--- a/app/jobs/dependabot_auto_merge_job.rb
+++ b/app/jobs/dependabot_auto_merge_job.rb
@@ -48,6 +48,7 @@ class DependabotAutoMergeJob < ApplicationJob
     return unless pr_data
 
     return if skip_auto_merge_label?(project, pr_data)
+    return if skip_merge_permission_cooldown?(project, pr_data)
     return if skip_unmergeable?(client, project, pr_data)
 
     merge_dependabot_pr(client, project, pr_data)
@@ -63,6 +64,7 @@ class DependabotAutoMergeJob < ApplicationJob
       next unless pr_data
 
       next if skip_auto_merge_label?(project, pr_data)
+      next if skip_merge_permission_cooldown?(project, pr_data)
       next if skip_unmergeable?(client, project, pr_data)
 
       merged = merge_dependabot_pr(client, project, pr_data)
@@ -118,6 +120,19 @@ class DependabotAutoMergeJob < ApplicationJob
     false
   end
 
+  def skip_merge_permission_cooldown?(project, pr_data)
+    pr_num = pr_number_from(pr_data)
+    issue = pull_request_issue(project, pr_num)
+    return false unless issue&.merge_permission_rejected? && !issue.merge_permission_retry_due?
+
+    Rails.logger.info(
+      message: "dependabot_auto_merge.merge_permission_cooldown",
+      project_id: project.id,
+      pr_number: pr_num
+    )
+    true
+  end
+
   def fetch_pr(client, project, pr_number)
     pr_data = client.pull_request(project.full_name, pr_number)
     return nil unless pr_data && dependabot_pr?(pr_data) && !merged?(pr_data)
@@ -165,11 +180,46 @@ class DependabotAutoMergeJob < ApplicationJob
   def merge_dependabot_pr(client, project, pr_data)
     pr_number = pr_number_from(pr_data)
 
+    merge_dependabot_pr_with(client, project, pr_number)
+  rescue GithubClient::ApiError => e
+    fallback_client = workflow_permission_rejection?(e) && project.git_push_fallback_client
+    if fallback_client
+      Rails.logger.info(
+        message: "dependabot_auto_merge.retrying_with_pat_fallback",
+        project_id: project.id,
+        pr_number: pr_number
+      )
+      begin
+        return merge_dependabot_pr_with(fallback_client, project, pr_number)
+      rescue GithubClient::ApiError => fallback_error
+        return handle_expected_merge_failure(project, pr_number, fallback_error, message: "dependabot_auto_merge.pat_fallback_failed")
+      end
+    end
+
+    handle_expected_merge_failure(project, pr_number, e, message: "dependabot_auto_merge.merge_failed_expected")
+  end
+
+  def handle_expected_merge_failure(project, pr_number, error, message:)
+    raise unless expected_merge_failure?(error)
+
+    record_merge_permission_rejection(project, pr_number, error.message) if workflow_permission_rejection?(error)
+
+    Rails.logger.warn(
+      message: message,
+      project_id: project.id,
+      pr_number: pr_number,
+      status: error.status,
+      error: error.message
+    )
+    false
+  end
+
+  def merge_dependabot_pr_with(client, project, pr_number)
     client.merge_pull_request(
       project.full_name, pr_number,
       merge_method: project.merge_method
     )
-
+    clear_merge_permission_rejection(project, pr_number)
     add_label(client, project, pr_number)
     add_comment(client, project, pr_number)
 
@@ -179,17 +229,31 @@ class DependabotAutoMergeJob < ApplicationJob
       pr_number: pr_number
     )
     true
-  rescue GithubClient::ApiError => e
-    raise unless EXPECTED_MERGE_STATUSES.include?(e.status)
+  end
 
-    Rails.logger.warn(
-      message: "dependabot_auto_merge.merge_failed_expected",
-      project_id: project.id,
-      pr_number: pr_number,
-      status: e.status,
-      error: e.message
-    )
-    false
+  def workflow_permission_rejection?(error)
+    return false if error.respond_to?(:status) && error.status != 403
+
+    AgentRun::PUSH_PERMISSION_REJECTION_KEYWORDS.any? { |keyword| error.message.include?(keyword) }
+  end
+
+  def expected_merge_failure?(error)
+    EXPECTED_MERGE_STATUSES.include?(error.status) || workflow_permission_rejection?(error)
+  end
+
+  def record_merge_permission_rejection(project, pr_number, reason)
+    pull_request_issue(project, pr_number)&.record_merge_permission_rejection!(reason: reason)
+  end
+
+  def clear_merge_permission_rejection(project, pr_number)
+    issue = pull_request_issue(project, pr_number)
+    return unless issue&.merge_permission_rejected?
+
+    issue.update!(merge_permission_rejected_at: nil, merge_permission_rejection_reason: nil)
+  end
+
+  def pull_request_issue(project, pr_number)
+    project.issues.find_by(github_number: pr_number, is_pull_request: true)
   end
 
   def add_label(client, project, pr_number)

--- a/docs/intent/auto-merge-strategy/auto-merge-strategy-design.md
+++ b/docs/intent/auto-merge-strategy/auto-merge-strategy-design.md
@@ -42,7 +42,11 @@ resolved dependencies.
 Execution is incremental rather than umbrella-driven. The dedicated
 `DependabotAutoMergeJob` evaluates candidate PRs, merges at most one green PR
 per pass, labels/comment-tags successful merges, and treats expected merge
-rejections as logged no-ops rather than crashes.
+rejections as logged no-ops rather than crashes. App-backed projects that have
+a PAT push fallback configured reuse that fallback when a Dependabot merge is
+rejected for a missing workflow permission. Terminal workflow-permission
+failures reuse the PR row's merge-permission cooldown so Paid does not retry
+the same permanent failure every poll cycle.
 
 ## What this is not
 

--- a/docs/intent/auto-merge-strategy/auto-merge-strategy-specs.md
+++ b/docs/intent/auto-merge-strategy/auto-merge-strategy-specs.md
@@ -25,6 +25,11 @@
   dependency auto-merge mode, the system SHALL merge only eligible Dependabot
   PRs, SHALL stop after the first successful merge in a batch, and SHALL add
   the Paid merge label/comment while treating expected merge conflicts or stale
-  mergeability failures as logged non-fatal outcomes.
+  mergeability failures as logged non-fatal outcomes. When the GitHub App
+  merge is rejected for a missing workflow permission and the project has a PAT
+  push fallback configured, it SHALL retry the merge with that fallback client.
+  Terminal workflow-permission merge rejections SHALL mark the synced PR row
+  for the existing merge-permission cooldown and clear that marker after a
+  later successful merge.
   *Code:* `app/jobs/dependabot_auto_merge_job.rb`.
   *Test:* `spec/jobs/dependabot_auto_merge_job_spec.rb`.

--- a/spec/jobs/dependabot_auto_merge_job_spec.rb
+++ b/spec/jobs/dependabot_auto_merge_job_spec.rb
@@ -236,6 +236,120 @@ RSpec.describe DependabotAutoMergeJob do
       expect { described_class.perform_now(project.id) }.not_to raise_error
     end
 
+    context "with a configured PAT fallback" do
+      let(:project) { create(:project, :with_github_installation, auto_merge_mode: "dependabot_only") }
+      let(:fallback_token) { create(:github_token, :with_workflow_scope, account: project.account) }
+      let(:fallback_client) { instance_double(GithubClient) }
+
+      before do
+        project.update!(git_push_pat_fallback_enabled: true, git_push_fallback_token: fallback_token)
+        allow(Github::AppInstallation).to receive(:token_for).and_return("ghs_app_token")
+        allow(GithubClient).to receive(:new) do |token:, **|
+          token == fallback_token.token ? fallback_client : client
+        end
+        allow(fallback_client).to receive(:merge_pull_request)
+        allow(fallback_client).to receive(:add_labels_to_issue)
+        allow(fallback_client).to receive(:add_comment)
+      end
+
+      it "retries workflow-permission merge failures with the fallback client" do
+        allow(client).to receive(:merge_pull_request).and_raise(
+          GithubClient::ApiError.new(
+            "refusing to allow a GitHub App to create or update workflow `.github/workflows/ci.yml` without `workflows` permission",
+            status: 403
+          )
+        )
+
+        described_class.perform_now(project.id)
+
+        expect(fallback_client).to have_received(:merge_pull_request).with(
+          project.full_name, 42, merge_method: project.merge_method
+        )
+        expect(fallback_client).to have_received(:add_labels_to_issue).with(
+          project.full_name, 42, [ "paid-auto-merged-dependabot" ]
+        )
+        expect(fallback_client).to have_received(:add_comment)
+      end
+
+      it "handles terminal fallback merge rejection without raising" do
+        rejection = "refusing to allow a GitHub App to create or update workflow `.github/workflows/ci.yml` without `workflows` permission"
+        allow(client).to receive(:merge_pull_request).and_raise(
+          GithubClient::ApiError.new(rejection, status: 403)
+        )
+        allow(fallback_client).to receive(:merge_pull_request).and_raise(
+          GithubClient::ApiError.new(rejection, status: 403)
+        )
+
+        expect { described_class.perform_now(project.id) }.not_to raise_error
+      end
+
+      it "records terminal fallback merge rejection on the synced PR row" do
+        issue = create(:issue, :pull_request, project: project, github_number: 42)
+        rejection = "refusing to allow a GitHub App to create or update workflow `.github/workflows/ci.yml` without `workflows` permission"
+        allow(client).to receive(:merge_pull_request).and_raise(
+          GithubClient::ApiError.new(rejection, status: 403)
+        )
+        allow(fallback_client).to receive(:merge_pull_request).and_raise(
+          GithubClient::ApiError.new(rejection, status: 403)
+        )
+
+        described_class.perform_now(project.id)
+
+        expect(issue.reload).to be_merge_permission_rejected
+        expect(issue.merge_permission_rejection_reason).to eq(rejection)
+      end
+
+      it "skips merge attempts while a permission rejection is cooling down" do
+        create(
+          :issue,
+          :pull_request,
+          project: project,
+          github_number: 42,
+          merge_permission_rejected_at: 1.hour.ago,
+          merge_permission_rejection_reason: "missing workflows permission"
+        )
+
+        described_class.perform_now(project.id)
+
+        expect(client).not_to have_received(:check_runs_for_ref)
+        expect(client).not_to have_received(:merge_pull_request)
+        expect(fallback_client).not_to have_received(:merge_pull_request)
+      end
+
+      it "clears stale permission rejection after a successful fallback merge" do
+        issue = create(
+          :issue,
+          :pull_request,
+          project: project,
+          github_number: 42,
+          merge_permission_rejected_at: 7.hours.ago,
+          merge_permission_rejection_reason: "missing workflows permission"
+        )
+        allow(client).to receive(:merge_pull_request).and_raise(
+          GithubClient::ApiError.new(
+            "refusing to allow a GitHub App to create or update workflow `.github/workflows/ci.yml` without `workflows` permission",
+            status: 403
+          )
+        )
+
+        described_class.perform_now(project.id)
+
+        expect(issue.reload).not_to be_merge_permission_rejected
+      end
+
+      it "does not use the fallback client for non-permission API failures" do
+        allow(client).to receive(:merge_pull_request).and_raise(
+          GithubClient::ApiError.new(
+            "server error mentioning `.github/workflows/ci.yml` without `workflows` permission",
+            status: 500
+          )
+        )
+
+        expect { described_class.perform_now(project.id) }.to raise_error(GithubClient::ApiError)
+        expect(fallback_client).not_to have_received(:merge_pull_request)
+      end
+    end
+
     it "skips when project is not found" do
       result = described_class.perform_now(999_999)
 


### PR DESCRIPTION
## Summary

Fixes Dependabot auto-merge for app-backed projects when GitHub rejects a workflow-file merge because the App installation token lacks the `workflows` permission.

## Root Cause

`DependabotAutoMergeJob` used `project.client`, which resolves to the GitHub App installation token for app-backed projects, and never retried with the project's configured PAT fallback. Regular merge handling already had this fallback path, but the Dependabot job bypassed it.

## Changes

- Retry Dependabot merge failures with `project.git_push_fallback_client` only for GitHub `403` workflow-permission rejections.
- Record terminal workflow-permission failures on the synced PR row and honor the existing merge-permission cooldown.
- Clear the merge-permission marker after a later successful merge.
- Update `AUTO-MERGE-003` intent docs and add focused regression coverage.

## Validation

- `bin/rspec spec/jobs/dependabot_auto_merge_job_spec.rb`
- `bin/rubocop app/jobs/dependabot_auto_merge_job.rb spec/jobs/dependabot_auto_merge_job_spec.rb`
- `bin/coherence-check.mjs`
- `git diff --check`