### PR TITLE
fix(auto-continue): stop stuck no-output followup loops

### DIFF
--- a/app/services/automation/strategies/auto_continue.rb
+++ b/app/services/automation/strategies/auto_continue.rb
@@ -41,14 +41,9 @@ module Automation
     class AutoContinue
       include Automation::Strategy
 
-      REVIEW_FOLLOWUP_TRIGGER_TYPES = %w[
-        changes_requested
+      REVIEW_RUN_TRIGGER_TYPES = %w[
         paid_agent_review_pending
-        review_bot_comments
-        review_bot_review_pending
-        review_bot_threads
         review_goal_retry
-        review_threads
       ].freeze
 
       # @param context [Automation::Context]
@@ -121,13 +116,13 @@ module Automation
         return false unless signals.no_progress_stuck
         return true if signals.review_goal_retry_limit_requires_escalation
         return false unless signals.failure_streak_limit_reached
-        return false if review_followup_pending?(signals)
+        return false if review_run_pending?(signals) # @spec FOCUSED-RUN-006
 
         true
       end
 
-      def review_followup_pending?(signals)
-        scan_trigger_types(signals).any? { |type| REVIEW_FOLLOWUP_TRIGGER_TYPES.include?(type) }
+      def review_run_pending?(signals)
+        scan_trigger_types(signals).any? { |type| REVIEW_RUN_TRIGGER_TYPES.include?(type) }
       end
 
       def dismiss_escalation_pending?(signals)

--- a/docs/intent/focused-agent-runs/focused-agent-runs-specs.md
+++ b/docs/intent/focused-agent-runs/focused-agent-runs-specs.md
@@ -63,3 +63,13 @@
   `ScanPaidPrsActivity::FOCUS_RESOLUTION_ATTRIBUTION_FOCUSES`.
   *Test:* `spec/temporal/activities/scan_paid_prs_activity_spec.rb`,
   `spec/temporal/activities/scan_paid_prs_activity_focus_resolution_spec.rb`.
+
+## Follow-up loop breaker
+
+- [x] **FOCUSED-RUN-006** — When PR scan lifecycle signals show a
+  create-pr follow-up loop is stuck with no meaningful progress, the
+  auto-continue strategy SHALL escalate instead of queueing another
+  create-pr follow-up for the same unresolved review/CI/comment trigger;
+  pending review-run triggers SHALL still be allowed to proceed.
+  *Code:* `Automation::Strategies::AutoContinue#escalation_candidate?`.
+  *Test:* `spec/services/automation/strategies/auto_continue_spec.rb`.

--- a/spec/services/automation/strategies/auto_continue_spec.rb
+++ b/spec/services/automation/strategies/auto_continue_spec.rb
@@ -215,6 +215,44 @@ RSpec.describe Automation::Strategies::AutoContinue do
         expect(decision_types(result)).to eq([ "queue_create_pr_run", "record_pr_followup" ])
       end
 
+      it "escalates instead of queuing another create_pr follow-up once review feedback is stuck" do # @spec FOCUSED-RUN-006
+        result = evaluate(
+          lifecycle: base_lifecycle.merge(
+            failure_streak_limit_reached: true,
+            no_progress_stuck: true,
+            consecutive_unsuccessful_automatic_runs: 3,
+            escalation_reason: "Automatic PR failure streak reached"
+          ),
+          scan: {
+            issue_id: pull_request.id,
+            pr_number: 42,
+            phase: "ready",
+            triggers: [ { type: "changes_requested" } ]
+          }
+        )
+
+        expect(result.to_h[:decisions].first).to include(type: "escalate")
+      end
+
+      it "still delegates when a review run is pending" do
+        result = evaluate(
+          lifecycle: base_lifecycle.merge(
+            failure_streak_limit_reached: true,
+            no_progress_stuck: true,
+            consecutive_unsuccessful_automatic_runs: 3,
+            escalation_reason: "Automatic PR failure streak reached"
+          ),
+          scan: {
+            issue_id: pull_request.id,
+            pr_number: 42,
+            phase: "ready",
+            triggers: [ { type: "paid_agent_review_pending" } ]
+          }
+        )
+
+        expect(decision_types(result)).to eq([ "queue_review_run" ])
+      end
+
       it "delegates to AutoReview when no unified gate is active" do
         result = evaluate(
           lifecycle: base_lifecycle,


### PR DESCRIPTION
## Summary
- stop stuck PR follow-up loops from queueing another create_pr run once lifecycle signals say there is no meaningful progress
- preserve paid_agent review-run retries so review-goal recovery still proceeds
- document FOCUSED-RUN-006 and add regression coverage

## Root cause
Recent No Output runs were automatic PR follow-up create_pr runs, not auto-pick issue runs. AutoContinue treated ordinary review-feedback triggers as a reason to suppress the no-progress escalation gate, so the scanner could keep queueing another create_pr follow-up for the same unresolved PR.

## Validation
- bin/rspec spec/services/automation/strategies/auto_continue_spec.rb spec/services/automation/strategies/auto_continue_lifecycle_transitions_spec.rb spec/services/automation/strategies/auto_continue_review_retry_no_db_spec.rb
- bin/rubocop app/services/automation/strategies/auto_continue.rb spec/services/automation/strategies/auto_continue_spec.rb
- pre-commit hook